### PR TITLE
✨ Mellomlagring av brev

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
@@ -1,0 +1,74 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/brev/mellomlager/"])
+@ProtectedWithClaims(issuer = "azuread")
+class BrevMellomlagerController(
+    private val tilgangService: TilgangService,
+    private val mellomlagringBrevService: MellomlagringBrevService,
+) {
+
+    @PostMapping("/{behandlingId}")
+    fun mellomlagreBrevverdier(
+        @PathVariable behandlingId: UUID,
+        @RequestBody mellomlagretBrev: MellomlagreBrevDto,
+    ): UUID {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return mellomlagringBrevService.mellomLagreBrev(
+            behandlingId,
+            mellomlagretBrev.brevverdier,
+            mellomlagretBrev.brevmal,
+        )
+    }
+
+    @GetMapping("/{behandlingId}")
+    fun hentMellomlagretBrevverdier(
+        @PathVariable behandlingId: UUID,
+        @RequestParam sanityVersjon: String,
+    ): MellomlagreBrevDto? {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+
+        return mellomlagringBrevService.hentMellomlagretBrev(
+            behandlingId,
+            sanityVersjon,
+        )
+    }
+
+    @PostMapping("/fagsak/{fagsakId}")
+    fun mellomlagreFrittståendeSanitybrev(
+        @PathVariable fagsakId: UUID,
+        @RequestBody mellomlagreBrev: MellomlagreBrevDto,
+    ): UUID {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return mellomlagringBrevService.mellomLagreFrittståendeSanitybrev(
+            fagsakId,
+            mellomlagreBrev.brevverdier,
+            mellomlagreBrev.brevmal,
+        )
+    }
+
+    @GetMapping("/fagsak/{fagsakId}")
+    fun hentMellomlagretFrittståendesanitybrev(
+        @PathVariable fagsakId: UUID,
+    ): MellomlagreBrevDto? {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+
+        return mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerBrevRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerBrevRepository.kt
@@ -1,0 +1,9 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface MellomlagerBrevRepository : RepositoryInterface<MellomlagretBrev, UUID>, InsertUpdateRepository<MellomlagretBrev>

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepository.kt
@@ -1,0 +1,14 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface MellomlagerFrittståendeBrevRepository :
+    RepositoryInterface<MellomlagretFrittståendeBrev, UUID>,
+    InsertUpdateRepository<MellomlagretFrittståendeBrev> {
+
+    fun findByFagsakIdAndSporbarEndretEndretAv(fagsakId: UUID, sporbarEndretEndretAv: String): MellomlagretFrittståendeBrev?
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepository.kt
@@ -10,5 +10,5 @@ interface MellomlagerFrittståendeBrevRepository :
     RepositoryInterface<MellomlagretFrittståendeBrev, UUID>,
     InsertUpdateRepository<MellomlagretFrittståendeBrev> {
 
-    fun findByFagsakIdAndSporbarEndretEndretAv(fagsakId: UUID, sporbarEndretEndretAv: String): MellomlagretFrittståendeBrev?
+    fun findByFagsakIdAndSporbarOpprettetAv(fagsakId: UUID, sporbarOpprettetAv: String): MellomlagretFrittståendeBrev?
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagreBrevDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagreBrevDto.kt
@@ -1,0 +1,6 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+data class MellomlagreBrevDto(
+    val brevverdier: String,
+    val brevmal: String,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagretBrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagretBrev.kt
@@ -1,0 +1,15 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Embedded
+import java.util.UUID
+
+data class MellomlagretBrev(
+    @Id
+    val behandlingId: UUID,
+    val brevverdier: String,
+    val brevmal: String,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar(),
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagretFrittståendeBrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagretFrittståendeBrev.kt
@@ -1,0 +1,18 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Embedded
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("mellomlagret_frittstaende_brev")
+data class MellomlagretFrittståendeBrev(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val fagsakId: UUID,
+    val brevverdier: String,
+    val brevmal: String,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar(),
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -1,0 +1,57 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class MellomlagringBrevService(
+    private val mellomlagerBrevRepository: MellomlagerBrevRepository,
+    private val mellomlagerFrittståendeBrevRepository: MellomlagerFrittståendeBrevRepository,
+) {
+
+    fun mellomLagreBrev(behandlingId: UUID, brevverdier: String, brevmal: String): UUID {
+        slettMellomlagringHvisFinnes(behandlingId)
+        val mellomlagretBrev = MellomlagretBrev(
+            behandlingId,
+            brevverdier,
+            brevmal,
+        )
+        return mellomlagerBrevRepository.insert(mellomlagretBrev).behandlingId
+    }
+
+    fun mellomLagreFrittståendeSanitybrev(
+        fagsakId: UUID,
+        brevverdier: String,
+        brevmal: String,
+    ): UUID {
+        slettMellomlagretFrittståendeBrev(fagsakId, SikkerhetContext.hentSaksbehandler())
+        val mellomlagretBrev = MellomlagretFrittståendeBrev(
+            fagsakId = fagsakId,
+            brevverdier = brevverdier,
+            brevmal = brevmal,
+        )
+        return mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev).fagsakId
+    }
+
+    fun hentMellomlagretFrittståendeSanitybrev(fagsakId: UUID): MellomlagreBrevDto? =
+        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(
+            fagsakId,
+            SikkerhetContext.hentSaksbehandler(),
+        )?.let { MellomlagreBrevDto(it.brevverdier, it.brevmal) }
+
+    fun hentMellomlagretBrev(behhandlingId: UUID, sanityVersjon: String): MellomlagreBrevDto? =
+        mellomlagerBrevRepository.findByIdOrNull(behhandlingId)?.let {
+            MellomlagreBrevDto(it.brevverdier, it.brevmal)
+        }
+
+    fun slettMellomlagringHvisFinnes(behandlingId: UUID) {
+        mellomlagerBrevRepository.deleteById(behandlingId)
+    }
+
+    fun slettMellomlagretFrittståendeBrev(fagsakId: UUID, saksbehandlerIdent: String) {
+        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(fagsakId, saksbehandlerIdent)
+            ?.let { mellomlagerFrittståendeBrevRepository.deleteById(it.id) }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -36,7 +36,7 @@ class MellomlagringBrevService(
     }
 
     fun hentMellomlagretFrittståendeSanitybrev(fagsakId: UUID): MellomlagreBrevDto? =
-        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(
+        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(
             fagsakId,
             SikkerhetContext.hentSaksbehandler(),
         )?.let { MellomlagreBrevDto(it.brevverdier, it.brevmal) }
@@ -51,7 +51,7 @@ class MellomlagringBrevService(
     }
 
     fun slettMellomlagretFrittståendeBrev(fagsakId: UUID, saksbehandlerIdent: String) {
-        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(fagsakId, saksbehandlerIdent)
+        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, saksbehandlerIdent)
             ?.let { mellomlagerFrittståendeBrevRepository.deleteById(it.id) }
     }
 }

--- a/src/main/resources/db/migration/V22__mellomlagring_brev.sql
+++ b/src/main/resources/db/migration/V22__mellomlagring_brev.sql
@@ -21,4 +21,6 @@ CREATE TABLE mellomlagret_frittstaende_brev (
     endret_tid    TIMESTAMP(3) NOT NULL
 );
 
+CREATE INDEX ON mellomlagret_frittstaende_brev (fagsak_id);
+
 

--- a/src/main/resources/db/migration/V22__mellomlagring_brev.sql
+++ b/src/main/resources/db/migration/V22__mellomlagring_brev.sql
@@ -1,0 +1,24 @@
+CREATE TABLE mellomlagret_brev (
+    behandling_id UUID PRIMARY KEY REFERENCES behandling (id),
+    brevverdier   VARCHAR      NOT NULL,
+    brevmal       VARCHAR      NOT NULL,
+
+    opprettet_av  VARCHAR      NOT NULL,
+    opprettet_tid TIMESTAMP(3) NOT NULL,
+    endret_av     VARCHAR      NOT NULL,
+    endret_tid    TIMESTAMP(3) NOT NULL
+);
+
+CREATE TABLE mellomlagret_frittstaende_brev (
+    id            UUID PRIMARY KEY,
+    fagsak_id     UUID         NOT NULL REFERENCES fagsak (id),
+    brevverdier   VARCHAR      NOT NULL,
+    brevmal       VARCHAR      NOT NULL,
+
+    opprettet_av  VARCHAR      NOT NULL,
+    opprettet_tid TIMESTAMP(3) NOT NULL,
+    endret_av     VARCHAR      NOT NULL,
+    endret_tid    TIMESTAMP(3) NOT NULL
+);
+
+

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -11,6 +11,8 @@ import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingId
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.Behandlingshistorikk
 import no.nav.tilleggsstonader.sak.brev.Vedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.Brevmottaker
+import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretBrev
+import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretFrittståendeBrev
 import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakDomain
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
@@ -112,6 +114,8 @@ abstract class IntegrationTest {
             Totrinnskontroll::class,
             Vedtaksbrev::class,
             Brevmottaker::class,
+            MellomlagretFrittståendeBrev::class,
+            MellomlagretBrev::class,
             Behandlingshistorikk::class,
             Behandlingsjournalpost::class,
             EksternBehandlingId::class,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepositoryTest.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.sak.brev.mellomlager
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.fagsak
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,11 +26,11 @@ internal class MellomlagerFrittståendeBrevRepositoryTest : IntegrationTest() {
         mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev)
 
         val mellomlagretBrevFraDb = mellomlagerFrittståendeBrevRepository.findById(mellomlagretBrev.id)
-        Assertions.assertThat(mellomlagretBrevFraDb).get()
+        assertThat(mellomlagretBrevFraDb).get()
             .usingRecursiveComparison()
             .ignoringFields("sporbar.endret.endretTid")
             .isEqualTo(mellomlagretBrev)
-        Assertions.assertThat(mellomlagretBrevFraDb.get().sporbar.endret.endretTid)
+        assertThat(mellomlagretBrevFraDb.get().sporbar.endret.endretTid)
             .isCloseTo(mellomlagretBrev.sporbar.endret.endretTid, within(1, ChronoUnit.SECONDS))
     }
 
@@ -54,7 +54,7 @@ internal class MellomlagerFrittståendeBrevRepositoryTest : IntegrationTest() {
                 .ignoringFields("sporbar.endret.endretTid")
                 .isEqualTo(mellomlagretBrev)
 
-            Assertions.assertThat(mellomlagretBrevFraDb!!.sporbar.endret.endretTid)
+            assertThat(mellomlagretBrevFraDb!!.sporbar.endret.endretTid)
                 .isCloseTo(mellomlagretBrev.sporbar.endret.endretTid, within(1, ChronoUnit.SECONDS))
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepositoryTest.kt
@@ -48,8 +48,8 @@ internal class MellomlagerFrittståendeBrevRepositoryTest : IntegrationTest() {
 
             mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev)
             val mellomlagretBrevFraDb =
-                mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(fagsak.id, saksbehandlerIdent)
-            Assertions.assertThat(mellomlagretBrevFraDb)
+                mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsak.id, saksbehandlerIdent)
+            assertThat(mellomlagretBrevFraDb)
                 .usingRecursiveComparison()
                 .ignoringFields("sporbar.endret.endretTid")
                 .isEqualTo(mellomlagretBrev)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagerFrittståendeBrevRepositoryTest.kt
@@ -1,0 +1,61 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.temporal.ChronoUnit
+
+internal class MellomlagerFrittståendeBrevRepositoryTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var mellomlagerFrittståendeBrevRepository: MellomlagerFrittståendeBrevRepository
+
+    @Test
+    internal fun `skal lagre mellomlagret brev`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val mellomlagretBrev = MellomlagretFrittståendeBrev(
+            fagsakId = fagsak.id,
+            brevverdier = "{}",
+            brevmal = "",
+        )
+
+        mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev)
+
+        val mellomlagretBrevFraDb = mellomlagerFrittståendeBrevRepository.findById(mellomlagretBrev.id)
+        Assertions.assertThat(mellomlagretBrevFraDb).get()
+            .usingRecursiveComparison()
+            .ignoringFields("sporbar.endret.endretTid")
+            .isEqualTo(mellomlagretBrev)
+        Assertions.assertThat(mellomlagretBrevFraDb.get().sporbar.endret.endretTid)
+            .isCloseTo(mellomlagretBrev.sporbar.endret.endretTid, within(1, ChronoUnit.SECONDS))
+    }
+
+    @Test
+    internal fun `skal finne igjen mellomlagret brev fra fagsakId og saksbehandlers ident`() {
+        val saksbehandlerIdent = "12345678910"
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+
+        testWithBrukerContext(saksbehandlerIdent) {
+            val mellomlagretBrev = MellomlagretFrittståendeBrev(
+                fagsakId = fagsak.id,
+                brevverdier = "{}",
+                brevmal = "",
+            )
+
+            mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev)
+            val mellomlagretBrevFraDb =
+                mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(fagsak.id, saksbehandlerIdent)
+            Assertions.assertThat(mellomlagretBrevFraDb)
+                .usingRecursiveComparison()
+                .ignoringFields("sporbar.endret.endretTid")
+                .isEqualTo(mellomlagretBrev)
+
+            Assertions.assertThat(mellomlagretBrevFraDb!!.sporbar.endret.endretTid)
+                .isCloseTo(mellomlagretBrev.sporbar.endret.endretTid, within(1, ChronoUnit.SECONDS))
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
@@ -60,7 +60,7 @@ class MellomlagringBrevServiceTest {
             brevmal = mellomlagretBrev.brevmal,
         )
 
-        every { mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(fagsakId, any()) } returns brev
+        every { mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, any()) } returns brev
 
         assertThat(mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId)).isEqualTo(
             MellomlagreBrevDto(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
@@ -1,0 +1,78 @@
+package no.nav.tilleggsstonader.sak.brev.mellomlager
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.data.repository.findByIdOrNull
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MellomlagringBrevServiceTest {
+
+    private val mellomlagerBrevRepository = mockk<MellomlagerBrevRepository>()
+    private val mellomlagerFrittståendeBrevRepository = mockk<MellomlagerFrittståendeBrevRepository>()
+    private val mellomlagringBrevService =
+        MellomlagringBrevService(mellomlagerBrevRepository, mellomlagerFrittståendeBrevRepository)
+
+    @BeforeAll
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler() } returns "bob"
+    }
+
+    @AfterAll
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Test
+    fun `hentOgValiderMellomlagretBrev skal returnere mellomlagret brev`() {
+        every { mellomlagerBrevRepository.findByIdOrNull(behandlingId) } returns mellomlagretBrev
+
+        assertThat(
+            mellomlagringBrevService.hentMellomlagretBrev(
+                behandlingId,
+                sanityVersjon,
+            ),
+        )
+            .isEqualTo(
+                MellomlagreBrevDto(
+                    brevmal = mellomlagretBrev.brevmal,
+                    brevverdier = mellomlagretBrev.brevverdier,
+                ),
+            )
+    }
+
+    @Test
+    fun `hentMellomlagretFrittståendeSanityBrev skal returnere mellomlagret frittstående brev`() {
+        val fagsakId = UUID.randomUUID()
+
+        val brev = MellomlagretFrittståendeBrev(
+            fagsakId = fagsakId,
+            brevverdier = mellomlagretBrev.brevverdier,
+            brevmal = mellomlagretBrev.brevmal,
+        )
+
+        every { mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarEndretEndretAv(fagsakId, any()) } returns brev
+
+        assertThat(mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId)).isEqualTo(
+            MellomlagreBrevDto(
+                brevmal = mellomlagretBrev.brevmal,
+                brevverdier = mellomlagretBrev.brevverdier,
+            ),
+        )
+    }
+
+    private val behandlingId = UUID.randomUUID()
+    private val brevmal = "testMal"
+    private val sanityVersjon = "1"
+    private val brevverdier = "{}"
+    private val mellomlagretBrev = MellomlagretBrev(behandlingId, brevverdier, brevmal)
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en saksbehandler går ut av brevfanen, og kommer tilbake skal man innholdet i brevmenyen være mellomlagret.

Gjenbrukt fra Enslig forsørger. Legger til endepunkter for å hente og lagre mellomlagrede brev. Frontend har ansvar for å parse/seriaøisere json til en streng som lagres i db.