### PR TITLE
Vilkårperiode v2 - ryddet opp i målgrupper og fikset typo på REELL

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -108,12 +108,10 @@ sealed interface VilkårperiodeType {
 
 enum class MålgruppeType(val gyldigeAktiviter: Set<AktivitetType>) : VilkårperiodeType {
     AAP(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    AAP_FERDIG_AVKLART(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    DAGPENGER(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    UFØRETRYGD(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-
     OMSTILLINGSSTØNAD(setOf(AktivitetType.REEL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
     OVERGANGSSTØNAD(setOf(AktivitetType.REEL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
+    NEDSATT_ARBEIDSEVNE(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
+    UFØRETRYGD(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
     ;
 
     override fun tilDbType(): String = this.name

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -108,8 +108,8 @@ sealed interface VilkårperiodeType {
 
 enum class MålgruppeType(val gyldigeAktiviter: Set<AktivitetType>) : VilkårperiodeType {
     AAP(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    OMSTILLINGSSTØNAD(setOf(AktivitetType.REEL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
-    OVERGANGSSTØNAD(setOf(AktivitetType.REEL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
+    OMSTILLINGSSTØNAD(setOf(AktivitetType.REELL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
+    OVERGANGSSTØNAD(setOf(AktivitetType.REELL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
     NEDSATT_ARBEIDSEVNE(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
     UFØRETRYGD(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
     ;
@@ -120,7 +120,7 @@ enum class MålgruppeType(val gyldigeAktiviter: Set<AktivitetType>) : Vilkårper
 enum class AktivitetType : VilkårperiodeType {
     TILTAK,
     UTDANNING,
-    REEL_ARBEIDSSØKER,
+    REELL_ARBEIDSSØKER,
     ;
 
     override fun tilDbType(): String = this.name

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringUtilTest.kt
@@ -71,7 +71,7 @@ internal class StønadsperiodeValideringUtilTest {
 
     @Test
     internal fun `skal kaste feil om ingen periode for målgruppe matcher`() {
-        val stønadsperiode = lagStønadsperiode(målgruppe = MålgruppeType.AAP_FERDIG_AVKLART)
+        val stønadsperiode = lagStønadsperiode(målgruppe = MålgruppeType.NEDSATT_ARBEIDSEVNE)
 
         assertThatThrownBy {
             validerStønadsperiode(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
* Fjernet `DAGPENGER` då vi ikke skal bruke den akkurat nå for tilsyn barn
* Fjernet `AAP_FERDIG_AVKLART` då det ikke er en målgruppe
* Lagt til `NEDSATT_ARBEIDSEVNE`

* Fikset typo på `REELL_ARBEIDSSØKER`