### PR TITLE
✨ Hent dokument/vedlegg fra journalpost

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
@@ -34,8 +34,7 @@ class JournalpostClient(
     private val dokarkivUri =
         UriComponentsBuilder.fromUri(integrasjonerBaseUrl).pathSegment("api/arkiv").build().toUri()
 
-    private val dokdistUri =
-        UriComponentsBuilder.fromUri(integrasjonerBaseUrl).pathSegment("api/dist").build().toUri()
+    private val dokdistUri = UriComponentsBuilder.fromUri(integrasjonerBaseUrl).pathSegment("api/dist").build().toUri()
 
     fun finnJournalposterForBruker(journalposterForBrukerRequest: JournalposterForBrukerRequest): List<Journalpost> {
         val uri = URI.create("$journalpostUri").toString()
@@ -44,13 +43,16 @@ class JournalpostClient(
     }
 
     fun hentJournalpost(journalpostId: String): Journalpost {
-        val uri =
-            UriComponentsBuilder.fromUri(journalpostUri).queryParam("journalpostId", "{journalpostId}").encode().toUriString()
+        val uri = UriComponentsBuilder.fromUri(journalpostUri).queryParam("journalpostId", "{journalpostId}").encode()
+            .toUriString()
 
         return getForEntity<Journalpost>(uri, uriVariables = journalpostIdUriVariables(journalpostId))
     }
 
-    fun opprettJournalpost(arkiverDokumentRequest: ArkiverDokumentRequest, saksbehandler: String?): ArkiverDokumentResponse {
+    fun opprettJournalpost(
+        arkiverDokumentRequest: ArkiverDokumentRequest,
+        saksbehandler: String?,
+    ): ArkiverDokumentResponse {
         return postForEntity(dokarkivUri.toString(), arkiverDokumentRequest, headerMedSaksbehandler(saksbehandler))
     }
 
@@ -68,7 +70,11 @@ class JournalpostClient(
         )
     }
 
-    fun ferdigstillJournalpost(journalpostId: String, journalførendeEnhet: String, saksbehandler: String?): OppdaterJournalpostResponse {
+    fun ferdigstillJournalpost(
+        journalpostId: String,
+        journalførendeEnhet: String,
+        saksbehandler: String?,
+    ): OppdaterJournalpostResponse {
         val uri = UriComponentsBuilder.fromUri(dokarkivUri).pathSegment("{journalpostId}", "ferdigstill")
             .queryParam("journalfoerendeEnhet", "{journalfoerendeEnhet}").encode().toUriString()
 
@@ -102,15 +108,13 @@ class JournalpostClient(
     }
 
     private fun jsonDokumentUri(journalpostId: String, dokumentInfoId: String): URI {
-        return UriComponentsBuilder
-            .fromUri(journalpostUri)
-            .pathSegment("hentdokument", journalpostId, dokumentInfoId)
-            .queryParam("variantFormat", Dokumentvariantformat.ORIGINAL)
-            .build()
-            .toUri()
+        return UriComponentsBuilder.fromUri(journalpostUri).pathSegment("hentdokument", journalpostId, dokumentInfoId)
+            .queryParam("variantFormat", Dokumentvariantformat.ORIGINAL).build().toUri()
     }
 
-    private fun journalpostIdUriVariables(journalpostId: String): Map<String, String> = mapOf("journalpostId" to journalpostId)
+    private fun journalpostIdUriVariables(journalpostId: String): Map<String, String> =
+        mapOf("journalpostId" to journalpostId)
+
     private fun journalførendeEnhetUriVariables(journalførendeEnhet: String): Map<String, String> =
         mapOf("journalfoerendeEnhet" to journalførendeEnhet)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
@@ -99,6 +99,19 @@ class JournalpostClient(
         )
     }
 
+    fun hentDokument(
+        journalpostId: String,
+        dokumentInfoId: String,
+        dokumentVariantformat: Dokumentvariantformat,
+    ): ByteArray {
+        // TODO: kastApiFeilDersomUtviklerMedVeilederrolle() for å ikke gi tilgang til dokumenter med feil tema i prod
+        val uri = UriComponentsBuilder.fromUri(journalpostUri)
+            .pathSegment("hentdokument", "{journalpostId}", "{dokumentInfoId}")
+            .queryParam("variantFormat", dokumentVariantformat).encode().toUriString()
+
+        return getForEntity<ByteArray>(uri, uriVariables = mapOf("journalpostId" to journalpostId))
+    }
+
     private fun headerMedSaksbehandler(saksbehandler: String?): HttpHeaders {
         val httpHeaders = HttpHeaders()
         if (saksbehandler != null) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
@@ -109,7 +109,7 @@ class JournalpostClient(
             .pathSegment("hentdokument", "{journalpostId}", "{dokumentInfoId}")
             .queryParam("variantFormat", dokumentVariantformat).encode().toUriString()
 
-        return getForEntity<ByteArray>(uri, uriVariables = mapOf("journalpostId" to journalpostId))
+        return getForEntity<ByteArray>(uri, uriVariables = mapOf("journalpostId" to journalpostId, "dokumentInfoId" to dokumentInfoId))
     }
 
     private fun headerMedSaksbehandler(saksbehandler: String?): HttpHeaders {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostController.kt
@@ -1,12 +1,6 @@
 package no.nav.tilleggsstonader.sak.journalføring
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
-import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
-import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.http.MediaType
@@ -22,43 +16,14 @@ import org.springframework.web.bind.annotation.RestController
 @Validated
 class JournalpostController(
     private val journalpostService: JournalpostService,
-    private val personService: PersonService,
     private val tilgangService: TilgangService,
 ) {
     @GetMapping("/{journalpostId}/dokument-pdf/{dokumentInfoId}", produces = [MediaType.APPLICATION_PDF_VALUE])
     fun hentDokumentSomPdf(@PathVariable journalpostId: String, @PathVariable dokumentInfoId: String): ByteArray {
-        val (journalpost, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
+        val (journalpost, personIdent) = journalpostService.finnJournalpostOgPersonIdent(journalpostId)
+
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.ACCESS)
-        validerDokumentKanHentes(journalpost, dokumentInfoId, journalpostId)
-        return journalpostService.hentDokument(journalpostId, dokumentInfoId)
-    }
 
-    private fun validerDokumentKanHentes(
-        journalpost: Journalpost,
-        dokumentInfoId: String,
-        journalpostId: String,
-    ) {
-        val dokument = journalpost.dokumenter?.find { it.dokumentInfoId == dokumentInfoId }
-        feilHvis(dokument == null) {
-            "Finner ikke dokument med $dokumentInfoId for journalpost=$journalpostId"
-        }
-        brukerfeilHvisIkke(
-            dokument.dokumentvarianter?.any { it.variantformat == Dokumentvariantformat.ARKIV }
-                ?: false,
-        ) {
-            "Vedlegget er sannsynligvis under arbeid, må åpnes i gosys"
-        }
-    }
-
-    private fun finnJournalpostOgPersonIdent(journalpostId: String): Pair<Journalpost, String> {
-        val journalpost = journalpostService.hentJournalpost(journalpostId)
-        val personIdent = journalpost.bruker?.let {
-            when (it.type) {
-                BrukerIdType.FNR -> it.id
-                BrukerIdType.AKTOERID -> personService.hentPersonIdenter(it.id).gjeldende().ident
-                BrukerIdType.ORGNR -> error("Kan ikke hente journalpost=$journalpostId for orgnr")
-            }
-        } ?: error("Kan ikke hente journalpost=$journalpostId uten bruker")
-        return Pair(journalpost, personIdent)
+        return journalpostService.hentDokument(journalpost, dokumentInfoId)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostController.kt
@@ -1,0 +1,64 @@
+package no.nav.tilleggsstonader.sak.journalføring
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.http.MediaType
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/journalpost")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class JournalpostController(
+    private val journalpostService: JournalpostService,
+    private val personService: PersonService,
+    private val tilgangService: TilgangService,
+) {
+    @GetMapping("/{journalpostId}/dokument-pdf/{dokumentInfoId}", produces = [MediaType.APPLICATION_PDF_VALUE])
+    fun hentDokumentSomPdf(@PathVariable journalpostId: String, @PathVariable dokumentInfoId: String): ByteArray {
+        val (journalpost, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
+        tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.ACCESS)
+        validerDokumentKanHentes(journalpost, dokumentInfoId, journalpostId)
+        return journalpostService.hentDokument(journalpostId, dokumentInfoId)
+    }
+
+    private fun validerDokumentKanHentes(
+        journalpost: Journalpost,
+        dokumentInfoId: String,
+        journalpostId: String,
+    ) {
+        val dokument = journalpost.dokumenter?.find { it.dokumentInfoId == dokumentInfoId }
+        feilHvis(dokument == null) {
+            "Finner ikke dokument med $dokumentInfoId for journalpost=$journalpostId"
+        }
+        brukerfeilHvisIkke(
+            dokument.dokumentvarianter?.any { it.variantformat == Dokumentvariantformat.ARKIV }
+                ?: false,
+        ) {
+            "Vedlegget er sannsynligvis under arbeid, må åpnes i gosys"
+        }
+    }
+
+    private fun finnJournalpostOgPersonIdent(journalpostId: String): Pair<Journalpost, String> {
+        val journalpost = journalpostService.hentJournalpost(journalpostId)
+        val personIdent = journalpost.bruker?.let {
+            when (it.type) {
+                BrukerIdType.FNR -> it.id
+                BrukerIdType.AKTOERID -> personService.hentPersonIdenter(it.id).gjeldende().ident
+                BrukerIdType.ORGNR -> error("Kan ikke hente journalpost=$journalpostId for orgnr")
+            }
+        } ?: error("Kan ikke hente journalpost=$journalpostId uten bruker")
+        return Pair(journalpost, personIdent)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
@@ -12,11 +12,14 @@ import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
 import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.vedlegg.VedleggRequest
 import org.springframework.stereotype.Service
 
 @Service
-class JournalpostService(private val journalpostClient: JournalpostClient) {
+class JournalpostService(private val journalpostClient: JournalpostClient, private val personService: PersonService) {
     fun finnJournalposterForBruker(personIdent: String, vedleggRequest: VedleggRequest): List<Journalpost> {
         return journalpostClient.finnJournalposterForBruker(
             JournalposterForBrukerRequest(
@@ -33,7 +36,10 @@ class JournalpostService(private val journalpostClient: JournalpostClient) {
         return journalpostClient.hentJournalpost(journalpostId)
     }
 
-    fun opprettJournalpost(arkiverDokumentRequest: ArkiverDokumentRequest, saksbehandler: String? = null): ArkiverDokumentResponse {
+    fun opprettJournalpost(
+        arkiverDokumentRequest: ArkiverDokumentRequest,
+        saksbehandler: String? = null,
+    ): ArkiverDokumentResponse {
         return journalpostClient.opprettJournalpost(arkiverDokumentRequest, saksbehandler)
     }
 
@@ -71,7 +77,11 @@ class JournalpostService(private val journalpostClient: JournalpostClient) {
         }
     }
 
-    private fun ferdigstillJournalføring(journalpostId: String, journalførendeEnhet: String, saksbehandler: String? = null) {
+    private fun ferdigstillJournalføring(
+        journalpostId: String,
+        journalførendeEnhet: String,
+        saksbehandler: String? = null,
+    ) {
         journalpostClient.ferdigstillJournalpost(journalpostId, journalførendeEnhet, saksbehandler)
     }
 
@@ -81,7 +91,8 @@ class JournalpostService(private val journalpostClient: JournalpostClient) {
         eksternFagsakId: Long,
         saksbehandler: String? = null,
     ) {
-        val oppdatertJournalpost = JournalføringHelper.lagOppdaterJournalpostRequest(journalpost, eksternFagsakId, dokumenttitler)
+        val oppdatertJournalpost =
+            JournalføringHelper.lagOppdaterJournalpostRequest(journalpost, eksternFagsakId, dokumenttitler)
         journalpostClient.oppdaterJournalpost(oppdatertJournalpost, journalpost.journalpostId, saksbehandler)
     }
 
@@ -90,11 +101,40 @@ class JournalpostService(private val journalpostClient: JournalpostClient) {
         return journalpostClient.hentSøknadTilsynBarn(søknadJournalpost.journalpostId, dokumentinfo.dokumentInfoId)
     }
 
+    fun finnJournalpostOgPersonIdent(journalpostId: String): Pair<Journalpost, String> {
+        val journalpost = hentJournalpost(journalpostId)
+        val personIdent = journalpost.bruker?.let {
+            when (it.type) {
+                BrukerIdType.FNR -> it.id
+                BrukerIdType.AKTOERID -> personService.hentPersonIdenter(it.id).gjeldende().ident
+                BrukerIdType.ORGNR -> error("Kan ikke hente journalpost=$journalpostId for orgnr")
+            }
+        } ?: error("Kan ikke hente journalpost=$journalpostId uten bruker")
+        return Pair(journalpost, personIdent)
+    }
+
     fun hentDokument(
-        journalpostId: String,
+        journalpost: Journalpost,
         dokumentInfoId: String,
         dokumentVariantformat: Dokumentvariantformat = Dokumentvariantformat.ARKIV,
     ): ByteArray {
-        return journalpostClient.hentDokument(journalpostId, dokumentInfoId, dokumentVariantformat)
+        validerDokumentKanHentes(journalpost, dokumentInfoId)
+        return journalpostClient.hentDokument(journalpost.journalpostId, dokumentInfoId, dokumentVariantformat)
+    }
+
+    private fun validerDokumentKanHentes(
+        journalpost: Journalpost,
+        dokumentInfoId: String,
+    ) {
+        val dokument = journalpost.dokumenter?.find { it.dokumentInfoId == dokumentInfoId }
+        feilHvis(dokument == null) {
+            "Finner ikke dokument med id=$dokumentInfoId for journalpost med id=${journalpost.journalpostId}"
+        }
+        brukerfeilHvisIkke(
+            dokument.dokumentvarianter?.any { it.variantformat == Dokumentvariantformat.ARKIV }
+                ?: false,
+        ) {
+            "Vedlegget er sannsynligvis under arbeid, må åpnes i gosys"
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
 import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
 import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.JournalposterForBrukerRequest
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
@@ -87,5 +88,13 @@ class JournalpostService(private val journalpostClient: JournalpostClient) {
     fun hentSøknadFraJournalpost(søknadJournalpost: Journalpost): Søknadsskjema<SøknadsskjemaBarnetilsyn> {
         val dokumentinfo = JournalføringHelper.plukkUtOriginaldokument(søknadJournalpost, DokumentBrevkode.BARNETILSYN)
         return journalpostClient.hentSøknadTilsynBarn(søknadJournalpost.journalpostId, dokumentinfo.dokumentInfoId)
+    }
+
+    fun hentDokument(
+        journalpostId: String,
+        dokumentInfoId: String,
+        dokumentVariantformat: Dokumentvariantformat = Dokumentvariantformat.ARKIV,
+    ): ByteArray {
+        return journalpostClient.hentDokument(journalpostId, dokumentInfoId, dokumentVariantformat)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
@@ -77,7 +77,7 @@ class JournalpostServiceTest() {
         )
 
         @Test
-        fun `skal ikke hente dokument om dokument med riktig id ikke er i journalpost`() {
+        fun `skal ikke hente dokument om ikke dokument med samme id finnes i journalpost`() {
             assertThatThrownBy {
                 journalpostService.hentDokument(
                     journalpost,
@@ -87,7 +87,7 @@ class JournalpostServiceTest() {
         }
 
         @Test
-        fun `skal ikke hente dokument om ikke har dokumentvariant av type ARKIV`() {
+        fun `skal ikke hente dokument om det ikke har en dokumentvariant på format ARKIV`() {
             assertThatThrownBy {
                 journalpostService.hentDokument(
                     journalpost,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
@@ -1,0 +1,99 @@
+package no.nav.tilleggsstonader.sak.journalføring
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
+import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.util.dokumentInfo
+import no.nav.tilleggsstonader.sak.util.dokumentvariant
+import no.nav.tilleggsstonader.sak.util.journalpost
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class JournalpostServiceTest() {
+    private val journalpostClient = mockk<JournalpostClient>()
+    private val personService = mockk<PersonService>()
+    private val journalpostService = JournalpostService(journalpostClient, personService)
+
+    @Nested
+    inner class FinnJournalpostOgPersonIdent {
+        val journalpostId = "123"
+
+        @Test
+        fun `skal kaste feil om journalpost ikke har bruker`() {
+            val journalpost = journalpost(journalpostId = journalpostId, bruker = null)
+            every { journalpostClient.hentJournalpost(any()) } returns journalpost
+
+            assertThatThrownBy {
+                journalpostService.finnJournalpostOgPersonIdent(journalpostId)
+            }.hasMessageContaining("Kan ikke hente journalpost=$journalpostId uten bruker")
+        }
+
+        @Test
+        fun `skal kaste feil om journalpost har org som bruker`() {
+            val bruker = Bruker(id = UUID.randomUUID().toString(), type = BrukerIdType.ORGNR)
+
+            val journalpost = journalpost(bruker = bruker)
+            every { journalpostClient.hentJournalpost(any()) } returns journalpost
+
+            assertThatThrownBy {
+                journalpostService.finnJournalpostOgPersonIdent(journalpostId)
+            }.hasMessageContaining("Kan ikke hente journalpost=$journalpostId for orgnr")
+        }
+
+        @Test
+        fun `skal hente journalpost og personIdent ved BrukerIdType = FNR`() {
+            val fnr = FnrGenerator.generer()
+            val bruker = Bruker(id = fnr, type = BrukerIdType.FNR)
+
+            val journalpost = journalpost(bruker = bruker)
+            every { journalpostClient.hentJournalpost(any()) } returns journalpost
+
+            val (mottatJournalpost, personIdent) = journalpostService.finnJournalpostOgPersonIdent(journalpostId)
+
+            assertThat(mottatJournalpost).isEqualTo(journalpost)
+            assertThat(personIdent).isEqualTo(fnr)
+        }
+    }
+
+    @Nested
+    inner class HentDokument {
+        private val bruker = Bruker(id = FnrGenerator.generer(), type = BrukerIdType.FNR)
+        private val dokumentInfoId = "dokumentInfoId"
+        private val journalpost = journalpost(
+            bruker = bruker,
+            dokumenter = listOf(
+                dokumentInfo(
+                    dokumentInfoId = dokumentInfoId,
+                    dokumentvarianter = listOf(dokumentvariant(Dokumentvariantformat.FULLVERSJON))
+                )
+            )
+        )
+
+        @Test
+        fun `skal ikke hente dokument om dokument med riktig id ikke er i journalpost`() {
+            assertThatThrownBy {
+                journalpostService.hentDokument(
+                    journalpost,
+                    "feilId"
+                )
+            }.hasMessageContaining("Finner ikke dokument med id")
+        }
+
+        @Test
+        fun `skal ikke hente dokument om ikke har dokumentvariant av type ARKIV`() {
+            assertThatThrownBy {
+                journalpostService.hentDokument(
+                    journalpost,
+                    dokumentInfoId
+                )
+            }.hasMessageContaining("Vedlegget er sannsynligvis under arbeid, må åpnes i gosys")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
@@ -71,9 +71,9 @@ class JournalpostServiceTest() {
             dokumenter = listOf(
                 dokumentInfo(
                     dokumentInfoId = dokumentInfoId,
-                    dokumentvarianter = listOf(dokumentvariant(Dokumentvariantformat.FULLVERSJON))
-                )
-            )
+                    dokumentvarianter = listOf(dokumentvariant(Dokumentvariantformat.FULLVERSJON)),
+                ),
+            ),
         )
 
         @Test
@@ -81,7 +81,7 @@ class JournalpostServiceTest() {
             assertThatThrownBy {
                 journalpostService.hentDokument(
                     journalpost,
-                    "feilId"
+                    "feilId",
                 )
             }.hasMessageContaining("Finner ikke dokument med id")
         }
@@ -91,7 +91,7 @@ class JournalpostServiceTest() {
             assertThatThrownBy {
                 journalpostService.hentDokument(
                     journalpost,
-                    dokumentInfoId
+                    dokumentInfoId,
                 )
             }.hasMessageContaining("Vedlegget er sannsynligvis under arbeid, må åpnes i gosys")
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -4,13 +4,11 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.Tema
 import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
 import no.nav.tilleggsstonader.kontrakter.journalpost.DokumentInfo
-import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentstatus
 import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariant
 import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
-import no.nav.tilleggsstonader.kontrakter.journalpost.LogiskVedlegg
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
@@ -327,19 +325,18 @@ fun dokumentInfo(
     dokumentvarianter: List<Dokumentvariant>? = null,
 ) = DokumentInfo(
     dokumentInfoId = dokumentInfoId,
-    dokumentvarianter = dokumentvarianter
+    dokumentvarianter = dokumentvarianter,
 )
-
 
 fun dokumentvariant(
     variantformat: Dokumentvariantformat = Dokumentvariantformat.FULLVERSJON,
     saksbehandlerHarTilgang: Boolean = true,
-    filnavn: String? = "filnavn"
+    filnavn: String? = "filnavn",
 ) =
     Dokumentvariant(
         variantformat = variantformat,
         saksbehandlerHarTilgang = saksbehandlerHarTilgang,
-        filnavn = filnavn
+        filnavn = filnavn,
     )
 /*
 fun vedtak(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -1,6 +1,16 @@
 package no.nav.tilleggsstonader.sak.util
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.DokumentInfo
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentstatus
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariant
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.kontrakter.journalpost.LogiskVedlegg
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
@@ -48,13 +58,12 @@ fun oppgave(
     erFerdigstilt: Boolean = false,
     gsakOppgaveId: Long = 123,
     type: Oppgavetype = Oppgavetype.Journalføring,
-): OppgaveDomain =
-    OppgaveDomain(
-        behandlingId = behandlingId,
-        gsakOppgaveId = gsakOppgaveId,
-        type = type,
-        erFerdigstilt = erFerdigstilt,
-    )
+): OppgaveDomain = OppgaveDomain(
+    behandlingId = behandlingId,
+    gsakOppgaveId = gsakOppgaveId,
+    type = type,
+    erFerdigstilt = erFerdigstilt,
+)
 
 fun behandling(
     fagsak: Fagsak = fagsak(),
@@ -70,23 +79,21 @@ fun behandling(
     henlagtÅrsak: HenlagtÅrsak? = HenlagtÅrsak.FEILREGISTRERT,
     vedtakstidspunkt: LocalDateTime? = null,
     kravMottatt: LocalDate? = null,
-): Behandling =
-    Behandling(
-        fagsakId = fagsak.id,
-        forrigeBehandlingId = forrigeBehandlingId,
-        id = id,
-        type = type,
-        status = status,
-        steg = steg,
-        kategori = kategori,
-        resultat = resultat,
-        sporbar = Sporbar(opprettetTid = opprettetTid),
-        årsak = årsak,
-        henlagtÅrsak = henlagtÅrsak,
-        vedtakstidspunkt = vedtakstidspunkt
-            ?: if (resultat != BehandlingResultat.IKKE_SATT) SporbarUtils.now() else null,
-        kravMottatt = kravMottatt,
-    )
+): Behandling = Behandling(
+    fagsakId = fagsak.id,
+    forrigeBehandlingId = forrigeBehandlingId,
+    id = id,
+    type = type,
+    status = status,
+    steg = steg,
+    kategori = kategori,
+    resultat = resultat,
+    sporbar = Sporbar(opprettetTid = opprettetTid),
+    årsak = årsak,
+    henlagtÅrsak = henlagtÅrsak,
+    vedtakstidspunkt = vedtakstidspunkt ?: if (resultat != BehandlingResultat.IKKE_SATT) SporbarUtils.now() else null,
+    kravMottatt = kravMottatt,
+)
 
 fun saksbehandling(
     fagsak: Fagsak = fagsak(),
@@ -100,57 +107,54 @@ fun saksbehandling(
     årsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
     henlagtÅrsak: HenlagtÅrsak? = HenlagtÅrsak.FEILREGISTRERT,
     kravMottatt: LocalDate? = null,
-): Saksbehandling =
-    saksbehandling(
-        fagsak,
-        Behandling(
-            fagsakId = fagsak.id,
-            forrigeBehandlingId = forrigeBehandlingId,
-            id = id,
-            type = type,
-            status = status,
-            steg = steg,
-            resultat = resultat,
-            sporbar = Sporbar(opprettetTid = opprettetTid),
-            årsak = årsak,
-            henlagtÅrsak = henlagtÅrsak,
-            kravMottatt = kravMottatt,
-            kategori = BehandlingKategori.NASJONAL,
-        ),
-    )
+): Saksbehandling = saksbehandling(
+    fagsak,
+    Behandling(
+        fagsakId = fagsak.id,
+        forrigeBehandlingId = forrigeBehandlingId,
+        id = id,
+        type = type,
+        status = status,
+        steg = steg,
+        resultat = resultat,
+        sporbar = Sporbar(opprettetTid = opprettetTid),
+        årsak = årsak,
+        henlagtÅrsak = henlagtÅrsak,
+        kravMottatt = kravMottatt,
+        kategori = BehandlingKategori.NASJONAL,
+    ),
+)
 
 fun saksbehandling(
     fagsak: Fagsak = fagsak(),
     behandling: Behandling = behandling(),
-): Saksbehandling =
-    Saksbehandling(
-        id = behandling.id,
-        eksternId = 0,
-        forrigeBehandlingId = behandling.forrigeBehandlingId,
-        type = behandling.type,
-        status = behandling.status,
-        steg = behandling.steg,
-        kategori = behandling.kategori,
-        årsak = behandling.årsak,
-        resultat = behandling.resultat,
-        vedtakstidspunkt = behandling.vedtakstidspunkt,
-        henlagtÅrsak = behandling.henlagtÅrsak,
-        ident = fagsak.hentAktivIdent(),
-        fagsakId = fagsak.id,
-        eksternFagsakId = fagsak.eksternId.id,
-        stønadstype = fagsak.stønadstype,
-        opprettetAv = behandling.sporbar.opprettetAv,
-        opprettetTid = behandling.sporbar.opprettetTid,
-        endretTid = behandling.sporbar.endret.endretTid,
-        kravMottatt = behandling.kravMottatt,
-    )
+): Saksbehandling = Saksbehandling(
+    id = behandling.id,
+    eksternId = 0,
+    forrigeBehandlingId = behandling.forrigeBehandlingId,
+    type = behandling.type,
+    status = behandling.status,
+    steg = behandling.steg,
+    kategori = behandling.kategori,
+    årsak = behandling.årsak,
+    resultat = behandling.resultat,
+    vedtakstidspunkt = behandling.vedtakstidspunkt,
+    henlagtÅrsak = behandling.henlagtÅrsak,
+    ident = fagsak.hentAktivIdent(),
+    fagsakId = fagsak.id,
+    eksternFagsakId = fagsak.eksternId.id,
+    stønadstype = fagsak.stønadstype,
+    opprettetAv = behandling.sporbar.opprettetAv,
+    opprettetTid = behandling.sporbar.opprettetTid,
+    endretTid = behandling.sporbar.endret.endretTid,
+    kravMottatt = behandling.kravMottatt,
+)
 
-fun Behandling.innvilgetOgFerdigstilt() =
-    this.copy(
-        resultat = BehandlingResultat.INNVILGET,
-        status = BehandlingStatus.FERDIGSTILT,
-        vedtakstidspunkt = SporbarUtils.now(),
-    )
+fun Behandling.innvilgetOgFerdigstilt() = this.copy(
+    resultat = BehandlingResultat.INNVILGET,
+    status = BehandlingStatus.FERDIGSTILT,
+    vedtakstidspunkt = SporbarUtils.now(),
+)
 
 fun behandlingBarn(
     id: UUID = UUID.randomUUID(),
@@ -201,20 +205,18 @@ fun fagsakDomain(
     id: UUID = UUID.randomUUID(),
     stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
     personId: UUID = UUID.randomUUID(),
-): FagsakDomain =
-    FagsakDomain(
-        id = id,
-        fagsakPersonId = personId,
-        stønadstype = stønadstype,
-    )
+): FagsakDomain = FagsakDomain(
+    id = id,
+    fagsakPersonId = personId,
+    stønadstype = stønadstype,
+)
 
-fun Fagsak.tilFagsakDomain() =
-    FagsakDomain(
-        id = id,
-        fagsakPersonId = fagsakPersonId,
-        stønadstype = stønadstype,
-        sporbar = sporbar,
-    )
+fun Fagsak.tilFagsakDomain() = FagsakDomain(
+    id = id,
+    fagsakPersonId = fagsakPersonId,
+    stønadstype = stønadstype,
+    sporbar = sporbar,
+)
 
 fun vilkår(
     behandlingId: UUID,
@@ -223,15 +225,14 @@ fun vilkår(
     delvilkår: List<Delvilkår> = emptyList(),
     barnId: UUID? = null,
     opphavsvilkår: Opphavsvilkår? = null,
-): Vilkår =
-    Vilkår(
-        behandlingId = behandlingId,
-        resultat = resultat,
-        type = type,
-        barnId = barnId,
-        delvilkårwrapper = DelvilkårWrapper(delvilkår),
-        opphavsvilkår = opphavsvilkår,
-    )
+): Vilkår = Vilkår(
+    behandlingId = behandlingId,
+    resultat = resultat,
+    type = type,
+    barnId = barnId,
+    delvilkårwrapper = DelvilkårWrapper(delvilkår),
+    opphavsvilkår = opphavsvilkår,
+)
 
 fun fagsakpersoner(vararg identer: String): Set<PersonIdent> = identer.map {
     PersonIdent(ident = it)
@@ -305,6 +306,41 @@ fun vedtaksbrev(
     beslutterIdent = beslutterIdent,
 )
 
+fun journalpost(
+    journalpostId: String = UUID.randomUUID().toString(),
+    journalposttype: Journalposttype = Journalposttype.U,
+    journalstatus: Journalstatus = Journalstatus.FERDIGSTILT,
+    tema: String = Tema.TSO.toString(),
+    dokumenter: List<DokumentInfo>? = null,
+    bruker: Bruker? = null,
+) = Journalpost(
+    journalpostId = journalpostId,
+    journalposttype = journalposttype,
+    journalstatus = journalstatus,
+    tema = tema,
+    dokumenter = dokumenter,
+    bruker = bruker,
+)
+
+fun dokumentInfo(
+    dokumentInfoId: String = UUID.randomUUID().toString(),
+    dokumentvarianter: List<Dokumentvariant>? = null,
+) = DokumentInfo(
+    dokumentInfoId = dokumentInfoId,
+    dokumentvarianter = dokumentvarianter
+)
+
+
+fun dokumentvariant(
+    variantformat: Dokumentvariantformat = Dokumentvariantformat.FULLVERSJON,
+    saksbehandlerHarTilgang: Boolean = true,
+    filnavn: String? = "filnavn"
+) =
+    Dokumentvariant(
+        variantformat = variantformat,
+        saksbehandlerHarTilgang = saksbehandlerHarTilgang,
+        filnavn = filnavn
+    )
 /*
 fun vedtak(
     behandlingId: UUID,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -329,7 +329,7 @@ fun dokumentInfo(
 )
 
 fun dokumentvariant(
-    variantformat: Dokumentvariantformat = Dokumentvariantformat.FULLVERSJON,
+    variantformat: Dokumentvariantformat = Dokumentvariantformat.ARKIV,
     saksbehandlerHarTilgang: Boolean = true,
     filnavn: String? = "filnavn",
 ) =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal være mulig å åpne et dokument/vedlegg/pdf, har derfor lagt til et endepunkt som returnerer selve filen ved kall. 

Endepunktet kalles direkte ved at SB trykker på lenke lagt inn i [PR 155](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/155) i frontend.
