### PR TITLE
🚧  Oppgaverepository

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegService.kt
@@ -38,7 +38,7 @@ class StegService(
         if (steg.kommerEtter(behandling.steg)) {
             error(
                 "Kan ikke resette behandling til steg=$steg når behandling allerede " +
-                        "er på ${behandling.steg} behandling=$behandlingId",
+                    "er på ${behandling.steg} behandling=$behandlingId",
             )
         }
 
@@ -118,7 +118,7 @@ class StegService(
         if (!nesteSteg.erGyldigIKombinasjonMedStatus(behandlingService.hentBehandling(saksbehandling.id).status)) {
             error(
                 "Steg '${nesteSteg.displayName()}' kan ikke settes " +
-                        "på behandling i kombinasjon med status ${saksbehandling.status}",
+                    "på behandling i kombinasjon med status ${saksbehandling.status}",
             )
         }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
@@ -1,0 +1,20 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave
+
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Embedded
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("oppgave")
+data class OppgaveDomain(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val behandlingId: UUID,
+    val gsakOppgaveId: Long,
+    val type: Oppgavetype,
+    var erFerdigstilt: Boolean = false,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar()
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
@@ -16,5 +16,5 @@ data class OppgaveDomain(
     val type: Oppgavetype,
     var erFerdigstilt: Boolean = false,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
-    val sporbar: Sporbar = Sporbar()
+    val sporbar: Sporbar = Sporbar(),
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
@@ -1,0 +1,26 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave
+
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface OppgaveRepository : RepositoryInterface<OppgaveDomain, Long>, InsertUpdateRepository<OppgaveDomain> {
+
+    fun findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(behandlingId: UUID, oppgavetype: Oppgavetype): OppgaveDomain?
+
+    fun findByType(oppgavetype: Oppgavetype): List<OppgaveDomain>
+
+    fun findByBehandlingIdAndType(
+        behandlingId: UUID,
+        oppgavetype: Oppgavetype,
+    ): List<OppgaveDomain>?
+
+    fun findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandlingId: UUID, oppgavetype: Set<Oppgavetype>): OppgaveDomain?
+
+    fun findByGsakOppgaveId(gsakOppgaveId: Long): OppgaveDomain?
+    fun findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandlingId: UUID): OppgaveDomain?
+    fun findTopByBehandlingIdAndTypeOrderBySporbarOpprettetTidDesc(behandlingId: UUID, type: Oppgavetype): OppgaveDomain?
+}

--- a/src/main/resources/db/migration/V19__oppgave.sql
+++ b/src/main/resources/db/migration/V19__oppgave.sql
@@ -1,0 +1,11 @@
+CREATE TABLE oppgave (
+    id              UUID PRIMARY KEY,
+    behandling_id   UUID REFERENCES behandling (id),
+    gsak_oppgave_id BIGINT       NOT NULL,
+    type            VARCHAR      NOT NULL,
+    er_ferdigstilt  BOOLEAN      NOT NULL,
+    opprettet_av    VARCHAR      NOT NULL DEFAULT 'VL',
+    opprettet_tid   TIMESTAMP(3) NOT NULL DEFAULT LOCALTIMESTAMP,
+    endret_av       VARCHAR      NOT NULL,
+    endret_tid      TIMESTAMP(3) NOT NULL DEFAULT LOCALTIMESTAMP
+);

--- a/src/main/resources/db/migration/V20__oppgave.sql
+++ b/src/main/resources/db/migration/V20__oppgave.sql
@@ -1,6 +1,6 @@
 CREATE TABLE oppgave (
     id              UUID PRIMARY KEY,
-    behandling_id   UUID REFERENCES behandling (id),
+    behandling_id   UUID         NOT NULL REFERENCES behandling (id),
     gsak_oppgave_id BIGINT       NOT NULL,
     type            VARCHAR      NOT NULL,
     er_ferdigstilt  BOOLEAN      NOT NULL,
@@ -9,3 +9,5 @@ CREATE TABLE oppgave (
     endret_av       VARCHAR      NOT NULL,
     endret_tid      TIMESTAMP(3) NOT NULL DEFAULT LOCALTIMESTAMP
 );
+
+CREATE INDEX ON oppgave (behandling_id);

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakDomain
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.RolleConfig
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveDomain
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SøknadBarnetilsyn
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SøknadBehandling
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.Simuleringsresultat
@@ -103,6 +104,7 @@ abstract class IntegrationTest {
             SøknadBehandling::class,
             SøknadBarnetilsyn::class,
 
+            OppgaveDomain::class,
             Totrinnskontroll::class,
             Vedtaksbrev::class,
             Behandlingshistorikk::class,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
@@ -1,0 +1,123 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave
+
+
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.oppgave
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+import java.util.UUID
+
+internal class OppgaveRepositoryTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var oppgaveRepository: OppgaveRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Test
+    internal fun findByBehandlingIdAndTypeAndErFerdigstiltIsFalse() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val oppgave = oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true))
+
+        assertThat(oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(UUID.randomUUID(), Oppgavetype.BehandleSak))
+            .isNull()
+        assertThat(oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(behandling.id, Oppgavetype.BehandleSak))
+            .isNull()
+        assertThat(oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(behandling.id, oppgave.type))
+            .isNull()
+
+        val oppgaveIkkeFerdigstilt = oppgaveRepository.insert(oppgave(behandling))
+        assertThat(oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(behandling.id, oppgave.type))
+            .isEqualTo(oppgaveIkkeFerdigstilt)
+    }
+
+    @Test
+    internal fun findByBehandlingIdAndTypeInAndErFerdigstiltIsFalse() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = false, type = Oppgavetype.Journalføring))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, type = Oppgavetype.BehandleSak))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = false, type = Oppgavetype.BehandleUnderkjentVedtak))
+
+        val oppgave =
+            oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
+                behandling.id,
+                setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak),
+            )
+        assertThat(oppgave).isNotNull
+        assertThat(oppgave?.type).isEqualTo(Oppgavetype.BehandleUnderkjentVedtak)
+    }
+
+    @Test
+    internal fun `skal finne nyeste oppgave for behandling`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val sporbar = Sporbar(opprettetTid = LocalDateTime.now().plusDays(1))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 1))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 2).copy(sporbar = sporbar))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 3))
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 4))
+
+        assertThat(oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandling.id)).isNotNull
+        assertThat(oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandling.id)?.gsakOppgaveId)
+            .isEqualTo(2)
+    }
+
+    @Test
+    internal fun `skal finne nyeste oppgave for riktig behandling`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling2 = behandlingRepository.insert(behandling(fagsak))
+
+        oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 1))
+        oppgaveRepository.insert(oppgave(behandling2, erFerdigstilt = true, gsakOppgaveId = 2))
+
+        assertThat(oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandling.id)).isNotNull()
+        assertThat(oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandling.id)?.gsakOppgaveId)
+            .isEqualTo(1)
+    }
+
+    @Test
+    internal fun `skal finne oppgaver for oppgavetype og personident`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        oppgaveRepository.insert(
+            OppgaveDomain(
+                behandlingId = behandling.id,
+                type = Oppgavetype.InnhentDokumentasjon,
+                gsakOppgaveId = 1,
+            ),
+        )
+        oppgaveRepository.insert(
+            OppgaveDomain(
+                behandlingId = behandling.id,
+                type = Oppgavetype.BehandleSak,
+                gsakOppgaveId = 1,
+            ),
+        )
+
+        assertThat(
+            oppgaveRepository.findByType(
+                Oppgavetype.InnhentDokumentasjon,
+            ).size,
+        ).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `skal ikke feile hvis det ikke finnes en oppgave for behandlingen`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+
+        assertThat(oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandling.id)).isNull()
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.opplysninger.oppgave
 
-
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.util
 
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingKategori
@@ -19,6 +20,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveDomain
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.tilleggsstonader.sak.vilkår.domain.Delvilkår
@@ -31,20 +33,18 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
-/*
 fun oppgave(
     behandling: Behandling,
     erFerdigstilt: Boolean = false,
     gsakOppgaveId: Long = 123,
     type: Oppgavetype = Oppgavetype.Journalføring,
-): Oppgave =
-    Oppgave(
+): OppgaveDomain =
+    OppgaveDomain(
         behandlingId = behandling.id,
         gsakOppgaveId = gsakOppgaveId,
         type = type,
         erFerdigstilt = erFerdigstilt,
     )
- */
 
 fun behandling(
     fagsak: Fagsak = fagsak(),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når vi automatisk journalfører skal vi opprette en behandle sak oppgave. Vi ønsker å lagre ned hvilke opppgaver vi oppretter for en gitt behandling. Legger derfor til domeneobjekt og repository.