### PR TITLE
Medlemskap skal vurderes for type=uføretrygd

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppe.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppe.kt
@@ -19,11 +19,11 @@ object EvalueringMålgruppe {
         return when (type) {
             MålgruppeType.AAP,
             MålgruppeType.OVERGANGSSTØNAD,
-            MålgruppeType.UFØRETRYGD,
             -> jaImplisitt(delvilkår, type)
 
             MålgruppeType.NEDSATT_ARBEIDSEVNE,
             MålgruppeType.OMSTILLINGSSTØNAD,
+            MålgruppeType.UFØRETRYGD,
             -> utledResultat(delvilkår)
 
             MålgruppeType.DAGPENGER -> utledResultat(delvilkår) // Foreløpig

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
@@ -99,7 +99,7 @@ class EvalueringMålgruppeTest {
 @ParameterizedTest
 @EnumSource(
     value = MålgruppeType::class,
-    names = ["NEDSATT_ARBEIDSEVNE", "OMSTILLINGSSTØNAD", "DAGPENGER"],
+    names = ["NEDSATT_ARBEIDSEVNE", "OMSTILLINGSSTØNAD", "DAGPENGER", "UFØRETRYGD"],
     mode = EnumSource.Mode.EXCLUDE,
 )
 private annotation class ImplisittParameterizedTest
@@ -107,7 +107,7 @@ private annotation class ImplisittParameterizedTest
 @ParameterizedTest
 @EnumSource(
     value = MålgruppeType::class,
-    names = ["AAP", "UFØRETRYGD", "OVERGANGSSTØNAD"],
+    names = ["AAP", "OVERGANGSSTØNAD"],
     mode = EnumSource.Mode.EXCLUDE,
 )
 private annotation class IkkeImplisittParameterizedTest


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Uføretrygd gis på samme måte som omstillingsstønad, så dersom de er vurdert etter andre ledd i uføreparagrafen oppfyller de ikke vårt vilkår for medlemskap. 

Gått fra å skulle ha `JA_IMPLISITT` til å måtte vurderes

Hører sammen med [PR 187](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/187) i sak-frontend