### PR TITLE
Totrinnskontroll send til beslutter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
@@ -120,6 +120,13 @@ class OppgaveService(
         return oppgaveClient.fordelOppgave(gsakOppgaveId, null, versjon = versjon)
     }
 
+    fun hentBehandleSakOppgaveSomIkkeErFerdigstilt(behandlingId: UUID): OppgaveDomain? {
+        return oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
+            behandlingId,
+            setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak),
+        )
+    }
+
     fun hentOppgave(gsakOppgaveId: Long): Oppgave {
         return oppgaveClient.finnOppgaveMedId(gsakOppgaveId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/tasks/FerdigstillOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/tasks/FerdigstillOppgaveTask.kt
@@ -1,0 +1,58 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.Properties
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FerdigstillOppgaveTask.TYPE,
+    beskrivelse = "Avslutt oppgave i GOSYS",
+    maxAntallFeil = 3,
+)
+class FerdigstillOppgaveTask(private val oppgaveService: OppgaveService) : AsyncTaskStep {
+
+    /**
+     * Då payload er unik per task type, så settes unik inn
+     */
+    data class FerdigstillOppgaveTaskData(
+        val behandlingId: UUID,
+        val oppgavetype: Oppgavetype,
+        val unik: LocalDateTime? = LocalDateTime.now(),
+    )
+
+    override fun doTask(task: Task) {
+        val data = objectMapper.readValue<FerdigstillOppgaveTaskData>(task.payload)
+        oppgaveService.ferdigstillBehandleOppgave(
+            behandlingId = data.behandlingId,
+            oppgavetype = data.oppgavetype,
+        )
+    }
+
+    companion object {
+
+        fun opprettTask(behandlingId: UUID, oppgavetype: Oppgavetype, oppgaveId: Long?): Task {
+            return Task(
+                type = TYPE,
+                payload = objectMapper.writeValueAsString(FerdigstillOppgaveTaskData(behandlingId, oppgavetype)),
+                properties = Properties().apply {
+                    setProperty("saksbehandler", SikkerhetContext.hentSaksbehandlerEllerSystembruker())
+                    setProperty("behandlingId", behandlingId.toString())
+                    setProperty("oppgavetype", oppgavetype.name)
+                    setProperty("oppgaveId", oppgaveId.toString())
+                },
+            )
+        }
+
+        const val TYPE = "ferdigstillOppgave"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/tasks/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/tasks/OpprettOppgaveTask.kt
@@ -1,0 +1,86 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.util.Properties
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = OpprettOppgaveTask.TYPE,
+    beskrivelse = "Opprett oppgave i GOSYS for behandling",
+    maxAntallFeil = 3,
+)
+class OpprettOppgaveTask(
+    private val oppgaveService: OppgaveService,
+    private val behandlingService: BehandlingService,
+) : AsyncTaskStep {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    /**
+     * Då payload er unik per task type, så settes unik inn
+     */
+    data class OpprettOppgaveTaskData(
+        val behandlingId: UUID,
+        val oppgavetype: Oppgavetype,
+        val tilordnetNavIdent: String? = null,
+        val beskrivelse: String? = null,
+        val unik: LocalDateTime? = LocalDateTime.now(),
+    )
+
+    override fun doTask(task: Task) {
+        val data = objectMapper.readValue<OpprettOppgaveTaskData>(task.payload)
+        val oppgavetype = data.oppgavetype
+
+        if (oppgavetype == Oppgavetype.BehandleSak) {
+            val behandling = behandlingService.hentBehandling(data.behandlingId)
+
+            /**
+             * Nødvendig sjekk for å unngå å lage en behandle sak oppgave som aldri ferdigstilles dersom
+             * SB sender til beslutter rett etter angring og oppgave ikke er opprettet enda.
+             */
+            if (behandling.status.behandlingErLåstForVidereRedigering()) {
+                logger.info("Opprettet ikke oppgave med oppgavetype = $oppgavetype fordi status = ${behandling.status}")
+                return
+            }
+        }
+
+        val oppgaveId = oppgaveService.opprettOppgave(
+            behandlingId = data.behandlingId,
+            oppgavetype = oppgavetype,
+            tilordnetNavIdent = data.tilordnetNavIdent,
+            beskrivelse = data.beskrivelse,
+        )
+        logger.info("Opprettet oppgave=$oppgaveId for oppgavetype=$oppgavetype")
+
+        task.metadata.setProperty("oppgaveId", oppgaveId.toString())
+    }
+
+    companion object {
+
+        fun opprettTask(data: OpprettOppgaveTaskData): Task {
+            return Task(
+                type = TYPE,
+                payload = objectMapper.writeValueAsString(data),
+                properties = Properties().apply {
+                    setProperty("saksbehandler", SikkerhetContext.hentSaksbehandlerEllerSystembruker())
+                    setProperty("behandlingId", data.behandlingId.toString())
+                    setProperty("oppgavetype", data.oppgavetype.name)
+                },
+            )
+        }
+
+        const val TYPE = "opprettOppgave"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksresultatService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksresultatService.kt
@@ -1,0 +1,19 @@
+package no.nav.tilleggsstonader.sak.vedtak
+
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.fagsak.Stønadstype
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class VedtaksresultatService(
+    private val tilsynBarnRepository: TilsynBarnVedtakRepository,
+) {
+
+    fun hentVedtaksresultat(saksbehandling: Saksbehandling): TypeVedtak {
+        return when (saksbehandling.stønadstype) {
+            Stønadstype.BARNETILSYN -> tilsynBarnRepository.findByIdOrNull(saksbehandling.id)?.type
+        } ?: error("Finner ikke vedtaksresultat for behandling=$saksbehandling")
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
@@ -1,0 +1,115 @@
+package no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll
+
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkService
+import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
+import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.VedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
+import no.nav.tilleggsstonader.sak.vilkår.VilkårService
+import org.springframework.stereotype.Service
+
+@Service
+class SendTilBeslutterSteg(
+    private val taskService: TaskService,
+    private val behandlingService: BehandlingService,
+    private val vedtaksbrevRepository: VedtaksbrevRepository,
+    private val behandlingshistorikkService: BehandlingshistorikkService,
+    private val vedtaksresultatService: VedtaksresultatService,
+    private val vilkårService: VilkårService,
+    private val oppgaveService: OppgaveService,
+) : BehandlingSteg<Void?> {
+
+    override fun validerSteg(saksbehandling: Saksbehandling) {
+        brukerfeilHvis(saksbehandling.steg != stegType()) {
+            "Behandling er i feil steg=${saksbehandling.steg}"
+        }
+        /* TODO feilutbetaling tilbakekreving
+        brukerfeilHvis(saksbehandlerMåTaStilingTilTilbakekreving(saksbehandling)) {
+            "Feilutbetaling detektert. Må ta stilling til feilutbetalingsvarsel under simulering"
+        }
+         */
+        validerRiktigTilstandVedInvilgelse(saksbehandling)
+        validerSaksbehandlersignatur(saksbehandling)
+        validerAtDetFinnesOppgave(saksbehandling)
+    }
+
+    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
+        behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.FATTER_VEDTAK)
+        opprettGodkjennVedtakOppgave(saksbehandling)
+        ferdigstillOppgave(saksbehandling)
+        // opprettTaskForBehandlingsstatistikk(saksbehandling.id) TODO DVH
+    }
+
+    private fun opprettGodkjennVedtakOppgave(saksbehandling: Saksbehandling) {
+        taskService.save(
+            OpprettOppgaveTask.opprettTask(
+                OpprettOppgaveTask.OpprettOppgaveTaskData(
+                    behandlingId = saksbehandling.id,
+                    oppgavetype = Oppgavetype.GodkjenneVedtak,
+                    beskrivelse = "Sendt til godkjenning av ${SikkerhetContext.hentSaksbehandlerNavn(true)}.",
+                ),
+            ),
+        )
+    }
+
+    private fun ferdigstillOppgave(saksbehandling: Saksbehandling) {
+        // TODO skriv om til å bruke totrinnskontrollService
+        val besluttetVedtakHendelse =
+            behandlingshistorikkService.finnSisteBehandlingshistorikk(saksbehandling.id, StegType.BESLUTTE_VEDTAK)
+        val oppgavetype = if (besluttetVedtakHendelse?.utfall == StegUtfall.BESLUTTE_VEDTAK_UNDERKJENT) {
+            Oppgavetype.BehandleUnderkjentVedtak
+        } else {
+            Oppgavetype.BehandleSak
+        }
+
+        taskService.save(
+            FerdigstillOppgaveTask.opprettTask(
+                behandlingId = saksbehandling.id,
+                oppgavetype,
+                null,
+            ),
+        )
+    }
+
+    private fun validerRiktigTilstandVedInvilgelse(saksbehandling: Saksbehandling) {
+        val vedtaksresultat = vedtaksresultatService.hentVedtaksresultat(saksbehandling)
+        if (vedtaksresultat == TypeVedtak.INNVILGET) {
+            brukerfeilHvisIkke(vilkårService.erAlleVilkårOppfylt(saksbehandling.id)) {
+                "Kan ikke innvilge hvis ikke alle vilkår er oppfylt for behandlingId: ${saksbehandling.id}"
+            }
+        }
+    }
+
+    private fun validerSaksbehandlersignatur(saksbehandling: Saksbehandling) {
+        if (saksbehandling.skalIkkeSendeBrev) return
+
+        val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(saksbehandling.id)
+
+        brukerfeilHvis(vedtaksbrev.saksbehandlersignatur != SikkerhetContext.hentSaksbehandler()) {
+            "En annen saksbehandler har signert vedtaksbrevet"
+        }
+    }
+
+    private fun validerAtDetFinnesOppgave(saksbehandling: Saksbehandling) {
+        feilHvis(oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(saksbehandling.id) == null) {
+            "Oppgaven for behandlingen er ikke tilgjengelig. Vennligst vent og prøv igjen om litt."
+        }
+    }
+
+    override fun stegType(): StegType = StegType.SEND_TIL_BESLUTTER
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
@@ -1,0 +1,39 @@
+package no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.StatusTotrinnskontrollDto
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/totrinnskontroll")
+@ProtectedWithClaims(issuer = "azuread")
+class TotrinnskontrollController(
+    private val tilgangService: TilgangService,
+    private val totrinnskontrollService: TotrinnskontrollService,
+    private val stegService: StegService,
+    private val sendTilBeslutterSteg: SendTilBeslutterSteg,
+) {
+
+    @GetMapping("{behandlingId}")
+    fun hentTotrinnskontroll(@PathVariable behandlingId: UUID): StatusTotrinnskontrollDto {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
+    }
+
+    @PostMapping("/{behandlingId}/send-til-beslutter")
+    fun sendTilBeslutter(
+        @PathVariable behandlingId: UUID,
+    ): StatusTotrinnskontrollDto {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        stegService.håndterSteg(behandlingId, sendTilBeslutterSteg)
+        return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
@@ -1,0 +1,225 @@
+package no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat.INNVILGET
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkService
+import no.nav.tilleggsstonader.sak.behandling.historikk.domain.Behandlingshistorikk
+import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.Vedtaksbrev
+import no.nav.tilleggsstonader.sak.brev.VedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.fagsak.Stønadstype
+import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask.OpprettOppgaveTaskData
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
+import no.nav.tilleggsstonader.sak.vilkår.VilkårService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import java.util.Properties
+import java.util.UUID
+
+class SendTilBeslutterStegTest {
+
+    private val taskService = mockk<TaskService>()
+    private val behandlingService = mockk<BehandlingService>(relaxed = true)
+    private val vedtaksbrevRepository = mockk<VedtaksbrevRepository>()
+    private val behandlingshistorikkService = mockk<BehandlingshistorikkService>()
+    private val vedtaksresultatService = mockk<VedtaksresultatService>()
+    private val vilkårService = mockk<VilkårService>()
+    private val oppgaveService = mockk<OppgaveService>()
+
+    private val beslutteVedtakSteg =
+        SendTilBeslutterSteg(
+            taskService,
+            behandlingService,
+            vedtaksbrevRepository,
+            behandlingshistorikkService,
+            vedtaksresultatService,
+            vilkårService,
+            oppgaveService,
+        )
+    private val fagsak = fagsak(
+        stønadstype = Stønadstype.BARNETILSYN,
+        identer = setOf(PersonIdent(ident = "12345678901")),
+    )
+    private val saksbehandlerNavn = "saksbehandlernavn"
+    private val vedtaksbrev = Vedtaksbrev(
+        behandlingId = UUID.randomUUID(),
+        saksbehandlersignatur = saksbehandlerNavn,
+        beslutterPdf = null,
+        saksbehandlerIdent = saksbehandlerNavn,
+        saksbehandlerHtml = "",
+    )
+
+    private val behandling = saksbehandling(
+        fagsak,
+        behandling(
+            fagsak = fagsak,
+            type = BehandlingType.FØRSTEGANGSBEHANDLING,
+            status = BehandlingStatus.UTREDES,
+            steg = beslutteVedtakSteg.stegType(),
+            resultat = BehandlingResultat.IKKE_SATT,
+            årsak = BehandlingÅrsak.SØKNAD,
+        ),
+    )
+
+    private val revurdering =
+        behandling.copy(type = BehandlingType.REVURDERING, resultat = INNVILGET)
+
+    private lateinit var taskSlot: MutableList<Task>
+
+    @BeforeEach
+    internal fun setUp() {
+        taskSlot = mutableListOf()
+        every {
+            taskService.save(capture(taskSlot))
+        } returns Task("", "", Properties())
+
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
+
+        every { vilkårService.erAlleVilkårOppfylt(any()) } returns true
+
+        every { vedtaksbrevRepository.existsById(any()) } returns true
+        every { oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(any()) } returns mockk()
+
+        // TODO tilbakekreving
+        // every { simuleringService.hentLagretSimuleringsoppsummering(any()) } returns simuleringsoppsummering
+        // every { tilbakekrevingService.harSaksbehandlerTattStillingTilTilbakekreving(any()) } returns true
+        // every { tilbakekrevingService.finnesÅpenTilbakekrevingsBehandling(any()) } returns true
+
+        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGET
+        every { behandlingshistorikkService.finnSisteBehandlingshistorikk(any(), any()) } returns
+            Behandlingshistorikk(behandlingId = UUID.randomUUID(), steg = StegType.SEND_TIL_BESLUTTER)
+        mockBrukerContext(saksbehandlerNavn)
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        clearBrukerContext()
+    }
+
+    @Test
+    internal fun `Innvilget behandling - alt ok`() {
+        val innvilgetBehandling = behandling.copy(resultat = INNVILGET)
+        beslutteVedtakSteg.validerSteg(innvilgetBehandling)
+    }
+
+    @Test
+    internal fun `Innvilget behandling - IKKE ok hvis erAlleVilkårOppfylt false`() {
+        every { vilkårService.erAlleVilkårOppfylt(any()) } returns false
+        val innvilgetBehandling = behandling.copy(resultat = INNVILGET)
+        val forvetetFeilmelding =
+            "Kan ikke innvilge hvis ikke alle vilkår er oppfylt for behandlingId: ${innvilgetBehandling.id}"
+        assertThat(catchThrowableOfType<ApiFeil> { beslutteVedtakSteg.validerSteg(innvilgetBehandling) }.feil)
+            .isEqualTo(forvetetFeilmelding)
+    }
+
+    @Test
+    internal fun `Skal avslutte oppgave BehandleSak hvis den finnes`() {
+        utførOgVerifiserKall(Oppgavetype.BehandleSak)
+        verifiserVedtattBehandlingsstatistikkTask()
+    }
+
+    @Test
+    internal fun `Skal avslutte oppgave BehandleUnderkjentVedtak hvis den finnes`() {
+        every { behandlingshistorikkService.finnSisteBehandlingshistorikk(any(), StegType.BESLUTTE_VEDTAK) } returns
+            Behandlingshistorikk(
+                behandlingId = UUID.randomUUID(),
+                steg = StegType.BESLUTTE_VEDTAK,
+                utfall = StegUtfall.BESLUTTE_VEDTAK_UNDERKJENT,
+            )
+        utførOgVerifiserKall(Oppgavetype.BehandleUnderkjentVedtak)
+        verifiserVedtattBehandlingsstatistikkTask()
+    }
+
+    @Test
+    internal fun `Skal kaste feil hvis oppgave med type BehandleUnderkjentVedtak eller BehandleSak ikke finnes`() {
+        every { behandlingshistorikkService.finnSisteBehandlingshistorikk(any(), StegType.BESLUTTE_VEDTAK) } returns
+            Behandlingshistorikk(
+                behandlingId = UUID.randomUUID(),
+                steg = StegType.BESLUTTE_VEDTAK,
+                utfall = StegUtfall.BESLUTTE_VEDTAK_UNDERKJENT,
+            )
+        every { oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(any()) } returns null
+        val feil = catchThrowableOfType<Feil> { beslutteVedtakSteg.validerSteg(behandling) }
+        assertThat(feil.frontendFeilmelding)
+            .contains("Oppgaven for behandlingen er ikke tilgjengelig. Vennligst vent og prøv igjen om litt.")
+    }
+
+    @Test
+    internal fun `Skal feile hvis saksbehandlersignatur i vedtaksbrev er ulik saksbehandleren som sendte til beslutter`() {
+        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev.copy(saksbehandlersignatur = "Saksbehandler A")
+        mockBrukerContext("Saksbehandler B")
+
+        assertThat(catchThrowableOfType<ApiFeil> { beslutteVedtakSteg.validerSteg(behandling) })
+            .hasMessageContaining("En annen saksbehandler har signert vedtaksbrevet")
+    }
+
+    @Test
+    internal fun `skal ikke hente brev når man håndterer behandling med årsak korrigering uten brev`() {
+        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGET
+        val behandling = behandling.copy(årsak = BehandlingÅrsak.KORRIGERING_UTEN_BREV)
+
+        beslutteVedtakSteg.validerSteg(behandling)
+
+        verify(exactly = 0) {
+            vedtaksbrevRepository.findByIdOrNull(any())
+        }
+    }
+
+    // TODO DVH
+    private fun verifiserVedtattBehandlingsstatistikkTask() {
+        // assertThat(taskSlot[2].type).isEqualTo(BehandlingsstatistikkTask.TYPE)
+        // assertThat(objectMapper.readValue<BehandlingsstatistikkTaskPayload>(taskSlot[2].payload).hendelse)
+        //    .isEqualTo(Hendelse.VEDTATT)
+    }
+
+    private fun utførOgVerifiserKall(oppgavetype: Oppgavetype) {
+        mockBrukerContext("saksbehandlernavn")
+
+        utførSteg()
+        clearBrukerContext()
+
+        verify { behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FATTER_VEDTAK) }
+
+        assertThat(taskSlot[0].type).isEqualTo(OpprettOppgaveTask.TYPE)
+        assertThat(objectMapper.readValue<OpprettOppgaveTaskData>(taskSlot[0].payload).oppgavetype)
+            .isEqualTo(Oppgavetype.GodkjenneVedtak)
+
+        assertThat(taskSlot[1].type).isEqualTo(FerdigstillOppgaveTask.TYPE)
+        assertThat(objectMapper.readValue<FerdigstillOppgaveTask.FerdigstillOppgaveTaskData>(taskSlot[1].payload).oppgavetype)
+            .isEqualTo(oppgavetype)
+    }
+
+    private fun utførSteg() {
+        beslutteVedtakSteg.utførSteg(behandling, null)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Denne trengs for å kunne godkjenne/underkjenne totrinnskontrollen, men ligger egentlige i en egen oppgave

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16071

Har kommentert ut kode koblet til feilutbetaling og DVH

EF har ny kode som sjekker om man er tilordnet oppgaven koblet til behandlingen, jeg sjekket kun om oppgaven finnes (som var det EF hadde tidligere)
```kotlin
private fun validerAtDetFinnesOppgave(saksbehandling: Saksbehandling) {
        feilHvis(tilordnetRessursService.hentEFOppgaveSomIkkeErFerdigstilt(saksbehandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak)) == null) {
```