### PR TITLE
Send til beslutter skal sjekke ident på saksbehandler og ikke navnet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
@@ -100,7 +100,7 @@ class SendTilBeslutterSteg(
 
         val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(saksbehandling.id)
 
-        brukerfeilHvis(vedtaksbrev.saksbehandlersignatur != SikkerhetContext.hentSaksbehandler()) {
+        brukerfeilHvis(vedtaksbrev.saksbehandlerIdent != SikkerhetContext.hentSaksbehandler()) {
             "En annen saksbehandler har signert vedtaksbrevet"
         }
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Testen dekker ikke helt denne, då mock av token setter både saksbehandlerIdent og navn med samme verdi.. Orker ikke gjøre noe åt den delen, men har fikset feilet :) 