### PR TITLE
Legger til felter om opphold i norge i dto til frontend

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
@@ -20,7 +20,7 @@ data class FaktaHovedytelse(
 data class SøknadsgrunnlagHovedytelse(
     val hovedytelse: List<Hovedytelse>,
     val boddSammenhengende: JaNei?,
-    val planleggerBoINorgeNeste12mnd: JaNei?
+    val planleggerBoINorgeNeste12mnd: JaNei?,
 )
 
 data class FaktaAktivtet(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
@@ -19,6 +19,8 @@ data class FaktaHovedytelse(
 
 data class SøknadsgrunnlagHovedytelse(
     val hovedytelse: List<Hovedytelse>,
+    val boddSammenhengende: JaNei?,
+    val planleggerBoINorgeNeste12mnd: JaNei?
 )
 
 data class FaktaAktivtet(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
@@ -50,6 +50,8 @@ class BehandlingFaktaService(
             søknadsgrunnlag = søknad?.let {
                 SøknadsgrunnlagHovedytelse(
                     hovedytelse = it.data.hovedytelse.hovedytelse,
+                    boddSammenhengende = it.data.hovedytelse.boddSammenhengende,
+                    planleggerBoINorgeNeste12mnd = it.data.hovedytelse.planleggerBoINorgeNeste12mnd,
                 )
             },
         )

--- a/src/test/resources/vilkår/vilkårGrunnlagDto.json
+++ b/src/test/resources/vilkår/vilkårGrunnlagDto.json
@@ -1,7 +1,9 @@
 {
   "hovedytelse" : {
     "søknadsgrunnlag" : {
-      "hovedytelse" : [ "AAP" ]
+      "hovedytelse" : [ "AAP" ],
+      "boddSammenhengende" : "NEI",
+      "planleggerBoINorgeNeste12mnd" : "JA"
     }
   },
   "aktivitet" : {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsket å legge til det sånn at det er gjort etter at vi har lagt til de i søknaden. For å ikke glømme bort de. 
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-18093

Har lagret ned de i https://github.com/navikt/tilleggsstonader-sak/pull/197


Visning i saksbehandlingen er ennå litt uklar, det finnes ikke noen skisser for det, men har begynt på
https://github.com/navikt/tilleggsstonader-sak-frontend/compare/s%C3%B8knad-grunnlag-opphold?expand=1
Dette blir foreløpig relativt stygt, så litt usikker på om det burde merges inn eller om vi faktiskt skal vente på at det finnes skisser
![image](https://github.com/navikt/tilleggsstonader-sak/assets/937168/fd33e10a-a8c7-4472-8c98-6ea42a995de8)
