### PR TITLE
Hent alle fagsakid-er som eksisterer på bruker

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonController.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.fagsak
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.fagsak.dto.FagsakPersonDto
 import no.nav.tilleggsstonader.sak.fagsak.dto.FagsakPersonUtvidetDto
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -22,16 +23,16 @@ class FagsakPersonController(
     private val fagsakService: FagsakService,
 ) {
 
-    /*@GetMapping("{fagsakPersonId}")
+    @GetMapping("{fagsakPersonId}")
     fun hentFagsakPerson(@PathVariable fagsakPersonId: UUID): FagsakPersonDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val person = fagsakPersonService.hentPerson(fagsakPersonId)
         val fagsaker = fagsakService.finnFagsakerForFagsakPersonId(person.id)
         return FagsakPersonDto(
             id = person.id,
-            barnetilsyn = fagsaker.barnetilsyn?.id,
+            tilsynBarn = fagsaker.barnetilsyn?.id,
         )
-    }*/
+    }
 
     @GetMapping("{fagsakPersonId}/utvidet")
     fun hentFagsakPersonUtvidet(@PathVariable fagsakPersonId: UUID): FagsakPersonUtvidetDto {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonControllerTest.kt
@@ -24,6 +24,7 @@ internal class FagsakPersonControllerTest : IntegrationTest() {
 
     @AfterEach
     override fun tearDown() {
+        super.tearDown()
         MDC.remove(MDCConstants.MDC_CALL_ID)
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonControllerTest.kt
@@ -32,6 +32,16 @@ internal class FagsakPersonControllerTest : IntegrationTest() {
         val person = testoppsettService.opprettPerson("1")
         val tilsynBarn = testoppsettService.lagreFagsak(fagsak(person = person, stønadstype = Stønadstype.BARNETILSYN))
 
+        val fagsakPersonDto = testWithBrukerContext { fagsakPersonController.hentFagsakPerson(person.id) }
+
+        assertThat(fagsakPersonDto.tilsynBarn).isEqualTo(tilsynBarn.id)
+    }
+
+    @Test
+    internal fun `skal finne utvidede fagsaker til person`() {
+        val person = testoppsettService.opprettPerson("1")
+        val tilsynBarn = testoppsettService.lagreFagsak(fagsak(person = person, stønadstype = Stønadstype.BARNETILSYN))
+
         val fagsakPersonDto = testWithBrukerContext { fagsakPersonController.hentFagsakPersonUtvidet(person.id) }
 
         assertThat(fagsakPersonDto.tilsynBarn?.id).isEqualTo(tilsynBarn.id)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Frittstående brev skal knyttes til en fagsak. Man er derfor nødt til å kunne hente alle fagsakId-ene som eksisterer på en bruker.  