### PR TITLE
Opprydding: Fjerner oppdatering av kategori på vilkår då vi ikke har noe vilkår s…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -166,6 +166,7 @@ class BehandlingService(
         return behandlingRepository.update(behandling.copy(status = status))
     }
 
+    // TODO skal vi sette kategori på behandling?
     fun oppdaterKategoriPåBehandling(behandlingId: UUID, kategori: BehandlingKategori): Behandling {
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegService.kt
@@ -19,7 +19,6 @@ import no.nav.tilleggsstonader.sak.vilkår.dto.SvarPåVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår
-import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår.utledBehandlingKategori
 import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår.utledResultatForVilkårSomGjelderFlereBarn
 import no.nav.tilleggsstonader.sak.vilkår.regler.hentVilkårsregel
 import org.springframework.http.HttpStatus
@@ -50,7 +49,7 @@ class VilkårStegService(
         val oppdatertVilkår = OppdaterVilkår.validerOgOppdatertVilkår(vilkår, svarPåVilkårDto.delvilkårsett)
         // blankettRepository.deleteById(behandlingId)
         val oppdatertVilkårDto = vilkårRepository.update(oppdatertVilkår).tilDto()
-        oppdaterStegOgKategoriPåBehandling(vilkår.behandlingId)
+        oppdaterStegPåBehandling(vilkår.behandlingId)
         return oppdatertVilkårDto
     }
 
@@ -65,7 +64,7 @@ class VilkårStegService(
         // blankettRepository.deleteById(behandlingId)
 
         val oppdatertVilkår = nullstillVilkårMedNyeHovedregler(behandlingId, vilkår)
-        oppdaterStegOgKategoriPåBehandling(behandlingId)
+        oppdaterStegPåBehandling(behandlingId)
         return oppdatertVilkår
     }
 
@@ -80,16 +79,15 @@ class VilkårStegService(
         // blankettRepository.deleteById(behandlingId)
 
         val oppdatertVilkår = oppdaterVilkårTilSkalIkkeVurderes(behandlingId, vilkår)
-        oppdaterStegOgKategoriPåBehandling(behandlingId)
+        oppdaterStegPåBehandling(behandlingId)
         return oppdatertVilkår
     }
 
-    private fun oppdaterStegOgKategoriPåBehandling(behandlingId: UUID) {
+    private fun oppdaterStegPåBehandling(behandlingId: UUID) {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         val vilkårsett = vilkårRepository.findByBehandlingId(behandlingId)
 
         oppdaterStegPåBehandling(saksbehandling, vilkårsett)
-        oppdaterKategoriPåBehandling(saksbehandling, vilkårsett)
     }
 
     private fun oppdaterStegPåBehandling(saksbehandling: Saksbehandling, vilkårsett: List<Vilkår>) {
@@ -116,18 +114,6 @@ class VilkårStegService(
                 metadata = null,
             )
             opprettBehandlingsstatistikkTask(saksbehandling)
-        }
-    }
-
-    private fun oppdaterKategoriPåBehandling(
-        saksbehandling: Saksbehandling,
-        vilkårsett: List<Vilkår>,
-    ) {
-        val lagretKategori = saksbehandling.kategori
-        val utledetKategori = utledBehandlingKategori(vilkårsett)
-
-        if (lagretKategori != utledetKategori) {
-            behandlingService.oppdaterKategoriPåBehandling(saksbehandling.id, utledetKategori)
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår.regler.evalutation
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingKategori
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vilkår.domain.DelvilkårWrapper
@@ -118,38 +117,6 @@ object OppdaterVilkår {
             )
         }
     }
-
-    fun utledBehandlingKategori(vilkårsett: List<Vilkår>): BehandlingKategori {
-        return BehandlingKategori.NASJONAL
-    }
-    /*
-    val medlemFolketrygd =
-        vilkårsett.utledVurderinger(VilkårType.FORUTGÅENDE_MEDLEMSKAP, RegelId.SØKER_MEDLEM_I_FOLKETRYGDEN)
-            .harSvar(SvarId.JA)
-
-    val unntakEøsAnnenForelder =
-        vilkårsett.utledVurderinger(VilkårType.FORUTGÅENDE_MEDLEMSKAP, RegelId.MEDLEMSKAP_UNNTAK)
-            .harSvar(SvarId.MEDLEM_MER_ENN_5_ÅR_EØS_ANNEN_FORELDER_TRYGDEDEKKET_I_NORGE)
-
-    val unntakEøsMedlemskap =
-        vilkårsett.utledVurderinger(VilkårType.FORUTGÅENDE_MEDLEMSKAP, RegelId.MEDLEMSKAP_UNNTAK)
-            .harSvar(SvarId.MEDLEM_MER_ENN_5_ÅR_EØS)
-
-    val borOgOppholderSegINorge =
-        vilkårsett.utledVurderinger(VilkårType.LOVLIG_OPPHOLD, RegelId.BOR_OG_OPPHOLDER_SEG_I_NORGE)
-            .harSvar(SvarId.JA)
-
-    val unntakEøsOpphold =
-        vilkårsett.utledVurderinger(VilkårType.LOVLIG_OPPHOLD, RegelId.OPPHOLD_UNNTAK)
-            .harSvar(SvarId.OPPHOLDER_SEG_I_ANNET_EØS_LAND)
-
-    val forutgåendeMedelmskapUtløserEøs =
-        !medlemFolketrygd && (unntakEøsAnnenForelder || unntakEøsMedlemskap)
-    val lovligOppholdUtløserEøs = !borOgOppholderSegINorge && unntakEøsOpphold
-
-    return if (forutgåendeMedelmskapUtløserEøs || lovligOppholdUtløserEøs) BehandlingKategori.EØS else BehandlingKategori.NASJONAL
-}
-*/
 
     fun erAlleVilkårOppfylt(
         vilkårsett: List<Vilkår>,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegServiceTest.kt
@@ -113,7 +113,6 @@ internal class VilkårStegServiceTest {
         every { behandlingService.hentSaksbehandling(behandlingId) } returns saksbehandling(fagsak, behandling)
         // every { behandlingService.hentAktivIdent(behandlingId) } returns søknad.fødselsnummer
         every { behandlingService.oppdaterStatusPåBehandling(any(), any()) } returns behandling
-        every { behandlingService.oppdaterKategoriPåBehandling(any(), any()) } returns behandling
         // every { søknadService.hentSøknadsgrunnlag(any()) }.returns(søknad)
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsak(stønadstype = Stønadstype.BARNETILSYN)
         every { vilkårRepository.insertAll(any()) } answers { firstArg() }


### PR DESCRIPTION
…om kan utlede den informasjonen

### Hvorfor er denne endringen nødvendig? ✨
Sånn som der ser ut nå skal vi kun vurdere om en person har medlemsskap eller ikke. Hvis vi skal sette kategori på en behandling får vi vurdere senere hvordan det skal gjøres.
