### PR TITLE
✨ Lagre vedtaksbrev

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevController.kt
@@ -1,20 +1,48 @@
 package no.nav.tilleggsstonader.sak.brev
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.Base64
+import java.util.UUID
 
 @RestController
 @RequestMapping("/api/brev")
 @ProtectedWithClaims(issuer = "azuread")
-class BrevController(private val familieDokumentClient: FamilieDokumentClient) {
+class BrevController(private val tilgangService: TilgangService, private val behandlingService: BehandlingService, private val brevService: BrevService) {
 
-    @PostMapping("lag-pdf")
-    fun genererPdf(@RequestBody request: GenererPdfRequest): ByteArray {
-        return Base64.getEncoder().encode(familieDokumentClient.genererPdf(request.html))
+    @PostMapping("/{behandlingId}")
+    fun genererPdf(@RequestBody request: GenererPdfRequest, @PathVariable behandlingId: UUID): ByteArray {
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+
+        tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return Base64.getEncoder().encode(brevService.lagSaksbehandlerBrev(saksbehandling, request.html))
+    }
+
+    @GetMapping("/{behandlingId}")
+    fun hentBrev(@PathVariable behandlingId: UUID): ByteArray {
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+
+        tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.UPDATE)
+
+        return Base64.getEncoder().encode(brevService.hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId))
+    }
+
+    @GetMapping("/beslutter/{behandlingId}")
+    fun forhåndsvisBeslutterbrev(@PathVariable behandlingId: UUID): ByteArray {
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+        tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarBeslutterrolle()
+        return Base64.getEncoder().encode(brevService.forhåndsvisBeslutterBrev(saksbehandling))
     }
 
     data class GenererPdfRequest(val html: String)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevService.kt
@@ -132,6 +132,10 @@ class BrevService(
             "Brev-HTML mangler placeholder for besluttersignatur"
         }
 
+        feilHvis(!html.contains(BESLUTTER_VEDTAKSDATO_PLACEHOLDER)) {
+            "Brev-HTML mangler placeholder for vedtaksdato"
+        }
+
         return html
             .replace(BESLUTTER_SIGNATUR_PLACEHOLDER, beslutterSignatur)
             .replace(BESLUTTER_VEDTAKSDATO_PLACEHOLDER, LocalDate.now().norskFormat())

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevService.kt
@@ -1,0 +1,155 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
+import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.util.norskFormat
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+@Service
+class BrevService(
+    private val vedtaksbrevRepository: VedtaksbrevRepository,
+    private val familieDokumentClient: FamilieDokumentClient,
+) {
+
+    fun lagSaksbehandlerBrev(saksbehandling: Saksbehandling, html: String): ByteArray {
+        validerRedigerbarBehandling(saksbehandling)
+
+        val saksbehandlersignatur = SikkerhetContext.hentSaksbehandlerNavn(strict = true)
+
+        lagreEllerOppdaterSaksbehandlerVedtaksbrev(
+            behandlingId = saksbehandling.id,
+            saksbehandlersignatur = saksbehandlersignatur,
+            saksbehandlerHtml = html,
+        )
+
+        return familieDokumentClient.genererPdf(html)
+    }
+
+    fun hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId: UUID): ByteArray {
+        val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(behandlingId)
+        return when (vedtaksbrev.beslutterPdf) {
+            null -> familieDokumentClient.genererPdf(vedtaksbrev.saksbehandlerHtml)
+            else -> vedtaksbrev.beslutterPdf.bytes
+        }
+    }
+
+    private fun lagreEllerOppdaterSaksbehandlerVedtaksbrev(
+        behandlingId: UUID,
+        saksbehandlersignatur: String,
+        saksbehandlerHtml: String,
+    ): Vedtaksbrev {
+        val vedtaksbrev = Vedtaksbrev(
+            behandlingId = behandlingId,
+            saksbehandlerHtml = saksbehandlerHtml,
+            saksbehandlersignatur = saksbehandlersignatur,
+            saksbehandlerIdent = SikkerhetContext.hentSaksbehandler(),
+            opprettetTid = SporbarUtils.now(),
+        )
+
+        return when (vedtaksbrevRepository.existsById(behandlingId)) {
+            true -> vedtaksbrevRepository.update(vedtaksbrev)
+            false -> vedtaksbrevRepository.insert(vedtaksbrev)
+        }
+    }
+
+    fun forhåndsvisBeslutterBrev(saksbehandling: Saksbehandling): ByteArray {
+        val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(saksbehandling.id)
+
+        val beslutterSignatur = SikkerhetContext.hentSaksbehandlerNavn(strict = true)
+
+        return lagBeslutterPdfMedSignatur(vedtaksbrev.saksbehandlerHtml, beslutterSignatur).bytes
+    }
+
+    fun lagEndeligBeslutterbrev(saksbehandling: Saksbehandling): Fil {
+        val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(saksbehandling.id)
+        val saksbehandlerHtml = hentSaksbehandlerHtml(vedtaksbrev, saksbehandling)
+        val beslutterIdent = SikkerhetContext.hentSaksbehandler()
+        val beslutterSignatur = SikkerhetContext.hentSaksbehandlerNavn(strict = true)
+
+        validerKanLageBeslutterbrev(saksbehandling, vedtaksbrev)
+        val beslutterPdf = lagBeslutterPdfMedSignatur(saksbehandlerHtml, beslutterSignatur)
+        val besluttervedtaksbrev = vedtaksbrev.copy(
+            besluttersignatur = beslutterSignatur,
+            beslutterIdent = beslutterIdent,
+            beslutterPdf = beslutterPdf,
+            besluttetTid = LocalDateTime.now(),
+        )
+        vedtaksbrevRepository.update(besluttervedtaksbrev)
+        return Fil(bytes = beslutterPdf.bytes)
+    }
+
+    private fun hentSaksbehandlerHtml(
+        vedtaksbrev: Vedtaksbrev,
+        saksbehandling: Saksbehandling,
+    ): String {
+        feilHvis(vedtaksbrev.saksbehandlerHtml.isEmpty()) {
+            "Mangler innhold i saksbehandlerbrev for behandling: ${saksbehandling.id}"
+        }
+        return vedtaksbrev.saksbehandlerHtml
+    }
+
+    private fun validerKanLageBeslutterbrev(
+        behandling: Saksbehandling,
+        vedtaksbrev: Vedtaksbrev,
+    ) {
+        if (behandling.steg != StegType.BESLUTTE_VEDTAK || behandling.status != BehandlingStatus.FATTER_VEDTAK) {
+            throw Feil(
+                "Behandling er i feil steg=${behandling.steg} status=${behandling.status}",
+                httpStatus = HttpStatus.BAD_REQUEST,
+            )
+        }
+
+        feilHvisIkke(vedtaksbrev.beslutterPdf == null) {
+            "Det finnes allerede et beslutterbrev"
+        }
+    }
+
+    private fun lagBeslutterPdfMedSignatur(
+        saksbehandlerHtml: String,
+        beslutterSignatur: String,
+    ): Fil {
+        val htmlMedBeslutterSignatur = settInnBeslutterSignaturOgVedtaksdato(
+            html = saksbehandlerHtml,
+            beslutterSignatur = beslutterSignatur,
+        )
+        return Fil(familieDokumentClient.genererPdf(htmlMedBeslutterSignatur))
+    }
+
+    private fun settInnBeslutterSignaturOgVedtaksdato(html: String, beslutterSignatur: String): String {
+        feilHvis(!html.contains(BESLUTTER_SIGNATUR_PLACEHOLDER)) {
+            "Brev-HTML mangler placeholder for besluttersignatur"
+        }
+
+        return html
+            .replace(BESLUTTER_SIGNATUR_PLACEHOLDER, beslutterSignatur)
+            .replace(BESLUTTER_VEDTAKSDATO_PLACEHOLDER, LocalDate.now().norskFormat())
+    }
+
+    private fun validerRedigerbarBehandling(saksbehandling: Saksbehandling) {
+        feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
+            "Behandling er i feil steg=${saksbehandling.steg} status=${saksbehandling.status}"
+        }
+    }
+
+    fun slettVedtaksbrev(saksbehandling: Saksbehandling) {
+        vedtaksbrevRepository.deleteById(saksbehandling.id)
+    }
+
+    companion object {
+
+        const val BESLUTTER_SIGNATUR_PLACEHOLDER = "BESLUTTER_SIGNATUR"
+        const val BESLUTTER_VEDTAKSDATO_PLACEHOLDER = "BESLUTTER_VEDTAKSDATO"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/Vedtaksbrev.kt
@@ -1,0 +1,19 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
+import org.springframework.data.annotation.Id
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class Vedtaksbrev(
+    @Id
+    val behandlingId: UUID,
+    val saksbehandlerHtml: String,
+    val saksbehandlersignatur: String,
+    val besluttersignatur: String? = null,
+    val beslutterPdf: Fil? = null,
+    val saksbehandlerIdent: String,
+    val beslutterIdent: String? = null,
+    val opprettetTid: LocalDateTime? = null,
+    val besluttetTid: LocalDateTime? = null,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/Vedtaksbrev.kt
@@ -14,6 +14,6 @@ data class Vedtaksbrev(
     val beslutterPdf: Fil? = null,
     val saksbehandlerIdent: String,
     val beslutterIdent: String? = null,
-    val opprettetTid: LocalDateTime? = null,
+    val opprettetTid: LocalDateTime,
     val besluttetTid: LocalDateTime? = null,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/VedtaksbrevRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/VedtaksbrevRepository.kt
@@ -1,0 +1,9 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface VedtaksbrevRepository : RepositoryInterface<Vedtaksbrev, UUID>, InsertUpdateRepository<Vedtaksbrev>

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/DatabaseConfiguration.kt
@@ -90,6 +90,9 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                 SkjemaBarnetilsynPGobjectConverter(),
                 PGobjectTilBarnMedBarnepass(),
                 BarnMedBarnepassPGobjectConverter(),
+
+                FilTilBytearrayConverter(),
+                BytearrayTilFilConverter(),
             ),
         )
     }
