### PR TITLE
Skal hente inn behandlingBarn sin id i grunnlagsdata 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/dto/VilkårsvurderingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/dto/VilkårsvurderingDto.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.kontrakter.søknad.JaNei
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.TypeBarnepass
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.ÅrsakBarnepass
 import java.time.LocalDate
+import java.util.UUID
 
 data class VilkårsvurderingDto(
     val vilkårsett: List<VilkårDto>,
@@ -35,6 +36,7 @@ data class SøknadsgrunnlagAktivitet(
 
 data class GrunnlagBarn(
     val ident: String,
+    val barnId: UUID,
     val registergrunnlag: RegistergrunnlagBarn,
     val søknadgrunnlag: SøknadsgrunnlagBarn?,
 )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -145,10 +145,12 @@ fun Behandling.innvilgetOgFerdigstilt() =
     )
 
 fun behandlingBarn(
+    id: UUID = UUID.randomUUID(),
     behandlingId: UUID = UUID.randomUUID(),
     personIdent: String = "1",
     søknadBarnId: UUID? = null,
 ) = BehandlingBarn(
+    id = id,
     behandlingId = behandlingId,
     søknadBarnId = søknadBarnId,
     ident = personIdent,

--- a/src/test/resources/vilkår/vilkårGrunnlagDto.json
+++ b/src/test/resources/vilkår/vilkårGrunnlagDto.json
@@ -11,6 +11,7 @@
   },
   "barn" : [ {
     "ident" : "1",
+    "barnId" : "60921c76-f8ef-4000-9824-f127a50a575e",
     "registergrunnlag" : {
       "navn" : "Fornavn mellomnavn Etternavn",
       "dødsdato" : null


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved lagring av vedtak knyttes utgifter til barnId (uuid). For å kunne hente ut denne informasjon i vedtak og beregning må det ligge sammen med grunnlagsdata om barnet. Uten dette må man evt. plukke ut `barnId` fra vilkårene, men disse eksisterer ikke enda. 

Endring er lagt til for å muliggjøre [PR 89](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/89)