### PR TITLE
✨ Automatisk vurdere om barn har start i 4. klasse

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
@@ -191,7 +191,11 @@ object OppdaterVilkår {
     ): List<Vilkår> {
         return vilkårsreglerForStønad(stønadstype)
             .flatMap { vilkårsregel ->
-                if (vilkårsregel.vilkårType.gjelderFlereBarn() && metadata.barn.isNotEmpty()) {
+                feilHvis(vilkårsregel.vilkårType.gjelderFlereBarn() && metadata.barn.isEmpty()) {
+                    "Kan ikke opprette vilkår når ingen barn er knyttet til behandling $behandlingId"
+                }
+
+                if (vilkårsregel.vilkårType.gjelderFlereBarn()) {
                     metadata.barn.map { lagNyVilkår(vilkårsregel, metadata, behandlingId, it.id) }
                 } else {
                     listOf(lagNyVilkår(vilkårsregel, metadata, behandlingId))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
@@ -1,6 +1,13 @@
 package no.nav.tilleggsstonader.sak.vilkår.regler.vilkår
 
+import no.nav.tilleggsstonader.libs.utils.fnr.Fødselsnummer
+import no.nav.tilleggsstonader.sak.infrastruktur.config.SecureLogger.secureLogger
+import no.nav.tilleggsstonader.sak.util.norskFormat
+import no.nav.tilleggsstonader.sak.vilkår.domain.Delvilkår
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkårsresultat
+import no.nav.tilleggsstonader.sak.vilkår.domain.Vurdering
+import no.nav.tilleggsstonader.sak.vilkår.regler.HovedregelMetadata
 import no.nav.tilleggsstonader.sak.vilkår.regler.NesteRegel
 import no.nav.tilleggsstonader.sak.vilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.regler.RegelSteg
@@ -9,12 +16,52 @@ import no.nav.tilleggsstonader.sak.vilkår.regler.SvarId
 import no.nav.tilleggsstonader.sak.vilkår.regler.Vilkårsregel
 import no.nav.tilleggsstonader.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.tilleggsstonader.sak.vilkår.regler.regelIder
+import java.time.LocalDate
+import java.util.UUID
 
 class PassBarnRegel : Vilkårsregel(
     vilkårType = VilkårType.PASS_BARN,
     regler = setOf(HAR_ALDER_LAVERE_ENN_GRENSEVERDI, UNNTAK_ALDER, DEKKES_UTGIFTER_ANNET_REGELVERK, ANNEN_FORELDER_MOTTAR_STØTTE, UTGIFTER_DOKUMENTERT),
     hovedregler = regelIder(HAR_ALDER_LAVERE_ENN_GRENSEVERDI, DEKKES_UTGIFTER_ANNET_REGELVERK, ANNEN_FORELDER_MOTTAR_STØTTE, UTGIFTER_DOKUMENTERT),
 ) {
+
+    override fun initiereDelvilkår(metadata: HovedregelMetadata, resultat: Vilkårsresultat, barnId: UUID?): List<Delvilkår> {
+        val personIdentForGjeldendeBarn = metadata.barn.firstOrNull { it.id == barnId }?.ident
+        val harFullførtFjerdetrinnSvar = if (personIdentForGjeldendeBarn == null ||
+            harFullførtFjerdetrinn(Fødselsnummer(personIdentForGjeldendeBarn).fødselsdato)
+        ) {
+            null
+        } else {
+            SvarId.NEI
+        }
+        secureLogger.info("BarnId: $barnId harFullførtFjerdetrinn: $harFullførtFjerdetrinnSvar fødselsdato")
+
+        return hovedregler.map {
+            if (it == RegelId.HAR_ALDER_LAVERE_ENN_GRENSEVERDI) {
+                Delvilkår(
+                    resultat = if (harFullførtFjerdetrinnSvar == SvarId.NEI) Vilkårsresultat.AUTOMATISK_OPPFYLT else Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                    listOf(
+                        Vurdering(
+                            regelId = RegelId.HAR_ALDER_LAVERE_ENN_GRENSEVERDI,
+                            svar = harFullførtFjerdetrinnSvar,
+                            begrunnelse = if (harFullførtFjerdetrinnSvar == SvarId.NEI) {
+                                "Automatisk vurdert: Ut ifra barnets alder er det ${
+                                    LocalDate.now()
+                                        .norskFormat()
+                                } automatisk vurdert at barnet ikke har fullført 4. skoleår."
+                            } else {
+                                null
+                            },
+                        ),
+
+                    ),
+                )
+            } else {
+                Delvilkår(resultat, vurderinger = listOf(Vurdering(it)))
+            }
+        }
+    }
+
     companion object {
 
         private val unntakAlderMapping =
@@ -67,5 +114,15 @@ class PassBarnRegel : Vilkårsregel(
                     hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
                 ),
             )
+    }
+
+    fun harFullførtFjerdetrinn(fødselsdato: LocalDate, datoForBeregning: LocalDate = LocalDate.now()): Boolean {
+        val alder = datoForBeregning.year - fødselsdato.year
+        var skoletrinn = alder - 5 // Begynner på skolen i det året de fyller 6
+        if (datoForBeregning.month.plus(1).value < 6) { // Legger til en sikkerhetsmargin på 1 mnd tilfelle de fyller år mens saken behandles
+            skoletrinn--
+        }
+        secureLogger.info("Fødselsdato: $fødselsdato gir skoletrinn $skoletrinn")
+        return skoletrinn > 4
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.vilkår.regler.SvarId
 import no.nav.tilleggsstonader.sak.vilkår.regler.Vilkårsregel
 import no.nav.tilleggsstonader.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.tilleggsstonader.sak.vilkår.regler.regelIder
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.PassBarnRegelUtil.harFullførtFjerdetrinn
 import java.time.LocalDate
 import java.util.UUID
 
@@ -126,7 +127,7 @@ class PassBarnRegel : Vilkårsregel(
         )
     }
 
-    fun harFullførtFjerdetrinn(
+    private fun harFullførtFjerdetrinn(
         barnId: UUID?,
         metadata: HovedregelMetadata,
         datoForBeregning: LocalDate = LocalDate.now(),
@@ -135,16 +136,5 @@ class PassBarnRegel : Vilkårsregel(
         feilHvis(ident == null) { "Fant ikke barn med id=$barnId i metadata" }
 
         return harFullførtFjerdetrinn(Fødselsnummer(ident).fødselsdato, datoForBeregning)
-    }
-
-    fun harFullførtFjerdetrinn(fødselsdato: LocalDate, datoForBeregning: LocalDate = LocalDate.now()): Boolean {
-        val alder = datoForBeregning.year - fødselsdato.year
-        var skoletrinn = alder - 5 // Begynner på skolen i det året de fyller 6
-
-        if (datoForBeregning.month.plus(1).value < 6) { // Legger til en sikkerhetsmargin på 1 mnd tilfelle de fyller år mens saken behandles
-            skoletrinn--
-        }
-
-        return skoletrinn > 4
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegel.kt
@@ -41,6 +41,10 @@ class PassBarnRegel : Vilkårsregel(
         resultat: Vilkårsresultat,
         barnId: UUID?,
     ): List<Delvilkår> {
+        if (resultat != Vilkårsresultat.IKKE_TATT_STILLING_TIL) {
+            return super.initiereDelvilkår(metadata, resultat, barnId)
+        }
+
         return hovedregler.map {
             if (it == RegelId.HAR_ALDER_LAVERE_ENN_GRENSEVERDI && !harFullførtFjerdetrinn(barnId, metadata)) {
                 automatiskVurderAlderLavereEnnGrenseverdi()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegelUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegelUtil.kt
@@ -1,0 +1,26 @@
+package no.nav.tilleggsstonader.sak.vilkår.regler.vilkår
+
+import java.time.LocalDate
+import java.time.Month
+
+object PassBarnRegelUtil {
+
+    /**
+     * Et barn født i 2013 har ikke avsluttet 3'e trinn før juni det året man fyller 10
+     *
+     * 2013 født
+     * 2014 fyller 1 år
+     * ...
+     * 2019 fyller 6 år - starter 1 trinn
+     * 2020 fyller 7 år - fullfører 1 trinn
+     * ...
+     * 2023 fyller 10 år - fullfører 4 trinn i juni
+     */
+    fun harFullførtFjerdetrinn(fødselsdato: LocalDate, datoForBeregning: LocalDate = LocalDate.now()): Boolean {
+        return if (datoForBeregning.month >= Month.JUNE) {
+            datoForBeregning.year - fødselsdato.year > 9
+        } else {
+            datoForBeregning.year - fødselsdato.year > 10
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadUtil.kt
@@ -13,7 +13,9 @@ import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.HovedytelseAvsnitt
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.TypeBarnepass
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.ÅrsakBarnepass
+import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
 import java.time.LocalDateTime
+import java.time.Year
 
 object SøknadUtil {
 
@@ -40,7 +42,11 @@ object SøknadUtil {
     }
 
     fun barnMedBarnepass(
-        ident: String = "fnr",
+        ident: String = FnrGenerator.generer(
+            Year.now().minusYears(1).value,
+            5,
+            19,
+        ),
         navn: String = "navn",
     ): BarnMedBarnepass = BarnMedBarnepass(
         ident = TekstFelt("", ident),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceTest.kt
@@ -84,17 +84,17 @@ internal class VilkårServiceTest {
 
     @Nested
     inner class OppretteVilkårBarnetilsyn {
+        val nyttVilkårsett = slot<List<Vilkår>>()
+
         @BeforeEach
         fun setUp() {
+            every { vilkårRepository.insertAll(capture(nyttVilkårsett)) } answers { firstArg() }
             every { vilkårRepository.findByBehandlingId(behandlingId) } returns emptyList()
             every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak()
         }
 
         @Test
         fun `skal opprette nye Vilkår for barnetilsyn med alle vilkår dersom ingen vurderinger finnes`() {
-            val nyttVilkårsett = slot<List<Vilkår>>()
-            every { vilkårRepository.insertAll(capture(nyttVilkårsett)) } answers { firstArg() }
-
             val aktuelleVilkårTyper = VilkårType.hentVilkårForStønad(Stønadstype.BARNETILSYN)
 
             vilkårService.hentEllerOpprettVilkårsvurdering(behandlingId)
@@ -113,9 +113,6 @@ internal class VilkårServiceTest {
 
         @Test
         fun `skal opprette et vilkår av type PASS_BARN per barn`() {
-            val nyttVilkårsett = slot<List<Vilkår>>()
-            every { vilkårRepository.insertAll(capture(nyttVilkårsett)) } answers { firstArg() }
-
             vilkårService.hentEllerOpprettVilkårsvurdering(behandlingId)
 
             val vilkårPassBarn = nyttVilkårsett.captured.finnVilkårAvType(VilkårType.PASS_BARN)
@@ -124,9 +121,6 @@ internal class VilkårServiceTest {
 
         @Test
         fun `skal initiere automatisk verdi for ALDER_LAVERE_ENN_GRENSEVERDI`() {
-            val nyttVilkårsett = slot<List<Vilkår>>()
-            every { vilkårRepository.insertAll(capture(nyttVilkårsett)) } answers { firstArg() }
-
             vilkårService.hentEllerOpprettVilkårsvurdering(behandlingId)
 
             val vilkårPassBarn = nyttVilkårsett.captured.finnVilkårAvType(VilkårType.PASS_BARN)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
@@ -31,6 +32,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.Year
 import java.util.UUID
 
 internal class VilkårServiceTest {
@@ -58,8 +60,8 @@ internal class VilkårServiceTest {
     private val søknad = SøknadsskjemaMapper.map(
         SøknadUtil.søknadskjemaBarnetilsyn(
             barnMedBarnepass = listOf(
-                barnMedBarnepass(ident = "19852098840"),
-                barnMedBarnepass(ident = "13811397592"),
+                barnMedBarnepass(ident = FnrGenerator.generer(Year.now().minusYears(1).value, 5, 19)),
+                barnMedBarnepass(ident = FnrGenerator.generer(Year.now().minusYears(11).value, 1, 13)),
             ),
         ),
         "id",

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceTest.kt
@@ -57,11 +57,15 @@ internal class VilkårServiceTest {
         barnService = barnService,
         fagsakService = fagsakService,
     )
+
+    private val barnUnder9år = FnrGenerator.generer(Year.now().minusYears(1).value, 5, 19)
+    private val barnOver10år = FnrGenerator.generer(Year.now().minusYears(11).value, 1, 13)
+
     private val søknad = SøknadsskjemaMapper.map(
         SøknadUtil.søknadskjemaBarnetilsyn(
             barnMedBarnepass = listOf(
-                barnMedBarnepass(ident = FnrGenerator.generer(Year.now().minusYears(1).value, 5, 19)),
-                barnMedBarnepass(ident = FnrGenerator.generer(Year.now().minusYears(11).value, 1, 13)),
+                barnMedBarnepass(ident = barnUnder9år),
+                barnMedBarnepass(ident = barnOver10år),
             ),
         ),
         "id",
@@ -127,11 +131,13 @@ internal class VilkårServiceTest {
 
             val vilkårPassBarn = nyttVilkårsett.captured.finnVilkårAvType(VilkårType.PASS_BARN)
 
-            val resultaterBarnUnder9år = vilkårPassBarn.finnVurderingResultaterForBarn(barn[0].id)
+            val resultaterBarnUnder9år =
+                vilkårPassBarn.finnVurderingResultaterForBarn(barn.single { it.ident == barnUnder9år }.id)
             assertThat(resultaterBarnUnder9år).containsOnlyOnce(AUTOMATISK_OPPFYLT)
 
-            val resultaterBarnOver9år = vilkårPassBarn.finnVurderingResultaterForBarn(barn[1].id)
-            assertThat(resultaterBarnOver9år).containsOnly(IKKE_TATT_STILLING_TIL)
+            val resultaterBarnOver10år =
+                vilkårPassBarn.finnVurderingResultaterForBarn(barn.single { it.ident == barnOver10år }.id)
+            assertThat(resultaterBarnOver10år).containsOnly(IKKE_TATT_STILLING_TIL)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegServiceTest.kt
@@ -45,8 +45,8 @@ import no.nav.tilleggsstonader.sak.vilkår.regler.HovedregelMetadata
 import no.nav.tilleggsstonader.sak.vilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.regler.SvarId
 import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkår
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkårsreglerForStønad
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -332,8 +332,8 @@ internal class VilkårStegServiceTest {
     }
 
     @Test
-    internal fun `behandlingen uten barn skal likevel opprette et vilkår for aleneomsorg`() {
-        val vilkårsett =
+    internal fun `behandlingen uten barn skal kaste feilmelding`() {
+        assertThatThrownBy {
             opprettNyeVilkår(
                 behandlingId,
                 HovedregelMetadata(
@@ -342,9 +342,7 @@ internal class VilkårStegServiceTest {
                 ),
                 Stønadstype.BARNETILSYN,
             )
-
-        assertThat(vilkårsett).hasSize(vilkårsreglerForStønad(Stønadstype.BARNETILSYN).size)
-        assertThat(vilkårsett.count { it.type == VilkårType.MÅLGRUPPE }).isEqualTo(1)
+        }.hasMessageContaining("Kan ikke opprette vilkår når ingen barn er knyttet til behandling")
     }
 
     // KUN FOR Å TESTE OPPDATERSTEG

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegelUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/vilkår/PassBarnRegelUtilTest.kt
@@ -1,0 +1,49 @@
+package no.nav.tilleggsstonader.sak.vilkår.regler.vilkår
+
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.PassBarnRegelUtil.harFullførtFjerdetrinn
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PassBarnRegelUtilTest {
+
+    fun datoer(år: Int) = listOf(
+        LocalDate.of(år, 1, 1),
+        LocalDate.of(år, 5, 1),
+        LocalDate.of(år, 10, 1),
+    )
+
+    val fødselsdatoer = datoer(2013) // liste over ulike fødselsdatoer 2013
+
+    @Test
+    fun `barn født i 2013 har ikke avsluttet 4e trinn før 2023, uavhengig føselsdato det året`() {
+        IntRange(2013, 2022).forEach { år ->
+            val kjøredatoer = datoer(år)
+            fødselsdatoer.forEach { fødselsdato ->
+                kjøredatoer.forEach { kjøredato ->
+                    assertThat(harFullførtFjerdetrinn(fødselsdato, kjøredato)).isFalse
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `barn født i 2013 har ikke avsluttet 4e trinn før juni 2023`() {
+        fødselsdatoer.forEach { fødselsdato ->
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2023, 1, 1))).isFalse
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2023, 3, 1))).isFalse
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2023, 5, 1))).isFalse
+        }
+    }
+
+    @Test
+    fun `barn født i 2013 har avsluttet 4e trinn etter juni 2023`() {
+        fødselsdatoer.forEach { fødselsdato ->
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2023, 6, 1))).isTrue
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2023, 8, 1))).isTrue
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2023, 10, 1))).isTrue
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2024, 1, 1))).isTrue
+            assertThat(harFullførtFjerdetrinn(fødselsdato, LocalDate.of(2024, 5, 1))).isTrue
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Dersom et barn er under 9 år kan det automatisk vurderes at barnet ikke har startet i 4. klasse. 
Har tatt inspo fra EF, men måtte tilpasse slik at de andre delvilkårene også kom med. 

Har lagt til tester for å sjekke at vilkår opprettes som vi ønsker.

### Til senere
Vi må vurdere om dette er "automatisk oppfylt" siden det ikke lagres ned. SB må fortsatt trykke lagre og da er det ikke sikkert vi skal kalle det automatisk. Tekster må også ses på senere. 