@@ -201,5 +204,21 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                 type = "json"
                 value = objectMapper.writeValueAsString(data)
             }
+    }
+
+    @WritingConverter
+    class FilTilBytearrayConverter : Converter<Fil, ByteArray> {
+
+        override fun convert(fil: Fil): ByteArray {
+            return fil.bytes
+        }
+    }
+
+    @ReadingConverter
+    class BytearrayTilFilConverter : Converter<ByteArray, Fil> {
+
+        override fun convert(bytes: ByteArray): Fil {
+            return Fil(bytes)
+        }
     }
 }

--- a/src/main/resources/db/migration/V18__vedtaksbrev.sql
+++ b/src/main/resources/db/migration/V18__vedtaksbrev.sql
@@ -1,11 +1,11 @@
 CREATE TABLE vedtaksbrev
 (
     behandling_id         UUID PRIMARY KEY REFERENCES behandling (id),
-    saksbehandler_html    VARCHAR NOT NULL,
-    saksbehandlersignatur VARCHAR NOT NULL ,
+    saksbehandler_html    VARCHAR      NOT NULL,
+    saksbehandlersignatur VARCHAR      NOT NULL,
     besluttersignatur     VARCHAR,
     beslutter_pdf         BYTEA,
-    saksbehandler_ident   VARCHAR NOT NULL,
+    saksbehandler_ident   VARCHAR      NOT NULL,
     beslutter_ident       VARCHAR,
     opprettet_tid         TIMESTAMP(3) NOT NULL,
     besluttet_tid         TIMESTAMP(3)

--- a/src/main/resources/db/migration/V18__vedtaksbrev.sql
+++ b/src/main/resources/db/migration/V18__vedtaksbrev.sql
@@ -7,6 +7,6 @@ CREATE TABLE vedtaksbrev
     beslutter_pdf         BYTEA,
     saksbehandler_ident   VARCHAR NOT NULL,
     beslutter_ident       VARCHAR,
-    opprettet_tid         TIMESTAMP(3),
+    opprettet_tid         TIMESTAMP(3) NOT NULL,
     besluttet_tid         TIMESTAMP(3)
 )

