### PR TITLE
Automatisk journalføring skal opprette manuell journalføring 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
@@ -11,6 +11,7 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
@@ -48,17 +49,19 @@ class OpprettOppgaveForOpprettetBehandlingTask(
         data: OpprettOppgaveTaskData,
         task: Task,
     ): Long? {
-        val behandling = behandlingService.hentBehandling(data.behandlingId)
+        val behandling = behandlingService.hentSaksbehandling(data.behandlingId)
         if (behandling.status == BehandlingStatus.OPPRETTET || behandling.status == BehandlingStatus.UTREDES) {
             val tilordnetNavIdent =
                 if (data.saksbehandler == SikkerhetContext.SYSTEM_FORKORTELSE) null else data.saksbehandler
             val oppgaveId = oppgaveService.opprettOppgave(
                 behandlingId = data.behandlingId,
-                oppgavetype = Oppgavetype.BehandleSak,
-                tilordnetNavIdent = tilordnetNavIdent,
-                beskrivelse = data.beskrivelse,
-                mappeId = data.mappeId,
-                prioritet = data.prioritet,
+                oppgave = OpprettOppgave(
+                    oppgavetype = Oppgavetype.BehandleSak,
+                    tilordnetNavIdent = tilordnetNavIdent,
+                    beskrivelse = data.beskrivelse,
+                    mappeId = data.mappeId,
+                    prioritet = data.prioritet,
+                ),
             )
             task.metadata.setProperty("oppgaveId", oppgaveId.toString())
             return oppgaveId

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
@@ -6,8 +6,10 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.sak.journalføring.AutomatiskJournalføringRequest
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService.Companion.MASKINELL_JOURNALFOERENDE_ENHET
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
@@ -24,6 +26,8 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OpprettOppgave.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OpprettOppgave.kt
@@ -1,0 +1,16 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave
+
+import no.nav.tilleggsstonader.kontrakter.oppgave.OppgavePrioritet
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import java.time.LocalDate
+
+data class OpprettOppgave(
+    val oppgavetype: Oppgavetype,
+    val beskrivelse: String? = null,
+    val tilordnetNavIdent: String? = null,
+    val enhetsnummer: String? = null,
+    val mappeId: Long? = null,
+    val prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
+    val fristFerdigstillelse: LocalDate? = null,
+    val journalpostId: String? = null,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import org.springframework.http.HttpStatus
@@ -52,8 +53,8 @@ class AngreSendTilBeslutterService(
     private fun opprettBehandleSakOppgave(saksbehandling: Saksbehandling) {
         taskService.save(
             OpprettOppgaveTask.opprettTask(
-                OpprettOppgaveTask.OpprettOppgaveTaskData(
-                    behandlingId = saksbehandling.id,
+                behandlingId = saksbehandling.id,
+                OpprettOppgave(
                     oppgavetype = Oppgavetype.BehandleSak,
                     beskrivelse = "Angret send til beslutter",
                     tilordnetNavIdent = SikkerhetContext.hentSaksbehandler(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.utbetaling.PollStatusFraUtbetalingTask
@@ -98,8 +99,8 @@ class BeslutteVedtakSteg(
     private fun opprettBehandleUnderkjentVedtakOppgave(saksbehandling: Saksbehandling, navIdent: String) {
         taskService.save(
             OpprettOppgaveTask.opprettTask(
-                OpprettOppgaveTask.OpprettOppgaveTaskData(
-                    behandlingId = saksbehandling.id,
+                behandlingId = saksbehandling.id,
+                OpprettOppgave(
                     oppgavetype = Oppgavetype.BehandleUnderkjentVedtak,
                     tilordnetNavIdent = navIdent,
                 ),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
@@ -59,8 +60,8 @@ class SendTilBeslutterSteg(
     private fun opprettGodkjennVedtakOppgave(saksbehandling: Saksbehandling) {
         taskService.save(
             OpprettOppgaveTask.opprettTask(
-                OpprettOppgaveTask.OpprettOppgaveTaskData(
-                    behandlingId = saksbehandling.id,
+                behandlingId = saksbehandling.id,
+                oppgave = OpprettOppgave(
                     oppgavetype = Oppgavetype.GodkjenneVedtak,
                     beskrivelse = "Sendt til godkjenning av ${SikkerhetContext.hentSaksbehandlerNavn(true)}.",
                 ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTaskTest.kt
@@ -7,10 +7,10 @@ import io.mockk.verify
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
-import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.saksbehandling
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -29,7 +29,7 @@ internal class OpprettOppgaveForOpprettetBehandlingTaskTest {
 
     @BeforeEach
     internal fun setUp() {
-        every { oppgaveService.opprettOppgave(any(), any(), any(), any(), any()) } returns oppgaveId
+        every { oppgaveService.opprettOppgave(any(), any()) } returns oppgaveId
         every { taskService.save(capture(opprettTaskSlot)) } answers { firstArg() }
     }
 
@@ -51,7 +51,7 @@ internal class OpprettOppgaveForOpprettetBehandlingTaskTest {
             ),
         )
 
-        verify(exactly = 1) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { oppgaveService.opprettOppgave(any(), any()) }
     }
 
     @EnumSource(
@@ -72,12 +72,12 @@ internal class OpprettOppgaveForOpprettetBehandlingTaskTest {
             ),
         )
 
-        verify(exactly = 0) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { oppgaveService.opprettOppgave(any(), any()) }
     }
 
-    private fun mockBehandling(status: BehandlingStatus): Behandling {
-        val behandling = behandling(status = status)
-        every { behandlingService.hentBehandling(behandling.id) } returns behandling
+    private fun mockBehandling(status: BehandlingStatus): Saksbehandling {
+        val behandling = saksbehandling(status = status)
+        every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
         return behandling
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
@@ -51,10 +51,40 @@ internal class OppgaveServiceTest {
             cacheManager,
         )
 
+    val opprettOppgaveDomainSlot = slot<OppgaveDomain>()
+
     @BeforeEach
     internal fun setUp() {
+        opprettOppgaveDomainSlot.clear()
         every { oppgaveClient.finnOppgaveMedId(any()) } returns lagEksternTestOppgave()
+        every { oppgaveRepository.insert(capture(opprettOppgaveDomainSlot)) } returns lagTestOppgave()
         every { oppgaveRepository.update(any()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `Opprett oppgave skal kunne opprettes uten behandlingId`() {
+        val slot = slot<OpprettOppgaveRequest>()
+        mockOpprettOppgave(slot)
+
+        oppgaveService.opprettOppgave(
+            personIdent = FNR,
+            stønadstype = Stønadstype.BARNETILSYN,
+            behandlingId = null,
+            oppgave = OpprettOppgave(oppgavetype = Oppgavetype.Journalføring),
+        )
+        assertThat(opprettOppgaveDomainSlot.captured.behandlingId).isNull()
+    }
+
+    @Test
+    fun `Opprett oppgave må ha kobling til behandling når man oppretter en BehandleSak-oppgave`() {
+        assertThatThrownBy {
+            oppgaveService.opprettOppgave(
+                personIdent = FNR,
+                stønadstype = Stønadstype.BARNETILSYN,
+                behandlingId = null,
+                oppgave = OpprettOppgave(oppgavetype = Oppgavetype.BehandleSak),
+            )
+        }.hasMessage("Må ha behandlingId når man oppretter oppgave for behandle sak")
     }
 
     @Test
@@ -62,7 +92,7 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         mockOpprettOppgave(slot)
 
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.opprettOppgave(BEHANDLING_ID, OpprettOppgave(oppgavetype = Oppgavetype.BehandleSak))
 
         assertThat(slot.captured.enhetsnummer).isEqualTo(ENHETSNUMMER)
         assertThat(slot.captured.ident).isEqualTo(OppgaveIdentV2(ident = FNR, gruppe = IdentGruppe.FOLKEREGISTERIDENT))
@@ -70,6 +100,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.TSO)
+        assertThat(opprettOppgaveDomainSlot.captured.behandlingId).isEqualTo(BEHANDLING_ID)
     }
 
     @Test
@@ -78,7 +109,7 @@ internal class OppgaveServiceTest {
         mockOpprettOppgave(slot)
         every { oppgaveClient.opprettOppgave(any()) } throws IntegrasjonException("En merkelig feil vi ikke kjenner til")
         assertThrows<IntegrasjonException> {
-            oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+            oppgaveService.opprettOppgave(BEHANDLING_ID, OpprettOppgave(oppgavetype = Oppgavetype.BehandleSak))
         }
     }
 
@@ -197,8 +228,6 @@ internal class OppgaveServiceTest {
     private fun mockOpprettOppgave(slot: CapturingSlot<OpprettOppgaveRequest>) {
         every { fagsakService.hentFagsakForBehandling(BEHANDLING_ID) } returns lagTestFagsak()
 
-        every { oppgaveRepository.insert(any()) } returns lagTestOppgave()
-
         every {
             oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(any(), any())
         } returns null
@@ -223,7 +252,11 @@ internal class OppgaveServiceTest {
     }
 
     private fun lagTestOppgave(): OppgaveDomain {
-        return OppgaveDomain(behandlingId = BEHANDLING_ID, type = Oppgavetype.BehandleSak, gsakOppgaveId = GSAK_OPPGAVE_ID)
+        return OppgaveDomain(
+            behandlingId = BEHANDLING_ID,
+            type = Oppgavetype.BehandleSak,
+            gsakOppgaveId = GSAK_OPPGAVE_ID,
+        )
     }
 
     private fun lagEksternTestOppgave(): Oppgave {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakStegTest.kt
@@ -136,12 +136,12 @@ class BeslutteVedtakStegTest {
             årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET),
         )
 
-        val deserializedPayload = objectMapper.readValue<OpprettOppgaveTask.OpprettOppgaveTaskData>(taskSlot[1].payload)
+        val taskData = objectMapper.readValue<OpprettOppgaveTask.OpprettOppgaveTaskData>(taskSlot[1].payload)
 
         assertThat(nesteSteg).isEqualTo(StegType.SEND_TIL_BESLUTTER)
         assertThat(taskSlot[0].type).isEqualTo(FerdigstillOppgaveTask.TYPE)
         assertThat(taskSlot[1].type).isEqualTo(OpprettOppgaveTask.TYPE)
-        assertThat(deserializedPayload.oppgavetype).isEqualTo(Oppgavetype.BehandleUnderkjentVedtak)
+        assertThat(taskData.oppgave.oppgavetype).isEqualTo(Oppgavetype.BehandleUnderkjentVedtak)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
@@ -29,7 +29,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
-import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask.OpprettOppgaveTaskData
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
@@ -211,8 +210,8 @@ class SendTilBeslutterStegTest {
         verify { behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FATTER_VEDTAK) }
 
         assertThat(taskSlot[0].type).isEqualTo(OpprettOppgaveTask.TYPE)
-        assertThat(objectMapper.readValue<OpprettOppgaveTaskData>(taskSlot[0].payload).oppgavetype)
-            .isEqualTo(Oppgavetype.GodkjenneVedtak)
+        val taskData = objectMapper.readValue<OpprettOppgaveTask.OpprettOppgaveTaskData>(taskSlot[0].payload)
+        assertThat(taskData.oppgave.oppgavetype).isEqualTo(Oppgavetype.GodkjenneVedtak)
 
         assertThat(taskSlot[1].type).isEqualTo(FerdigstillOppgaveTask.TYPE)
         assertThat(objectMapper.readValue<FerdigstillOppgaveTask.FerdigstillOppgaveTaskData>(taskSlot[1].payload).oppgavetype)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis det ikke er mulig å håndtere automatisk journalføring så skal man opprette en manuell oppgave

Metodene i `OppgaveService` er skrevet om sånn at de tar inn `behandlingId`, eller `behandlingId, ident og stønadstype`, sammen med ett OpprettOppgave-objekt som inneholder all metainformasjon til oppgaven.

`OpprettOppgave` er også en del av det som lagres ned i OpprettOppgaveTasken, for å enkelt kunne sende den videre til `OppgaveService`.

Det er splittet opp i 2 commits, en som gjør interface-endringen og en som legger til håndtering av manuell journalføring

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17188

Dette er i dev nå ✅ 