### PR TITLE
Vilkårperiode v2 del 5 - Slettemarkere rad

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårController.kt
@@ -4,8 +4,10 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.dto.OppdaterVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.dto.SlettVikårperiode
 import no.nav.tilleggsstonader.sak.vilkår.dto.SvarPåVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårperiodeDto
@@ -14,6 +16,7 @@ import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårsvurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.regler.Vilkårsregler
 import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -110,5 +113,17 @@ class VilkårController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         return vilkårService.opprettVilkårperiode(behandlingId, opprettVilkårperiode)
+    }
+
+    @DeleteMapping("{behandlingId}/periode/{id}")
+    fun slettPeriode(
+        @PathVariable("behandlingId") behandlingId: UUID,
+        @PathVariable("id") id: UUID,
+        @RequestBody slettVikårperiode: SlettVikårperiode,
+    ): Vilkårperiode {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return vilkårService.slettVilkårperiode(behandlingId, id, slettVikårperiode)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
@@ -2,10 +2,12 @@ package no.nav.tilleggsstonader.sak.vilkår
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.validerBehandlingIdErLik
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
@@ -13,12 +15,14 @@ import no.nav.tilleggsstonader.sak.vilkår.EvalueringVilkårperiode.evaulerVilk�
 import no.nav.tilleggsstonader.sak.vilkår.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.domain.KildeVilkårsperiode
 import no.nav.tilleggsstonader.sak.vilkår.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårRepository
 import no.nav.tilleggsstonader.sak.vilkår.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeType
 import no.nav.tilleggsstonader.sak.vilkår.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.dto.SlettVikårperiode
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårperiodeDto
@@ -89,7 +93,7 @@ class VilkårService(
         )
     }
 
-    private inline fun <reified T : VilkårperiodeType>finnPerioder(
+    private inline fun <reified T : VilkårperiodeType> finnPerioder(
         vilkårsperioder: List<Vilkårperiode>,
     ) = vilkårsperioder.filter { it.type is T }.map(Vilkårperiode::tilDto)
 
@@ -113,6 +117,25 @@ class VilkårService(
         )
 
         return vilkårperiode.tilDto()
+    }
+
+    fun slettVilkårperiode(behandlingId: UUID, id: UUID, slettVikårperiode: SlettVikårperiode): Vilkårperiode {
+        val vilkårperiode = vilkårperiodeRepository.findByIdOrThrow(id)
+
+        validerBehandlingIdErLik(behandlingId, vilkårperiode.behandlingId)
+
+        feilHvis(behandlingErLåstForVidereRedigering(vilkårperiode.behandlingId)) {
+            "Kan ikke slette vilkårperiode når behandling er låst for videre redigering"
+        }
+
+        // TODO skal kun slettemarkere hvis den ble opprettet i denne behandlingen
+
+        return vilkårperiodeRepository.update(
+            vilkårperiode.copy(
+                resultat = ResultatVilkårperiode.SLETTET,
+                slettetKommentar = slettVikårperiode.kommentar,
+            ),
+        )
     }
 
     private fun vilkårsregelForVilkårsperiodeType(vilkårperiodeType: VilkårperiodeType) =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårService.kt
@@ -128,8 +128,6 @@ class VilkårService(
             "Kan ikke slette vilkårperiode når behandling er låst for videre redigering"
         }
 
