### PR TITLE
🐛  Config EgenAnsattClient

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -70,8 +70,11 @@ spec:
     outbound:
       rules:
         - application: tilleggsstonader-integrasjoner
+        - application: skjermede-personer-pip
+          namespace: nom
       external:
         - host: pdl-api-q1.dev-fss-pub.nais.io
+
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -70,6 +70,8 @@ spec:
     outbound:
       rules:
         - application: tilleggsstonader-integrasjoner
+        - application: skjermede-personer-pip
+          namespace: nom
       external:
         - host: pdl-api.prod-fss-pub.nais.io
   env:

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/egenansatt/EgenAnsattClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/egenansatt/EgenAnsattClient.kt
@@ -1,11 +1,12 @@
 package no.nav.tilleggsstonader.sak.opplysninger.egenansatt
 
+import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
-import org.springframework.web.client.RestOperations
+import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.exchange
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
@@ -13,21 +14,21 @@ import java.net.URI
 @Component
 class EgenAnsattClient(
     @Value("\${clients.egen_ansatt.uri}") private val uri: URI,
-    @Qualifier("utenAuth") private val restOperations: RestOperations,
-) {
+    @Qualifier("azureClientCredential") restTemplate: RestTemplate,
+) : AbstractRestClient(restTemplate) {
 
     private val egenAnsattUri: URI = UriComponentsBuilder.fromUri(uri).pathSegment("skjermet").build().toUri()
     private val egenAnsattBulkUri: URI = UriComponentsBuilder.fromUri(uri).pathSegment("skjermetBulk").build().toUri()
 
     fun erEgenAnsatt(personIdent: String): Boolean =
-        restOperations.exchange<Boolean>(
+        restTemplate.exchange<Boolean>(
             egenAnsattUri,
             HttpMethod.POST,
             HttpEntity(SkjermetDataRequestDTO(personIdent)),
         ).body ?: error("Mangler body")
 
     fun erEgenAnsatt(personidenter: Set<String>): Map<String, Boolean> =
-        restOperations.exchange<Map<String, Boolean>>(
+        restTemplate.exchange<Map<String, Boolean>>(
             egenAnsattBulkUri,
             HttpMethod.POST,
             HttpEntity(SkjermetDataBolkRequestDTO(personidenter)),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,6 @@ clients:
     uri: https://pdl-api.${CLIENT_ENV}-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.pdl.pdl-api/.default
   egen_ansatt:
-    uri: http://nom.skjermede-personer-pip
+    uri: http://skjermede-personer-pip.nom
     scope: api://${CLIENT_ENV}-gcp.nom.skjermede-personer-pip/.default
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fikk feil mot skjermede-personer-tjenesten pga. feil config.

**Endringer:**
- Bruker service discovery på formen `http://<service>.<namespace>` istedenfor `http://<namespace>.<service>` jf. [nais doc](https://doc.nais.io/clusters/service-discovery/?h=servi#short-names)
- Bruker httpklient med azure client credential auth da skjermede-personer-tjenesten krever auth
- Legger til skjermede-personer-pip i accessPolicy for å få gjøre kall

Testet i preprod ✅ 🤠 
