### PR TITLE
Vilkårperiode v2 - Hvert delvilkår skal kunne inneholde begrunnelse

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -79,6 +79,7 @@ enum class ResultatVilkårperiode {
 sealed class DelvilkårVilkårperiode {
     data class Vurdering(
         val svar: SvarJaNei?,
+        val begrunnelse: String? = null,
         val resultat: ResultatDelvilkårperiode,
     )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -81,7 +81,16 @@ sealed class DelvilkårVilkårperiode {
         val svar: SvarJaNei?,
         val begrunnelse: String? = null,
         val resultat: ResultatDelvilkårperiode,
-    )
+    ) {
+        init {
+            feilHvis(svar == SvarJaNei.JA_IMPLISITT && begrunnelse != null) {
+                "Kan ikke ha begrunnelse når svar=$svar"
+            }
+            feilHvis(resultat == ResultatDelvilkårperiode.IKKE_AKTUELT && (svar != null || begrunnelse != null)) {
+                "Ugyldig resultat=$resultat når svar=$svar begrunnelseErNull=${begrunnelse == null}"
+            }
+        }
+    }
 }
 
 enum class ResultatDelvilkårperiode {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårAktiv
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
@@ -63,11 +64,15 @@ fun DelvilkårVilkårperiode.tilDto() = when (this) {
     )
 }
 
+// Returnerer ikke vurdering hvis resultatet er IKKE_AKTUELT
 fun DelvilkårVilkårperiode.Vurdering.tilDto() =
-    VurderingDto(
-        svar = svar,
-        begrunnelse = begrunnelse,
-    )
+    this.takeIf { resultat != ResultatDelvilkårperiode.IKKE_AKTUELT }
+        ?.let {
+            VurderingDto(
+                svar = svar,
+                begrunnelse = begrunnelse,
+            )
+        }
 
 data class Datoperiode(
     override val fom: LocalDate,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -53,9 +53,21 @@ fun Vilkårperiode.tilDto() =
     )
 
 fun DelvilkårVilkårperiode.tilDto() = when (this) {
-    is DelvilkårMålgruppe -> DelvilkårMålgruppeDto(medlemskap = medlemskap.svar)
-    is DelvilkårAktivitet -> DelvilkårAktivitetDto(lønnet = lønnet.svar, mottarSykepenger = mottarSykepenger.svar)
+    is DelvilkårMålgruppe -> DelvilkårMålgruppeDto(
+        medlemskap = medlemskap.tilDto(),
+    )
+
+    is DelvilkårAktivitet -> DelvilkårAktivitetDto(
+        lønnet = lønnet.tilDto(),
+        mottarSykepenger = mottarSykepenger.tilDto(),
+    )
 }
