### PR TITLE
Lagt til task for å opprette internt vedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
@@ -70,13 +70,6 @@ enum class StegType(
         tillattFor = BehandlerRolle.SYSTEM,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.IVERKSETTER_VEDTAK),
     ),
-
-    /*
-    LAG_SAKSBEHANDLINGSBLANKETT(
-        rekkefølge = 6,
-        tillattFor = BehandlerRolle.SYSTEM,
-        gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.IVERKSETTER_VEDTAK),
-    ),*/
     FERDIGSTILLE_BEHANDLING(
         rekkefølge = 7,
         tillattFor = BehandlerRolle.SYSTEM,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/FerdigstillBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/FerdigstillBehandlingSteg.kt
@@ -1,8 +1,10 @@
 package no.nav.tilleggsstonader.sak.behandlingsflyt
 
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.interntVedtak.InterntVedtakTask
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Service
 @Service
 class FerdigstillBehandlingSteg(
     private val behandlingService: BehandlingService,
+    private val taskService: TaskService,
 ) : BehandlingSteg<Void?> {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -17,6 +20,8 @@ class FerdigstillBehandlingSteg(
     override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
         logger.info("Ferdigstiller behandling=${saksbehandling.id}")
         behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.FERDIGSTILT)
+
+        taskService.save(InterntVedtakTask.lagTask(saksbehandling.id))
 
         // TODO publiser vedtakshendelser, behandlingsstatistikk
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakTask.kt
@@ -52,7 +52,7 @@ class InterntVedtakTask(
                         dokumenttype = stønadstype.dokumentTypeInterntVedtak(),
                     ),
                 ),
-                fagsakId = null,
+                fagsakId = interntVedtak.behandling.eksternFagsakId.toString(),
                 avsenderMottaker = null,
                 journalførendeEnhet = enhet,
                 eksternReferanseId = "$behandlingId-blankett",

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakTask.kt
@@ -1,0 +1,70 @@
+package no.nav.tilleggsstonader.sak.interntVedtak
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.dokumentTypeInterntVedtak
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.brev.FamilieDokumentClient
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = InterntVedtakTask.TYPE,
+    beskrivelse = "Oppretter og journalfører internt vedtak",
+    maxAntallFeil = 3,
+)
+class InterntVedtakTask(
+    private val interntVedtakService: InterntVedtakService,
+    private val htmlifyClient: HtmlifyClient,
+    private val dokumentClient: FamilieDokumentClient,
+    private val journalpostService: JournalpostService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val behandlingId = UUID.fromString(task.payload)
+        val interntVedtak = interntVedtakService.lagInterntVedtak(behandlingId)
+        val html = htmlifyClient.generateHtml(interntVedtak)
+        val pdf = dokumentClient.genererPdf(html)
+        arkiver(interntVedtak, pdf)
+    }
+
+    private fun arkiver(interntVedtak: InterntVedtak, pdf: ByteArray) {
+        val behandlingId = interntVedtak.behandling.behandlingId
+        val stønadstype = interntVedtak.behandling.stønadstype
+        val enhet = arbeidsfordelingService.hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(interntVedtak.behandling.ident)
+        journalpostService.opprettJournalpost(
+            ArkiverDokumentRequest(
+                fnr = interntVedtak.behandling.ident,
+                forsøkFerdigstill = true,
+                hoveddokumentvarianter = listOf(
+                    Dokument(
+                        dokument = pdf,
+                        filtype = Filtype.PDFA,
+                        filnavn = null,
+                        tittel = "Internt vedtak $stønadstype",
+                        dokumenttype = stønadstype.dokumentTypeInterntVedtak(),
+                    ),
+                ),
+                fagsakId = null,
+                avsenderMottaker = null,
+                journalførendeEnhet = enhet,
+                eksternReferanseId = "$behandlingId-blankett",
+            ),
+        )
+    }
+
+    companion object {
+        const val TYPE = "lagInterntVedtak"
+
+        fun lagTask(behandlingId: UUID): Task {
+            return Task(TYPE, behandlingId.toString())
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,5 +132,4 @@ clients:
     uri: https://tilleggsstonader-arena.${CLIENT_ENV}-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.tilleggsstonader.tilleggsstonader-arena/.default
   htmlify:
-    uri: https://tilleggsstonader-htmlify.${CLIENT_ENV}-gcp-pub.nais.io
-    scope: api://${CLIENT_ENV}-gcp.tilleggsstonader.tilleggsstonader-arena/.default
+    uri: http://tilleggsstonader-htmlify

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -69,6 +69,7 @@ class DefaultRestTemplateConfiguration {
     "mock-oppgave",
     "mock-journalpost",
     "mock-featuretoggle",
+    "mock-htmlify",
 )
 @EnableMockOAuth2Server
 abstract class IntegrationTest {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
@@ -25,4 +25,6 @@ fun appLocal(): SpringApplicationBuilder =
             "mock-iverksett",
             "mock-oppgave",
             "mock-featuretoggle",
+            "mock-journalpost",
+            "mock-htmlify",
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/FerdigstillBehandlingStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/FerdigstillBehandlingStegTest.kt
@@ -8,9 +8,11 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.interntVedtak.InterntVedtakTask
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -19,10 +21,11 @@ class FerdigstillBehandlingStegTest {
     private val behandlingService = mockk<BehandlingService>(relaxed = true)
     private val taskService = mockk<TaskService>()
 
-    private val steg = FerdigstillBehandlingSteg(behandlingService)
+    private val steg = FerdigstillBehandlingSteg(behandlingService, taskService)
 
-    private val fagsak = fagsak()
     private val taskSlot = mutableListOf<Task>()
+    private val fagsak = fagsak()
+    private val behandling = saksbehandling(fagsak, behandling(fagsak, type = BehandlingType.REVURDERING))
 
     @BeforeEach
     internal fun setUp() {
@@ -32,8 +35,15 @@ class FerdigstillBehandlingStegTest {
 
     @Test
     internal fun `skal oppdatere status på behandlingen`() {
-        val behandling = saksbehandling(fagsak, behandling(fagsak, type = BehandlingType.REVURDERING))
         steg.utførSteg(behandling, null)
         verify { behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FERDIGSTILT) }
+    }
+
+    @Test
+    fun `skal opprette task for å lage internt vedtak`() {
+        steg.utførSteg(behandling, null)
+        val tasks = taskSlot.filter { it.type == InterntVedtakTask.TYPE }
+        assertThat(tasks).hasSize(1)
+        assertThat(tasks[0].payload).isEqualTo(behandling.id.toString())
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/HtmlifyClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/HtmlifyClientConfig.kt
@@ -1,0 +1,22 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.mocks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.sak.interntVedtak.HtmlifyClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("mock-htmlify")
+class HtmlifyClientConfig {
+
+    @Bean
+    @Primary
+    fun htmlifyClient(): HtmlifyClient {
+        val client = mockk<HtmlifyClient>()
+        every { client.generateHtml(any()) } returns "<body>body</body>"
+        return client
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Task for å opprette internt vedtak.
Tasken er frittstående og ikke direkt koblet til et steg. Den kjøres i ferdigstill behandling, og kan feile uten at påvirke steg-prosessen. 

Bygger videre på https://github.com/navikt/tilleggsstonader-sak/pull/181