### PR TITLE
✨ Eget steg for inngangsvilkår

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -103,7 +103,7 @@ class BehandlingService(
         behandlingType: BehandlingType,
         fagsakId: UUID,
         status: BehandlingStatus = BehandlingStatus.OPPRETTET,
-        stegType: StegType = StegType.VILKÅR,
+        stegType: StegType = StegType.INNGANGSVILKÅR,
         behandlingsårsak: BehandlingÅrsak,
         kravMottatt: LocalDate? = null,
         erMigrering: Boolean = false,
@@ -140,7 +140,7 @@ class BehandlingService(
         behandlingshistorikkService.opprettHistorikkInnslag(
             behandlingshistorikk = Behandlingshistorikk(
                 behandlingId = behandling.id,
-                steg = StegType.VILKÅR, // TODO se over dette ping Sara
+                steg = stegType,
             ),
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/domain/Behandlingshistorikk.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/domain/Behandlingshistorikk.kt
@@ -61,7 +61,7 @@ private fun Behandlingshistorikk.mapUtfallTilHendelse() =
 
 private fun Behandlingshistorikk.mapStegTilHendelse(saksbehandling: Saksbehandling) =
     when (this.steg) {
-        StegType.VILKÅR -> Hendelse.OPPRETTET
+        StegType.INNGANGSVILKÅR -> Hendelse.OPPRETTET
         StegType.SEND_TIL_BESLUTTER -> Hendelse.SENDT_TIL_BESLUTTER
         StegType.BEHANDLING_FERDIGSTILT -> mapFraFerdigstiltTilHendelse(saksbehandling.resultat)
         StegType.FERDIGSTILLE_BEHANDLING -> mapFraFerdigstilleTilHendelse(saksbehandling.resultat)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
@@ -40,23 +40,28 @@ enum class StegType(
         tillattFor = BehandlerRolle.SAKSBEHANDLER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.OPPRETTET, BehandlingStatus.UTREDES),
     ),
-    VILKÅR(
+    INNGANGSVILKÅR(
         rekkefølge = 1,
         tillattFor = BehandlerRolle.SAKSBEHANDLER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.OPPRETTET, BehandlingStatus.UTREDES),
     ),
-    BEREGNE_YTELSE(
+    VILKÅR(
         rekkefølge = 2,
         tillattFor = BehandlerRolle.SAKSBEHANDLER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.UTREDES),
     ),
-    SEND_TIL_BESLUTTER(
+    BEREGNE_YTELSE(
         rekkefølge = 3,
         tillattFor = BehandlerRolle.SAKSBEHANDLER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.UTREDES),
     ),
-    BESLUTTE_VEDTAK(
+    SEND_TIL_BESLUTTER(
         rekkefølge = 4,
+        tillattFor = BehandlerRolle.SAKSBEHANDLER,
+        gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.UTREDES),
+    ),
+    BESLUTTE_VEDTAK(
+        rekkefølge = 5,
         tillattFor = BehandlerRolle.BESLUTTER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.FATTER_VEDTAK),
     ),
@@ -96,7 +101,8 @@ enum class StegType(
 
     fun hentNesteSteg(): StegType {
         return when (this) {
-            REVURDERING_ÅRSAK -> VILKÅR
+            REVURDERING_ÅRSAK -> INNGANGSVILKÅR
+            INNGANGSVILKÅR -> VILKÅR
             VILKÅR -> BEREGNE_YTELSE
             BEREGNE_YTELSE -> SEND_TIL_BESLUTTER
             SEND_TIL_BESLUTTER -> BESLUTTE_VEDTAK

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårSteg.kt
@@ -9,13 +9,18 @@ import org.springframework.stereotype.Service
 
 @Service
 class InngangsvilkårSteg(
-    val behandlingService: BehandlingService,
+    private val behandlingService: BehandlingService,
 ) : BehandlingSteg<Void?> {
 
     override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
-        behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.UTREDES)
+        if (saksbehandling.status != BehandlingStatus.UTREDES) {
+            behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.UTREDES)
+        }
     }
 
+    /**
+     * håndteres av [StønadsperiodeService]
+     */
     override fun settInnHistorikk() = false
 
     override fun stegType(): StegType = StegType.INNGANGSVILKÅR

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårSteg.kt
@@ -1,0 +1,22 @@
+package no.nav.tilleggsstonader.sak.vilkår
+
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import org.springframework.stereotype.Service
+
+@Service
+class InngangsvilkårSteg(
+    val behandlingService: BehandlingService,
+) : BehandlingSteg<Void?> {
+
+    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
+        behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.UTREDES)
+    }
+
+    override fun settInnHistorikk() = false
+
+    override fun stegType(): StegType = StegType.INNGANGSVILKÅR
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -1,13 +1,26 @@
 package no.nav.tilleggsstonader.sak.vilkår
 
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import org.springframework.stereotype.Service
 
 @Service
-class VilkårSteg : BehandlingSteg<Void?> {
-    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {}
+class VilkårSteg(
+    private val behandlingService: BehandlingService,
+) : BehandlingSteg<Void?> {
+    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
+        if (saksbehandling.status != BehandlingStatus.UTREDES) {
+            behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.UTREDES)
+        }
+    }
 
     override fun stegType(): StegType = StegType.VILKÅR
+
+    /**
+     * håndteres av [VilkårStegService]
+     */
+    override fun settInnHistorikk(): Boolean = false
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -1,18 +1,13 @@
 package no.nav.tilleggsstonader.sak.vilkår
 
-import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import org.springframework.stereotype.Service
 
 @Service
-class VilkårSteg(private val behandlingService: BehandlingService) : BehandlingSteg<Void?> {
-
-    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
-        behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.UTREDES)
-    }
+class VilkårSteg : BehandlingSteg<Void?> {
+    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {}
 
     override fun stegType(): StegType = StegType.VILKÅR
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsperiode
 
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.vilkår.InngangsvilkårSteg
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
@@ -16,6 +18,8 @@ class StønadsperiodeService(
     private val behandlingService: BehandlingService,
     private val stønadsperiodeRepository: StønadsperiodeRepository,
     private val vilkårperiodeService: VilkårperiodeService,
+    private val stegService: StegService,
+    private val inngangsvilkårSteg: InngangsvilkårSteg,
 ) {
     fun hentStønadsperioder(behandlingId: UUID): List<StønadsperiodeDto> {
         return stønadsperiodeRepository.findAllByBehandlingId(behandlingId).tilSortertDto()
@@ -27,6 +31,8 @@ class StønadsperiodeService(
             "Kan ikke lagre stønadsperioder når behandlingen er låst"
         }
         validerStønadsperioder(behandlingId, stønadsperioder)
+
+        stegService.håndterSteg(behandlingId, inngangsvilkårSteg)
 
         val tidligereStønadsperioder = stønadsperiodeRepository.findAllByBehandlingId(behandlingId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -41,7 +41,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.opprettVilkårperiode(vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(periode)
+        return vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(periode)
     }
 
     @PostMapping("{id}")
@@ -53,7 +53,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.oppdaterVilkårperiode(id, vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(periode)
+        return vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(periode)
     }
 
     @DeleteMapping("{id}")
@@ -65,6 +65,6 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.slettVilkårperiode(id, slettVikårperiode)
-        return vilkårperiodeService.validerOgLagResponse(periode)
+        return vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(periode)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -76,7 +76,7 @@ class VilkårperiodeService(
     private fun håndterMuligStegendring(
         saksbehandling: Saksbehandling,
         valideringsresultat: Result<Unit>,
-        periode: Vilkårperiode
+        periode: Vilkårperiode,
     ) {
         // TODO: Hvis vi legger aktivitetsdager på vilkårsperioder må vi rekjøre steget ved endring av vilkårsperioder for å sikre at beregning er gjort med oppdaterte vilkårsperioder
         if (saksbehandling.steg == StegType.INNGANGSVILKÅR && valideringsresultat.isSuccess) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -2,8 +2,12 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
 
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.validerBehandlingIdErLik
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.vilkår.InngangsvilkårSteg
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeValideringUtil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
@@ -32,6 +36,8 @@ class VilkårperiodeService(
     private val behandlingService: BehandlingService,
     private val vilkårperiodeRepository: VilkårperiodeRepository,
     private val stønadsperiodeRepository: StønadsperiodeRepository,
+    private val stegService: StegService,
+    private val inngangsvilkårSteg: InngangsvilkårSteg,
 ) {
 
     fun hentVilkårperioder(behandlingId: UUID): Vilkårperioder {
@@ -51,16 +57,33 @@ class VilkårperiodeService(
         vilkårsperioder: List<Vilkårperiode>,
     ) = vilkårsperioder.filter { it.type is T }
 
-    fun validerOgLagResponse(
+    fun oppdaterBehandlingstegOgLagResponse(
         periode: Vilkårperiode,
     ): LagreVilkårperiodeResponse {
+        val saksbehandling = behandlingService.hentSaksbehandling(periode.behandlingId)
+
         val valideringsresultat = validerStønadsperioder(periode.behandlingId)
+
+        håndterMuligStegendring(saksbehandling, valideringsresultat, periode)
 
         return LagreVilkårperiodeResponse(
             periode.tilDto(),
             stønadsperiodeStatus = if (valideringsresultat.isSuccess) Stønadsperiodestatus.OK else Stønadsperiodestatus.FEIL,
             stønadsperiodeFeil = valideringsresultat.exceptionOrNull()?.message,
         )
+    }
+
+    private fun håndterMuligStegendring(
+        saksbehandling: Saksbehandling,
+        valideringsresultat: Result<Unit>,
+        periode: Vilkårperiode
+    ) {
+        // TODO: Hvis vi legger aktivitetsdager på vilkårsperioder må vi rekjøre steget ved endring av vilkårsperioder for å sikre at beregning er gjort med oppdaterte vilkårsperioder
+        if (saksbehandling.steg == StegType.INNGANGSVILKÅR && valideringsresultat.isSuccess) {
+            stegService.håndterSteg(periode.behandlingId, inngangsvilkårSteg)
+        } else if (saksbehandling.steg != StegType.INNGANGSVILKÅR && valideringsresultat.isFailure) {
+            stegService.resetSteg(periode.behandlingId, StegType.INNGANGSVILKÅR)
+        }
     }
 
     @Transactional

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkControllerTest.kt
@@ -56,9 +56,9 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
         val behandling = testoppsettService.lagre(behandling(fagsak))
 
-        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
-        leggInnHistorikk(behandling, "2", LocalDateTime.now().minusDays(1), StegType.VILKÅR)
-        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(1), StegType.VILKÅR)
+        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.INNGANGSVILKÅR)
+        leggInnHistorikk(behandling, "2", LocalDateTime.now().minusDays(1), StegType.INNGANGSVILKÅR)
+        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(1), StegType.INNGANGSVILKÅR)
 
         val respons = hentHistorikk(behandling.id)
         assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("2")
@@ -69,17 +69,18 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
         val behandling = testoppsettService.lagre(behandling(fagsak))
 
-        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
-        leggInnHistorikk(behandling, "2", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
-        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(2), StegType.SEND_TIL_BESLUTTER)
+        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.INNGANGSVILKÅR)
+        leggInnHistorikk(behandling, "2", LocalDateTime.now(), StegType.VILKÅR)
+        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
+        leggInnHistorikk(behandling, "4", LocalDateTime.now().plusDays(2), StegType.SEND_TIL_BESLUTTER)
         leggInnHistorikk(
             behandling,
-            "4",
+            "5",
             LocalDateTime.now().plusDays(3),
             StegType.BESLUTTE_VEDTAK,
             stegUtfall = StegUtfall.BESLUTTE_VEDTAK_GODKJENT,
         )
-        leggInnHistorikk(behandling, "5", LocalDateTime.now().plusDays(4), StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)
+        leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(4), StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)
         // leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(5), StegType.LAG_SAKSBEHANDLINGSBLANKETT)
         leggInnHistorikk(behandling, "7", LocalDateTime.now().plusDays(6), StegType.FERDIGSTILLE_BEHANDLING)
         leggInnHistorikk(behandling, "8", LocalDateTime.now().plusDays(7), StegType.PUBLISER_VEDTAKSHENDELSE)
@@ -91,7 +92,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
             ),
         )
         val respons = hentHistorikk(behandling.id)
-        assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("7", "4", "3", "1")
+        assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("7", "5", "4", "1")
     }
 
     @Test
@@ -99,18 +100,19 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
         val behandling = testoppsettService.lagre(behandling(fagsak))
 
-        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
-        leggInnHistorikk(behandling, "2", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
-        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(2), StegType.SEND_TIL_BESLUTTER)
+        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.INNGANGSVILKÅR)
+        leggInnHistorikk(behandling, "2", LocalDateTime.now(), StegType.VILKÅR)
+        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
+        leggInnHistorikk(behandling, "4", LocalDateTime.now().plusDays(2), StegType.SEND_TIL_BESLUTTER)
         leggInnHistorikk(
             behandling,
-            "4",
+            "5",
             LocalDateTime.now().plusDays(3),
             StegType.BESLUTTE_VEDTAK,
             stegUtfall = StegUtfall.BESLUTTE_VEDTAK_UNDERKJENT,
         )
-        leggInnHistorikk(behandling, "5", LocalDateTime.now().plusDays(6), StegType.FERDIGSTILLE_BEHANDLING)
-        leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(8), StegType.BEHANDLING_FERDIGSTILT)
+        leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(6), StegType.FERDIGSTILLE_BEHANDLING)
+        leggInnHistorikk(behandling, "7", LocalDateTime.now().plusDays(8), StegType.BEHANDLING_FERDIGSTILT)
         behandlingRepository.update(
             behandling.copy(
                 resultat = BehandlingResultat.HENLAGT,
@@ -118,7 +120,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
             ),
         )
         val respons = hentHistorikk(behandling.id)
