### PR TITLE
OppgaveDomain må ikke ha kobling til behandlingId, eks for journalfør…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 data class OppgaveDomain(
     @Id
     val id: UUID = UUID.randomUUID(),
-    val behandlingId: UUID,
+    val behandlingId: UUID?,
     val gsakOppgaveId: Long,
     val type: Oppgavetype,
     var erFerdigstilt: Boolean = false,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface OppgaveRepository : RepositoryInterface<OppgaveDomain, Long>, InsertUpdateRepository<OppgaveDomain> {
+interface OppgaveRepository : RepositoryInterface<OppgaveDomain, UUID>, InsertUpdateRepository<OppgaveDomain> {
 
     fun findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(behandlingId: UUID, oppgavetype: Oppgavetype): OppgaveDomain?
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/OppgaveDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/OppgaveDto.kt
@@ -3,6 +3,6 @@ package no.nav.tilleggsstonader.sak.opplysninger.oppgave.dto
 import java.util.UUID
 
 data class OppgaveDto(
-    val behandlingId: UUID,
+    val behandlingId: UUID?,
     val gsakOppgaveId: Long,
 )

--- a/src/main/resources/db/migration/V25__oppgave_nullable_behandlingId.sql
+++ b/src/main/resources/db/migration/V25__oppgave_nullable_behandlingId.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oppgave ALTER COLUMN behandling_id DROP NOT NULL;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OpprettOppgaveConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OpprettOppgaveConfig.kt
@@ -47,10 +47,12 @@ class OpprettOppgaveConfig(
             .filterNot { it.erFerdigstilt }
             .filter { oppgavetyper.contains(it.type) }
         oppgaver.forEach { oppgave ->
-            val behandling = behandlingService.hentSaksbehandling(oppgave.behandlingId)
-            val nyttOppgaveId = opprettOppgave(behandling, oppgave)
-            // Oppdaterer oppgaveId på oppgaven då vi oppretter alle oppgaver på nytt, og får då et nytt oppgaveId
-            oppgaveRepository.update(oppgave.copy(gsakOppgaveId = nyttOppgaveId))
+            oppgave.behandlingId?.let { behandlingId ->
+                val behandling = behandlingService.hentSaksbehandling(behandlingId)
+                val nyttOppgaveId = opprettOppgave(behandling, oppgave)
+                // Oppdaterer oppgaveId på oppgaven då vi oppretter alle oppgaver på nytt, og får då et nytt oppgaveId
+                oppgaveRepository.update(oppgave.copy(gsakOppgaveId = nyttOppgaveId))
+            }
         }
         logger.info("Opprettet ${oppgaver.size} oppgaver")
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.oppgave
@@ -21,6 +22,13 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
+
+    @Test
+    fun `skal kunne opprette oppgave uten kobling til behandling`() {
+        val oppgave = oppgaveRepository.insert(oppgave(behandlingId = null))
+
+        assertThat(oppgaveRepository.findByIdOrThrow(oppgave.id).behandlingId).isNull()
+    }
 
     @Test
     internal fun findByBehandlingIdAndTypeAndErFerdigstiltIsFalse() {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -45,7 +45,7 @@ fun oppgave(
 ): OppgaveDomain = oppgave(behandling.id, erFerdigstilt, gsakOppgaveId, type)
 
 fun oppgave(
-    behandlingId: UUID,
+    behandlingId: UUID?,
     erFerdigstilt: Boolean = false,
     gsakOppgaveId: Long = 123,
     type: Oppgavetype = Oppgavetype.Journalføring,


### PR DESCRIPTION
…ingsoppgaver

### Hvorfor er denne endringen nødvendig? ✨
For å kunne lagre ned oppgaver som ikke har kobling til en behandling, eks manuelle journalføringsoppgaver som ikke har en fagsak/behandling ennå.