### PR TITLE
🚧 Verifiser kall kommer fra soknad api

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -67,6 +67,7 @@ spec:
         - application: tilleggsstonader-sak-frontend
         - application: tilleggsstonader-sak-frontend-lokal
         - application: tilleggsstonader-prosessering
+        - application: tilleggsstonader-soknad-api
     outbound:
       rules:
         - application: tilleggsstonader-integrasjoner

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -67,6 +67,7 @@ spec:
       rules:
         - application: tilleggsstonader-sak-frontend
         - application: tilleggsstonader-prosessering
+        - application: tilleggsstonader-soknad-api
     outbound:
       rules:
         - application: tilleggsstonader-integrasjoner

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -32,6 +32,8 @@ object SikkerhetContext {
         return applikasjonsnavn.endsWith(forventetApplikasjonsSuffix)
     }
 
+    fun kallKommerFraSoknadApi(): Boolean = kallKommerFra("tilleggsstonader:tilleggsstonader-soknad-api")
+
     fun hentSaksbehandler(): String {
         val result = hentSaksbehandlerEllerSystembruker()
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContextTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContextTest.kt
@@ -1,0 +1,30 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet
+
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class SikkerhetContextTest {
+
+    @Test
+    internal fun `skal ikke godkjenne kall fra soknad-api for andre applikasjoner`() {
+        mockBrukerContext("", azp_name = "prod-gcp:tilleggsstonader:tilleggsstonader-integrasjoner")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isFalse
+        clearBrukerContext()
+
+        mockBrukerContext("", azp_name = "prod-gcp:teamfamilie:familie-ef-sak")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isFalse
+        clearBrukerContext()
+    }
+
+    @Test
+    internal fun `skal gjenkjenne kall fra soknad-api`() {
+        mockBrukerContext("", azp_name = "prod-gcp:tilleggsstonader:tilleggsstonader-soknad-api")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isTrue
+        clearBrukerContext()
+        mockBrukerContext("", azp_name = "dev-gcp:tilleggsstonader:tilleggsstonader-soknad-api")
+        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isTrue
+        clearBrukerContext()
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vil sjekke dette ved automatisk journalføring

Inbound-reglene er strengt talt ikke nødvendige i denne PRen men tar dem uansett med for å kunne teste i dev 🤠 