-        assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("6", "4", "3", "1")
+        assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("7", "5", "4", "1")
     }
 
     @Test
@@ -126,27 +128,28 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(""))))
         val behandling = testoppsettService.lagre(behandling(fagsak))
 
-        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
-        leggInnHistorikk(behandling, "2", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
-        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(2), StegType.SEND_TIL_BESLUTTER)
+        leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.INNGANGSVILKÅR)
+        leggInnHistorikk(behandling, "2", LocalDateTime.now(), StegType.VILKÅR)
+        leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(1), StegType.BEREGNE_YTELSE)
+        leggInnHistorikk(behandling, "4", LocalDateTime.now().plusDays(2), StegType.SEND_TIL_BESLUTTER)
         leggInnHistorikk(
             behandling,
-            "4",
+            "5",
             LocalDateTime.now().plusDays(3),
             StegType.BESLUTTE_VEDTAK,
             stegUtfall = StegUtfall.BESLUTTE_VEDTAK_UNDERKJENT,
         )
-        leggInnHistorikk(behandling, "5", LocalDateTime.now().plusDays(4), StegType.SEND_TIL_BESLUTTER)
+        leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(4), StegType.SEND_TIL_BESLUTTER)
         leggInnHistorikk(
             behandling,
-            "6",
+            "7",
             LocalDateTime.now().plusDays(5),
             StegType.BESLUTTE_VEDTAK,
             stegUtfall = StegUtfall.BESLUTTE_VEDTAK_GODKJENT,
         )
 
         val respons = hentHistorikk(behandling.id)
