### PR TITLE
Flytter vilkårperiode-kode fra VilkårService/Controller til Vilkårper…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -4,14 +4,14 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiod
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
 class StønadsperiodeService(
     private val stønadsperiodeRepository: StønadsperiodeRepository,
-    private val vilkårService: VilkårService,
+    private val vilkårperiodeService: VilkårperiodeService,
 ) {
     fun hentStønadsperioder(behandlingId: UUID): List<StønadsperiodeDto> {
         return stønadsperiodeRepository.findAllByBehandlingId(behandlingId).tilSortertDto()
@@ -36,7 +36,7 @@ class StønadsperiodeService(
     }
 
     fun validerStønadsperioder(behandlingId: UUID, stønadsperioder: List<StønadsperiodeDto>) {
-        val vilkårperioder = vilkårService.hentVilkårperioder(behandlingId)
+        val vilkårperioder = vilkårperiodeService.hentVilkårperioder(behandlingId)
 
         StønadsperiodeValideringUtil.validerStønadsperioder(stønadsperioder, vilkårperioder)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårController.kt
@@ -9,14 +9,8 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.VilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.VilkårsvurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.Vilkårsregler
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OpprettVilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.Vilkårperioder
 import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -96,34 +90,4 @@ class VilkårController(
         return vurderingService.hentEllerOpprettVurderinger(request.behandlingId)
     }
      */
-
-    @GetMapping("{behandlingId}/periode")
-    fun hentMålgrupper(@PathVariable behandlingId: UUID): Vilkårperioder {
-        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-
-        return vilkårService.hentVilkårperioder(behandlingId)
-    }
-
-    @PostMapping("{behandlingId}/periode")
-    fun opprettVilkårMedPeriode(
-        @PathVariable behandlingId: UUID,
-        @RequestBody opprettVilkårperiode: OpprettVilkårperiode,
-    ): VilkårperiodeDto {
-        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
-
-        return vilkårService.opprettVilkårperiode(behandlingId, opprettVilkårperiode)
-    }
-
-    @DeleteMapping("{behandlingId}/periode/{id}")
-    fun slettPeriode(
-        @PathVariable("behandlingId") behandlingId: UUID,
-        @PathVariable("id") id: UUID,
-        @RequestBody slettVikårperiode: SlettVikårperiode,
-    ): Vilkårperiode {
-        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
-
-        return vilkårService.slettVilkårperiode(behandlingId, id, slettVikårperiode)
-    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -1,0 +1,58 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.Vilkårperioder
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/vilkarperiode"])
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class VilkårperiodeController(
+    private val tilgangService: TilgangService,
+    private val vilkårperiodeService: VilkårperiodeService,
+) {
+
+    @GetMapping("behandling/{behandlingId}")
+    fun hentMålgrupper(@PathVariable behandlingId: UUID): Vilkårperioder {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+
+        return vilkårperiodeService.hentVilkårperioder(behandlingId)
+    }
+
+    @PostMapping("behandling/{behandlingId}")
+    fun opprettVilkårMedPeriode(
+        @PathVariable behandlingId: UUID,
+        @RequestBody opprettVilkårperiode: OpprettVilkårperiode,
+    ): VilkårperiodeDto {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return vilkårperiodeService.opprettVilkårperiode(behandlingId, opprettVilkårperiode)
+    }
+
+    @DeleteMapping("{id}")
+    fun slettPeriode(
+        @PathVariable("id") id: UUID,
+        @RequestBody slettVikårperiode: SlettVikårperiode,
+    ): Vilkårperiode {
+        tilgangService.validerTilgangTilBehandling(slettVikårperiode.behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return vilkårperiodeService.slettVilkårperiode(id, slettVikårperiode)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -1,0 +1,84 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
+
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.validerBehandlingIdErLik
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.Vilkårperioder
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilDto
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class VilkårperiodeService(
+    private val behandlingService: BehandlingService,
+    private val vilkårperiodeRepository: VilkårperiodeRepository,
+) {
+
+    fun hentVilkårperioder(behandlingId: UUID): Vilkårperioder {
+        val vilkårsperioder = vilkårperiodeRepository.findByBehandlingId(behandlingId)
+
+        return Vilkårperioder(
+            målgrupper = finnPerioder<MålgruppeType>(vilkårsperioder),
+            aktiviteter = finnPerioder<AktivitetType>(vilkårsperioder),
+        )
+    }
+
+    private inline fun <reified T : VilkårperiodeType> finnPerioder(
+        vilkårsperioder: List<Vilkårperiode>,
+    ) = vilkårsperioder.filter { it.type is T }.map(Vilkårperiode::tilDto)
+
+    @Transactional
+    fun opprettVilkårperiode(behandlingId: UUID, opprettVilkårperiode: OpprettVilkårperiode): VilkårperiodeDto {
+        feilHvis(behandlingErLåstForVidereRedigering(behandlingId)) {
+            "Kan ikke opprette vilkår når behandling er låst for videre redigering"
+        }
+
+        val resultatEvaluering = EvalueringVilkårperiode.evaulerVilkårperiode(opprettVilkårperiode.delvilkår)
+        val vilkårperiode = vilkårperiodeRepository.insert(
+            Vilkårperiode(
+                behandlingId = behandlingId,
+                fom = opprettVilkårperiode.fom,
+                tom = opprettVilkårperiode.tom,
+                type = opprettVilkårperiode.type,
+                delvilkår = resultatEvaluering.delvilkår,
+                begrunnelse = opprettVilkårperiode.begrunnelse,
+                resultat = resultatEvaluering.resultat,
+                kilde = KildeVilkårsperiode.MANUELL,
+            ),
+        )
+
+        return vilkårperiode.tilDto()
+    }
+
+    fun slettVilkårperiode(id: UUID, slettVikårperiode: SlettVikårperiode): Vilkårperiode {
+        val vilkårperiode = vilkårperiodeRepository.findByIdOrThrow(id)
+
+        validerBehandlingIdErLik(slettVikårperiode.behandlingId, vilkårperiode.behandlingId)
+
+        feilHvis(behandlingErLåstForVidereRedigering(vilkårperiode.behandlingId)) {
+            "Kan ikke slette vilkårperiode når behandling er låst for videre redigering"
+        }
+
+        return vilkårperiodeRepository.update(
+            vilkårperiode.copy(
+                resultat = ResultatVilkårperiode.SLETTET,
+                slettetKommentar = slettVikårperiode.kommentar,
+            ),
+        )
+    }
+
+    private fun behandlingErLåstForVidereRedigering(behandlingId: UUID) =
+        behandlingService.hentBehandling(behandlingId).status.behandlingErLåstForVidereRedigering()
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -95,6 +95,7 @@ data class DelvilkårAktivitetDto(
 ) : DelvilkårVilkårperiodeDto()
 
 data class SlettVikårperiode(
+    val behandlingId: UUID,
     val kommentar: String,
 )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeControllerTest.kt
@@ -7,7 +7,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientConfig
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.behandlingBarn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
@@ -30,7 +30,7 @@ class StønadsperiodeControllerTest : IntegrationTest() {
     lateinit var barnRepository: BarnRepository
 
     @Autowired
-    lateinit var vilkårService: VilkårService
+    lateinit var vilkårperiodeService: VilkårperiodeService
 
     private val dagensDato = LocalDate.now()
 
@@ -63,7 +63,7 @@ class StønadsperiodeControllerTest : IntegrationTest() {
     }
 
     private fun opprettMålgruppe(behandling: Behandling): VilkårperiodeDto =
-        vilkårService.opprettVilkårperiode(
+        vilkårperiodeService.opprettVilkårperiode(
             behandling.id,
             OpprettVilkårperiode(
                 type = MålgruppeType.AAP,
@@ -76,7 +76,7 @@ class StønadsperiodeControllerTest : IntegrationTest() {
         )
 
     private fun opprettAktivitet(behandling: Behandling): VilkårperiodeDto =
-        vilkårService.opprettVilkårperiode(
+        vilkårperiodeService.opprettVilkårperiode(
             behandling.id,
             OpprettVilkårperiode(
                 type = AktivitetType.TILTAK,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
@@ -8,11 +8,8 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
-import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
-import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SøknadBarnetilsyn
-import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.SøknadUtil
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
@@ -25,16 +22,9 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.HovedregelMetadata
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.EksempelRegel
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeDomainUtil.målgruppe
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
@@ -55,9 +45,6 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
 
     @Autowired
     lateinit var barnRepository: BarnRepository
-
-    @Autowired
-    lateinit var vilkårperiodeRepository: VilkårperiodeRepository
 
     @Test
     internal fun `kopierVilkårsettTilNyBehandling - skal kopiere vilkår til ny behandling`() {
@@ -127,77 +114,6 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
             },
         )
             .hasMessage("Tidligere behandling=$tidligereBehandlingId har ikke noen vilkår")
-    }
-
-    @Nested
-    inner class SlettVilkårperiode {
-
-        @Test
-        fun `skal ikke kunne slette kommentar hvis behandlingen ikke er under behandling`() {
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling(status = BehandlingStatus.FERDIGSTILT))
-            val målgruppe = målgruppe(
-                behandlingId = behandling.id,
-                kilde = KildeVilkårsperiode.MANUELL,
-            )
-            val periode = vilkårperiodeRepository.insert(målgruppe)
-
-            assertThatThrownBy {
-                vilkårService.slettVilkårperiode(behandling.id, periode.id, SlettVikårperiode("kommentar"))
-            }.hasMessageContaining("Kan ikke slette vilkårperiode når behandling er låst for videre redigering")
-        }
-
-        @Test
-        fun `skal ikke kunne slette kommentar hvis man mangler kommentar`() {
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
-            val målgruppe = målgruppe(
-                behandlingId = behandling.id,
-                kilde = KildeVilkårsperiode.MANUELL,
-            )
-            val periode = vilkårperiodeRepository.insert(målgruppe)
-
-            assertThatThrownBy {
-                vilkårService.slettVilkårperiode(behandling.id, periode.id, SlettVikårperiode("    "))
-            }.hasMessageContaining("Mangler kommentar")
-        }
-
-        @Test
-        fun `skal ikke kunne slette kommentar hvis kilden er system`() {
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
-            val målgruppe = målgruppe(
-                behandlingId = behandling.id,
-                kilde = KildeVilkårsperiode.SYSTEM,
-            )
-            val periode = vilkårperiodeRepository.insert(målgruppe)
-
-            assertThatThrownBy {
-                vilkårService.slettVilkårperiode(behandling.id, periode.id, SlettVikårperiode("kommentar"))
-            }.hasMessageContaining("Kan ikke slette når kilde=")
-        }
-
-        @Test
-        fun `skal kunne slette kommentar som er manuellt opprettet`() {
-            val saksbehandler = "saksbehandlerX"
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
-            val målgruppe = målgruppe(
-                behandlingId = behandling.id,
-                kilde = KildeVilkårsperiode.MANUELL,
-            )
-            val periode = vilkårperiodeRepository.insert(målgruppe)
-
-            assertThat(periode.sporbar.endret.endretAv).isEqualTo(SYSTEM_FORKORTELSE)
-
-            testWithBrukerContext(saksbehandler) {
-                vilkårService.slettVilkårperiode(behandling.id, periode.id, SlettVikårperiode("kommentar"))
-            }
-
-            val oppdatertPeriode = vilkårperiodeRepository.findByIdOrThrow(periode.id)
-            assertThat(oppdatertPeriode.resultat).isEqualTo(ResultatVilkårperiode.SLETTET)
-            assertThat(oppdatertPeriode.sporbar.endret.endretAv).isEqualTo(saksbehandler)
-        }
     }
 
     private fun opprettVilkårsvurderinger(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
@@ -28,7 +28,6 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresult
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat.IKKE_TATT_STILLING_TIL
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat.OPPFYLT
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat.SKAL_IKKE_VURDERES
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -41,7 +40,6 @@ internal class VilkårServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val søknadService = mockk<SøknadService>()
     private val vilkårRepository = mockk<VilkårRepository>()
-    private val vilkårperiodeRepository = mockk<VilkårperiodeRepository>()
 
     // private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     // private val blankettRepository = mockk<BlankettRepository>()
@@ -55,7 +53,6 @@ internal class VilkårServiceTest {
         behandlingService = behandlingService,
         søknadService = søknadService,
         vilkårRepository = vilkårRepository,
-        vilkårperiodeRepository = vilkårperiodeRepository,
         vilkårGrunnlagService = vilkårGrunnlagService,
         // grunnlagsdataService = grunnlagsdataService,
         barnService = barnService,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårStegServiceTest.kt
@@ -39,7 +39,6 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarn
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.catchThrowable
@@ -55,7 +54,6 @@ internal class VilkårStegServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val søknadService = mockk<SøknadService>()
     private val vilkårRepository = mockk<VilkårRepository>()
-    private val vilkårperiodeRepository = mockk<VilkårperiodeRepository>()
     private val barnService = mockk<BarnService>()
 
     // private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
@@ -74,7 +72,6 @@ internal class VilkårStegServiceTest {
         behandlingService,
         søknadService,
         vilkårRepository,
-        vilkårperiodeRepository,
         barnService,
         vilkårGrunnlagService,
         // grunnlagsdataService,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -1,0 +1,101 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeDomainUtil
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class VilkårperiodeServiceTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    lateinit var vilkårperiodeService: VilkårperiodeService
+
+    @Autowired
+    lateinit var vilkårperiodeRepository: VilkårperiodeRepository
+
+    @Nested
+    inner class SlettVilkårperiode {
+
+        @Test
+        fun `skal ikke kunne slette kommentar hvis behandlingen ikke er under behandling`() {
+            val behandling =
+                testoppsettService.opprettBehandlingMedFagsak(behandling(status = BehandlingStatus.FERDIGSTILT))
+            val målgruppe = VilkårperiodeDomainUtil.målgruppe(
+                behandlingId = behandling.id,
+                kilde = KildeVilkårsperiode.MANUELL,
+            )
+            val periode = vilkårperiodeRepository.insert(målgruppe)
+
+            Assertions.assertThatThrownBy {
+                vilkårperiodeService.slettVilkårperiode(periode.id, SlettVikårperiode(behandling.id, "kommentar"))
+            }.hasMessageContaining("Kan ikke slette vilkårperiode når behandling er låst for videre redigering")
+        }
+
+        @Test
+        fun `skal ikke kunne slette kommentar hvis man mangler kommentar`() {
+            val behandling =
+                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val målgruppe = VilkårperiodeDomainUtil.målgruppe(
+                behandlingId = behandling.id,
+                kilde = KildeVilkårsperiode.MANUELL,
+            )
+            val periode = vilkårperiodeRepository.insert(målgruppe)
+
+            Assertions.assertThatThrownBy {
+                vilkårperiodeService.slettVilkårperiode(periode.id, SlettVikårperiode(behandling.id, "    "))
+            }.hasMessageContaining("Mangler kommentar")
+        }
+
+        @Test
+        fun `skal ikke kunne slette kommentar hvis kilden er system`() {
+            val behandling =
+                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val målgruppe = VilkårperiodeDomainUtil.målgruppe(
+                behandlingId = behandling.id,
+                kilde = KildeVilkårsperiode.SYSTEM,
+            )
+            val periode = vilkårperiodeRepository.insert(målgruppe)
+
+            Assertions.assertThatThrownBy {
+                vilkårperiodeService.slettVilkårperiode(periode.id, SlettVikårperiode(behandling.id, "kommentar"))
+            }.hasMessageContaining("Kan ikke slette når kilde=")
+        }
+
+        @Test
+        fun `skal kunne slette kommentar som er manuellt opprettet`() {
+            val saksbehandler = "saksbehandlerX"
+            val behandling =
+                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val målgruppe = VilkårperiodeDomainUtil.målgruppe(
+                behandlingId = behandling.id,
+                kilde = KildeVilkårsperiode.MANUELL,
+            )
+            val periode = vilkårperiodeRepository.insert(målgruppe)
+
+            Assertions.assertThat(periode.sporbar.endret.endretAv).isEqualTo(SikkerhetContext.SYSTEM_FORKORTELSE)
+
+            BrukerContextUtil.testWithBrukerContext(saksbehandler) {
+                vilkårperiodeService.slettVilkårperiode(periode.id, SlettVikårperiode(behandling.id, "kommentar"))
+            }
+
+            val oppdatertPeriode = vilkårperiodeRepository.findByIdOrThrow(periode.id)
+            Assertions.assertThat(oppdatertPeriode.resultat).isEqualTo(ResultatVilkårperiode.SLETTET)
+            Assertions.assertThat(oppdatertPeriode.sporbar.endret.endretAv).isEqualTo(saksbehandler)
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Flytting av kode for vilkårperiode
VilkårController -> VilkårperiodeController
VilkårService -> VilkårperiodeService

Nye endepunkter for opprett/hente vilkårperiode (api/vilkar -> api/vilkarperiode )

Endring på data for slett periode - behandlingId er flyttet inn til objektet, og har kun ID til vilkårperiode med i path

Bygger videre på, så fint om denne ses på
* https://github.com/navikt/tilleggsstonader-sak/pull/155