### PR TITLE
Skal kun iverksette aktuelle andeler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -98,6 +98,10 @@ class IverksettService(
                         iverksetting = iverksetting,
                     )
                 } else {
+                    feilHvis(it.statusIverksetting != StatusIverksetting.OK) {
+                        "Kan ikke iverksette behandling=${tilkjentYtelse.behandlingId} iverksetting=$iverksettingId " +
+                            "når det finnes tidligere andeler med annen status enn OK/UBEHANDLET"
+                    }
                     it
                 }
             }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -2,8 +2,10 @@ package no.nav.tilleggsstonader.sak.utbetaling.iverksetting
 
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Iverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
@@ -15,6 +17,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.YearMonth
 import java.util.UUID
 
 @Service
@@ -30,40 +33,90 @@ class IverksettService(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     /**
+     * Skal brukes når man iverksetter en behandling første gang, uansatt om det er behandling 1 eller behandling 2 på en fagsak
+     * Dette fordi man skal iverksette alle andeler tom forrige måned.
+     * Dvs denne skal brukes fra [no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.BeslutteVedtakSteg]
+     *
      * Ved første iverksetting av en behandling er det krav på at det gjøres med jwt, dvs med saksbehandler-token
      * Neste iverksettinger kan gjøres med client_credentials
-     *
+     */
+    @Transactional
+    fun iverksettBehandlingFørsteGang(behandlingId: UUID) {
+        iverksett(behandlingId, behandlingId, YearMonth.now().minusMonths(1))
+    }
+
+    /**
      * Hvis kallet feiler er det viktig at den samme iverksettingId brukes for å kunne ignorere conflict
      * Vid første iverksetting som gjøres burde man bruke behandlingId for å iverksette
      * for å enkelt kunne gjenbruke samme id vid neste iverksetting
+     *
+     * @param [måned] Når man iverksetter en behandling første gangen så skal [måned] settes til forrige måned
+     * fordi man skal iverksette tidligere måneder direkte.
+     * Når man iverksetter samme behandling neste gang skal man bruke inneværende måned for å iverksette aktuell måned
      */
     @Transactional
-    fun iverksett(behandlingId: UUID, iverksettingId: UUID) {
+    fun iverksett(behandlingId: UUID, iverksettingId: UUID, måned: YearMonth = YearMonth.now()) {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         if (!behandling.resultat.skalIverksettes) {
             logger.info("Iverksetter ikke behandling=$behandlingId då status=${behandling.status}")
             return
         }
-        val tilkjentYtelse = hentTilkjentYtelseOgOppdaterAndeler(behandlingId, iverksettingId)
+        val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandlingId)
         val totrinnskontroll = hentTotrinnskontroll(behandlingId)
 
         val dto = IverksettDtoMapper.map(
             behandling = behandling,
-            tilkjentYtelse = tilkjentYtelse,
+            andelerTilkjentYtelse = finnAndelerTilIverksetting(tilkjentYtelse, iverksettingId, måned),
             totrinnskontroll = totrinnskontroll,
             iverksettingId = iverksettingId,
-            forrigeIverksetting = forrigeIverksetting(),
+            forrigeIverksetting = forrigeIverksetting(behandling, tilkjentYtelse),
         )
         opprettPollStatusFraIverksettingTask(behandlingId, iverksettingId)
         iverksettClient.iverksett(dto)
     }
 
     /**
-     * TODO denne skal finne forrige iverksetting og behandlingId som ble brukt
-     * I en iverksetting nr 2 på en og samme behandling kan det være den samme behandlingId som man har, og ikke forrigeBehandlingId på behandlingen
+     * Henter aktuelle andeler
+     * Oppdaterer aktuelle perioder med status og iverksettingId
+     * Returnerer andeler som har beløp=0 då vi fortsatt ønsker å iverksette,
+     * men filtrer vekk disse i IverksettDtoMapper, for å eventuell opphøre tidligere perioder
      */
-    private fun forrigeIverksetting(): ForrigeIverksettingDto? {
-        return null
+    private fun finnAndelerTilIverksetting(
+        tilkjentYtelse: TilkjentYtelse,
+        iverksettingId: UUID,
+        måned: YearMonth,
+    ): List<AndelTilkjentYtelse> {
+        val sisteDagenIMåneden = måned.atEndOfMonth()
+        val iverksetting = Iverksetting(iverksettingId, LocalDateTime.now())
+        val aktuelleAndeler = tilkjentYtelse.andelerTilkjentYtelse
+            .filter { it.tom <= sisteDagenIMåneden }
+            .map {
+                if (it.statusIverksetting == StatusIverksetting.UBEHANDLET) {
+                    it.copy(
+                        statusIverksetting = StatusIverksetting.SENDT,
+                        iverksetting = iverksetting,
+                    )
+                } else {
+                    it
+                }
+            }
+        oppdaterAndeler(aktuelleAndeler, iverksetting)
+        return aktuelleAndeler
+    }
+
+    /**
+     * Oppdaterer andeler som ikke tidligere blitt iverksatte med iverksettingId
+     */
+    private fun oppdaterAndeler(
+        aktuelleAndeler: List<AndelTilkjentYtelse>,
+        iverksetting: Iverksetting,
+    ) {
+        val andelerSomSkalOppdateres = aktuelleAndeler.filter { it.iverksetting == iverksetting }
+
+        feilHvis(andelerSomSkalOppdateres.isEmpty()) {
+            "Forventet å oppdatere noen andeler"
+        }
+        andelTilkjentYtelseRepository.updateAll(andelerSomSkalOppdateres)
     }
 
     private fun hentTotrinnskontroll(behandlingId: UUID): Totrinnskontroll {
@@ -84,20 +137,35 @@ class IverksettService(
         )
     }
 
-    private fun hentTilkjentYtelseOgOppdaterAndeler(
-        behandlingId: UUID,
-        iverksettingId: UUID,
-    ): TilkjentYtelse {
-        val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandlingId)
-        val iverksetting = Iverksetting(iverksettingId, LocalDateTime.now())
-        val oppdaterteAndeler = tilkjentYtelse.andelerTilkjentYtelse.map {
-            it.copy(
-                statusIverksetting = StatusIverksetting.SENDT,
-                iverksetting = iverksetting,
-            )
-        }
-        // TODO skal kun oppdatere andeler som har fått iverksettingId
-        andelTilkjentYtelseRepository.updateAll(oppdaterteAndeler)
-        return tilkjentYtelse.copy(andelerTilkjentYtelse = oppdaterteAndeler.toSet())
+    /**
+     * Finner forrigeIverksetting fra denne eller forrige behandling
+     * Når man iverksetter behandling 1 første gang: null
+     * Når man iverksetter behandling 1 andre gang: (behandling1, forrige iverksettingId for behandling 1)
+     * Når man iverksetter behandling 2 første gang: (behandling1, siste iverksetting for behandling 1)
+     * Når man iverksetter behandling 2 andre gang: (behandling2, forrigeIverksettingId for behandling 2)
+     */
+    private fun forrigeIverksetting(
+        behandling: Saksbehandling,
+        tilkjentYtelse: TilkjentYtelse,
+    ): ForrigeIverksettingDto? {
+        return tilkjentYtelse.forrigeIverksetting(behandling.id)
+            ?: forrigeIverksettingForrigeBehandling(behandling)
     }
+
+    private fun forrigeIverksettingForrigeBehandling(behandling: Saksbehandling): ForrigeIverksettingDto? {
+        val forrigeBehandlingId = behandling.forrigeBehandlingId
+        return forrigeBehandlingId?.let {
+            tilkjentYtelseService.hentForBehandling(forrigeBehandlingId).forrigeIverksetting(forrigeBehandlingId)
+        }
+    }
+
+    /**
+     * Utleder [ForrigeIverksettingDto] ut fra andel med siste tidspunkt for iverksetting
+     */
+    private fun TilkjentYtelse.forrigeIverksetting(behandlingId: UUID): ForrigeIverksettingDto? =
+        andelerTilkjentYtelse
+            .mapNotNull { it.iverksetting }
+            .maxByOrNull { it.iverksettingTidspunkt }
+            ?.iverksettingId
+            ?.let { ForrigeIverksettingDto(behandlingId = behandlingId, iverksettingId = it) }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -42,6 +42,7 @@ class IverksettService(
      */
     @Transactional
     fun iverksettBehandlingFørsteGang(behandlingId: UUID) {
+        // TODO denne skal oppdatere andeler i forrige behandling til UAKTUELL hvis de ikke er iverksatte
         iverksett(behandlingId, behandlingId, YearMonth.now().minusMonths(1))
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -62,7 +62,7 @@ class BeslutteVedtakSteg(
             brevService.lagEndeligBeslutterbrev(saksbehandling)
             opprettJournalførVedtaksbrevTask(saksbehandling)
 
-            // TODO iverksettService.iverksett(saksbehandling.id, saksbehandling.id)
+            // TODO iverksettService.iverksettBehandlingFørsteGang(saksbehandling.id)
 
             StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV
         } else {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
@@ -1,25 +1,33 @@
 package no.nav.tilleggsstonader.sak.utbetaling.iverksetting
 
+import io.mockk.CapturingSlot
 import io.mockk.justRun
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.IverksettClientConfig.Companion.clearMock
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.TotrinnInternStatus
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.TotrinnskontrollRepository
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.TotrinnskontrollUtil.totrinnskontroll
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.YearMonth
+import java.util.UUID
 
 class IverksettServiceTest : IntegrationTest() {
 
@@ -34,6 +42,10 @@ class IverksettServiceTest : IntegrationTest() {
 
     @Autowired
     lateinit var totrinnskontrollRepository: TotrinnskontrollRepository
+
+    val forrigeMåned = YearMonth.now().minusMonths(1)
+    val nåværendeMåned = YearMonth.now()
+    val nesteMåned = YearMonth.now().plusMonths(1)
 
     val iverksettingDto = slot<IverksettDto>()
 
@@ -76,6 +88,164 @@ class IverksettServiceTest : IntegrationTest() {
         assertThat(andel.statusIverksetting).isEqualTo(StatusIverksetting.SENDT)
     }
 
+    @Nested
+    inner class IverksettingFlyt {
+
+        val fagsak = fagsak()
+
+        val behandling =
+            behandling(fagsak, resultat = BehandlingResultat.INNVILGET, status = BehandlingStatus.FERDIGSTILT)
+        val behandling2 =
+            behandling(
+                fagsak,
+                resultat = BehandlingResultat.INNVILGET,
+                status = BehandlingStatus.FERDIGSTILT,
+                forrigeBehandlingId = behandling.id,
+            )
+
+        val tilkjentYtelse =
+            tilkjentYtelse(behandlingId = behandling.id, startdato = null, andeler = lag3Andeler(behandling))
+        val tilkjentYtelse2 =
+            tilkjentYtelse(behandlingId = behandling2.id, startdato = null, andeler = lag3Andeler(behandling2))
+
+        @BeforeEach
+        fun setUp() {
+            testoppsettService.opprettBehandlingMedFagsak(behandling)
+            tilkjentYtelseRepository.insert(tilkjentYtelse)
+            lagreTotrinnskontroll(behandling)
+            iverksettService.iverksettBehandlingFørsteGang(behandling.id)
+        }
+
+        @Test
+        fun `første behandling - første iverksetting`() {
+            val andeler = hentAndeler(behandling)
+
+            andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, behandling.id)
+
+            andeler.forMåned(nåværendeMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            andeler.forMåned(nesteMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            iverksettingDto.assertUtbetalingerInneholder(forrigeMåned)
+
+            assertThat(iverksettingDto.captured.forrigeIverksetting).isNull()
+        }
+
+        @Test
+        fun `første behandling  - andre iverksetting`() {
+            val iverksettingId = UUID.randomUUID()
+            iverksettService.iverksett(behandling.id, iverksettingId, nåværendeMåned)
+
+            val andeler = hentAndeler(behandling)
+
+            andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, behandling.id)
+
+            andeler.forMåned(nåværendeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, iverksettingId)
+
+            andeler.forMåned(nesteMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            iverksettingDto.assertUtbetalingerInneholder(forrigeMåned, nåværendeMåned)
+
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(behandling.id)
+        }
+
+        @Test
+        fun `andre behandling - første iverksetting - skal bruke behandling2 som iverksettingId`() {
+            testoppsettService.lagre(behandling2)
+            tilkjentYtelseRepository.insert(tilkjentYtelse2)
+            lagreTotrinnskontroll(behandling2)
+            iverksettService.iverksettBehandlingFørsteGang(behandling2.id)
+
+            val andeler = hentAndeler(behandling2)
+
+            andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, behandling2.id)
+
+            andeler.forMåned(nåværendeMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            andeler.forMåned(nesteMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            iverksettingDto.assertUtbetalingerInneholder(forrigeMåned)
+
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(behandling.id)
+        }
+
+        @Test
+        fun `andre behandling - første iverksetting med 2 iverksettinger`() {
+            val iverksettingIdBehandling1 = UUID.randomUUID()
+            iverksettService.iverksett(behandling.id, iverksettingIdBehandling1, nåværendeMåned)
+
+            testoppsettService.lagre(behandling2)
+            tilkjentYtelseRepository.insert(tilkjentYtelse2)
+            lagreTotrinnskontroll(behandling2)
+            iverksettService.iverksettBehandlingFørsteGang(behandling2.id)
+
+            val andeler = hentAndeler(behandling2)
+
+            andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, behandling2.id)
+
+            andeler.forMåned(nåværendeMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            andeler.forMåned(nesteMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            iverksettingDto.assertUtbetalingerInneholder(forrigeMåned)
+
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(iverksettingIdBehandling1)
+        }
+
+        @Test
+        fun `andre behandling  - andre iverksetting`() {
+            val iverksettingId = UUID.randomUUID()
+
+            testoppsettService.lagre(behandling2)
+            tilkjentYtelseRepository.insert(tilkjentYtelse2)
+            lagreTotrinnskontroll(behandling2)
+
+            iverksettService.iverksettBehandlingFørsteGang(behandling2.id)
+            iverksettService.iverksett(behandling2.id, iverksettingId)
+
+            val andeler = hentAndeler(behandling2)
+
+            andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, behandling2.id)
+
+            andeler.forMåned(nåværendeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, iverksettingId)
+
+            andeler.forMåned(nesteMåned).assertHarStatusOgId(StatusIverksetting.UBEHANDLET)
+
+            iverksettingDto.assertUtbetalingerInneholder(forrigeMåned, nåværendeMåned)
+
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling2.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(behandling2.id)
+        }
+
+        @Test
+        fun `andre behandling kun med 0-beløp - skal ikke sende noen andeler`() {
+            testoppsettService.lagre(behandling2)
+            tilkjentYtelseRepository.insert(
+                tilkjentYtelse(
+                    behandling2.id,
+                    null,
+                    lagAndel(behandling, forrigeMåned, beløp = 0),
+                ),
+            )
+            lagreTotrinnskontroll(behandling2)
+            iverksettService.iverksettBehandlingFørsteGang(behandling2.id)
+
+            val andeler = hentAndeler(behandling2)
+
+            andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.SENDT, behandling2.id)
+
+            assertThat(iverksettingDto.captured.vedtak.utbetalinger).isEmpty()
+        }
+    }
+
+    private fun CapturingSlot<IverksettDto>.assertUtbetalingerInneholder(vararg måned: YearMonth) {
+        assertThat(captured.vedtak.utbetalinger.map { YearMonth.from(it.fraOgMedDato) })
+            .containsExactly(*måned)
+    }
+
     private fun lagreTotrinnskontroll(behandling: Behandling) {
         totrinnskontrollRepository.insert(
             totrinnskontroll(
@@ -85,4 +255,29 @@ class IverksettServiceTest : IntegrationTest() {
             ),
         )
     }
+
+    private fun hentAndeler(behandling: Behandling): Set<AndelTilkjentYtelse> {
+        return tilkjentYtelseRepository.findByBehandlingId(behandling.id)!!.andelerTilkjentYtelse
+    }
+
+    private fun Collection<AndelTilkjentYtelse>.forMåned(yearMonth: YearMonth) =
+        this.single { it.fom == yearMonth.atDay(1) }
+
+    fun AndelTilkjentYtelse.assertHarStatusOgId(statusIverksetting: StatusIverksetting, iverksettingId: UUID? = null) {
+        assertThat(this.statusIverksetting).isEqualTo(statusIverksetting)
+        assertThat(this.iverksetting?.iverksettingId).isEqualTo(iverksettingId)
+    }
+
+    private fun lag3Andeler(behandling: Behandling) = arrayOf(
+        lagAndel(behandling, forrigeMåned),
+        lagAndel(behandling, nåværendeMåned),
+        lagAndel(behandling, nesteMåned),
+    )
+
+    private fun lagAndel(behandling: Behandling, måned: YearMonth, beløp: Int = 10) = andelTilkjentYtelse(
+        kildeBehandlingId = behandling.id,
+        fom = måned.atDay(1),
+        tom = måned.atEndOfMonth(),
+        beløp = beløp,
+    )
 }


### PR DESCRIPTION
Aktuelle andeler er andeler som har tom <= måned som blir sendt inn

### Hvorfor er denne endringen nødvendig? ✨
Når vi iverksetter så skal vi kun iverksette aktuelle andeler.
For første iverksetting av en behandling er aktuelle andeler de som har `tom <= siste dag i forrige måned` (foreløpig)
For iverksetting etter første for den samme behandlingen skal man iverksette med nåværende måned. 

Sånn at hvis vi iverksetter en behandling i `feb` med andeler i `jan, feb, og mars` så kommer vi iverksette `jan` direkte. `feb` kommer iverksettes i en task som ikke er satt opp ennå.

For at kunne teste dette ordentligt la jeg til riktig støtte for `forrigeIverksetting`og. Som desseverre gjorde endringen litt større i `IverksettingService` enn hva den hadde behøvt. Tenker vi kan ta en kodegjennomgang i neste uke. 

❗ Uklart hvilket dato som er kjøredato for oss, hvis man eks har kjøredato den 20e i måneden og vi innvilger en stønad 25 feb, så skal vi iverksette både jan og feb direkte(?) Dette er noe som får fikses opp på senere.


Fortsetting på 
* https://github.com/navikt/tilleggsstonader-sak/pull/191