-        assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("6", "5", "4", "3", "1")
+        assertThat(respons.body!!.map { it.endretAvNavn }).containsExactly("7", "6", "5", "4", "1")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkServiceTest.kt
@@ -71,11 +71,11 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
         val behandling = testoppsettService.lagre(behandling(fagsak))
         val beslutteVedtak = behandling.copy(steg = StegType.BESLUTTE_VEDTAK)
 
-        insert(behandling.copy(steg = StegType.VILKÅR), LocalDateTime.now().minusDays(8))
-        insert(behandling.copy(steg = StegType.VILKÅR), LocalDateTime.now().minusDays(7))
+        insert(behandling.copy(steg = StegType.INNGANGSVILKÅR), LocalDateTime.now().minusDays(8))
+        insert(behandling.copy(steg = StegType.INNGANGSVILKÅR), LocalDateTime.now().minusDays(7))
         insert(behandling.copy(steg = StegType.SEND_TIL_BESLUTTER), LocalDateTime.now().minusDays(6))
         insert(beslutteVedtak, LocalDateTime.now().minusDays(5), StegUtfall.BESLUTTE_VEDTAK_UNDERKJENT)
-        insert(behandling.copy(steg = StegType.VILKÅR), LocalDateTime.now().minusDays(4))
+        insert(behandling.copy(steg = StegType.INNGANGSVILKÅR), LocalDateTime.now().minusDays(4))
         insert(behandling.copy(steg = StegType.SEND_TIL_BESLUTTER), LocalDateTime.now().minusDays(3))
         insert(beslutteVedtak, LocalDateTime.now().minusDays(2), StegUtfall.BESLUTTE_VEDTAK_GODKJENT)
 
