### PR TITLE
🐛 Fix. Fjern sanityversjon-parameter for mellomlagring brev

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -38,13 +37,11 @@ class BrevMellomlagerController(
     @GetMapping("/{behandlingId}")
     fun hentMellomlagretBrevverdier(
         @PathVariable behandlingId: UUID,
-        @RequestParam sanityVersjon: String,
     ): MellomlagreBrevDto? {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 
         return mellomlagringBrevService.hentMellomlagretBrev(
             behandlingId,
-            sanityVersjon,
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -41,7 +41,7 @@ class MellomlagringBrevService(
             SikkerhetContext.hentSaksbehandler(),
         )?.let { MellomlagreBrevDto(it.brevverdier, it.brevmal) }
 
-    fun hentMellomlagretBrev(behhandlingId: UUID, sanityVersjon: String): MellomlagreBrevDto? =
+    fun hentMellomlagretBrev(behhandlingId: UUID): MellomlagreBrevDto? =
         mellomlagerBrevRepository.findByIdOrNull(behhandlingId)?.let {
             MellomlagreBrevDto(it.brevverdier, it.brevmal)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
@@ -39,7 +39,6 @@ class MellomlagringBrevServiceTest {
         assertThat(
             mellomlagringBrevService.hentMellomlagretBrev(
                 behandlingId,
-                sanityVersjon,
             ),
         )
             .isEqualTo(
@@ -72,7 +71,6 @@ class MellomlagringBrevServiceTest {
 
     private val behandlingId = UUID.randomUUID()
     private val brevmal = "testMal"
-    private val sanityVersjon = "1"
     private val brevverdier = "{}"
     private val mellomlagretBrev = MellomlagretBrev(behandlingId, brevverdier, brevmal)
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Feltes brukes ikke, og sendes ikke med fra frontend. Ble kopiert over ved et uhell.