+
+fun DelvilkårVilkårperiode.Vurdering.tilDto() =
+    VurderingDto(
+        svar = svar,
+        begrunnelse = begrunnelse,
+    )
 
 data class Datoperiode(
     override val fom: LocalDate,
@@ -101,13 +113,18 @@ data class OpprettVilkårperiode(
 sealed class DelvilkårVilkårperiodeDto
 
 data class DelvilkårMålgruppeDto(
-    val medlemskap: SvarJaNei?,
+    val medlemskap: VurderingDto?,
 ) : DelvilkårVilkårperiodeDto()
 
 data class DelvilkårAktivitetDto(
-    val lønnet: SvarJaNei?,
-    val mottarSykepenger: SvarJaNei?,
+    val lønnet: VurderingDto?,
+    val mottarSykepenger: VurderingDto?,
 ) : DelvilkårVilkårperiodeDto()
+
+data class VurderingDto(
+    val svar: SvarJaNei? = null,
+    val begrunnelse: String? = null,
+)
 
 data class SlettVikårperiode(
     val behandlingId: UUID,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppe.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppe.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringVilkårperiode.tilVurdering
 
 object EvalueringMålgruppe {
 
@@ -33,7 +34,7 @@ object EvalueringMålgruppe {
         delvilkår: DelvilkårMålgruppeDto,
         type: MålgruppeType,
     ): ResultatEvaluering {
-        val medlemskap = delvilkår.medlemskap
+        val medlemskap = delvilkår.medlemskap?.svar
         feilHvis(medlemskap != null && medlemskap != SvarJaNei.JA_IMPLISITT) {
             "Kan ikke evaluere svar=$medlemskap på medlemskap for type=$type"
         }
@@ -42,8 +43,8 @@ object EvalueringMålgruppe {
 
     private fun utledResultat(delvilkår: DelvilkårMålgruppeDto): ResultatEvaluering {
         val medlemskap = delvilkår.medlemskap
-        val resultatDelvilkår = utledResultatMedlemskap(medlemskap)
-        val oppdatertDelvilkår = DelvilkårMålgruppe(medlemskap = Vurdering(svar = medlemskap, resultatDelvilkår))
+        val resultatDelvilkår = utledResultatMedlemskap(medlemskap?.svar)
+        val oppdatertDelvilkår = DelvilkårMålgruppe(medlemskap = medlemskap.tilVurdering(resultatDelvilkår))
         val resultatVilkår = when (resultatDelvilkår) {
             ResultatDelvilkårperiode.OPPFYLT -> ResultatVilkårperiode.OPPFYLT
             ResultatDelvilkårperiode.IKKE_OPPFYLT -> ResultatVilkårperiode.IKKE_OPPFYLT
@@ -64,6 +65,7 @@ object EvalueringMålgruppe {
         DelvilkårMålgruppe(
             medlemskap = Vurdering(
                 svar = SvarJaNei.JA_IMPLISITT,
+                begrunnelse = null,
                 resultat = ResultatDelvilkårperiode.OPPFYLT,
             ),
         ),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiode.kt
@@ -3,11 +3,13 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårVilkårperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 
 data class ResultatEvaluering(
     val delvilkår: DelvilkårVilkårperiode,
@@ -26,4 +28,11 @@ object EvalueringVilkårperiode {
             else -> error("Ugyldig kombinasjon type=$type delvilkår=${delvilkår.javaClass.simpleName}")
         }
     }
+
+    fun VurderingDto?.tilVurdering(resultat: ResultatDelvilkårperiode) =
+        DelvilkårVilkårperiode.Vurdering(
+            svar = this?.svar,
+            begrunnelse = this?.begrunnelse,
+            resultat = resultat,
+        )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeControllerTest.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -75,8 +76,8 @@ class StønadsperiodeControllerTest : IntegrationTest() {
                 fom = dagensDato,
                 tom = dagensDato,
                 delvilkår = DelvilkårAktivitetDto(
-                    lønnet = SvarJaNei.NEI,
-                    mottarSykepenger = SvarJaNei.NEI,
+                    lønnet = VurderingDto(SvarJaNei.NEI),
+                    mottarSykepenger = VurderingDto(SvarJaNei.NEI),
                 ),
             ),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
@@ -208,7 +209,7 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         type = type,
         fom = fom,
         tom = tom,
-        delvilkår = DelvilkårMålgruppeDto(medlemskap),
+        delvilkår = DelvilkårMålgruppeDto(VurderingDto(medlemskap)),
     )
 
     private fun aktivitet(
@@ -221,7 +222,7 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         type = type,
         fom = fom,
         tom = tom,
-        delvilkår = DelvilkårAktivitetDto(lønnet, mottarSykepenger),
+        delvilkår = DelvilkårAktivitetDto(VurderingDto(lønnet), VurderingDto(mottarSykepenger)),
     )
 
     private fun stønadsperiodeDto(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeExtensions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeExtensions.kt
@@ -1,0 +1,27 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
+
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårAktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårMålgruppe
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.ResultatEvaluering
+
+object VilkårperiodeExtensions {
+    val Vilkårperiode.medlemskap: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap
+
+    val Vilkårperiode.lønnet: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårAktivitet).lønnet
+
+    val Vilkårperiode.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
+
+    val ResultatEvaluering.medlemskap: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap
+
+    val ResultatEvaluering.lønnet: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårAktivitet).lønnet
+
+    val ResultatEvaluering.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeExtensions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeExtensions.kt
@@ -4,6 +4,10 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårAktiv
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.ResultatEvaluering
 
 object VilkårperiodeExtensions {
@@ -15,6 +19,15 @@ object VilkårperiodeExtensions {
 
     val Vilkårperiode.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
+
+    val VilkårperiodeDto.medlemskap: VurderingDto?
+        get() = (this.delvilkår as DelvilkårMålgruppeDto).medlemskap
+
+    val VilkårperiodeDto.lønnet: VurderingDto?
+        get() = (this.delvilkår as DelvilkårAktivitetDto).lønnet
+
+    val VilkårperiodeDto.mottarSykepenger: VurderingDto?
+        get() = (this.delvilkår as DelvilkårAktivitetDto).mottarSykepenger
 
     val ResultatEvaluering.medlemskap: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -99,7 +99,10 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal kaste feil hvis målgruppe er ugyldig for stønadstype`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-            val opprettVilkårperiode = opprettVilkårperiode(type = MålgruppeType.DAGPENGER, medlemskap = SvarJaNei.NEI)
+            val opprettVilkårperiode = opprettVilkårperiodeMålgruppe(
+                type = MålgruppeType.DAGPENGER,
+                medlemskap = VurderingDto(SvarJaNei.NEI),
+            )
 
             assertThatThrownBy {
                 vilkårperiodeService.opprettVilkårperiode(behandling.id, opprettVilkårperiode)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivite
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OppdaterVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -88,7 +89,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 fom = nyttDato,
                 tom = nyttDato,
                 begrunnelse = "Oppdatert begrunnelse",
-                delvilkår = DelvilkårMålgruppeDto(medlemskap = SvarJaNei.JA),
+                delvilkår = DelvilkårMålgruppeDto(medlemskap = VurderingDto(SvarJaNei.JA)),
             )
             val oppdatertPeriode = vilkårperiodeService.oppdaterVilkårperiode(vilkårperiode.id, oppdatering)
 
@@ -115,7 +116,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
             val oppdatering = vilkårperiode.tilOddatering().copy(
                 begrunnelse = "Oppdatert begrunnelse",
-                delvilkår = DelvilkårMålgruppeDto(medlemskap = SvarJaNei.NEI),
+                delvilkår = DelvilkårMålgruppeDto(medlemskap = VurderingDto(SvarJaNei.NEI)),
             )
             val oppdatertPeriode = vilkårperiodeService.oppdaterVilkårperiode(vilkårperiode.id, oppdatering)
 
@@ -177,12 +178,12 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         private fun Vilkårperiode.tilOddatering(): OppdaterVilkårperiode {
             val delvilkårDto = when (this.delvilkår) {
                 is DelvilkårMålgruppe ->
-                    DelvilkårMålgruppeDto((this.delvilkår as DelvilkårMålgruppe).medlemskap.svar)
+                    DelvilkårMålgruppeDto(VurderingDto((this.delvilkår as DelvilkårMålgruppe).medlemskap.svar))
 
                 is DelvilkårAktivitet -> (this.delvilkår as DelvilkårAktivitet).let {
                     DelvilkårAktivitetDto(
-                        it.lønnet.svar,
-                        it.mottarSykepenger.svar,
+                        lønnet = VurderingDto(it.lønnet.svar),
+                        mottarSykepenger = VurderingDto(it.mottarSykepenger.svar),
                     )
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -8,9 +8,9 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
 import no.nav.tilleggsstonader.sak.util.behandling
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.lønnet
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.medlemskap
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.mottarSykepenger
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.lønnet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.medlemskap
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.mottarSykepenger
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.opprettVilkårperiodeAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.opprettVilkårperiodeMålgruppe

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -42,6 +42,7 @@ object VilkårperiodeTestUtil {
     fun delvilkårMålgruppe() = DelvilkårMålgruppe(
         medlemskap = DelvilkårVilkårperiode.Vurdering(
             svar = SvarJaNei.JA_IMPLISITT,
+            begrunnelse = "begrunnelse",
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
     )
@@ -73,10 +74,12 @@ object VilkårperiodeTestUtil {
     fun delvilkårAktivitet() = DelvilkårAktivitet(
         lønnet = DelvilkårVilkårperiode.Vurdering(
             svar = SvarJaNei.NEI,
+            begrunnelse = "begrunnelse",
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
         mottarSykepenger = DelvilkårVilkårperiode.Vurdering(
             svar = SvarJaNei.NEI,
+            begrunnelse = "begrunnelse",
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
     )
@@ -86,17 +89,41 @@ object VilkårperiodeTestUtil {
         mottarSykepenger = VurderingDto(SvarJaNei.NEI),
     )
 
-    fun opprettVilkårperiode(
+    fun opprettVilkårperiodeMålgruppe(
         type: MålgruppeType = MålgruppeType.OMSTILLINGSSTØNAD,
         fom: LocalDate = LocalDate.now(),
         tom: LocalDate = LocalDate.now(),
-        medlemskap: SvarJaNei? = null,
+        medlemskap: VurderingDto? = null,
         begrunnelse: String? = null,
     ) = OpprettVilkårperiode(
         type = type,
         fom = fom,
         tom = tom,
-        delvilkår = DelvilkårMålgruppeDto(medlemskap = VurderingDto(medlemskap)),
+        delvilkår = DelvilkårMålgruppeDto(medlemskap = medlemskap),
         begrunnelse = begrunnelse,
     )
+
+    fun opprettVilkårperiodeAktivitet(
+        type: AktivitetType = AktivitetType.TILTAK,
+        fom: LocalDate = LocalDate.now(),
+        tom: LocalDate = LocalDate.now(),
+        lønnet: VurderingDto? = null,
+        mottarSykepenger: VurderingDto? = null,
+        begrunnelse: String? = null,
+    ) = OpprettVilkårperiode(
+        type = type,
+        fom = fom,
+        tom = tom,
+        delvilkår = DelvilkårAktivitetDto(lønnet, mottarSykepenger),
+        begrunnelse = begrunnelse,
+    )
+
+    val Vilkårperiode.medlemskap: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap
+
+    val Vilkårperiode.lønnet: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårAktivitet).lønnet
+
+    val Vilkårperiode.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
+        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.OpprettVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import java.time.LocalDate
 import java.util.UUID
 
@@ -46,7 +47,7 @@ object VilkårperiodeTestUtil {
     )
 
     fun delvilkårMålgruppeDto() = DelvilkårMålgruppeDto(
-        medlemskap = SvarJaNei.JA_IMPLISITT,
+        medlemskap = VurderingDto(SvarJaNei.JA_IMPLISITT),
     )
 
     fun aktivitet(
@@ -81,8 +82,8 @@ object VilkårperiodeTestUtil {
     )
 
     fun delvilkårAktivitetDto() = DelvilkårAktivitetDto(
-        lønnet = SvarJaNei.NEI,
-        mottarSykepenger = SvarJaNei.NEI,
+        lønnet = VurderingDto(SvarJaNei.NEI),
+        mottarSykepenger = VurderingDto(SvarJaNei.NEI),
     )
 
     fun opprettVilkårperiode(
@@ -95,7 +96,7 @@ object VilkårperiodeTestUtil {
         type = type,
         fom = fom,
         tom = tom,
-        delvilkår = DelvilkårMålgruppeDto(medlemskap = medlemskap),
+        delvilkår = DelvilkårMålgruppeDto(medlemskap = VurderingDto(medlemskap)),
         begrunnelse = begrunnelse,
     )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -42,7 +42,7 @@ object VilkårperiodeTestUtil {
     fun delvilkårMålgruppe() = DelvilkårMålgruppe(
         medlemskap = DelvilkårVilkårperiode.Vurdering(
             svar = SvarJaNei.JA_IMPLISITT,
-            begrunnelse = "begrunnelse",
+            begrunnelse = null,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
     )
@@ -74,12 +74,12 @@ object VilkårperiodeTestUtil {
     fun delvilkårAktivitet() = DelvilkårAktivitet(
         lønnet = DelvilkårVilkårperiode.Vurdering(
             svar = SvarJaNei.NEI,
-            begrunnelse = "begrunnelse",
+            begrunnelse = null,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
         mottarSykepenger = DelvilkårVilkårperiode.Vurdering(
             svar = SvarJaNei.NEI,
-            begrunnelse = "begrunnelse",
+            begrunnelse = null,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -117,13 +117,4 @@ object VilkårperiodeTestUtil {
         delvilkår = DelvilkårAktivitetDto(lønnet, mottarSykepenger),
         begrunnelse = begrunnelse,
     )
-
-    val Vilkårperiode.medlemskap: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap
-
-    val Vilkårperiode.lønnet: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårAktivitet).lønnet
-
-    val Vilkårperiode.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/DelvilkårVilkårperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/DelvilkårVilkårperiodeTest.kt
@@ -1,0 +1,36 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class DelvilkårVilkårperiodeTest {
+
+    @Nested
+    inner class VurderingDelvilkår {
+
+        @Test
+        fun `kan ikke ha begrunnelse sammen når svar=JA_IMPLISITT`() {
+            assertThatThrownBy {
+                DelvilkårVilkårperiode.Vurdering(SvarJaNei.JA_IMPLISITT, "", ResultatDelvilkårperiode.OPPFYLT)
+            }.hasMessageContaining("Kan ikke ha begrunnelse når svar=JA_IMPLISITT")
+        }
+
+        @Test
+        fun `kan ikke ha begrunnelse sammen med resultat=IKKE_AKTUELT`() {
+            assertThatThrownBy {
+                DelvilkårVilkårperiode.Vurdering(null, "", ResultatDelvilkårperiode.IKKE_AKTUELT)
+            }.hasMessageContaining("Ugyldig resultat=IKKE_AKTUELT når svar=null begrunnelseErNull=false")
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SvarJaNei::class)
+        fun `kan ikke ha svar når resultat=IKKE_AKTUELT`(svar: SvarJaNei) {
+            assertThatThrownBy {
+                DelvilkårVilkårperiode.Vurdering(svar, null, ResultatDelvilkårperiode.IKKE_AKTUELT)
+            }.hasMessageContaining("Ugyldig resultat=IKKE_AKTUELT når svar=$svar begrunnelseErNull=true")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
@@ -1,8 +1,16 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto
 
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.medlemskap
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårMålgruppe
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 
 class VilkårperiodeDtoTest {
@@ -15,5 +23,43 @@ class VilkårperiodeDtoTest {
                 tom = LocalDate.now().minusDays(1),
             ).tilDto()
         }.hasMessageContaining("Til-og-med før fra-og-med")
+    }
+
+    @Nested
+    inner class MappingAvVurdering {
+
+        @ParameterizedTest
+        @EnumSource(
+            value = ResultatDelvilkårperiode::class,
+            names = ["IKKE_AKTUELT"],
+            mode = EnumSource.Mode.EXCLUDE,
+        )
+        fun `skal returnere delviljår hvis resultat != IKKE_AKTUELT`(resultat: ResultatDelvilkårperiode) {
+            val målgruppe = målgruppe(
+                delvilkår = DelvilkårMålgruppe(
+                    medlemskap = DelvilkårVilkårperiode.Vurdering(
+                        svar = null,
+                        begrunnelse = null,
+                        resultat = resultat,
+                    ),
+                ),
+            ).tilDto()
+            assertThat(målgruppe.medlemskap).isNotNull()
+            assertThat(målgruppe.medlemskap?.svar).isNull()
+        }
+
+        @Test
+        fun `skal returnere delvilkårsresultat IKKE_AKTUELT som vurdering=null`() {
+            val målgruppe = målgruppe(
+                delvilkår = DelvilkårMålgruppe(
+                    medlemskap = DelvilkårVilkårperiode.Vurdering(
+                        svar = null,
+                        begrunnelse = null,
+                        resultat = ResultatDelvilkårperiode.IKKE_AKTUELT,
+                    ),
+                ),
+            ).tilDto()
+            assertThat(målgruppe.medlemskap).isNull()
+        }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringAktivitetTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringAktivitetTest.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringAktivitet.utledResultat
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -148,7 +149,7 @@ class EvalueringAktivitetTest {
                 utledResultat(
                     type = AktivitetType.TILTAK,
                     delvilkår = DelvilkårAktivitetDto(
-                        lønnet = SvarJaNei.JA_IMPLISITT,
+                        lønnet = VurderingDto(SvarJaNei.JA_IMPLISITT),
                         mottarSykepenger = null,
                     ),
                 )
@@ -163,7 +164,7 @@ class EvalueringAktivitetTest {
                     type = type,
                     delvilkår = DelvilkårAktivitetDto(
                         lønnet = null,
-                        mottarSykepenger = SvarJaNei.JA_IMPLISITT,
+                        mottarSykepenger = VurderingDto(SvarJaNei.JA_IMPLISITT),
                     ),
                 )
             }.hasMessageContaining("Svar=JA_IMPLISITT er ikke gyldig svar for mottarSykepenger")
@@ -173,7 +174,7 @@ class EvalueringAktivitetTest {
     private fun delvilkårAktivitetDto(
         lønnet: SvarJaNei? = null,
         mottarSykepenger: SvarJaNei? = null,
-    ) = DelvilkårAktivitetDto(lønnet = lønnet, mottarSykepenger = mottarSykepenger)
+    ) = DelvilkårAktivitetDto(lønnet = VurderingDto(lønnet), mottarSykepenger = VurderingDto(mottarSykepenger))
 
     private val ResultatEvaluering.lønnet: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårAktivitet).lønnet

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringMålgruppe.utledResultat
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -16,10 +17,10 @@ import org.junit.jupiter.params.provider.EnumSource
 
 class EvalueringMålgruppeTest {
 
-    val svarJa = DelvilkårMålgruppeDto(SvarJaNei.JA)
-    val svarImplisitt = DelvilkårMålgruppeDto(SvarJaNei.JA_IMPLISITT)
-    val svarNei = DelvilkårMålgruppeDto(SvarJaNei.NEI)
-    val svarMangler = DelvilkårMålgruppeDto(null)
+    val svarJa = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.JA))
+    val svarImplisitt = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.JA_IMPLISITT))
+    val svarNei = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.NEI))
+    val svarMangler = DelvilkårMålgruppeDto(VurderingDto(null))
 
     @Nested
     inner class Implisitt {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering
 
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårMålgruppe
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.medlemskap
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
@@ -95,9 +94,6 @@ class EvalueringMålgruppeTest {
             }.hasMessageContaining("Ugyldig svar=JA_IMPLISITT")
         }
     }
-
-    private val ResultatEvaluering.medlemskap: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap
 }
 
 @ParameterizedTest

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiodeTest.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkår
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringVilkårperiode.evaulerVilkårperiode
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -16,7 +17,7 @@ class EvalueringVilkårperiodeTest {
     @Test
     fun `skal evaluere gyldig kombinasjon av målgruppe`() {
         val resultatMålgruppe =
-            evaulerVilkårperiode(MålgruppeType.OMSTILLINGSSTØNAD, DelvilkårMålgruppeDto(SvarJaNei.JA))
+            evaulerVilkårperiode(MålgruppeType.OMSTILLINGSSTØNAD, DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.JA)))
         assertThat(resultatMålgruppe.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
     }
 
@@ -24,7 +25,7 @@ class EvalueringVilkårperiodeTest {
     fun `skal evaluere gyldig kombinasjon av aktivitet`() {
         val resultatAktivitet = evaulerVilkårperiode(
             AktivitetType.TILTAK,
-            DelvilkårAktivitetDto(SvarJaNei.NEI, SvarJaNei.NEI),
+            DelvilkårAktivitetDto(VurderingDto(SvarJaNei.NEI), VurderingDto(SvarJaNei.NEI)),
         )
         assertThat(resultatAktivitet.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
     }
@@ -32,7 +33,7 @@ class EvalueringVilkårperiodeTest {
     @Test
     fun `skal kaste feil hvis man kaller med feil type`() {
         assertThatThrownBy {
-            evaulerVilkårperiode(MålgruppeType.AAP, DelvilkårAktivitetDto(null, null))
+            evaulerVilkårperiode(MålgruppeType.AAP, DelvilkårAktivitetDto(VurderingDto(null), VurderingDto(null)))
         }.hasMessageContaining("Ugyldig kombinasjon")
 
         assertThatThrownBy {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig at kunne begrunne hvert delvilkår med en begrunnelse, i tillegg til begrunnelsen på selve perioden.

**Noter at denne endrer grensesnittet mot frontend, der de ulike vilkåren tidligere kun var svaren, men nå er vurdering.**

Målgruppe
```json
{
  "medlemskap": {
    "svar": "JA",
    "begrunnelse": null,
  }
}
```

Målgruppe tidligere
```json
{
  "medlemskap": "JA"
}
```

Typingen blir kanskje litt uheldig då jeg tenkte at frontend egentlige ikke trenger å sende inn noe vurdering på eks medlemskap når man oppretter.
```kotlin
data class DelvilkårMålgruppeDto(
    val medlemskap: VurderingDto?,
```
Selv om den er null, så returneres alltid Vurdering fra backend.
For eks utdanning så returneres
```json
{
  "lønnet": {
    "svar": null,
    "begrunnelse": null,
    "resultat": "IKKE_AKTUELT",
  },
  "mottarSykepenger": {
    "svar": "NEI",
    "begrunnelse": null,
    "resultat": "OPPFYLT",
  }
}
```