--- a/src/main/resources/db/migration/V18__vedtaksbrev.sql
+++ b/src/main/resources/db/migration/V18__vedtaksbrev.sql
@@ -1,0 +1,12 @@
+CREATE TABLE vedtaksbrev
+(
+    behandling_id         UUID PRIMARY KEY REFERENCES behandling (id),
+    saksbehandler_html    VARCHAR NOT NULL,
+    saksbehandlersignatur VARCHAR NOT NULL ,
+    besluttersignatur     VARCHAR,
+    beslutter_pdf         BYTEA,
+    saksbehandler_ident   VARCHAR NOT NULL,
+    beslutter_ident       VARCHAR,
+    opprettet_tid         TIMESTAMP(3),
+    besluttet_tid         TIMESTAMP(3)
+)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandlingsjournalpost
 import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingId
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.Behandlingshistorikk
+import no.nav.tilleggsstonader.sak.brev.Vedtaksbrev
 import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakDomain
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
@@ -103,6 +104,7 @@ abstract class IntegrationTest {
             SøknadBarnetilsyn::class,
 
             Totrinnskontroll::class,
+            Vedtaksbrev::class,
             Behandlingshistorikk::class,
             Behandlingsjournalpost::class,
             EksternBehandlingId::class,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevRepositoryTest.kt
@@ -4,10 +4,13 @@ import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 internal class BrevRepositoryTest : IntegrationTest() {
 
@@ -30,6 +33,7 @@ internal class BrevRepositoryTest : IntegrationTest() {
             beslutterPdf = null,
             saksbehandlerIdent = "123",
             beslutterIdent = "321",
+            opprettetTid = LocalDateTime.now(),
         )
 
         vedtaksbrevRepository.insert(vedtaksbrev)
@@ -37,6 +41,7 @@ internal class BrevRepositoryTest : IntegrationTest() {
         val brevFraDb = vedtaksbrevRepository.findByIdOrNull(behandling.id)
 
         assertThat(brevFraDb).isNotNull
-        assertThat(brevFraDb).isEqualTo(vedtaksbrev)
+        assertThat(brevFraDb).usingRecursiveComparison().ignoringFields("opprettetTid").isEqualTo(vedtaksbrev)
+        assertThat(brevFraDb!!.opprettetTid).isCloseTo(vedtaksbrev.opprettetTid, Assertions.within(1, ChronoUnit.SECONDS))
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevRepositoryTest.kt
@@ -1,0 +1,42 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+
+internal class BrevRepositoryTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var vedtaksbrevRepository: VedtaksbrevRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Test
+    internal fun `lagre og hent vedtaksbrev`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+
+        val vedtaksbrev = Vedtaksbrev(
+            behandlingId = behandling.id,
+            saksbehandlerHtml = "noe html",
+            saksbehandlersignatur = "Sakliga Behandlersen",
+            besluttersignatur = "Beslutter",
+            beslutterPdf = null,
+            saksbehandlerIdent = "123",
+            beslutterIdent = "321",
+        )
+
+        vedtaksbrevRepository.insert(vedtaksbrev)
+
+        val brevFraDb = vedtaksbrevRepository.findByIdOrNull(behandling.id)
+
+        assertThat(brevFraDb).isNotNull
+        assertThat(brevFraDb).isEqualTo(vedtaksbrev)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevServiceTest.kt
@@ -1,0 +1,199 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.BrevService.Companion.BESLUTTER_SIGNATUR_PLACEHOLDER
+import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
+import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus.BAD_REQUEST
+
+internal class BrevServiceTest {
+
+    private val fagsak = fagsak(setOf(PersonIdent("12345678910")))
+    private val behandling = behandling(fagsak)
+
+    private val vedtaksbrevRepository = mockk<VedtaksbrevRepository>()
+    private val familieDokumentClient = mockk<FamilieDokumentClient>()
+
+    private val brevService = BrevService(vedtaksbrevRepository, familieDokumentClient)
+
+    private val vedtaksbrev: Vedtaksbrev = lagVedtaksbrev("malnavn")
+    private val beslutterNavn = "456"
+
+    @BeforeEach
+    fun setUp() {
+        mockBrukerContext(beslutterNavn)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearBrukerContext()
+    }
+
+    @Test
+    internal fun `lagBeslutterBrev - skal kaste feil hvis behandlingen ikke har riktig steg`() {
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
+
+        val feil = assertThrows<Feil> {
+            brevService.lagEndeligBeslutterbrev(
+                saksbehandling(
+                    fagsak,
+                    behandlingForBeslutter.copy(steg = StegType.VILKÅR),
+                ),
+            )
+        }
+        assertThat(feil.message).contains("Behandling er i feil steg")
+        assertThat(feil.httpStatus).isEqualTo(BAD_REQUEST)
+    }
+
+    @Test
+    internal fun `lagBeslutterBrev - skal kaste feil hvis behandlingen ikke har riktig status`() {
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
+
+        val feilFerdigstilt = assertThrows<Feil> {
+            brevService.lagEndeligBeslutterbrev(
+                saksbehandling(
+                    fagsak,
+                    behandlingForBeslutter.copy(
+                        status =
+                        BehandlingStatus.FERDIGSTILT,
+                    ),
+                ),
+            )
+        }
+        assertThat(feilFerdigstilt.httpStatus).isEqualTo(BAD_REQUEST)
+        assertThat(feilFerdigstilt.message).contains("Behandling er i feil steg")
+
+        val feilUtredes = assertThrows<Feil> {
+            brevService.lagEndeligBeslutterbrev(
+                saksbehandling(
+                    fagsak,
+                    behandling.copy(status = BehandlingStatus.UTREDES),
+                ),
+            )
+        }
+        assertThat(feilUtredes.httpStatus).isEqualTo(BAD_REQUEST)
+        assertThat(feilUtredes.message).contains("Behandling er i feil steg")
+    }
+
+    @Test
+    internal fun `skal kaste feil når det finnes beslutterpdf i forveien`() {
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(beslutterPdf = Fil("123".toByteArray()))
+
+        val feil = assertThrows<Feil> {
+            brevService.lagEndeligBeslutterbrev(
+                saksbehandling(
+                    fagsak,
+                    behandlingForBeslutter,
+                ),
+            )
+        }
+        assertThat(feil.message).isEqualTo("Det finnes allerede et beslutterbrev")
+    }
+
+    @Test
+    internal fun `skal lage brev med innlogget beslutterident beslutterident `() {
+        val beslutterIdent = SikkerhetContext.hentSaksbehandler()
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(beslutterIdent = "tilfeldigvisFeilIdent")
+        val brevSlot = slot<Vedtaksbrev>()
+        every { vedtaksbrevRepository.update(capture(brevSlot)) } returns mockk()
+        every { familieDokumentClient.genererPdf(any()) } returns "brev".toByteArray()
+
+        // Når
+        brevService.lagEndeligBeslutterbrev(saksbehandling(fagsak, behandlingForBeslutter))
+
+        assertThat(beslutterIdent).isNotNull()
+        assertThat(brevSlot.captured.beslutterIdent).isEqualTo(beslutterIdent)
+    }
+
+    @Test
+    internal fun `lagSaksbehandlerBrev skal kaste feil når behandling er låst for videre behandling`() {
+        assertThrows<Feil> {
+            brevService
+                .lagSaksbehandlerBrev(
+                    saksbehandling(
+                        fagsak,
+                        behandlingForBeslutter.copy(
+                            status =
+                            BehandlingStatus.FERDIGSTILT,
+                        ),
+                    ),
+                    "html",
+                )
+        }
+    }
+
+    private val behandlingForBeslutter = behandling(
+        fagsak,
+        status = BehandlingStatus.FATTER_VEDTAK,
+        steg = StegType.BESLUTTE_VEDTAK,
+    )
+
+    private val behandlingForSaksbehandler = behandling(
+        fagsak,
+        status = BehandlingStatus.UTREDES,
+        steg = StegType.SEND_TIL_BESLUTTER,
+    )
+
+    private fun lagVedtaksbrev(brevmal: String, saksbehandlerIdent: String = "123") = Vedtaksbrev(
+        behandlingId = behandling.id,
+        saksbehandlerHtml = "Brev med $BESLUTTER_SIGNATUR_PLACEHOLDER",
+        saksbehandlersignatur = "Saksbehandler Signatur",
+        besluttersignatur = null,
+        beslutterPdf = null,
+        saksbehandlerIdent = saksbehandlerIdent,
+        beslutterIdent = null,
+    )
+
+    @Test
+    fun `skal kaste feil hvis saksbehandlerHtml ikke inneholder placeholder for besluttersignatur`() {
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(saksbehandlerHtml = "html uten placeholder")
+
+        val feilmelding = assertThrows<Feil> {
+            brevService.forhåndsvisBeslutterBrev(saksbehandling(fagsak, behandlingForBeslutter))
+        }.message
+        assertThat(feilmelding).isEqualTo("Brev-HTML mangler placeholder for besluttersignatur")
+    }
+
+    @Test
+    fun `Skal erstatte placeholder med besluttersignatur`() {
+        val htmlSlot = slot<String>()
+
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(saksbehandlerHtml = "html med placeholder $BESLUTTER_SIGNATUR_PLACEHOLDER og en liten avslutning")
+        every { vedtaksbrevRepository.update(any()) } returns vedtaksbrev
+        every { familieDokumentClient.genererPdf(capture(htmlSlot)) } returns "123".toByteArray()
+
+        brevService.forhåndsvisBeslutterBrev(saksbehandling(fagsak, behandlingForBeslutter))
+
+        assertThat(htmlSlot.captured).isEqualTo("html med placeholder $beslutterNavn og en liten avslutning")
+    }
+
+    @Test
+    internal fun `skal oppdatere vedtaksbrev med nytt tidspunkt`() {
+        val vedtaksbrevSlot = slot<Vedtaksbrev>()
+        every { vedtaksbrevRepository.existsById(any()) } returns true
+        every { vedtaksbrevRepository.update(capture(vedtaksbrevSlot)) } answers { firstArg() }
+        every { familieDokumentClient.genererPdf(any()) } returns "123".toByteArray()
+
+        val now = SporbarUtils.now()
+        brevService.lagSaksbehandlerBrev(saksbehandling(fagsak, behandling), "html")
+        assertThat(vedtaksbrevSlot.captured.opprettetTid).isAfterOrEqualTo(now)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.brev
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.brev.BrevService.Companion.BESLUTTER_SIGNATUR_PLACEHOLDER
@@ -21,7 +22,6 @@ import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import java.time.LocalDateTime
 
@@ -52,7 +52,7 @@ internal class BrevServiceTest {
     internal fun `lagBeslutterBrev - skal kaste feil hvis behandlingen ikke har riktig steg`() {
         every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
 
-        val feil = assertThrows<Feil> {
+        val feil = catchThrowableOfType<Feil> {
             brevService.lagEndeligBeslutterbrev(
                 saksbehandling(
                     fagsak,
@@ -68,7 +68,7 @@ internal class BrevServiceTest {
     internal fun `lagBeslutterBrev - skal kaste feil hvis behandlingen ikke har riktig status`() {
         every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
 
-        val feilFerdigstilt = assertThrows<Feil> {
+        val feilFerdigstilt = catchThrowableOfType<Feil> {
             brevService.lagEndeligBeslutterbrev(
                 saksbehandling(
                     fagsak,
@@ -82,7 +82,7 @@ internal class BrevServiceTest {
         assertThat(feilFerdigstilt.httpStatus).isEqualTo(BAD_REQUEST)
         assertThat(feilFerdigstilt.message).contains("Behandling er i feil steg")
 
-        val feilUtredes = assertThrows<Feil> {
+        val feilUtredes = catchThrowableOfType<Feil> {
             brevService.lagEndeligBeslutterbrev(
                 saksbehandling(
                     fagsak,
@@ -98,7 +98,7 @@ internal class BrevServiceTest {
     internal fun `skal kaste feil når det finnes beslutterpdf i forveien`() {
         every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(beslutterPdf = Fil("123".toByteArray()))
 
-        val feil = assertThrows<Feil> {
+        val feil = catchThrowableOfType<Feil> {
             brevService.lagEndeligBeslutterbrev(
                 saksbehandling(
                     fagsak,
@@ -126,7 +126,7 @@ internal class BrevServiceTest {
 
     @Test
     internal fun `lagSaksbehandlerBrev skal kaste feil når behandling er låst for videre behandling`() {
-        assertThrows<Feil> {
+        catchThrowableOfType<Feil> {
             brevService
                 .lagSaksbehandlerBrev(
                     saksbehandling(
@@ -168,7 +168,7 @@ internal class BrevServiceTest {
     fun `skal kaste feil hvis saksbehandlerHtml ikke inneholder placeholder for besluttersignatur`() {
         every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(saksbehandlerHtml = "html uten placeholder")
 
-        val feilmelding = assertThrows<Feil> {
+        val feilmelding = catchThrowableOfType<Feil> {
             brevService.forhåndsvisBeslutterBrev(saksbehandling(fagsak, behandlingForBeslutter))
         }.message
         assertThat(feilmelding).isEqualTo("Brev-HTML mangler placeholder for besluttersignatur")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevServiceTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import java.time.LocalDateTime
 
 internal class BrevServiceTest {
 
@@ -159,6 +160,7 @@ internal class BrevServiceTest {
         besluttersignatur = null,
         beslutterPdf = null,
         saksbehandlerIdent = saksbehandlerIdent,
+        opprettetTid = LocalDateTime.now(),
         beslutterIdent = null,
     )
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal lagre vedtaksbrev når saksbehandler generer pdf. Legger også til støtte for å hente beslutterbrevet når behandling er sendt til godkjenning.

Har i stor grad kopiert kode fra `familie-ef-sak`

**Hva mangler? ❌**
- Signering med saksbehandlers enhet