@@ -92,7 +92,7 @@ internal class BehandlingshistorikkServiceTest : IntegrationTest() {
     @Test
     internal fun `flere sett og av vent skal ikke slåes sammen`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
-        val behandling = testoppsettService.lagre(behandling(fagsak, steg = StegType.VILKÅR))
+        val behandling = testoppsettService.lagre(behandling(fagsak, steg = StegType.INNGANGSVILKÅR))
         insert(behandling, LocalDateTime.now().minusDays(10))
         insert(behandling, LocalDateTime.now().minusDays(8), StegUtfall.SATT_PÅ_VENT)
         insert(behandling, LocalDateTime.now().minusDays(5), StegUtfall.TATT_AV_VENT)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -64,7 +64,7 @@ fun oppgave(
 fun behandling(
     fagsak: Fagsak = fagsak(),
     status: BehandlingStatus = BehandlingStatus.OPPRETTET,
-    steg: StegType = StegType.VILKÅR,
+    steg: StegType = StegType.INNGANGSVILKÅR,
     kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
     id: UUID = UUID.randomUUID(),
     type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -96,7 +96,7 @@ class StønadsperiodeServiceTest : IntegrationTest() {
                 målgruppe = MålgruppeType.OVERGANGSSTØNAD,
                 aktivitet = AktivitetType.UTDANNING,
             )
-            val oppdatertePerioder = testWithBrukerContext(SAKSHEH_B) {
+            val oppdatertePerioder = testWithBrukerContext(SAKSHEH_B, groups = listOf(rolleConfig.saksbehandlerRolle)) {
                 stønadsperiodeService.lagreStønadsperioder(behandling.id, listOf(oppdatertPeriode))
             }
             assertThat(oppdatertePerioder).hasSize(1)
@@ -153,7 +153,7 @@ class StønadsperiodeServiceTest : IntegrationTest() {
                 aktivitet = AktivitetType.UTDANNING,
             )
             val nyPeriode = stønadsperiodeDto(fom = FOM.plusDays(10), tom = FOM.plusDays(10))
-            val stønadsperioder2 = testWithBrukerContext(SAKSHEH_B) {
+            val stønadsperioder2 = testWithBrukerContext(SAKSHEH_B, groups = listOf(rolleConfig.saksbehandlerRolle)) {
                 stønadsperiodeService.lagreStønadsperioder(
                     behandling.id,
                     listOf(oppdatertPeriode, nyPeriode),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -2,18 +2,21 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsperiode
 
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiodeResponse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -46,8 +49,8 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal feile hvis man prøver å opprette en støndsperiode med id`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
+            opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
+            opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
 
             val periode = stønadsperiodeDto(UUID.randomUUID())
             assertThatThrownBy {
@@ -58,8 +61,8 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal kunne opprette flere stønadsperioder`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
+            opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
+            opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
 
             val lagredeStønadsperioder = testWithBrukerContext(SAKSHEH_A) {
                 stønadsperiodeService.lagreStønadsperioder(
@@ -81,10 +84,21 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         @Test
         fun `endring av perioden oppdaterer felter men ikke opprettetAv`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(MålgruppeType.OVERGANGSSTØNAD, behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(AktivitetType.UTDANNING, lønnet = null, behandlingId = behandling.id))
+            opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
+            opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
+            opprettVilkårperiode(
+                målgruppe(
+                    MålgruppeType.OVERGANGSSTØNAD,
+                    behandlingId = behandling.id,
+                ),
+            )
+            opprettVilkårperiode(
+                aktivitet(
+                    AktivitetType.UTDANNING,
+                    lønnet = null,
+                    behandlingId = behandling.id,
+                ),
+            )
 
             val periode = stønadsperiodeService.lagreStønadsperioder(
                 behandling.id,
@@ -115,8 +129,8 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal kunne slette en periode`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
+            opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
+            opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
 
             stønadsperiodeService.lagreStønadsperioder(
                 behandling.id,
@@ -131,10 +145,21 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal kunne endre, legge til og slette i en oppdatering`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(målgruppe(MålgruppeType.OVERGANGSSTØNAD, behandlingId = behandling.id))
-            vilkårperiodeService.opprettVilkårperiode(aktivitet(AktivitetType.UTDANNING, lønnet = null, behandlingId = behandling.id))
+            opprettVilkårperiode(målgruppe(behandlingId = behandling.id))
+            opprettVilkårperiode(aktivitet(behandlingId = behandling.id))
+            opprettVilkårperiode(
+                målgruppe(
+                    MålgruppeType.OVERGANGSSTØNAD,
+                    behandlingId = behandling.id,
+                ),
+            )
+            opprettVilkårperiode(
+                aktivitet(
+                    AktivitetType.UTDANNING,
+                    lønnet = null,
+                    behandlingId = behandling.id,
+                ),
+            )
 
             val stønadsperioder = stønadsperiodeService.lagreStønadsperioder(
                 behandling.id,
@@ -198,6 +223,62 @@ class StønadsperiodeServiceTest : IntegrationTest() {
                 stønadsperiodeService.lagreStønadsperioder(behandlingId = behandling.id, listOf())
             }.hasMessageContaining("Kan ikke lagre stønadsperioder når behandlingen er låst")
         }
+
+        @Test
+        fun `skal være i steg VILKÅR etter lagring av stønadsperioder`() {
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
+            assertThat(behandling.steg).isEqualTo(StegType.INNGANGSVILKÅR)
+
+            val fom1 = LocalDate.of(2024, 1, 1)
+            val tom1 = LocalDate.of(2024, 2, 1)
+            val fom2 = LocalDate.of(2024, 2, 1)
+            val tom2 = LocalDate.of(2024, 3, 1)
+
+            // Opprett vilkårperioder og stønadsperioder som er gyldige
+            opprettVilkårperiode(
+                LagreVilkårperiode(
+                    type = MålgruppeType.AAP,
+                    fom = fom1,
+                    tom = tom2,
+                    delvilkår = VilkårperiodeTestUtil.delvilkårMålgruppeDto(),
+                    behandlingId = behandling.id,
+                ),
+            )
+            val oppprettetTiltakPeriode = opprettVilkårperiode(
+                LagreVilkårperiode(
+                    type = AktivitetType.TILTAK,
+                    fom = fom1,
+                    tom = tom1,
+                    delvilkår = VilkårperiodeTestUtil.delvilkårAktivitetDto(),
+                    behandlingId = behandling.id,
+                ),
+            ).periode
+            val opprettetStønadsperioder = stønadsperiodeService.lagreStønadsperioder(behandling.id, listOf(stønadsperiodeDto(fom = fom1, tom = tom1)))
+            assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.VILKÅR)
+
+            // Oppdater med nye vilkårsperioder som gjør stønadsperioder ugyldige
+            val oppdatertPeriode = vilkårperiodeService.oppdaterVilkårperiode(
+                id = oppprettetTiltakPeriode.id,
+                vilkårperiode = LagreVilkårperiode(
+                    type = AktivitetType.TILTAK,
+                    fom = fom2,
+                    tom = tom2,
+                    delvilkår = VilkårperiodeTestUtil.delvilkårAktivitetDto(),
+                    behandlingId = behandling.id,
+                ),
+            )
+            vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(oppdatertPeriode)
+
+            assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.INNGANGSVILKÅR)
+
+            // Oppdater stønadsperioder som gjør stønadsperioder gyldige igjen
+            stønadsperiodeService.lagreStønadsperioder(
+                behandling.id,
+                listOf(stønadsperiodeDto(opprettetStønadsperioder.first().id, fom = fom2, tom = tom2)),
+            )
+
+            assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.VILKÅR)
+        }
     }
 
     private fun målgruppe(
@@ -242,4 +323,9 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         målgruppe = målgruppeType,
         aktivitet = aktivitet,
     )
+
+    private fun opprettVilkårperiode(periode: LagreVilkårperiode): LagreVilkårperiodeResponse {
+        val oppdatertPeriode = vilkårperiodeService.opprettVilkårperiode(periode)
+        return vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(oppdatertPeriode)
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -333,7 +333,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 ),
             )
 
-            val response = vilkårperiodeService.validerOgLagResponse(periode)
+            val response = vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(periode)
 
             assertThat(response.stønadsperiodeStatus).isEqualTo(Stønadsperiodestatus.OK)
             assertThat(response.stønadsperiodeFeil).isNull()
@@ -381,7 +381,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 ),
             )
 
-            assertThat(vilkårperiodeService.validerOgLagResponse(oppdatertPeriode).stønadsperiodeStatus).isEqualTo(Stønadsperiodestatus.FEIL)
+            assertThat(vilkårperiodeService.oppdaterBehandlingstegOgLagResponse(oppdatertPeriode).stønadsperiodeStatus).isEqualTo(Stønadsperiodestatus.FEIL)
         }
 
         private fun nyStønadsperiode(fom: LocalDate = LocalDate.now(), tom: LocalDate = LocalDate.now()) =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å sikre at vilkårsperioder og stønadsperioder valideres før beregning oppretter vi et eget steg for inngangsvilkår.


**Ting som må avklares**
- Skal man kunne gå til vedtak og beregning uten at man har fyllt inn stønadsperioder? (Behov ved avslag)
- Skal man trykke på en neste-knapp når man er ferdig på inngangsvilkårsiden
- Hva trenger vi av behandlingsshistorikk mellom stegene INNGANGSVILKÅR og VILKÅR
- Burde steget VILKÅR få et annet navn, feks STØNADSSPESIFIKKE_VILKÅR