### PR TITLE
🚧 Automatisk journalføring: Skal sjekke om man kan automatisk journalføre for en person

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -67,6 +67,7 @@ spec:
         - application: tilleggsstonader-sak-frontend
         - application: tilleggsstonader-sak-frontend-lokal
         - application: tilleggsstonader-prosessering
+        - application: tilleggsstonader-soknad-api
     outbound:
       rules:
         - application: tilleggsstonader-integrasjoner

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -67,6 +67,7 @@ spec:
       rules:
         - application: tilleggsstonader-sak-frontend
         - application: tilleggsstonader-prosessering
+        - application: tilleggsstonader-soknad-api
     outbound:
       rules:
         - application: tilleggsstonader-integrasjoner

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringController.kt
@@ -1,0 +1,61 @@
+package no.nav.tilleggsstonader.sak.ekstern.journalføring
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.util.FnrUtil.validerIdent
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(
+    path = ["/api/ekstern/automatisk-journalforing"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+class AutomatiskJournalføringController(private val automatiskJournalføringService: AutomatiskJournalføringService) {
+
+    /**
+     * Skal bare brukes av tilleggsstonader-soknad-api for å vurdere om en journalføring skal automatisk ferdigstilles
+     * eller manuelt gjennomgås.
+     */
+
+    @PostMapping("kan-opprette-behandling")
+    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
+    fun kanOppretteBehandling(
+        @RequestBody personIdent: PersonIdent,
+        @RequestParam type: Stønadstype,
+    ): Boolean {
+        if (!SikkerhetContext.kallKommerFraSoknadApi()) {
+            throw Feil(message = "Kallet utføres ikke av en autorisert klient", httpStatus = HttpStatus.UNAUTHORIZED)
+        }
+        validerIdent(personIdent.ident)
+        return automatiskJournalføringService.kanOppretteBehandling(personIdent.ident, type)
+    }
+
+//    /**
+//     * Skal bare brukes av tilleggsstonader-soknad-api for å automatisk journalføre
+//     */
+//    @PostMapping("journalfor")
+//    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
+//    fun automatiskJournalfør(@RequestBody request: AutomatiskJournalføringRequest): AutomatiskJournalføringResponse {
+//        if (!SikkerhetContext.kallKommerFraSoknadApi()) {
+//            throw Feil(message = "Kallet utføres ikke av en autorisert klient", httpStatus = HttpStatus.UNAUTHORIZED)
+//        }
+//        validerIdent(request.personIdent)
+//        return automatiskJournalføringService.automatiskJournalførTilBehandling(
+//            journalpostId = request.journalpostId,
+//            personIdent = request.personIdent,
+//            stønadstype = request.stønadstype,
+//            mappeId = request.mappeId,
+//            prioritet = request.prioritet,
+//        )
+//    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
@@ -1,0 +1,128 @@
+package no.nav.tilleggsstonader.sak.ekstern.journalføring
+
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
+import no.nav.tilleggsstonader.sak.fagsak.tilInternType
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AutomatiskJournalføringService(
+//    private val journalføringService: JournalføringService,
+    private val fagsakService: FagsakService,
+    private val personService: PersonService,
+//    private val arbeidsfordelingService: ArbeidsfordelingService,
+//    private val journalpostService: JournalpostService,
+    private val behandlingService: BehandlingService,
+) {
+
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+//    @Transactional
+//    fun automatiskJournalførTilBehandling(
+//        journalpostId: String,
+//        personIdent: String,
+//        stønadstype: Stønadstype,
+//        mappeId: Long?,
+//        prioritet: OppgavePrioritet,
+//    ): AutomatiskJournalføringResponse {
+//        val journalpost = journalpostService.hentJournalpost(journalpostId)
+//        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent, stønadstype)
+//        val nesteBehandlingstype = utledNesteBehandlingstype(behandlingService.hentBehandlinger(fagsak.id))
+//        val journalførendeEnhet =
+//            arbeidsfordelingService.hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(fagsak.hentAktivIdent())
+//
+//        validerKanAutomatiskJournalføre(personIdent, stønadstype, journalpost)
+//
+//        return journalføringService.automatiskJournalfør(
+//            fagsak,
+//            journalpost,
+//            journalførendeEnhet,
+//            mappeId,
+//            nesteBehandlingstype,
+//            prioritet,
+//        )
+//    }
+
+    fun kanOppretteBehandling(ident: String, stønadstype: Stønadstype): Boolean {
+        val allePersonIdenter = personService.hentPersonIdenter(ident).identer()
+        val fagsak = fagsakService.finnFagsak(allePersonIdenter, stønadstype.tilInternType())
+        val behandlinger = fagsak?.let { behandlingService.hentBehandlinger(fagsak.id) } ?: emptyList()
+        val behandlingstype = utledNesteBehandlingstype(behandlinger)
+
+        return when (behandlingstype) {
+            BehandlingType.FØRSTEGANGSBEHANDLING -> true
+            BehandlingType.REVURDERING -> kanAutomatiskJournalføreRevurdering(behandlinger, fagsak)
+        }
+    }
+
+    private fun kanAutomatiskJournalføreRevurdering(behandlinger: List<Behandling>, fagsak: Fagsak?): Boolean {
+        return if (!harÅpenBehandling(behandlinger)) {
+            secureLogger.info("Kan automatisk journalføre for fagsak: ${fagsak?.id}")
+            true
+        } else {
+            secureLogger.info("Kan ikke automatisk journalføre for fagsak: ${fagsak?.id}")
+            false
+        }
+    }
+
+    private fun validerKanAutomatiskJournalføre(
+        personIdent: String,
+        stønadstype: Stønadstype,
+        journalpost: Journalpost,
+    ) {
+        val allePersonIdenter = personService.hentPersonIdenter(personIdent).identer()
+
+        feilHvisIkke(kanOppretteBehandling(personIdent, stønadstype)) {
+            "Kan ikke opprette førstegangsbehandling for $stønadstype da det allerede finnes en behandling i infotrygd eller ny løsning"
+        }
+
+        feilHvis(journalpost.bruker == null) {
+            "Journalposten mangler bruker. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
+        }
+
+        journalpost.bruker?.let {
+            feilHvisIkke(fagsakPersonOgJournalpostBrukerErSammePerson(allePersonIdenter, personIdent, it)) {
+                "Ikke samsvar mellom personident på journalposten og personen vi forsøker å opprette behandling for. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
+            }
+        }
+
+        feilHvis(journalpost.journalstatus != Journalstatus.MOTTATT) {
+            "Journalposten har ugyldig journalstatus ${journalpost.journalstatus}. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
+        }
+    }
+
+    private fun fagsakPersonOgJournalpostBrukerErSammePerson(
+        allePersonIdenter: Set<String>,
+        gjeldendePersonIdent: String,
+        journalpostBruker: Bruker,
+    ): Boolean = when (journalpostBruker.type) {
+        BrukerIdType.FNR -> allePersonIdenter.contains(journalpostBruker.id)
+        BrukerIdType.AKTOERID -> hentAktørIderForPerson(gjeldendePersonIdent).contains(journalpostBruker.id)
+        BrukerIdType.ORGNR -> false
+    }
+
+    private fun hentAktørIderForPerson(personIdent: String) =
+        personService.hentAktørIder(personIdent).identer()
+
+    private fun utledNesteBehandlingstype(behandlinger: List<Behandling>): BehandlingType {
+        return if (behandlinger.all { it.resultat == BehandlingResultat.HENLAGT }) BehandlingType.FØRSTEGANGSBEHANDLING else BehandlingType.REVURDERING
+    }
+
+    private fun harÅpenBehandling(behandlinger: List<Behandling>): Boolean {
+        return behandlinger.any { !it.erAvsluttet() }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/Stønadstype.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/Stønadstype.kt
@@ -1,5 +1,10 @@
 package no.nav.tilleggsstonader.sak.fagsak
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype as StønadstypeKontrakter
+
 enum class Stønadstype {
     BARNETILSYN,
+}
+fun StønadstypeKontrakter.tilInternType(): Stønadstype = when (this) {
+    StønadstypeKontrakter.BARNETILSYN -> Stønadstype.BARNETILSYN
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -32,6 +32,8 @@ object SikkerhetContext {
         return applikasjonsnavn.endsWith(forventetApplikasjonsSuffix)
     }
 
+    fun kallKommerFraSoknadApi(): Boolean = kallKommerFra("tilleggsstonader:tilleggsstonader-soknad-api")
+
     fun hentSaksbehandler(): String {
         val result = hentSaksbehandlerEllerSystembruker()
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringServiceTest.kt
@@ -1,0 +1,371 @@
+package no.nav.tilleggsstonader.sak.ekstern.journalføring
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdent
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class AutomatiskJournalføringServiceTest {
+//    val journalføringService: JournalføringService = mockk()
+    val behandlingService: BehandlingService = mockk()
+    val fagsakService: FagsakService = mockk()
+    val personService: PersonService = mockk()
+//    val arbeidsfordelingService: ArbeidsfordelingService = mockk()
+//    val journalpostService: JournalpostService = mockk()
+
+    val automatiskJournalføringService = AutomatiskJournalføringService(
+//        journalføringService = journalføringService,
+        behandlingService = behandlingService,
+        fagsakService = fagsakService,
+        personService = personService,
+//        arbeidsfordelingService = arbeidsfordelingService,
+//        journalpostService = journalpostService,
+    )
+
+    val enhet = "4489"
+    val mappeId = null
+    val personIdent = "123456789"
+    val aktørId = "9876543210127"
+    val tidligerePersonIdent = "9123456789"
+    val personIdentAnnen = "9876543210"
+    val aktørIdAnnen = "987654321012783123"
+    val fagsak = fagsak()
+    val journalpostId = "1"
+    val journalpost = Journalpost(
+        journalpostId = journalpostId,
+        journalposttype = Journalposttype.I,
+        journalstatus = Journalstatus.MOTTATT,
+        dokumenter = emptyList(),
+        bruker = Bruker(personIdent, BrukerIdType.FNR),
+    )
+
+    @BeforeEach
+    internal fun setUp() {
+        every { personService.hentPersonIdenter(any()) } returns PdlIdenter(
+            identer = listOf(
+                PdlIdent(personIdent, false),
+                PdlIdent(tidligerePersonIdent, false),
+            ),
+        )
+        every { fagsakService.hentEllerOpprettFagsak(any(), any()) } returns fagsak
+//        every { arbeidsfordelingService.hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(any()) } returns enhet
+        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//        every {
+//            journalføringService.automatiskJournalfør(
+//                any(),
+//                any(),
+//                any(),
+//                any(),
+//                any(),
+//                any(),
+//            )
+//        } returns mockk()
+    }
+
+    @Test
+    internal fun `kan ikke opprette behandling hvis det eksisterer en åpen behandling i ny løsning`() {
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(behandling(status = BehandlingStatus.UTREDES))
+        val kanOppretteBehandling =
+            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+        assertThat(kanOppretteBehandling).isFalse
+    }
+
+    @Test
+    internal fun `kan opprette behandling hvis det ikke finnes innslag i ny løsning`() {
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf()
+        val kanOppretteBehandling =
+            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+        assertThat(kanOppretteBehandling).isTrue
+    }
+
+    @Test
+    internal fun `kan opprette behandling hvis alle behandlinger i ny løsning er henlagt`() {
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(behandling(resultat = BehandlingResultat.HENLAGT))
+        val kanOppretteBehandling =
+            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+        assertThat(kanOppretteBehandling).isTrue
+    }
+
+    @Test
+    internal fun `kan opprette behandling hvis det finnes innslag i ny løsning der alle er ferdigstilt`() {
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(
+            behandling(
+                resultat = BehandlingResultat.INNVILGET,
+                status = BehandlingStatus.FERDIGSTILT,
+            ),
+            behandling(resultat = BehandlingResultat.AVSLÅTT, status = BehandlingStatus.FERDIGSTILT),
+        )
+        val kanOppretteBehandling =
+            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+        assertThat(kanOppretteBehandling).isTrue
+    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis journalpostens bruker og personident ikke samsvarer`() {
+//        val enAnnenBruker = Bruker(
+//            id = personIdentAnnen,
+//            type = BrukerIdType.FNR,
+//        )
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = enAnnenBruker)
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        val feil = assertThrows<Feil> {
+//            automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                journalpostId,
+//                personIdent,
+//                StønadType.OVERGANGSSTØNAD,
+//                mappeId,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//        assertThat(feil.message).contains("Ikke samsvar mellom personident på journalposten")
+//    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis journalpostens aktørId-bruker og personident ikke samsvarer`() {
+//        val enAnnenBruker = Bruker(
+//            id = aktørIdAnnen,
+//            type = AKTOERID,
+//        )
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = enAnnenBruker)
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        every { personService.hentAktørIder(any()) } returns PdlIdenter(listOf(PdlIdent(personIdentAnnen, false)))
+//        val feil = assertThrows<Feil> {
+//            automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                journalpostId,
+//                personIdent,
+//                StønadType.OVERGANGSSTØNAD,
+//                mappeId,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//        assertThat(feil.message).contains("Ikke samsvar mellom personident på journalposten")
+//    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis journalpostens bruker mangler`() {
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = null)
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        every { personService.hentAktørIder(any()) } returns PdlIdenter(listOf(PdlIdent(aktørId, false)))
+//        val feil = assertThrows<Feil> {
+//            automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                journalpostId,
+//                personIdent,
+//                StønadType.OVERGANGSSTØNAD,
+//                mappeId,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//        assertThat(feil.message).contains("Journalposten mangler bruker")
+//    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis journalpostens bruker er orgnr`() {
+//        val enAnnenBruker = Bruker(
+//            id = aktørIdAnnen,
+//            type = ORGNR,
+//        )
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = enAnnenBruker)
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        every { personService.hentAktørIder(any()) } returns PdlIdenter(listOf(PdlIdent(aktørId, false)))
+//        val feil = assertThrows<Feil> {
+//            automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                journalpostId,
+//                personIdent,
+//                StønadType.OVERGANGSSTØNAD,
+//                mappeId,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//        assertThat(feil.message).contains("Ikke samsvar mellom personident på journalposten")
+//    }
+
+//    @Test
+//    internal fun `skal kunne automatisk journalføre hvis journalpostens aktørId-bruker og personident samsvarer`() {
+//        val aktørIdBruker = Bruker(
+//            id = aktørId,
+//            type = AKTOERID,
+//        )
+//        val journalpostMedAktørId = journalpost.copy(bruker = aktørIdBruker)
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpostMedAktørId
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        every { personService.hentAktørIder(any()) } returns PdlIdenter(listOf(PdlIdent(aktørId, false)))
+//        automatiskJournalføringService.automatiskJournalførTilBehandling(
+//            journalpostId,
+//            personIdent,
+//            StønadType.OVERGANGSSTØNAD,
+//            mappeId,
+//            OppgavePrioritet.NORM,
+//        )
+//        verify {
+//            journalføringService.automatiskJournalfør(
+//                fagsak,
+//                journalpostMedAktørId,
+//                enhet,
+//                mappeId,
+//                FØRSTEGANGSBEHANDLING,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//    }
+
+//    @Test
+//    internal fun `skal kunne automatisk journalføre hvis journalpostens personIdent er en historisk ident`() {
+//        val enAnnenBruker = Bruker(
+//            id = tidligerePersonIdent,
+//            type = BrukerIdType.FNR,
+//        )
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = enAnnenBruker)
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        every {
+//            journalføringService.automatiskJournalfør(
+//                any(),
+//                any(),
+//                any(),
+//                any(),
+//                any(),
+//                any(),
+//            )
+//        } returns mockk()
+//        automatiskJournalføringService.automatiskJournalførTilBehandling(
+//            journalpostId,
+//            personIdent,
+//            StønadType.OVERGANGSSTØNAD,
+//            mappeId,
+//            OppgavePrioritet.NORM,
+//        )
+//    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis det finnes sak i infotrygd`() {
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//        every { infotrygdService.eksisterer(any(), any()) } returns true
+//        val feil = assertThrows<Feil> {
+//            automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                journalpostId,
+//                personIdent,
+//                StønadType.OVERGANGSSTØNAD,
+//                mappeId,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//        assertThat(feil.message).contains("Kan ikke opprette førstegangsbehandling")
+//    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis det finnes ikke-henlagte behandlinger`() {
+//        every { infotrygdService.eksisterer(any(), any()) } returns false
+//        BehandlingResultat.values().filter { it != HENLAGT }.forEach { behandlingsresultat ->
+//            val behandling = behandling(fagsak = fagsak, resultat = behandlingsresultat, status = BehandlingStatus.FERDIGSTILT)
+//            val henlagtBehandling = behandling(fagsak = fagsak, resultat = HENLAGT, status = BehandlingStatus.FERDIGSTILT)
+//            every { journalpostService.hentJournalpost(journalpostId) } returns journalpost
+//            every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(
+//                henlagtBehandling,
+//                behandling,
+//                henlagtBehandling,
+//            )
+//            automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                journalpostId,
+//                personIdent,
+//                StønadType.OVERGANGSSTØNAD,
+//                mappeId,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//    }
+
+//    @Test
+//    internal fun `skal kunne automaitsk journalføre dersom det finnes behandlinger som er henlagte`() {
+//        val henlagtBehandling = behandling(fagsak = fagsak, resultat = HENLAGT, status = BehandlingStatus.FERDIGSTILT)
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(henlagtBehandling)
+//        automatiskJournalføringService.automatiskJournalførTilBehandling(
+//            journalpostId,
+//            personIdent,
+//            StønadType.OVERGANGSSTØNAD,
+//            mappeId,
+//            OppgavePrioritet.NORM,
+//        )
+//        verify {
+//            journalføringService.automatiskJournalfør(
+//                fagsak,
+//                journalpost,
+//                enhet,
+//                mappeId,
+//                FØRSTEGANGSBEHANDLING,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//    }
+
+//    @Test
+//    internal fun `skal kunne automaitsk journalføre dersom det finnes behandlinger som er ferdigstilte`() {
+//        val førstegangsbehandling = behandling(fagsak = fagsak, resultat = INNVILGET, type = FØRSTEGANGSBEHANDLING, status = BehandlingStatus.FERDIGSTILT)
+//        val revurdering = behandling(fagsak = fagsak, resultat = OPPHØRT, type = REVURDERING, status = BehandlingStatus.FERDIGSTILT)
+//        val henlagtBehandling = behandling(fagsak = fagsak, resultat = HENLAGT, type = REVURDERING, status = BehandlingStatus.FERDIGSTILT)
+//        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost
+//        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+//
+//        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(førstegangsbehandling, revurdering, henlagtBehandling)
+//        automatiskJournalføringService.automatiskJournalførTilBehandling(
+//            journalpostId,
+//            personIdent,
+//            StønadType.OVERGANGSSTØNAD,
+//            mappeId,
+//            OppgavePrioritet.NORM,
+//        )
+//        verify {
+//            journalføringService.automatiskJournalfør(
+//                fagsak,
+//                journalpost,
+//                enhet,
+//                mappeId,
+//                REVURDERING,
+//                OppgavePrioritet.NORM,
+//            )
+//        }
+//    }
+
+//    @Test
+//    internal fun `skal ikke kunne automatisk journalføre hvis journalposten har annen status enn MOTTATT`() {
+//        Journalstatus.values().filter { it != Journalstatus.MOTTATT }.forEach { journalstatus ->
+//            every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(journalstatus = journalstatus)
+//            every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+//            val feil = assertThrows<Feil> {
+//                automatiskJournalføringService.automatiskJournalførTilBehandling(
+//                    journalpostId,
+//                    personIdent,
+//                    StønadType.OVERGANGSSTØNAD,
+//                    mappeId,
+//                    OppgavePrioritet.NORM,
+//                )
+//            }
+//            assertThat(feil.message).contains("Journalposten har ugyldig journalstatus $journalstatus")
+//        }
+//    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContextTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContextTest.kt
@@ -1,0 +1,30 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet
+
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SikkerhetContextTest {
+
+    @Test
+    internal fun `skal ikke godkjenne kall fra familie-ef-mottak for andre applikasjoner`() {
+        mockBrukerContext("", azp_name = "prod-gcp:tilleggsstonader:tilleggsstonader-integrasjoner")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isFalse
+        clearBrukerContext()
+
+        mockBrukerContext("", azp_name = "prod-gcp:teamfamilie:familie-ef-sak")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isFalse
+        clearBrukerContext()
+    }
+
+    @Test
+    internal fun `skal gjenkjenne kall fra familie-ef-mottak`() {
+        mockBrukerContext("", azp_name = "prod-gcp:tilleggsstonader:tilleggsstonader-soknad-api")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isTrue
+        clearBrukerContext()
+        mockBrukerContext("", azp_name = "dev-gcp:tilleggsstonader:tilleggsstonader-soknad-api")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isTrue
+        clearBrukerContext()
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å kunne [åpne en behandling](https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16159) trenger vi automatisk journalføring. Derfor trenger `soknad-api` et endepunkt for å sjekke om en søknad/person kan automatisk journalføres.

Har kopiert kode og tester fra ef-sak med litt tilpassinger.

**Hva mangler? ❌**
- Koden som faktisk journalfører og oppretter ny behandling (har kommentert det ut)

