### PR TITLE
✨ 🚧  Opprette regel for pass av barn

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
@@ -92,7 +92,7 @@ class VilkårService(
         val behandling = behandlingService.hentBehandling(behandlingId)
         val barn = barnService.finnBarnPåBehandling(behandlingId)
         val grunnlag = vilkårGrunnlagService.hentGrunnlag(behandlingId)
-        return Pair(grunnlag, HovedregelMetadata(emptyList(), behandling))
+        return Pair(grunnlag, HovedregelMetadata(barn, behandling))
     }
 
     private fun hentEllerOpprettVilkår(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkår.kt
@@ -106,7 +106,7 @@ enum class VilkårType(val beskrivelse: String, val gjelderStønader: List<Støn
     PASSBARN("PassBarn", listOf(Stønadstype.BARNETILSYN)),
     ;
 
-    fun gjelderFlereBarn(): Boolean = false
+    fun gjelderFlereBarn(): Boolean = this == PASSBARN
 
     companion object {
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkår.kt
@@ -103,6 +103,7 @@ enum class VilkårType(val beskrivelse: String, val gjelderStønader: List<Støn
     EKSEMPEL2("Eksempel 2", listOf(Stønadstype.BARNETILSYN)),
     MÅLGRUPPE("Målgruppe", listOf(Stønadstype.BARNETILSYN)),
     AKTIVITET("Aktivitet", listOf(Stønadstype.BARNETILSYN)),
+    PASSBARN("PassBarn", listOf(Stønadstype.BARNETILSYN)),
     ;
 
     fun gjelderFlereBarn(): Boolean = false

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/RegelId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/RegelId.kt
@@ -13,4 +13,11 @@ enum class RegelId(val beskrivelse: String) {
 
     // AKTIVITET
     ER_AKTIVITET_REGISTRERT("Er bruker registrert med en aktivitet?"),
+
+    // PASSBARN
+    DEKKES_UTGIFTER_ANNET_REGELVERK("Dekkes utgifter av annet regelverk?"),
+    ANNEN_FORELDER_MOTTAR_STØTTE("Mottar den andre forelderen støtte for dette barnet?"),
+    UTGIFTER_DOKUMENTERT("Er utgiftene tilfredstillende dokumentert?"),
+    HAR_ALDER_LAVERE_ENN_GRENSEVERDI("Har barnet fullført 4. skoleår?"),
+    UNNTAK_ALDER("Oppfylles unntak etter å ha fullført 4. skoleår?"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/SvarId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/SvarId.kt
@@ -6,6 +6,7 @@ enum class SvarId {
     JA,
     NEI,
 
-    // Eksempel
-    ANNET_SVAR,
+    // PASSBARN
+    FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID,
+    TRENGER_MER_TILSYN_ENN_JEVNALDRENDE,
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/Vilkårsregler.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetRegel
 import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.PassBarnRegel
 
 /**
  * Singleton for å holde på alle regler
@@ -23,6 +24,7 @@ fun vilkårsreglerForStønad(stønadstype: Stønadstype): List<Vilkårsregel> =
         Stønadstype.BARNETILSYN -> listOf(
             MålgruppeRegel(),
             AktivitetRegel(),
+            PassBarnRegel(),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
@@ -1,0 +1,71 @@
+package no.nav.tilleggsstonader.sak.vilkår.regler.vilkår
+
+import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.regler.NesteRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.RegelId
+import no.nav.tilleggsstonader.sak.vilkår.regler.RegelSteg
+import no.nav.tilleggsstonader.sak.vilkår.regler.SluttSvarRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.SvarId
+import no.nav.tilleggsstonader.sak.vilkår.regler.Vilkårsregel
+import no.nav.tilleggsstonader.sak.vilkår.regler.jaNeiSvarRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.regelIder
+
+class PassBarnRegel : Vilkårsregel(
+    vilkårType = VilkårType.PASSBARN,
+    regler = setOf(HAR_ALDER_LAVERE_ENN_GRENSEVERDI, UNNTAK_ALDER, DEKKES_UTGIFTER_ANNET_REGELVERK, ANNEN_FORELDER_MOTTAR_STØTTE, UTGIFTER_DOKUMENTERT),
+    hovedregler = regelIder(HAR_ALDER_LAVERE_ENN_GRENSEVERDI, DEKKES_UTGIFTER_ANNET_REGELVERK, ANNEN_FORELDER_MOTTAR_STØTTE, UTGIFTER_DOKUMENTERT),
+) {
+    companion object {
+
+        private val unntakAlderMapping =
+            setOf(
+                SvarId.TRENGER_MER_TILSYN_ENN_JEVNALDRENDE,
+                SvarId.FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID,
+            )
+                .associateWith {
+                    SluttSvarRegel.OPPFYLT_MED_PÅKREVD_BEGRUNNELSE
+                } + mapOf(SvarId.NEI to SluttSvarRegel.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE)
+
+        private val UNNTAK_ALDER =
+            RegelSteg(
+                regelId = RegelId.UNNTAK_ALDER,
+                svarMapping = unntakAlderMapping,
+            )
+
+        private val HAR_ALDER_LAVERE_ENN_GRENSEVERDI =
+            RegelSteg(
+                regelId = RegelId.HAR_ALDER_LAVERE_ENN_GRENSEVERDI,
+                svarMapping = jaNeiSvarRegel(
+                    hvisJa = NesteRegel(UNNTAK_ALDER.regelId),
+                    hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                ),
+            )
+
+        private val UTGIFTER_DOKUMENTERT =
+            RegelSteg(
+                regelId = RegelId.UTGIFTER_DOKUMENTERT,
+                jaNeiSvarRegel(
+                    hvisJa = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisNei = SluttSvarRegel.IKKE_OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                ),
+            )
+
+        private val ANNEN_FORELDER_MOTTAR_STØTTE =
+            RegelSteg(
+                regelId = RegelId.ANNEN_FORELDER_MOTTAR_STØTTE,
+                jaNeiSvarRegel(
+                    hvisJa = SluttSvarRegel.IKKE_OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                ),
+            )
+
+        private val DEKKES_UTGIFTER_ANNET_REGELVERK =
+            RegelSteg(
+                regelId = RegelId.DEKKES_UTGIFTER_ANNET_REGELVERK,
+                jaNeiSvarRegel(
+                    hvisJa = SluttSvarRegel.IKKE_OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                ),
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårTypeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårTypeTest.kt
@@ -12,6 +12,7 @@ internal class VilkårTypeTest {
         VilkårType.EKSEMPEL2,
         VilkårType.MÅLGRUPPE,
         VilkårType.AKTIVITET,
+        VilkårType.PASSBARN,
     )
 
     @Test

--- a/src/test/resources/vilkår/regler/PASSBARN.json
+++ b/src/test/resources/vilkår/regler/PASSBARN.json
@@ -1,0 +1,74 @@
+{
+  "vilkårType" : "PASSBARN",
+  "regler" : {
+    "HAR_ALDER_LAVERE_ENN_GRENSEVERDI" : {
+      "regelId" : "HAR_ALDER_LAVERE_ENN_GRENSEVERDI",
+      "svarMapping" : {
+        "JA" : {
+          "regelId" : "UNNTAK_ALDER",
+          "begrunnelseType" : "UTEN"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    },
+    "UNNTAK_ALDER" : {
+      "regelId" : "UNNTAK_ALDER",
+      "svarMapping" : {
+        "TRENGER_MER_TILSYN_ENN_JEVNALDRENDE" : {
+          "begrunnelseType" : "PÅKREVD",
+          "regelId" : "SLUTT_NODE"
+        },
+        "FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID" : {
+          "begrunnelseType" : "PÅKREVD",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "PÅKREVD",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    },
+    "DEKKES_UTGIFTER_ANNET_REGELVERK" : {
+      "regelId" : "DEKKES_UTGIFTER_ANNET_REGELVERK",
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    },
+    "ANNEN_FORELDER_MOTTAR_STØTTE" : {
+      "regelId" : "ANNEN_FORELDER_MOTTAR_STØTTE",
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    },
+    "UTGIFTER_DOKUMENTERT" : {
+      "regelId" : "UTGIFTER_DOKUMENTERT",
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Må kunne vurdere div ting for hvert barn (om det dekkes av annen forelder, dokumentasjon, alder og annet regelverk). 

**Hva er gjort:**
- Opprettet regel med ja/nei svar, bortsett fra alder hvor det er lagt til unntak. 
- Regel gjelder flere barn
- Knyttet barnId til vilkår når vilkåret opprettes. 

**Videre arbeid (backend):**
- Initiering av alder - man trenger ikke svare om barn har fullført 4. klasse om barnet er under 9 år (som i EF).

**Ting å vurdere:**
Hvis dere prøver å kjøre dette nå på en gammel behandling vil ikke reglene syntes fordi vilkårne ble opprettet før reglene eksisterte. Man må slette eksisterende vilkår og så laste siden på nytt. Vi kan vurdere å lage noe funksjonalitet for å få oppdatert vilkår (få inn nye) i ettertid.