-        // TODO skal kun slettemarkere hvis den ble opprettet i denne behandlingen
-
         return vilkårperiodeRepository.update(
             vilkårperiode.copy(
                 resultat = ResultatVilkårperiode.SLETTET,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkårperiode.kt
@@ -36,19 +36,21 @@ data class Vilkårperiode(
             "Ugyldig kombinasjon type=${type.javaClass.simpleName} detaljer=${detaljer.javaClass.simpleName}"
         }
 
-        validerSlettet()
+        validerSlettefelter()
     }
 
-    private fun validerSlettet() {
-        feilHvis(kilde != KildeVilkårsperiode.MANUELL && resultat == ResultatVilkårperiode.SLETTET) {
-            "Kan ikke slette når kilde=$kilde"
-        }
-        feilHvis(resultat == ResultatVilkårperiode.SLETTET && slettetKommentar.isNullOrBlank()) {
-            "Mangler kommentar for resultat=$resultat"
-        }
-
-        feilHvis(resultat != ResultatVilkårperiode.SLETTET && !slettetKommentar.isNullOrBlank()) {
-            "Kan ikke ha slettetkommentar med resultat=$resultat"
+    private fun validerSlettefelter() {
+        if (resultat == ResultatVilkårperiode.SLETTET) {
+            feilHvis(kilde != KildeVilkårsperiode.MANUELL) {
+                "Kan ikke slette når kilde=$kilde"
+            }
+            feilHvis(slettetKommentar.isNullOrBlank()) {
+                "Mangler kommentar for resultat=$resultat"
+            }
+        } else {
+            feilHvis(!slettetKommentar.isNullOrBlank()) {
+                "Kan ikke ha slettetkommentar med resultat=$resultat"
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/Vilkårperiode.kt
@@ -35,6 +35,21 @@ data class Vilkårperiode(
         feilHvis(ugyldigTypeOgDetaljer) {
             "Ugyldig kombinasjon type=${type.javaClass.simpleName} detaljer=${detaljer.javaClass.simpleName}"
         }
+
+        validerSlettet()
+    }
+
+    private fun validerSlettet() {
+        feilHvis(kilde != KildeVilkårsperiode.MANUELL && resultat == ResultatVilkårperiode.SLETTET) {
+            "Kan ikke slette når kilde=$kilde"
+        }
+        feilHvis(resultat == ResultatVilkårperiode.SLETTET && slettetKommentar.isNullOrBlank()) {
+            "Mangler kommentar for resultat=$resultat"
+        }
+
+        feilHvis(resultat != ResultatVilkårperiode.SLETTET && !slettetKommentar.isNullOrBlank()) {
+            "Kan ikke ha slettetkommentar med resultat=$resultat"
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/dto/VilkårperiodeDto.kt
@@ -27,6 +27,7 @@ data class VilkårperiodeDto(
     val resultat: ResultatVilkårperiode,
     val begrunnelse: String?,
     val kilde: KildeVilkårsperiode,
+    val slettetKommentar: String?,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
@@ -43,6 +44,7 @@ fun Vilkårperiode.tilDto() =
         resultat = this.resultat,
         begrunnelse = this.begrunnelse,
         kilde = this.kilde,
+        slettetKommentar = this.slettetKommentar,
     )
 
 data class Datoperiode(
@@ -72,6 +74,10 @@ data class OpprettVilkårperiode(
     val detaljer: DetaljerVilkårperiode,
     val begrunnelse: String? = null,
 ) : Periode<LocalDate>
+
+data class SlettVikårperiode(
+    val kommentar: String,
+)
 
 data class Vilkårperioder(
     val målgrupper: List<VilkårperiodeDto>,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårControllerTest.kt
@@ -3,13 +3,17 @@ package no.nav.tilleggsstonader.sak.vilkår
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientConfig.Companion.barn2Fnr
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientConfig.Companion.barnFnr
+import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.behandlingBarn
+import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.vilkår.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.domain.VilkårperiodeDomainUtil.detaljerMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.dto.SlettVikårperiode
 import no.nav.tilleggsstonader.sak.vilkår.dto.VilkårperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.dto.Vilkårperioder
 import org.assertj.core.api.Assertions.assertThat
@@ -20,6 +24,7 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.web.client.exchange
 import java.time.LocalDate
+import java.util.UUID
 
 class VilkårControllerTest : IntegrationTest() {
 
@@ -56,6 +61,32 @@ class VilkårControllerTest : IntegrationTest() {
         assertThat(målgruppe.type).isEqualTo(MålgruppeType.AAP)
     }
 
+    @Test
+    fun `skal feile hvis man ikke sender inn lik behandlingId som det er på vilkårperioden`() {
+        val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
+        val behandlingForAnnenFagsak = testoppsettService.lagreFagsak(fagsak(setOf(PersonIdent("1")))).let {
+            testoppsettService.lagre(behandling(it))
+        }
+
+        val periode = opprettVilkårperiode(
+            behandling,
+            OpprettVilkårperiode(
+                type = MålgruppeType.AAP,
+                fom = LocalDate.now(),
+                tom = LocalDate.now(),
+                detaljer = detaljerMålgruppe(),
+            ),
+        )
+        val exception = catchProblemDetailException {
+            slettVilkårperiode(
+                behandlingId = behandlingForAnnenFagsak.id,
+                vilkårperiodeId = periode.id,
+                SlettVikårperiode("test"),
+            )
+        }
+        assertThat(exception.detail.detail).contains("BehandlingId er ikke lik")
+    }
+
     private fun hentVilkårperioder(behandling: Behandling) =
         restTemplate.exchange<Vilkårperioder>(
             localhost("api/vilkar/${behandling.id}/periode"),
@@ -70,5 +101,15 @@ class VilkårControllerTest : IntegrationTest() {
         localhost("api/vilkar/${behandling.id}/periode"),
         HttpMethod.POST,
         HttpEntity(opprettVilkårperiode, headers),
+    ).body!!
+
+    private fun slettVilkårperiode(
+        behandlingId: UUID,
+        vilkårperiodeId: UUID,
+        slettVikårperiode: SlettVikårperiode,
+    ) = restTemplate.exchange<VilkårperiodeDto>(
+        localhost("api/vilkar/$behandlingId/periode/$vilkårperiodeId"),
+        HttpMethod.DELETE,
+        HttpEntity(slettVikårperiode, headers),
     ).body!!
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/VilkårperiodeDomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/VilkårperiodeDomainUtil.kt
@@ -12,7 +12,7 @@ object VilkårperiodeDomainUtil {
         type: MålgruppeType = MålgruppeType.AAP,
         detaljer: DetaljerMålgruppe = detaljerMålgruppe(),
         begrunnelse: String? = null,
-        kilde: KildeVilkårsperiode = KildeVilkårsperiode.MANUELL,
+        kilde: KildeVilkårsperiode = KildeVilkårsperiode.SYSTEM,
         resultat: ResultatVilkårperiode = ResultatVilkårperiode.OPPFYLT,
     ) = Vilkårperiode(
         behandlingId = behandlingId,
@@ -36,7 +36,7 @@ object VilkårperiodeDomainUtil {
         type: AktivitetType = AktivitetType.TILTAK,
         detaljer: DetaljerAktivitet = detaljerAktivitet(),
         begrunnelse: String? = null,
-        kilde: KildeVilkårsperiode = KildeVilkårsperiode.MANUELL,
+        kilde: KildeVilkårsperiode = KildeVilkårsperiode.SYSTEM,
         resultat: ResultatVilkårperiode = ResultatVilkårperiode.OPPFYLT,
     ) = Vilkårperiode(
         behandlingId = behandlingId,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/VilkårperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/domain/VilkårperiodeTest.kt
@@ -37,4 +37,37 @@ class VilkårperiodeTest {
             }.hasMessageContaining("Ugyldig kombinasjon")
         }
     }
+
+    @Nested
+    inner class ValideringSlettet {
+
+        @Test
+        fun `kan ikke slette periode som er opprettet av systemet`() {
+            assertThatThrownBy {
+                målgruppe(kilde = KildeVilkårsperiode.SYSTEM).copy(resultat = ResultatVilkårperiode.SLETTET)
+            }.hasMessageContaining("Kan ikke slette når kilde=")
+        }
+
+        @Test
+        fun `kan ha kommentar når resultat er slettet`() {
+            målgruppe(kilde = KildeVilkårsperiode.MANUELL)
+                .copy(resultat = ResultatVilkårperiode.SLETTET, slettetKommentar = "Abc")
+        }
+
+        @Test
+        fun `feiler hvis man mangler kommentar når resultat er slettet`() {
+            assertThatThrownBy {
+                målgruppe(kilde = KildeVilkårsperiode.MANUELL)
+                    .copy(resultat = ResultatVilkårperiode.SLETTET)
+            }.hasMessageContaining("Mangler kommentar for resultat=")
+        }
+
+        @Test
+        fun `feiler hvis man har kommentar når resultat er slettet`() {
+            assertThatThrownBy {
+                målgruppe(kilde = KildeVilkårsperiode.MANUELL)
+                    .copy(slettetKommentar = "Abc")
+            }.hasMessageContaining("Kan ikke ha slettetkommentar")
+        }
+    }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne slette en rad som man har lagt inn manuellt. 

Noter at valideringen at man kun kan slette manuelle skjer i domeneobjektet, og har integrasjonstester for det i `VilkårServiceIntegrasjonsTest `

Bygger videre på
* https://github.com/navikt/tilleggsstonader-sak/pull/151