### PR TITLE
🚧 Skal opprette regel for målgruppe

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkår.kt
@@ -101,6 +101,7 @@ enum class Vilkårsresultat(val beskrivelse: String) {
 enum class VilkårType(val beskrivelse: String, val gjelderStønader: List<Stønadstype>) {
     EKSEMPEL("Eksempel", listOf(Stønadstype.BARNETILSYN)),
     EKSEMPEL2("Eksempel 2", listOf(Stønadstype.BARNETILSYN)),
+    MÅLGRUPPE("Målgruppe", listOf(Stønadstype.BARNETILSYN)),
     AKTIVITET("Aktivitet", listOf(Stønadstype.BARNETILSYN)),
     ;
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/RegelId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/RegelId.kt
@@ -8,6 +8,9 @@ enum class RegelId(val beskrivelse: String) {
     HAR_ET_NAVN2("Har et navn 2"),
     HAR_ET_NAVN3("Har et navn 3"),
 
+    // MÅLGRUPPE
+    MÅLGRUPPE("Tilhører bruker riktig målgruppe?"),
+
     // AKTIVITET
     ER_AKTIVITET_REGISTRERT("Er bruker registrert med en aktivitet?"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/Vilkårsregler.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.fagsak.Stønadstype
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetRegel
 import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.EksempelRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeRegel
 
 /**
  * Singleton for å holde på alle regler
@@ -22,6 +23,7 @@ fun vilkårsreglerForStønad(stønadstype: Stønadstype): List<Vilkårsregel> =
     when (stønadstype) {
         Stønadstype.BARNETILSYN -> listOf(
             EksempelRegel(),
+            MålgruppeRegel(),
             AktivitetRegel(),
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/MålgruppeRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/MålgruppeRegel.kt
@@ -1,0 +1,26 @@
+package no.nav.tilleggsstonader.sak.vilkår.regler.vilkår
+
+import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.regler.RegelId
+import no.nav.tilleggsstonader.sak.vilkår.regler.RegelSteg
+import no.nav.tilleggsstonader.sak.vilkår.regler.SluttSvarRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.Vilkårsregel
+import no.nav.tilleggsstonader.sak.vilkår.regler.jaNeiSvarRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.regelIder
+
+class MålgruppeRegel : Vilkårsregel(
+    vilkårType = VilkårType.MÅLGRUPPE,
+    regler = setOf(HOVEDYTELSE),
+    hovedregler = regelIder(HOVEDYTELSE),
+) {
+    companion object {
+        private val HOVEDYTELSE =
+            RegelSteg(
+                regelId = RegelId.MÅLGRUPPE,
+                jaNeiSvarRegel(
+                    hvisJa = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisNei = SluttSvarRegel.IKKE_OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                ),
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårTypeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårTypeTest.kt
@@ -10,6 +10,7 @@ internal class VilkårTypeTest {
     private val vilkårForBarnetilsyn = listOf(
         VilkårType.EKSEMPEL,
         VilkårType.EKSEMPEL2,
+        VilkårType.MÅLGRUPPE,
         VilkårType.AKTIVITET,
     )
 

--- a/src/test/resources/vilkår/regler/MÅLGRUPPE.json
+++ b/src/test/resources/vilkår/regler/MÅLGRUPPE.json
@@ -1,0 +1,18 @@
+{
+  "vilkårType" : "MÅLGRUPPE",
+  "regler" : {
+    "MÅLGRUPPE" : {
+      "regelId" : "MÅLGRUPPE",
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lager en enkel regel for målgruppe med "ja" "nei" svar fordi jeg fortsatt ikke helt vet hva de vil ha her. Ved å svare ja/nei på om de tilhører riktig målgruppe så får man hvertfall faktisk vilkårsvurdert så det er en start. 

Ulempen med ja/nei er manglende oversikt over egne målgrupper frem til vi evt. kan hente denne informasjonen fra andre systemer