### PR TITLE
Totrinnskontroll angre sendt til beslutter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
@@ -1,0 +1,126 @@
+package no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll
+
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkService
+import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class AngreSendTilBeslutterService(
+    private val oppgaveService: OppgaveService,
+    private val behandlingService: BehandlingService,
+    private val behandlingshistorikkService: BehandlingshistorikkService,
+    private val taskService: TaskService,
+    private val totrinnskontrollService: TotrinnskontrollService,
+) {
+
+    @Transactional
+    fun angreSendTilBeslutter(behandlingId: UUID) {
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+
+        validerKanAngreSendTilBeslutter(saksbehandling)
+
+        behandlingshistorikkService.opprettHistorikkInnslag(
+            behandlingId = behandlingId,
+            stegtype = saksbehandling.steg,
+            utfall = StegUtfall.ANGRE_SEND_TIL_BESLUTTER,
+            metadata = null,
+        )
+
+        ferdigstillGodkjenneVedtakOppgave(saksbehandling)
+        opprettBehandleSakOppgave(saksbehandling)
+
+        behandlingService.oppdaterStegPåBehandling(behandlingId, StegType.SEND_TIL_BESLUTTER)
+        behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES)
+    }
+
+    private fun opprettBehandleSakOppgave(saksbehandling: Saksbehandling) {
+        taskService.save(
+            OpprettOppgaveTask.opprettTask(
+                OpprettOppgaveTask.OpprettOppgaveTaskData(
+                    behandlingId = saksbehandling.id,
+                    oppgavetype = Oppgavetype.BehandleSak,
+                    beskrivelse = "Angret send til beslutter",
+                    tilordnetNavIdent = SikkerhetContext.hentSaksbehandler(),
+                ),
+            ),
+        )
+    }
+
+    private fun ferdigstillGodkjenneVedtakOppgave(saksbehandling: Saksbehandling) {
+        oppgaveService.hentOppgaveSomIkkeErFerdigstilt(saksbehandling.id, Oppgavetype.GodkjenneVedtak)?.let {
+            taskService.save(
+                FerdigstillOppgaveTask.opprettTask(
+                    behandlingId = saksbehandling.id,
+                    oppgavetype = Oppgavetype.GodkjenneVedtak,
+                    it.gsakOppgaveId,
+                ),
+            )
+        }
+    }
+
+    private fun validerKanAngreSendTilBeslutter(saksbehandling: Saksbehandling) {
+        validerSaksbehandlerSomAngrer(saksbehandling)
+        validerSteg(saksbehandling)
+        validerStatus(saksbehandling)
+        validerOppgave(saksbehandling)
+    }
+
+    private fun validerSaksbehandlerSomAngrer(saksbehandling: Saksbehandling) {
+        val saksbehandlerSendtTilBeslutter =
+            totrinnskontrollService.hentSaksbehandlerSomSendteTilBeslutter(saksbehandling.id)
+
+        brukerfeilHvis(saksbehandlerSendtTilBeslutter != SikkerhetContext.hentSaksbehandler()) {
+            "Kan kun angre send til beslutter dersom du er saksbehandler på vedtaket"
+        }
+    }
+
+    private fun validerSteg(saksbehandling: Saksbehandling) {
+        val beslutter = totrinnskontrollService.hentBeslutter(saksbehandling.id)
+        feilHvis(saksbehandling.steg != StegType.BESLUTTE_VEDTAK, httpStatus = HttpStatus.BAD_REQUEST) {
+            if (saksbehandling.steg.kommerEtter(StegType.BESLUTTE_VEDTAK)) {
+                "Kan ikke angre send til beslutter da vedtaket er godkjent av $beslutter"
+            } else {
+                "Kan ikke angre send til beslutter når behandling er i steg ${saksbehandling.steg}"
+            }
+        }
+    }
+
+    private fun validerStatus(saksbehandling: Saksbehandling) {
+        feilHvis(saksbehandling.status != BehandlingStatus.FATTER_VEDTAK, httpStatus = HttpStatus.BAD_REQUEST) {
+            "Kan ikke angre send til beslutter når behandlingen har status ${saksbehandling.status}"
+        }
+    }
+
+    private fun validerOppgave(
+        saksbehandling: Saksbehandling,
+    ) {
+        val efOppgave = oppgaveService.hentOppgaveSomIkkeErFerdigstilt(
+            behandlingId = saksbehandling.id,
+            oppgavetype = Oppgavetype.GodkjenneVedtak,
+        ) ?: throw ApiFeil(
+            feil = "Systemet har ikke rukket å opprette godkjenne vedtak oppgaven enda. Prøv igjen om litt.",
+            httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+        )
+
+        val tilordnetRessurs = oppgaveService.hentOppgave(efOppgave.gsakOppgaveId).tilordnetRessurs
+        brukerfeilHvis(tilordnetRessurs != null && tilordnetRessurs != SikkerhetContext.hentSaksbehandler()) {
+            "Kan ikke angre send til beslutter når oppgave er plukket av $tilordnetRessurs"
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
@@ -110,7 +110,7 @@ class AngreSendTilBeslutterService(
     private fun validerOppgave(
         saksbehandling: Saksbehandling,
     ) {
-        val efOppgave = oppgaveService.hentOppgaveSomIkkeErFerdigstilt(
+        val oppgave = oppgaveService.hentOppgaveSomIkkeErFerdigstilt(
             behandlingId = saksbehandling.id,
             oppgavetype = Oppgavetype.GodkjenneVedtak,
         ) ?: throw ApiFeil(
@@ -118,7 +118,7 @@ class AngreSendTilBeslutterService(
             httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
         )
 
-        val tilordnetRessurs = oppgaveService.hentOppgave(efOppgave.gsakOppgaveId).tilordnetRessurs
+        val tilordnetRessurs = oppgaveService.hentOppgave(oppgave.gsakOppgaveId).tilordnetRessurs
         brukerfeilHvis(tilordnetRessurs != null && tilordnetRessurs != SikkerhetContext.hentSaksbehandler()) {
             "Kan ikke angre send til beslutter når oppgave er plukket av $tilordnetRessurs"
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
@@ -54,6 +54,8 @@ class TotrinnskontrollController(
     @PostMapping("/{behandlingId}/angre-send-til-beslutter")
     fun angreSendTilBeslutter(@PathVariable behandlingId: UUID): StatusTotrinnskontrollDto {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
         angreSendTilBeslutterService.angreSendTilBeslutter(behandlingId)
         return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
@@ -23,6 +23,7 @@ class TotrinnskontrollController(
     private val stegService: StegService,
     private val beslutteVedtakSteg: BeslutteVedtakSteg,
     private val sendTilBeslutterSteg: SendTilBeslutterSteg,
+    private val angreSendTilBeslutterService: AngreSendTilBeslutterService,
 ) {
 
     @GetMapping("{behandlingId}")
@@ -47,6 +48,13 @@ class TotrinnskontrollController(
     ): StatusTotrinnskontrollDto {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         stegService.håndterSteg(behandlingId, beslutteVedtakSteg, request)
+        return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
+    }
+
+    @PostMapping("/{behandlingId}/angre-send-til-beslutter")
+    fun angreSendTilBeslutter(@PathVariable behandlingId: UUID): StatusTotrinnskontrollDto {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        angreSendTilBeslutterService.angreSendTilBeslutter(behandlingId)
         return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -38,9 +38,16 @@ fun oppgave(
     erFerdigstilt: Boolean = false,
     gsakOppgaveId: Long = 123,
     type: Oppgavetype = Oppgavetype.Journalføring,
+): OppgaveDomain = oppgave(behandling.id, erFerdigstilt, gsakOppgaveId, type)
+
+fun oppgave(
+    behandlingId: UUID,
+    erFerdigstilt: Boolean = false,
+    gsakOppgaveId: Long = 123,
+    type: Oppgavetype = Oppgavetype.Journalføring,
 ): OppgaveDomain =
     OppgaveDomain(
-        behandlingId = behandling.id,
+        behandlingId = behandlingId,
         gsakOppgaveId = gsakOppgaveId,
         type = type,
         erFerdigstilt = erFerdigstilt,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterServiceTest.kt
@@ -1,0 +1,134 @@
+package no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgave
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
+import no.nav.tilleggsstonader.sak.util.oppgave
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class AngreSendTilBeslutterServiceTest {
+
+    private val oppgaveService = mockk<OppgaveService>()
+    private val behandlingService = mockk<BehandlingService>(relaxed = true)
+    private val totrinnskontrollService = mockk<TotrinnskontrollService>()
+
+    val service = AngreSendTilBeslutterService(
+        oppgaveService = oppgaveService,
+        behandlingService = behandlingService,
+        behandlingshistorikkService = mockk(relaxed = true),
+        taskService = mockk(relaxed = true),
+        totrinnskontrollService = totrinnskontrollService,
+    )
+
+    val behandling = saksbehandling(steg = StegType.BESLUTTE_VEDTAK, status = BehandlingStatus.FATTER_VEDTAK)
+    val saksbehandler1 = "saksbehandler1"
+    val saksbehandler2 = "saksbehandler2"
+    val oppgave = oppgave(behandlingId = behandling.id)
+
+    @BeforeEach
+    fun setUp() {
+        BrukerContextUtil.mockBrukerContext(saksbehandler1)
+        every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
+        every { totrinnskontrollService.hentSaksbehandlerSomSendteTilBeslutter(behandling.id) } returns saksbehandler1
+        every { totrinnskontrollService.hentBeslutter(behandling.id) } returns null
+        every { oppgaveService.hentOppgaveSomIkkeErFerdigstilt(behandling.id, Oppgavetype.GodkjenneVedtak) } returns
+            oppgave(behandlingId = behandling.id)
+        every { oppgaveService.hentOppgave(oppgave.gsakOppgaveId) } returns Oppgave(id = 123, tilordnetRessurs = null)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        BrukerContextUtil.clearBrukerContext()
+    }
+
+    @Test
+    fun `skal oppdatere steg og status på behandling`() {
+        service.angreSendTilBeslutter(behandling.id)
+
+        verify(exactly = 1) {
+            behandlingService.oppdaterStegPåBehandling(behandling.id, StegType.SEND_TIL_BESLUTTER)
+            behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.UTREDES)
+        }
+    }
+
+    @Nested
+    inner class Validering {
+
+        @Test
+        fun `saksbehandler som angrer må være den som sendt til beslutter`() {
+            BrukerContextUtil.mockBrukerContext(saksbehandler2)
+
+            assertThat(
+                catchThrowableOfType<ApiFeil> {
+                    service.angreSendTilBeslutter(behandling.id)
+                },
+            ).hasMessageContaining("Kan kun angre send til beslutter dersom du er saksbehandler på vedtaket")
+        }
+
+        @Test
+        fun `skal validere at steget ikke er før beslutte vedtak`() {
+            every { behandlingService.hentSaksbehandling(behandling.id) } returns
+                behandling.copy(steg = StegType.VILKÅR)
+
+            assertThat(
+                catchThrowableOfType<Feil> {
+                    service.angreSendTilBeslutter(behandling.id)
+                },
+            ).hasMessageContaining("Kan ikke angre send til beslutter når behandling er i steg VILKÅR")
+        }
+
+        @Test
+        fun `skal validere at steget ikke er etter beslutte vedtak`() {
+            every { behandlingService.hentSaksbehandling(behandling.id) } returns
+                behandling.copy(steg = StegType.VENTE_PÅ_STATUS_FRA_IVERKSETT)
+
+            assertThat(
+                catchThrowableOfType<Feil> {
+                    service.angreSendTilBeslutter(behandling.id)
+                },
+            ).hasMessageContaining("Kan ikke angre send til beslutter da vedtaket er godkjent av")
+        }
+
+        @Test
+        fun `skal validere at steget er i fatter vedtak`() {
+            BehandlingStatus.entries.filterNot { it == BehandlingStatus.FATTER_VEDTAK }.forEach {
+                every { behandlingService.hentSaksbehandling(behandling.id) } returns
+                    behandling.copy(status = it)
+                assertThat(
+                    catchThrowableOfType<Feil> {
+                        service.angreSendTilBeslutter(behandling.id)
+                    },
+                ).hasMessageContaining("Kan ikke angre send til beslutter når behandlingen har status")
+            }
+        }
+
+        @Test
+        fun `skal kaste feil hvis saksbehandler ikke tilordnetRessurs på oppgaven`() {
+            every { oppgaveService.hentOppgave(oppgave.gsakOppgaveId) } returns Oppgave(
+                id = 123,
+                tilordnetRessurs = saksbehandler2,
+            )
+
+            assertThat(
+                catchThrowableOfType<ApiFeil> {
+                    service.angreSendTilBeslutter(behandling.id)
+                },
+            ).hasMessageContaining("Kan ikke angre send til beslutter når oppgave er plukket av $saksbehandler2")
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler som sendt behandling til beslutter skal kunne angre og gjøre endringer i behandlingen for å sen sende til beslutter på nytt

Testfilen er helt ny, den fantes ikke

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16831