### PR TITLE
Splittet ut vilkårsperiode til egen service for å unngå circular depe…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/StønadsperiodeService.kt
@@ -5,17 +5,19 @@ import no.nav.tilleggsstonader.sak.vilkår.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.tilSortertDto
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Service
 class StønadsperiodeService(
     private val stønadsperiodeRepository: StønadsperiodeRepository,
-    private val vilkårService: VilkårService,
+    private val vilkårperiodeService: VilkårperiodeService,
 ) {
     fun hentStønadsperioder(behandlingId: UUID): List<StønadsperiodeDto> {
         return stønadsperiodeRepository.findAllByBehandlingId(behandlingId).tilSortertDto()
     }
 
+    @Transactional
     fun lagreStønadsperioder(behandlingId: UUID, stønadsperioder: List<StønadsperiodeDto>): List<StønadsperiodeDto> {
         // TODO valider behandling er ikke låst
         validerStønadsperioder(behandlingId, stønadsperioder)
@@ -34,8 +36,13 @@ class StønadsperiodeService(
         ).tilSortertDto()
     }
 
-    fun validerStønadsperioder(behandlingId: UUID, stønadsperioder: List<StønadsperiodeDto>) {
-        val vilkårperioder = vilkårService.hentVilkårperioder(behandlingId)
+    fun validerStønadsperioder(behandlingId: UUID) {
+        val stønadsperioder = stønadsperiodeRepository.findAllByBehandlingId(behandlingId)
+        validerStønadsperioder(behandlingId, stønadsperioder.tilSortertDto())
+    }
+
+    private fun validerStønadsperioder(behandlingId: UUID, stønadsperioder: List<StønadsperiodeDto>) {
+        val vilkårperioder = vilkårperiodeService.hentVilkårperioder(behandlingId)
 
         StønadsperiodeValideringUtil.validerStønadsperioder(stønadsperioder, vilkårperioder)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårController.kt
@@ -28,6 +28,7 @@ import java.util.UUID
 @Validated
 class VilkårController(
     private val vilkårService: VilkårService,
+    private val vilkårperiodeService: VilkårperiodeService,
     private val vilkårStegService: VilkårStegService,
     private val tilgangService: TilgangService,
     // private val gjenbrukVilkårService: GjenbrukVilkårService,
@@ -98,7 +99,7 @@ class VilkårController(
     fun hentMålgrupper(@PathVariable behandlingId: UUID): Vilkårperioder {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 
-        return vilkårService.hentVilkårperioder(behandlingId)
+        return vilkårperiodeService.hentVilkårperioder(behandlingId)
     }
 
     @PostMapping("{behandlingId}/periode")
@@ -109,6 +110,6 @@ class VilkårController(
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
-        return vilkårService.opprettVilkårperiode(behandlingId, opprettVilkårperiode)
+        return vilkårperiodeService.opprettVilkårperiode(behandlingId, opprettVilkårperiode)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
@@ -9,34 +9,16 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
-import no.nav.tilleggsstonader.sak.vilkår.domain.AktivitetType
-import no.nav.tilleggsstonader.sak.vilkår.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårRepository
-import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
-import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeRepository
-import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeType
-import no.nav.tilleggsstonader.sak.vilkår.dto.OpprettVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårGrunnlagDto
-import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårperiodeDto
-import no.nav.tilleggsstonader.sak.vilkår.dto.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårsvurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.regler.HovedregelMetadata
 import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår
-import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår.lagNyttVilkår
 import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkår
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetReelArbeidssøkerRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetTiltakRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetUtdanningRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeAAPFerdigAvklartRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeAAPRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeDagpengerRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeOmstillingsstønadRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeOvergangsstønadRegel
-import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeUføretrygdRegel
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -79,62 +61,6 @@ class VilkårService(
         }
         return hentEllerOpprettVilkårsvurdering(behandlingId)
     }
-
-    fun hentVilkårperioder(behandlingId: UUID): Vilkårperioder {
-        val vilkår = vilkårRepository.findByBehandlingId(behandlingId)
-        val vilkårsperioder =
-            vilkårperiodeRepository.finnVilkårperioderForBehandling(behandlingId).associateBy { it.vilkårId }
-
-        return Vilkårperioder(
-            målgrupper = finnPerioder(vilkår, vilkårsperioder, VilkårType::gjelderMålgruppe),
-            aktiviteter = finnPerioder(vilkår, vilkårsperioder, VilkårType::gjelderAktivitet),
-        )
-    }
-
-    private fun finnPerioder(
-        vilkår: List<Vilkår>,
-        vilkårsperioder: Map<UUID, Vilkårperiode>,
-        gjelderFilter: (VilkårType) -> Boolean,
-    ) = vilkår.filter { gjelderFilter(it.type) }.map { vilkårsperioder.getValue(it.id).tilDto(it.tilDto()) }
-
-    @Transactional
-    fun opprettVilkårperiode(behandlingId: UUID, opprettVilkårperiode: OpprettVilkårperiode): VilkårperiodeDto {
-        feilHvis(behandlingErLåstForVidereRedigering(behandlingId)) {
-            "Kan ikke opprette vilkår når behandling er låst for videre redigering"
-        }
-
-        val vilkår = lagNyttVilkår(
-            vilkårsregel = vilkårsregelForVilkårsperiodeType(opprettVilkårperiode.type),
-            metadata = hentGrunnlagOgMetadata(behandlingId).second,
-            behandlingId = behandlingId,
-        )
-        vilkårRepository.insert(vilkår)
-
-        val vilkårperiode = vilkårperiodeRepository.insert(
-            Vilkårperiode(
-                vilkårId = vilkår.id,
-                fom = opprettVilkårperiode.fom,
-                tom = opprettVilkårperiode.tom,
-                type = opprettVilkårperiode.type,
-            ),
-        )
-
-        return vilkårperiode.tilDto(vilkår.tilDto())
-    }
-
-    private fun vilkårsregelForVilkårsperiodeType(vilkårperiodeType: VilkårperiodeType) =
-        when (vilkårperiodeType) {
-            MålgruppeType.AAP -> MålgruppeAAPRegel()
-            MålgruppeType.AAP_FERDIG_AVKLART -> MålgruppeAAPFerdigAvklartRegel()
-            MålgruppeType.DAGPENGER -> MålgruppeDagpengerRegel()
-            MålgruppeType.OMSTILLINGSSTØNAD -> MålgruppeOmstillingsstønadRegel()
-            MålgruppeType.OVERGANGSSTØNAD -> MålgruppeOvergangsstønadRegel()
-            MålgruppeType.UFØRETRYGD -> MålgruppeUføretrygdRegel()
-
-            AktivitetType.TILTAK -> AktivitetTiltakRegel()
-            AktivitetType.UTDANNING -> AktivitetUtdanningRegel()
-            AktivitetType.REEL_ARBEIDSSØKER -> AktivitetReelArbeidssøkerRegel()
-        }
 
     fun hentVilkårsett(behandlingId: UUID): List<VilkårDto> {
         val vilkårsett = vilkårRepository.findByBehandlingId(behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegService.kt
@@ -36,6 +36,7 @@ class VilkårStegService(
     // private val taskService: TaskService,
     // private val blankettRepository: BlankettRepository,
     private val behandlingshistorikkService: BehandlingshistorikkService,
+    private val stønadsperiodeService: StønadsperiodeService,
 ) {
 
     @Transactional

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårperiodeService.kt
@@ -1,0 +1,94 @@
+package no.nav.tilleggsstonader.sak.vilkår
+
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.vilkår.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeType
+import no.nav.tilleggsstonader.sak.vilkår.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.dto.Vilkårperioder
+import no.nav.tilleggsstonader.sak.vilkår.dto.tilDto
+import no.nav.tilleggsstonader.sak.vilkår.regler.HovedregelMetadata
+import no.nav.tilleggsstonader.sak.vilkår.regler.evalutation.OppdaterVilkår
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetReelArbeidssøkerRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetTiltakRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.AktivitetUtdanningRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeAAPFerdigAvklartRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeAAPRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeDagpengerRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeOmstillingsstønadRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeOvergangsstønadRegel
+import no.nav.tilleggsstonader.sak.vilkår.regler.vilkår.MålgruppeUføretrygdRegel
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class VilkårperiodeService(
+    private val behandlingService: BehandlingService,
+    private val vilkårRepository: VilkårRepository,
+    private val vilkårperiodeRepository: VilkårperiodeRepository,
+) {
+    fun hentVilkårperioder(behandlingId: UUID): Vilkårperioder {
+        val vilkår = vilkårRepository.findByBehandlingId(behandlingId)
+        val vilkårsperioder =
+            vilkårperiodeRepository.finnVilkårperioderForBehandling(behandlingId).associateBy { it.vilkårId }
+
+        return Vilkårperioder(
+            målgrupper = finnPerioder(vilkår, vilkårsperioder, VilkårType::gjelderMålgruppe),
+            aktiviteter = finnPerioder(vilkår, vilkårsperioder, VilkårType::gjelderAktivitet),
+        )
+    }
+
+    @Transactional
+    fun opprettVilkårperiode(behandlingId: UUID, opprettVilkårperiode: OpprettVilkårperiode): VilkårperiodeDto {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke opprette vilkår når behandling er låst for videre redigering"
+        }
+
+        val vilkår = OppdaterVilkår.lagNyttVilkår(
+            vilkårsregel = vilkårsregelForVilkårsperiodeType(opprettVilkårperiode.type),
+            metadata = HovedregelMetadata(emptyList(), behandling),
+            behandlingId = behandlingId,
+        )
+        vilkårRepository.insert(vilkår)
+
+        val vilkårperiode = vilkårperiodeRepository.insert(
+            Vilkårperiode(
+                vilkårId = vilkår.id,
+                fom = opprettVilkårperiode.fom,
+                tom = opprettVilkårperiode.tom,
+                type = opprettVilkårperiode.type,
+            ),
+        )
+
+        return vilkårperiode.tilDto(vilkår.tilDto())
+    }
+
+    private fun vilkårsregelForVilkårsperiodeType(vilkårperiodeType: VilkårperiodeType) =
+        when (vilkårperiodeType) {
+            MålgruppeType.AAP -> MålgruppeAAPRegel()
+            MålgruppeType.AAP_FERDIG_AVKLART -> MålgruppeAAPFerdigAvklartRegel()
+            MålgruppeType.DAGPENGER -> MålgruppeDagpengerRegel()
+            MålgruppeType.OMSTILLINGSSTØNAD -> MålgruppeOmstillingsstønadRegel()
+            MålgruppeType.OVERGANGSSTØNAD -> MålgruppeOvergangsstønadRegel()
+            MålgruppeType.UFØRETRYGD -> MålgruppeUføretrygdRegel()
+
+            AktivitetType.TILTAK -> AktivitetTiltakRegel()
+            AktivitetType.UTDANNING -> AktivitetUtdanningRegel()
+            AktivitetType.REEL_ARBEIDSSØKER -> AktivitetReelArbeidssøkerRegel()
+        }
+
+    private fun finnPerioder(
+        vilkår: List<Vilkår>,
+        vilkårsperioder: Map<UUID, Vilkårperiode>,
+        gjelderFilter: (VilkårType) -> Boolean,
+    ) = vilkår.filter { gjelderFilter(it.type) }.map { vilkårsperioder.getValue(it.id).tilDto(it.tilDto()) }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/StønadsperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/StønadsperiodeControllerTest.kt
@@ -32,7 +32,7 @@ class StønadsperiodeControllerTest : IntegrationTest() {
     lateinit var barnRepository: BarnRepository
 
     @Autowired
-    lateinit var vilkårService: VilkårService
+    lateinit var vilkårperiodeService: VilkårperiodeService
 
     @Autowired
     lateinit var vilkårStegService: VilkårStegService
@@ -91,13 +91,13 @@ class StønadsperiodeControllerTest : IntegrationTest() {
     }
 
     private fun opprettMålgruppe(behandling: Behandling): VilkårperiodeDto =
-        vilkårService.opprettVilkårperiode(
+        vilkårperiodeService.opprettVilkårperiode(
             behandling.id,
             OpprettVilkårperiode(MålgruppeType.AAP, dagensDato, dagensDato),
         )
 
     private fun opprettAktivitet(behandling: Behandling): VilkårperiodeDto =
-        vilkårService.opprettVilkårperiode(
+        vilkårperiodeService.opprettVilkårperiode(
             behandling.id,
             OpprettVilkårperiode(AktivitetType.TILTAK, dagensDato, dagensDato),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårStegServiceTest.kt
@@ -97,6 +97,7 @@ internal class VilkårStegServiceTest {
         vilkårSteg = mockk<VilkårSteg>(relaxed = true),
         // taskService = taskService,
         behandlingshistorikkService = behandlingshistorikkService,
+        stønadsperiodeService = mockk(),
     )
     private val søknad = SøknadsskjemaMapper.map(
         søknadskjemaBarnetilsyn(),


### PR DESCRIPTION
…ndency fra VilkårSteg og Stønadsperiode

### Hvorfor er denne endringen nødvendig? ✨

Når man endrer en stønadsperiode trenger vi å validere at de er gyldige i henhold til vilkårsperiodene
Når man endrer vilkår på en vilkårsperiode så trenger vi å validere at stønadsperiodene fortsatt er gyldige, for å kunne vite om man skal endre steg

Tidligere:
`VilkårService` inneholdt `Vilkårperioder`
Stønadsperiode trenger å hente vilkårsperioder ved validering av endring på stønadsperiode
VilkårService trenger å kalle på stønadsperioder for å validere steg

Nytt:
Flyttet ut Vilkårsperioder til egen service, `VilkårsperiodeService`
Då kan StønadsperiodeService kalle på `VilkårsperiodeService` for å hente vilkårsperiode
VilkårStegService kan kalle på `StønadsperiodeService`/`VilkårsperiodeService` for å validere/vurdere nytt steg

Fortsetter på validering/oppdatere steg i egen branch https://github.com/navikt/tilleggsstonader-sak/compare/vilk%C3%A5rperiode-steg-circular-dependency...vilk%C3%A5r-st%C3%B8nadsperiode-endring-oppdater-steg-p%C3%A5-behandling?expand=1
