### PR TITLE
Endret kallKommerFra til å ta inn en enum for å kun ha en metode for …

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringController.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.ekstern.journalføring
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.sak.journalføring.AutomatiskJournalføringRequest
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.util.FnrUtil.validerIdent
 import org.springframework.http.HttpStatus
@@ -23,7 +24,7 @@ class AutomatiskJournalføringController(private val automatiskJournalføringSer
     @PostMapping
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
     fun håndterSøknad(@RequestBody request: AutomatiskJournalføringRequest) {
-        feilHvisIkke(SikkerhetContext.kallKommerFraSoknadApi(), HttpStatus.UNAUTHORIZED) {
+        feilHvisIkke(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API), HttpStatus.UNAUTHORIZED) {
             "Kallet utføres ikke av en autorisert klient"
         }
         validerIdent(request.personIdent)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
@@ -1,0 +1,5 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet
+
+enum class EksternApplikasjon(val namespaceAppNavn: String) {
+    SOKNAD_API("tilleggsstonader:tilleggsstonader-soknad-api"),
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -24,15 +24,12 @@ object SikkerhetContext {
             claims.getAsList("roles").contains("access_as_application")
     }
 
-    // eks kallKommerFra("teamfamilie:familie-ef-mottak")
-    private fun kallKommerFra(forventetApplikasjonsSuffix: String): Boolean {
+    fun kallKommerFra(eksternApplikasjon: EksternApplikasjon): Boolean {
         val claims = SpringTokenValidationContextHolder().tokenValidationContext.getClaims("azuread")
         val applikasjonsnavn = claims.get("azp_name")?.toString() ?: "" // e.g. dev-gcp:some-team:application-name
         secureLogger.info("Applikasjonsnavn: $applikasjonsnavn")
-        return applikasjonsnavn.endsWith(forventetApplikasjonsSuffix)
+        return applikasjonsnavn.endsWith(eksternApplikasjon.namespaceAppNavn)
     }
-
-    fun kallKommerFraSoknadApi(): Boolean = kallKommerFra("tilleggsstonader:tilleggsstonader-soknad-api")
 
     fun hentSaksbehandler(): String {
         val result = hentSaksbehandlerEllerSystembruker()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SøknadRoutingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SøknadRoutingController.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.migrering.routing
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.IdentStønadstype
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,7 +21,7 @@ class SøknadRoutingController(
     @PostMapping
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
     fun sjekkRoutingForPerson(@RequestBody request: IdentStønadstype): SøknadRoutingResponse {
-        feilHvisIkke(SikkerhetContext.kallKommerFraSoknadApi(), HttpStatus.UNAUTHORIZED) {
+        feilHvisIkke(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API), HttpStatus.UNAUTHORIZED) {
             "Kallet utføres ikke av en autorisert klient"
         }
         return søknadRoutingService.sjekkRoutingForPerson(request)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContextTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContextTest.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet
 
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class SikkerhetContextTest {
@@ -10,21 +10,21 @@ class SikkerhetContextTest {
     @Test
     internal fun `skal ikke godkjenne kall fra soknad-api for andre applikasjoner`() {
         mockBrukerContext("", azp_name = "prod-gcp:tilleggsstonader:tilleggsstonader-integrasjoner")
-        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isFalse
+        assertThat(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API)).isFalse
         clearBrukerContext()
 
         mockBrukerContext("", azp_name = "prod-gcp:teamfamilie:familie-ef-sak")
-        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isFalse
+        assertThat(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API)).isFalse
         clearBrukerContext()
     }
 
     @Test
     internal fun `skal gjenkjenne kall fra soknad-api`() {
         mockBrukerContext("", azp_name = "prod-gcp:tilleggsstonader:tilleggsstonader-soknad-api")
-        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isTrue
+        assertThat(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API)).isTrue
         clearBrukerContext()
         mockBrukerContext("", azp_name = "dev-gcp:tilleggsstonader:tilleggsstonader-soknad-api")
-        Assertions.assertThat(SikkerhetContext.kallKommerFraSoknadApi()).isTrue
+        assertThat(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API)).isTrue
         clearBrukerContext()
     }
 }


### PR DESCRIPTION
…å sjekke at kall kommer fra en applikasjon

### Hvorfor er denne endringen nødvendig? ✨
For å unngå at vi oppretter flere metoder av typen `kallKommerFraSoknadApi` `kallKommerFraArena` la jeg til at man sender inn en enum i stedet, så vi kun har 1 metode for dette.