### PR TITLE
Lagt til endepunkt for personopplysninger

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/FrittståendeBrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/FrittståendeBrevController.kt
@@ -2,11 +2,13 @@ package no.nav.tilleggsstonader.sak.brev
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.Base64
+import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/frittstaende-brev"])
@@ -16,8 +18,9 @@ class FrittståendeBrevController(
     private val tilgangService: TilgangService,
 ) {
 
-    @PostMapping
+    @PostMapping("{fagsakPersonId}")
     fun forhåndsvisFrittsåendeSanitybrev(
+        @PathVariable("fagsakPersonId") uuid: UUID,
         @RequestBody request: GenererPdfRequest,
     ): ByteArray {
         tilgangService.validerHarSaksbehandlerrolle()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/FrittståendeBrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/FrittståendeBrevController.kt
@@ -2,13 +2,11 @@ package no.nav.tilleggsstonader.sak.brev
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.Base64
-import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/frittstaende-brev"])
@@ -18,9 +16,8 @@ class FrittståendeBrevController(
     private val tilgangService: TilgangService,
 ) {
 
-    @PostMapping("{fagsakPersonId}")
+    @PostMapping
     fun forhåndsvisFrittsåendeSanitybrev(
-        @PathVariable("fagsakPersonId") uuid: UUID,
         @RequestBody request: GenererPdfRequest,
     ): ByteArray {
         tilgangService.validerHarSaksbehandlerrolle()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningController.kt
@@ -1,0 +1,32 @@
+package no.nav.tilleggsstonader.sak.opplysninger
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.opplysninger.dto.PersonopplysningerDto
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/personopplysninger"])
+@ProtectedWithClaims(issuer = "azuread")
+class PersonopplysningController(
+    private val tilgangService: TilgangService,
+    private val personopplysningerService: PersonopplysningerService,
+) {
+
+    @GetMapping("{behandlingId}")
+    fun hentPersonopplysninger(@PathVariable behandlingId: UUID): PersonopplysningerDto {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        return personopplysningerService.hentPersonopplysninger(behandlingId)
+    }
+
+    @GetMapping("fagsak-person/{fagsakPersonId}")
+    fun hentPersonopplysningerForPerson(@PathVariable fagsakPersonId: UUID): PersonopplysningerDto {
+        tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
+        return personopplysningerService.hentPersonopplysningerForFagsakPerson(fagsakPersonId)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
@@ -1,0 +1,35 @@
+package no.nav.tilleggsstonader.sak.opplysninger
+
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.opplysninger.dto.NavnDto
+import no.nav.tilleggsstonader.sak.opplysninger.dto.PersonopplysningerDto
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gjeldende
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class PersonopplysningerService(
+    private val fagsakPersonService: FagsakPersonService,
+    private val behandlingService: BehandlingService,
+    private val personService: PersonService,
+) {
+
+    // TODO denne burde hente fra grunnlag?
+    fun hentPersonopplysninger(behandlingId: UUID): PersonopplysningerDto {
+        return hentPersonopplysninger(behandlingService.hentAktivIdent(behandlingId))
+    }
+
+    fun hentPersonopplysningerForFagsakPerson(fagsakPersonId: UUID): PersonopplysningerDto {
+        return hentPersonopplysninger(fagsakPersonService.hentAktivIdent(fagsakPersonId))
+    }
+
+    private fun hentPersonopplysninger(ident: String): PersonopplysningerDto {
+        val pdlSøker = personService.hentSøker(ident)
+        return PersonopplysningerDto(
+            personIdent = ident,
+            navn = pdlSøker.navn.gjeldende().let { NavnDto.fraNavn(it) },
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
@@ -7,21 +7,6 @@ import java.time.LocalDate
 data class PersonopplysningerDto(
     val personIdent: String,
     val navn: NavnDto,
-    val kjønn: Kjønn,
-    val adressebeskyttelse: Adressebeskyttelse?,
-    val folkeregisterpersonstatus: Folkeregisterpersonstatus?,
-    val fødselsdato: LocalDate?,
-    val dødsdato: LocalDate?,
-    val statsborgerskap: List<StatsborgerskapDto>,
-    val sivilstand: List<SivilstandDto>,
-    val adresse: List<AdresseDto>,
-    val fullmakt: List<FullmaktDto>,
-    val egenAnsatt: Boolean,
-    val barn: List<BarnDto>,
-    val innflyttingTilNorge: List<InnflyttingDto>,
-    val utflyttingFraNorge: List<UtflyttingDto>,
-    val oppholdstillatelse: List<OppholdstillatelseDto>,
-    val vergemål: List<VergemålDto>,
 )
 
 data class StatsborgerskapDto(
@@ -153,7 +138,7 @@ enum class Folkeregisterpersonstatus(private val pdlStatus: String, val visnings
 
     companion object {
 
-        private val map = values().associateBy(Folkeregisterpersonstatus::pdlStatus)
+        private val map = entries.associateBy(Folkeregisterpersonstatus::pdlStatus)
         fun fraPdl(status: no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Folkeregisterpersonstatus) =
             map.getOrDefault(status.status, UKJENT)
     }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,5 +8,5 @@
 
 
     <logger name="no" level="INFO"/>
-    <logger name="no.tilleggsstonad" level="DEBUG"/>
+    <logger name="no.nav.tilleggsstonader" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er idag hardkodet navn og ident i frontend og burde hente denne data fra pdl
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17364

Når man henter personopplysinger for behandling burde man egentligen hente lagret grunnlagsdata, sånn at man viser hvordan informasjonen så ut for saksbehandler, i de tilfeller man eks viser noe tags for andre personopplysninger

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/133