### PR TITLE
Frikobler fagsak og behandling fra eksternIder då EmbeddedCollection …

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -15,6 +15,8 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandlingsjournalpost
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingsjournalpostRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingId
+import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingIdRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.Journalposttype
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
@@ -42,6 +44,7 @@ import java.util.UUID
 class BehandlingService(
     private val behandlingsjournalpostRepository: BehandlingsjournalpostRepository,
     private val behandlingRepository: BehandlingRepository,
+    private val eksternBehandlingIdRepository: EksternBehandlingIdRepository,
     private val behandlingshistorikkService: BehandlingshistorikkService,
     // private val taskService: TaskService,
 ) {
@@ -132,6 +135,7 @@ class BehandlingService(
                 kategori = BehandlingKategori.NASJONAL,
             ),
         )
+        eksternBehandlingIdRepository.insert(EksternBehandlingId(behandlingId = behandling.id))
 
         behandlingshistorikkService.opprettHistorikkInnslag(
             behandlingshistorikk = Behandlingshistorikk(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/Behandling.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Embedded
-import org.springframework.data.relational.core.mapping.MappedCollection
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -20,8 +19,6 @@ data class Behandling(
     val id: UUID = UUID.randomUUID(),
     val fagsakId: UUID,
     val forrigeBehandlingId: UUID? = null,
-    @MappedCollection(idColumn = "behandling_id")
-    val eksternId: EksternBehandlingId = EksternBehandlingId(),
     // @Version ?
     val versjon: Int = 0,
 
@@ -111,4 +108,5 @@ enum class BehandlingStatus {
 data class EksternBehandlingId(
     @Id
     val id: Long = 0,
+    val behandlingId: UUID,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/EksternBehandlingIdRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/EksternBehandlingIdRepository.kt
@@ -1,0 +1,14 @@
+package no.nav.tilleggsstonader.sak.behandling.domain
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface EksternBehandlingIdRepository :
+    RepositoryInterface<EksternBehandlingId, Long>,
+    InsertUpdateRepository<EksternBehandlingId> {
+
+    fun findByBehandlingId(behandlingId: UUID): EksternBehandlingId
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/EksternFagsakIdRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/EksternFagsakIdRepository.kt
@@ -1,0 +1,12 @@
+package no.nav.tilleggsstonader.sak.fagsak.domain
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface EksternFagsakIdRepository : RepositoryInterface<EksternFagsakId, Long>, InsertUpdateRepository<EksternFagsakId> {
+
+    fun findByFagsakId(fagsakId: UUID): EksternFagsakId
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Embedded
-import org.springframework.data.relational.core.mapping.MappedCollection
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
@@ -35,8 +34,6 @@ data class FagsakDomain(
     @Id
     val id: UUID = UUID.randomUUID(),
     val fagsakPersonId: UUID,
-    @MappedCollection(idColumn = "fagsak_id")
-    val eksternId: EksternFagsakId = EksternFagsakId(),
     @Column("stonadstype")
     val stønadstype: Stønadstype,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
@@ -47,14 +44,15 @@ data class FagsakDomain(
 data class EksternFagsakId(
     @Id
     val id: Long = 0,
+    val fagsakId: UUID,
 )
 
-fun FagsakDomain.tilFagsakMedPerson(personIdenter: Set<PersonIdent>): Fagsak =
+fun FagsakDomain.tilFagsakMedPerson(personIdenter: Set<PersonIdent>, eksternFagsakId: EksternFagsakId): Fagsak =
     Fagsak(
         id = id,
         fagsakPersonId = fagsakPersonId,
         personIdenter = personIdenter,
-        eksternId = eksternId,
+        eksternId = eksternFagsakId,
         stønadstype = stønadstype,
         sporbar = sporbar,
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingControllerTest.kt
@@ -36,7 +36,7 @@ internal class BehandlingControllerTest : IntegrationTest() {
     @Test
     internal fun `Skal returnere 403 dersom man ikke har tilgang til brukeren`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent("ikkeTilgang"))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val respons = catchThrowableOfType<HttpClientErrorException.Forbidden> { hentBehandling(behandling.id) }
 
         assertThat(respons.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
@@ -45,7 +45,7 @@ internal class BehandlingControllerTest : IntegrationTest() {
     @Test
     internal fun `Skal henlegge behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent("12345678901"))))
-        val behandling = behandlingRepository.insert(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING))
+        val behandling = testoppsettService.lagre(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING))
         val respons = henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.FEILREGISTRERT))
 
         assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
@@ -56,7 +56,7 @@ internal class BehandlingControllerTest : IntegrationTest() {
     @Test
     internal fun `Skal henlegge FØRSTEGANGSBEHANDLING`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent("12345678901"))))
-        val behandling = behandlingRepository.insert(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING))
+        val behandling = testoppsettService.lagre(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING))
         val respons = henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.FEILREGISTRERT))
 
         assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceIntegrationTest.kt
@@ -27,7 +27,7 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
     @Test
     internal fun `opprettBehandling skal ikke være mulig å opprette en revurdering om forrige behandling ikke er ferdigstilt`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        behandlingRepository.insert(
+        testoppsettService.lagre(
             behandling(
                 fagsak = fagsak,
                 status = BehandlingStatus.UTREDES,
@@ -64,8 +64,8 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
     @Test
     internal fun `hentBehandlinger - skal returnere behandlinger`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
-        val behandling2 = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling2 = testoppsettService.lagre(behandling(fagsak))
 
         assertThat(behandlingService.hentBehandlinger(setOf(behandling.id, behandling2.id))).hasSize(2)
     }
@@ -73,7 +73,7 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
     @Test
     internal fun `skal finne siste behandling med avslåtte hvis kun avslått`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(
+        val behandling = testoppsettService.lagre(
             behandling(fagsak, resultat = BehandlingResultat.AVSLÅTT, status = BehandlingStatus.FERDIGSTILT),
         )
         val sisteBehandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
@@ -83,10 +83,10 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
     @Test
     internal fun `skal finne siste behandling med avslåtte hvis avslått og henlagt`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val avslag = behandlingRepository.insert(
+        val avslag = testoppsettService.lagre(
             behandling(fagsak, resultat = BehandlingResultat.AVSLÅTT, status = BehandlingStatus.FERDIGSTILT),
         )
-        behandlingRepository.insert(
+        testoppsettService.lagre(
             behandling(fagsak, resultat = BehandlingResultat.HENLAGT, status = BehandlingStatus.FERDIGSTILT),
         )
         val sisteBehandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
@@ -96,13 +96,13 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
     @Test
     internal fun `skal plukke ut førstegangsbehandling hvis det finnes førstegangsbehandling, avslått og henlagt`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val førstegang = behandlingRepository.insert(
+        val førstegang = testoppsettService.lagre(
             behandling(fagsak, resultat = BehandlingResultat.INNVILGET, status = BehandlingStatus.FERDIGSTILT),
         )
-        behandlingRepository.insert(
+        testoppsettService.lagre(
             behandling(fagsak, resultat = BehandlingResultat.AVSLÅTT, status = BehandlingStatus.FERDIGSTILT),
         )
-        behandlingRepository.insert(
+        testoppsettService.lagre(
             behandling(fagsak, resultat = BehandlingResultat.HENLAGT, status = BehandlingStatus.FERDIGSTILT),
         )
         val sisteBehandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
@@ -132,16 +132,16 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
             ),
         )
 
-        behandlingRepository.insert(
+        testoppsettService.lagre(
             behandling(fagsakOs, resultat = BehandlingResultat.HENLAGT, status = BehandlingStatus.FERDIGSTILT),
         )
-        val førstegangBt = behandlingRepository.insert(
+        val førstegangBt = testoppsettService.lagre(
             behandling(fagsakBt, resultat = BehandlingResultat.INNVILGET, status = BehandlingStatus.FERDIGSTILT),
         )
-        val førstegangSp = behandlingRepository.insert(
+        val førstegangSp = testoppsettService.lagre(
             behandling(fagsakSp, resultat = BehandlingResultat.INNVILGET, status = BehandlingStatus.FERDIGSTILT),
         )
-        val revurderingUnderArbeidSP = behandlingRepository.insert(
+        val revurderingUnderArbeidSP = testoppsettService.lagre(
             behandling(fagsakSp, resultat = BehandlingResultat.IKKE_SATT, status = BehandlingStatus.UTREDES),
         )
 
@@ -156,7 +156,7 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
         @Test
         internal fun `opprettBehandling av førstegangsbehandling er ikke mulig hvis det finnes en førstegangsbehandling på vent`() {
             val fagsak = testoppsettService.lagreFagsak(fagsak())
-            behandlingRepository.insert(behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT))
+            testoppsettService.lagre(behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT))
             assertThatThrownBy {
                 behandlingService.opprettBehandling(
                     BehandlingType.FØRSTEGANGSBEHANDLING,
@@ -169,7 +169,7 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
         @Test
         internal fun `opprettBehandling av revurdering er ikke mulig hvis det finnes en førstegangsbehandling på vent`() {
             val fagsak = testoppsettService.lagreFagsak(fagsak())
-            behandlingRepository.insert(behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT))
+            testoppsettService.lagre(behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT))
             assertThatThrownBy {
                 behandlingService.opprettBehandling(
                     BehandlingType.REVURDERING,
@@ -182,8 +182,8 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
         @Test
         internal fun `opprettBehandling er mulig hvis det finnes en revurdering på vent`() {
             val fagsak = testoppsettService.lagreFagsak(fagsak())
-            behandlingRepository.insert(behandling(fagsak, BehandlingStatus.FERDIGSTILT))
-            behandlingRepository.insert(
+            testoppsettService.lagre(behandling(fagsak, BehandlingStatus.FERDIGSTILT))
+            testoppsettService.lagre(
                 behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT, type = BehandlingType.REVURDERING),
             )
             behandlingService.opprettBehandling(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
@@ -50,6 +50,7 @@ internal class BehandlingServiceTest {
         BehandlingService(
             mockk(),
             behandlingRepository,
+            mockk(),
             behandlingshistorikkService,
             // taskService,
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingsjournalpostRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingsjournalpostRepositoryTest.kt
@@ -20,8 +20,8 @@ internal class BehandlingsjournalpostRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal kunne lagre flere journalposter på samme behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling1 = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
-        val behandling2 = behandlingRepository.insert(behandling(fagsak))
+        val behandling1 = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling2 = testoppsettService.lagre(behandling(fagsak))
         behandlingsjournalpostRepository.insert(Behandlingsjournalpost(behandling1.id, "1", Journalposttype.U))
         behandlingsjournalpostRepository.insert(Behandlingsjournalpost(behandling1.id, "2", Journalposttype.U))
         // setter inn en på behandling 2
@@ -33,7 +33,7 @@ internal class BehandlingsjournalpostRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal ikke være mulig å legge inn 2 journalposter med samme journalpostId`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling1 = behandlingRepository.insert(behandling(fagsak))
+        val behandling1 = testoppsettService.lagre(behandling(fagsak))
         behandlingsjournalpostRepository.insert(Behandlingsjournalpost(behandling1.id, "1", Journalposttype.U))
         val throwable = catchThrowable {
             behandlingsjournalpostRepository.insert(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkControllerTest.kt
@@ -45,7 +45,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
     @Test
     internal fun `Skal returnere 403 dersom man ikke har tilgang til brukeren`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent("ikkeTilgang"))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val respons = catchThrowableOfType<HttpClientErrorException.Forbidden> { hentHistorikk(behandling.id) }
 
         assertThat(respons.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
@@ -54,7 +54,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
     @Test
     internal fun `skal kun returnere den første hendelsen av typen OPPRETTET - etterfølgende hendelser av denne typen skal lukes vekk`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
         leggInnHistorikk(behandling, "2", LocalDateTime.now().minusDays(1), StegType.VILKÅR)
@@ -67,7 +67,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
     @Test
     internal fun `skal returnere hendelser av alle typer i riktig rekkefølge for invilget behandling `() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
         leggInnHistorikk(behandling, "2", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
@@ -97,7 +97,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
     @Test
     internal fun `skal returnere hendelser av alle typer i riktig rekkefølge for henlagt behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
         leggInnHistorikk(behandling, "2", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
@@ -124,7 +124,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
     @Test
     internal fun `skal returnere alle hendelser dersom en behandling blir underkjent i totrinnskontroll, deretter sendt til beslutter på nytt og deretter godkjent`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
         leggInnHistorikk(behandling, "2", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
@@ -152,7 +152,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
     @Test
     internal fun `skal returnere metadata som json`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val jsonMap = mapOf("key" to "value")
         val metadata = JsonWrapper(objectMapper.writeValueAsString(jsonMap))

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkServiceTest.kt
@@ -34,7 +34,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     fun `lagre behandling og hent historikk`() {
         /** Lagre */
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val behandlingHistorikk =
             behandlingshistorikkRepository.insert(
                 Behandlingshistorikk(
@@ -57,7 +57,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     fun `Finn hendelseshistorikk på behandling uten historikk`() {
         /** Lagre */
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         /** Hent */
         val list = behandlingshistorikkService.finnHendelseshistorikk(saksbehandling(fagsak, behandling))
@@ -68,7 +68,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     @Test
     internal fun `skal slå sammen hendelser av typen opprettet`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val beslutteVedtak = behandling.copy(steg = StegType.BESLUTTE_VEDTAK)
 
         insert(behandling.copy(steg = StegType.VILKÅR), LocalDateTime.now().minusDays(8))
@@ -92,7 +92,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     @Test
     internal fun `flere sett og av vent skal ikke slåes sammen`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, steg = StegType.VILKÅR))
+        val behandling = testoppsettService.lagre(behandling(fagsak, steg = StegType.VILKÅR))
         insert(behandling, LocalDateTime.now().minusDays(10))
         insert(behandling, LocalDateTime.now().minusDays(8), StegUtfall.SATT_PÅ_VENT)
         insert(behandling, LocalDateTime.now().minusDays(5), StegUtfall.TATT_AV_VENT)
@@ -112,7 +112,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     @Test
     internal fun `finn seneste behandlinghistorikk`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         insert(behandling, "A", LocalDateTime.now().minusDays(1))
         insert(behandling, "B", LocalDateTime.now().plusDays(1))
@@ -125,7 +125,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     @Test
     internal fun `finn seneste behandlinghistorikk med type`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         insert(behandling, "A", LocalDateTime.now().minusDays(1))
         insert(behandling, "B", LocalDateTime.now().plusDays(1))

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevRepositoryTest.kt
@@ -22,7 +22,7 @@ internal class BrevRepositoryTest : IntegrationTest() {
     @Test
     internal fun `lagre og hent vedtaksbrev`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val vedtaksbrev = Vedtaksbrev(
             behandlingId = behandling.id,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevmottakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/BrevmottakerRepositoryTest.kt
@@ -27,7 +27,7 @@ internal class BrevmottakerRepositoryTest : IntegrationTest() {
 
     @Test internal fun `lagre og hent brevmottaker`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val brevmottaker = Brevmottaker(
             behandlingId = behandling.id,
@@ -58,7 +58,7 @@ internal class BrevmottakerRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal ikke kunne lagre to journalpostResultat på samme behandling med samme mottaker`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val brevmottaker1 = Brevmottaker(
             behandlingId = behandling.id,
@@ -87,7 +87,7 @@ internal class BrevmottakerRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal kunne lagre to journalpostResultat på samme behandling med forskjellige mottakere`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val brevmottaker = Brevmottaker(
             behandlingId = behandling.id,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakRepositoryTest.kt
@@ -29,6 +29,9 @@ class FagsakRepositoryTest : IntegrationTest() {
     private lateinit var fagsakPersonRepository: FagsakPersonRepository
 
     @Autowired
+    private lateinit var eksternFagsakIdRepository: EksternFagsakIdRepository
+
+    @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
     @Autowired
@@ -38,7 +41,7 @@ class FagsakRepositoryTest : IntegrationTest() {
     @Test
     fun `harLøpendeUtbetaling returnerer true for fagsak med ferdigstilt behandling med aktiv utbetaling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(PersonIdent("321"))))
-        val behandling = behandlingRepository.insert(
+        val behandling = testoppsettService.lagre(
             behandling(
                 fagsak,
                 resultat = BehandlingResultat.INNVILGET,
@@ -55,7 +58,7 @@ class FagsakRepositoryTest : IntegrationTest() {
     @Test
     fun `harLøpendeUtbetaling returnerer true for fagsak med flere aktive ytelser`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(PersonIdent("321"))))
-        val behandling = behandlingRepository.insert(
+        val behandling = testoppsettService.lagre(
             behandling(
                 fagsak,
                 resultat = BehandlingResultat.INNVILGET,
@@ -73,7 +76,7 @@ class FagsakRepositoryTest : IntegrationTest() {
     @Test
     fun `harLøpendeUtbetaling returnerer false for fagsak med ferdigstilt behandling med inaktiv utbetaling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(PersonIdent("321"))))
-        val behandling = behandlingRepository.insert(
+        val behandling = testoppsettService.lagre(
             behandling(
                 fagsak,
                 resultat = BehandlingResultat.INNVILGET,
@@ -221,12 +224,12 @@ class FagsakRepositoryTest : IntegrationTest() {
     internal fun `skal hente fagsak på behandlingId`() {
         var fagsak = opprettFagsakMedFlereIdenter()
         fagsak = testoppsettService.lagreFagsak(fagsak)
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val finnFagsakTilBehandling = fagsakRepository.finnFagsakTilBehandling(behandling.id)!!
 
         assertThat(finnFagsakTilBehandling.id).isEqualTo(fagsak.id)
-        assertThat(finnFagsakTilBehandling.eksternId).isEqualTo(fagsak.eksternId)
+        assertThat(eksternFagsakIdRepository.findByFagsakId(fagsak.id)).isEqualTo(fagsak.eksternId)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
@@ -33,7 +33,7 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
     @Test
     internal fun findByBehandlingIdAndTypeAndErFerdigstiltIsFalse() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val oppgave = oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true))
 
         assertThat(oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(UUID.randomUUID(), Oppgavetype.BehandleSak))
@@ -51,7 +51,7 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
     @Test
     internal fun findByBehandlingIdAndTypeInAndErFerdigstiltIsFalse() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = false, type = Oppgavetype.Journalføring))
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, type = Oppgavetype.BehandleSak))
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = false, type = Oppgavetype.BehandleUnderkjentVedtak))
@@ -68,7 +68,7 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal finne nyeste oppgave for behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val sporbar = Sporbar(opprettetTid = LocalDateTime.now().plusDays(1))
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 1))
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 2).copy(sporbar = sporbar))
@@ -83,8 +83,8 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal finne nyeste oppgave for riktig behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
-        val behandling2 = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling2 = testoppsettService.lagre(behandling(fagsak))
 
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 1))
         oppgaveRepository.insert(oppgave(behandling2, erFerdigstilt = true, gsakOppgaveId = 2))
@@ -97,7 +97,7 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal finne oppgaver for oppgavetype og personident`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
         oppgaveRepository.insert(
             OppgaveDomain(
                 behandlingId = behandling.id,
@@ -123,7 +123,7 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
     @Test
     internal fun `skal ikke feile hvis det ikke finnes en oppgave for behandlingen`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         assertThat(oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandling.id)).isNull()
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
@@ -217,7 +217,7 @@ internal class OppgaveServiceTest {
         return fagsak(
             id = FAGSAK_ID,
             stønadstype = Stønadstype.BARNETILSYN,
-            eksternId = EksternFagsakId(FAGSAK_EKSTERN_ID),
+            eksternId = EksternFagsakId(FAGSAK_EKSTERN_ID, FAGSAK_ID),
             identer = setOf(PersonIdent(ident = FNR)),
         )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/SøknadServiceTest.kt
@@ -28,8 +28,8 @@ class SøknadServiceTest : IntegrationTest() {
     @Test
     internal fun `skal kopiere kobling av søknad til ny behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
-        val revurdering = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val revurdering = testoppsettService.lagre(behandling(fagsak))
 
         val søknadsskjema = lagreSøknad(behandling)
         val søknadsskjemaForRevurdering = kopierSøknadTilRevurdering(behandling, revurdering)
@@ -40,8 +40,8 @@ class SøknadServiceTest : IntegrationTest() {
     @Test
     internal fun `kopiering av søknad til annen behandling skal kun beholde søknadId`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
-        val revurdering = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val revurdering = testoppsettService.lagre(behandling(fagsak))
 
         lagreSøknad(behandling)
         kopierSøknadTilRevurdering(behandling, revurdering)
@@ -57,7 +57,7 @@ class SøknadServiceTest : IntegrationTest() {
     @Test
     fun `skal kunne lagre komplett søknad for barnetilsyn`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val skjema = søknadskjemaBarnetilsyn(
             barnMedBarnepass = listOf(barnMedBarnepass(ident = "barn1", navn = "navn1")),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
@@ -43,7 +43,7 @@ internal class SimuleringControllerTest : IntegrationTest() {
     internal fun `Skal returnere 200 OK for simulering av behandling`() {
         val personIdent = "12345678901"
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(personIdent))))
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         tilkjentYtelseRepository
             .insert(
                 TilkjentYtelse(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/TilkjentYtelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/TilkjentYtelseRepositoryTest.kt
@@ -54,6 +54,6 @@ internal class TilkjentYtelseRepositoryTest : IntegrationTest() {
     private fun opprettBehandling(): Behandling {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
 
-        return behandlingRepository.insert(behandling(fagsak))
+        return testoppsettService.lagre(behandling(fagsak))
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -9,7 +9,6 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
-import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingId
 import no.nav.tilleggsstonader.sak.behandling.domain.HenlagtÅrsak
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
@@ -69,7 +68,6 @@ fun behandling(
     forrigeBehandlingId: UUID? = null,
     årsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
     henlagtÅrsak: HenlagtÅrsak? = HenlagtÅrsak.FEILREGISTRERT,
-    eksternId: EksternBehandlingId = EksternBehandlingId(),
     vedtakstidspunkt: LocalDateTime? = null,
     kravMottatt: LocalDate? = null,
 ): Behandling =
@@ -85,7 +83,6 @@ fun behandling(
         sporbar = Sporbar(opprettetTid = opprettetTid),
         årsak = årsak,
         henlagtÅrsak = henlagtÅrsak,
-        eksternId = eksternId,
         vedtakstidspunkt = vedtakstidspunkt
             ?: if (resultat != BehandlingResultat.IKKE_SATT) SporbarUtils.now() else null,
         kravMottatt = kravMottatt,
@@ -128,7 +125,7 @@ fun saksbehandling(
 ): Saksbehandling =
     Saksbehandling(
         id = behandling.id,
-        eksternId = behandling.eksternId.id,
+        eksternId = 0,
         forrigeBehandlingId = behandling.forrigeBehandlingId,
         type = behandling.type,
         status = behandling.status,
@@ -176,7 +173,7 @@ fun fagsak(
     identer: Set<PersonIdent> = defaultIdenter,
     stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
     id: UUID = UUID.randomUUID(),
-    eksternId: EksternFagsakId = EksternFagsakId(),
+    eksternId: EksternFagsakId = EksternFagsakId(fagsakId = id),
     sporbar: Sporbar = Sporbar(),
     fagsakPersonId: UUID = UUID.randomUUID(),
 ): Fagsak {
@@ -187,7 +184,7 @@ fun fagsak(
     stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
     id: UUID = UUID.randomUUID(),
     person: FagsakPerson,
-    eksternId: EksternFagsakId = EksternFagsakId(),
+    eksternId: EksternFagsakId = EksternFagsakId(fagsakId = id),
     sporbar: Sporbar = Sporbar(),
 ): Fagsak {
     return Fagsak(
@@ -204,13 +201,11 @@ fun fagsakDomain(
     id: UUID = UUID.randomUUID(),
     stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
     personId: UUID = UUID.randomUUID(),
-    eksternId: EksternFagsakId = EksternFagsakId(),
 ): FagsakDomain =
     FagsakDomain(
         id = id,
         fagsakPersonId = personId,
         stønadstype = stønadstype,
-        eksternId = eksternId,
     )
 
 fun Fagsak.tilFagsakDomain() =
@@ -218,7 +213,6 @@ fun Fagsak.tilFagsakDomain() =
         id = id,
         fagsakPersonId = fagsakPersonId,
         stønadstype = stønadstype,
-        eksternId = eksternId,
         sporbar = sporbar,
     )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårServiceIntegrasjonsTest.kt
@@ -49,8 +49,8 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
     @Test
     internal fun `kopierVilkårsettTilNyBehandling - skal kopiere vilkår til ny behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
-        val revurdering = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val revurdering = testoppsettService.lagre(behandling(fagsak))
         val søknadskjema = lagreSøknad(behandling)
         val barnPåFørsteSøknad = barnRepository.insertAll(søknadBarnTilBehandlingBarn(søknadskjema.barn, behandling.id))
         val barnPåRevurdering = barnRepository.insertAll(søknadBarnTilBehandlingBarn(søknadskjema.barn, revurdering.id))
@@ -89,7 +89,7 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
     @Test
     internal fun `oppdaterGrunnlagsdataOgHentEllerOpprettVurderinger - skal kaste feil dersom behandlingen er låst for videre behandling`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling = testoppsettService.lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
         assertThat(catchThrowable { vilkårService.oppdaterGrunnlagsdataOgHentEllerOpprettVurderinger(behandling.id) })
             .hasMessage("Kan ikke laste inn nye grunnlagsdata for behandling med status ${behandling.status}")
     }
@@ -98,7 +98,7 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
     internal fun `kopierVilkårsettTilNyBehandling - skal kaste feil hvis det ikke finnes noen vurderinger`() {
         val tidligereBehandlingId = UUID.randomUUID()
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val revurdering = behandlingRepository.insert(behandling(fagsak))
+        val revurdering = testoppsettService.lagre(behandling(fagsak))
         val metadata = HovedregelMetadata(
             emptyList(),
             mockk(),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/VilkårRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/VilkårRepositoryTest.kt
@@ -29,7 +29,7 @@ internal class VilkårRepositoryTest : IntegrationTest() {
     @Test
     internal fun findByBehandlingId() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val vurderinger = listOf(Vurdering(RegelId.HAR_ET_NAVN, SvarId.JA, "ja"))
         val vilkår = vilkårRepository.insert(
@@ -50,7 +50,7 @@ internal class VilkårRepositoryTest : IntegrationTest() {
     @Test
     internal fun `vilkårsvurdering uten opphavsvilkår`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
         val vilkår = vilkårRepository.insert(
             vilkår(
                 behandlingId = behandling.id,
@@ -65,7 +65,7 @@ internal class VilkårRepositoryTest : IntegrationTest() {
     @Test
     internal fun oppdaterEndretTid() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val vilkår = vilkårRepository.insert(
             vilkår(
@@ -87,7 +87,7 @@ internal class VilkårRepositoryTest : IntegrationTest() {
     internal fun `setter maskinellt opprettet på vilkår`() {
         val saksbehandler = "C000"
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val behandling = testoppsettService.lagre(behandling(fagsak))
 
         val vilkår: Vilkår = testWithBrukerContext(preferredUsername = saksbehandler) {
             vilkårRepository.insert(


### PR DESCRIPTION
…ikke helt virker i spring 3.2.0

### Hvorfor er denne endringen nødvendig? ✨
Pga https://github.com/spring-projects/spring-data-relational/issues/1684 så får vi ikke tatt inn spring boot 3.2.0
Det skaper fort litt problem når man ikke får tatt inn siste kontrakter/libs i sak.

Endringen er å frikoble Fagsak og EksternFagsakId, samt Behandling og EksternBehandlingId
Disse blir nå opprettede separat. Akkurat nå brukes de nog ikke til noe spesielt.

Det er mulig å revertere denne commit senere hvis vi føler vi ønsker å ta inn den

Nytt: I tester så erstattes 
`behandlingRepository.insert` -> `testoppsettService.lagre`, `TestOppsettService` oppretter `EksternBehandlingId` sånn at man får hentet ut den når man henter ut `Saksbehandling`

jdk21 branchen virker med denne endring
https://github.com/navikt/tilleggsstonader-sak/actions/runs/7220612375 
