### PR TITLE
Task for månedskjøring av iverksetting

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettBehandlingMånedTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettBehandlingMånedTask.kt
@@ -1,0 +1,77 @@
+package no.nav.tilleggsstonader.sak.utbetaling.iverksetting
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.PropertiesWrapper
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.util.IdUtils
+import no.nav.familie.prosessering.util.MDCConstants
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+import java.util.*
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = IverksettBehandlingMånedTask.TYPE,
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 60L,
+    beskrivelse = "Iverksetter behandling for en måned.",
+)
+class IverksettBehandlingMånedTask(
+    private val behandlingService: BehandlingService,
+    private val iverksettService: IverksettService,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val taskData = objectMapper.readValue<TaskData>(task.payload)
+        val iverksettingId = task.metadata.getProperty("iverksettingId") ?: error("Mangler iverksettingId")
+
+        validerErSisteBehandling(taskData.behandlingId)
+
+        iverksettService.iverksett(taskData.behandlingId, UUID.fromString(iverksettingId), taskData.måned)
+    }
+
+    private fun validerErSisteBehandling(behandlingId: UUID) {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        val sisteBehandling = behandlingService.finnSisteIverksatteBehandling(behandling.fagsakId)
+
+        val vedtakstidspunkt = sisteBehandling?.vedtakstidspunktEllerFeil()
+
+        feilHvis(vedtakstidspunkt != null && vedtakstidspunkt > behandling.vedtakstidspunktEllerFeil()) {
+            "En revurdering har erstattet denne behandlingen. Denne tasken kan avvikshåndteres."
+        }
+
+        feilHvisIkke(behandling.id == sisteBehandling?.id) {
+            "Behandling ${behandling.id} er ikke siste behandling for fagsak ${behandling.fagsakId}. Uklar årsak."
+        }
+    }
+
+    companion object {
+
+        fun opprettTask(behandlingId: UUID, måned: YearMonth): Task {
+            val properties = Properties().apply {
+                setProperty("behandlingId", behandlingId.toString())
+                setProperty("iverksettingId", UUID.randomUUID().toString())
+                setProperty("måned", måned.toString())
+                setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
+            }
+
+            val payload = objectMapper.writeValueAsString(TaskData(behandlingId, måned))
+
+            return Task(TYPE, payload).copy(metadataWrapper = PropertiesWrapper(properties))
+        }
+
+        const val TYPE = "IverksettBehandlingMåned"
+    }
+
+    private data class TaskData(
+        val behandlingId: UUID,
+        val måned: YearMonth,
+    )
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettMånedTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettMånedTask.kt
@@ -51,6 +51,7 @@ class IverksettMånedTask(
             }
 
             return Task(TYPE, måned.toString()).copy(metadataWrapper = PropertiesWrapper(properties))
+                .medTriggerTid(måned.atEndOfMonth().atTime(6, 4)) // TODO når skal vi iverksette
         }
 
         const val TYPE = "IverksettMåned"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettMånedTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettMånedTask.kt
@@ -1,0 +1,58 @@
+package no.nav.tilleggsstonader.sak.utbetaling.iverksetting
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.PropertiesWrapper
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.familie.prosessering.util.IdUtils
+import no.nav.familie.prosessering.util.MDCConstants
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelseRepository
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+import java.util.Properties
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = IverksettMånedTask.TYPE,
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 60L,
+    beskrivelse = "Oppretter en task for hver iverksetting av en måned.",
+)
+class IverksettMånedTask(
+    private val taskService: TaskService,
+    private val andelTilkjentYtelseRepository: AndelTilkjentYtelseRepository,
+) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        // finn alle behandlinger som skal iverksettes for denne måneden som har andeler
+
+        val måned = YearMonth.parse(task.payload)
+
+        val behandlinger =
+            andelTilkjentYtelseRepository.finnBehandlingerForIverksetting(sisteDatoIMåned = måned.atEndOfMonth())
+
+        behandlinger.forEach {
+            taskService.save(IverksettBehandlingMånedTask.opprettTask(behandlingId = it, måned = måned))
+        }
+    }
+
+    override fun onCompletion(task: Task) {
+        taskService.save(opprettTask(YearMonth.parse(task.payload).plusMonths(1)))
+    }
+
+    companion object {
+
+        fun opprettTask(måned: YearMonth): Task {
+            val properties = Properties().apply {
+                setProperty("måned", måned.toString())
+                setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
+            }
+
+            return Task(TYPE, måned.toString()).copy(metadataWrapper = PropertiesWrapper(properties))
+        }
+
+        const val TYPE = "IverksettMåned"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.TotrinnskontrollServi
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.TotrinnInternStatus
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.Totrinnskontroll
 import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -107,6 +108,16 @@ class IverksettService(
             }
         oppdaterAndeler(aktuelleAndeler, iverksetting)
         return aktuelleAndeler
+    }
+
+    // TODO denne skal fjernes når vi har opprettet denne i produksjon
+    @Scheduled(initialDelay = 10000, fixedDelay = Long.MAX_VALUE)
+    fun opprettTaskForMånedkjøring() {
+        try {
+            taskService.save(IverksettMånedTask.opprettTask(YearMonth.of(2024, 1)))
+        } catch (e: Exception) {
+            logger.error("Oppretter ikke task for månedkjøring pga den allerede er opprettet")
+        }
     }
 
     /**

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -58,11 +58,15 @@ class IverksettService(
      */
     @Transactional
     fun iverksett(behandlingId: UUID, iverksettingId: UUID, måned: YearMonth = YearMonth.now()) {
+        feilHvis(måned > YearMonth.now()) {
+            "Kan ikke iverksette for måned=$måned som er frem i tiden"
+        }
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         if (!behandling.resultat.skalIverksettes) {
             logger.info("Iverksetter ikke behandling=$behandlingId då status=${behandling.status}")
             return
         }
+
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandlingId)
         val totrinnskontroll = hentTotrinnskontroll(behandlingId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
@@ -2,9 +2,21 @@ package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain
 
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
-import java.util.UUID
+import java.time.LocalDate
+import java.util.*
 
 @Repository
 interface AndelTilkjentYtelseRepository :
-    RepositoryInterface<AndelTilkjentYtelse, UUID>, InsertUpdateRepository<AndelTilkjentYtelse>
+    RepositoryInterface<AndelTilkjentYtelse, UUID>, InsertUpdateRepository<AndelTilkjentYtelse> {
+
+    @Query(
+        """
+        SELECT DISTINCT ty.behandling_id from andel_tilkjent_ytelse aty
+        JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse_id = ty.id
+        WHERE aty.tom <= :sisteDatoIMåned AND aty.status_iverksetting = 'UBEHANDLET'
+        """,
+    )
+    fun finnBehandlingerForIverksetting(sisteDatoIMåned: LocalDate): List<UUID>
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
@@ -15,7 +15,9 @@ interface AndelTilkjentYtelseRepository :
         """
         SELECT DISTINCT ty.behandling_id from andel_tilkjent_ytelse aty
         JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse_id = ty.id
+        JOIN behandling b ON b.id = ty.behandling_id
         WHERE aty.tom <= :sisteDatoIMåned AND aty.status_iverksetting = 'UBEHANDLET'
+        AND b.status = 'FERDIGSTILT' AND b.resultat IN ('INNVILGET', 'OPPHØRT')
         """,
     )
     fun finnBehandlingerForIverksetting(sisteDatoIMåned: LocalDate): List<UUID>

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -41,7 +41,7 @@ class BeslutteVedtakSteg(
     private val totrinnskontrollService: TotrinnskontrollService,
     private val vedtaksresultatService: VedtaksresultatService,
     private val brevService: BrevService,
-    private val iverksettService: IverksettService
+    private val iverksettService: IverksettService,
 ) : BehandlingSteg<BeslutteVedtakDto> {
 
     override fun validerSteg(saksbehandling: Saksbehandling) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
+import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.IverksettService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
@@ -40,6 +41,7 @@ class BeslutteVedtakSteg(
     private val totrinnskontrollService: TotrinnskontrollService,
     private val vedtaksresultatService: VedtaksresultatService,
     private val brevService: BrevService,
+    private val iverksettService: IverksettService
 ) : BehandlingSteg<BeslutteVedtakDto> {
 
     override fun validerSteg(saksbehandling: Saksbehandling) {
@@ -62,7 +64,7 @@ class BeslutteVedtakSteg(
             brevService.lagEndeligBeslutterbrev(saksbehandling)
             opprettJournalførVedtaksbrevTask(saksbehandling)
 
-            // TODO iverksettService.iverksettBehandlingFørsteGang(saksbehandling.id)
+            iverksettService.iverksettBehandlingFørsteGang(saksbehandling.id)
 
             StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV
         } else {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettBehandlingMånedTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettBehandlingMånedTaskTest.kt
@@ -1,0 +1,61 @@
+package no.nav.tilleggsstonader.sak.utbetaling.iverksetting
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.util.UUID
+
+class IverksettBehandlingMånedTaskTest {
+
+    private val behandlingService = mockk<BehandlingService>()
+    private val iverksettService = mockk<IverksettService>(relaxed = true)
+    private val taskStep = IverksettBehandlingMånedTask(behandlingService, iverksettService)
+
+    val fagsak = fagsak()
+    val behandling = behandling(fagsak, vedtakstidspunkt = LocalDateTime.now().minusDays(1))
+    val behandling2 = behandling(fagsak, forrigeBehandlingId = behandling.id, vedtakstidspunkt = LocalDateTime.now())
+    val måned = YearMonth.now()
+
+    @BeforeEach
+    fun setUp() {
+        mockHentBehandling(behandling)
+    }
+
+    @Test
+    fun `skal kalle på iverksetting`() {
+        mockFinnSisteIverksatteBehandling(behandling)
+        val task = IverksettBehandlingMånedTask.opprettTask(behandling.id, måned)
+        val iverksettingId = UUID.fromString(task.metadata.getProperty("iverksettingId"))
+
+        taskStep.doTask(task)
+
+        verify(exactly = 1) { iverksettService.iverksett(behandling.id, iverksettingId, måned) }
+    }
+
+    @Test
+    fun `skal feile hvis det finnes en behandling som er iverksatt etter behandlingen for tasken`() {
+        mockFinnSisteIverksatteBehandling(behandling2)
+
+        val task = IverksettBehandlingMånedTask.opprettTask(behandlingId = behandling.id, måned)
+        assertThatThrownBy {
+            taskStep.doTask(task)
+        }.hasMessageContaining("En revurdering har erstattet denne behandlingen.")
+    }
+
+    private fun mockHentBehandling(behandling: Behandling) {
+        every { behandlingService.hentBehandling(behandling.id) } returns behandling
+    }
+
+    private fun mockFinnSisteIverksatteBehandling(behandling: Behandling) {
+        every { behandlingService.finnSisteIverksatteBehandling(behandling.fagsakId) } returns behandling
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
@@ -114,6 +114,17 @@ class IverksettServiceTest : IntegrationTest() {
     }
 
     @Nested
+    inner class Validering {
+
+        @Test
+        fun `kan ikke iverksette frem i tiden`() {
+            assertThatThrownBy {
+                iverksettService.iverksett(UUID.randomUUID(), UUID.randomUUID(), YearMonth.now().plusMonths(1))
+            }.hasMessageContaining("som er frem i tiden")
+        }
+    }
+
+    @Nested
     inner class IverksettingFlyt {
 
         val fagsak = fagsak()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakStegTest.kt
@@ -27,6 +27,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveDomain
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
+import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.IverksettService
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
@@ -55,6 +56,7 @@ class BeslutteVedtakStegTest {
     private val vedtaksresultatService = mockk<VedtaksresultatService>()
     private val brevService = mockk<BrevService>()
     private val behandlingService = mockk<BehandlingService>()
+    private val iverksettService = mockk<IverksettService>(relaxed = true)
 
     private val beslutteVedtakSteg = BeslutteVedtakSteg(
         taskService = taskService,
@@ -64,6 +66,7 @@ class BeslutteVedtakStegTest {
         behandlingService = behandlingService,
         vedtaksresultatService = vedtaksresultatService,
         brevService = brevService,
+        iverksettService = iverksettService,
     )
 
     private val innloggetBeslutter = "sign2"
@@ -114,7 +117,8 @@ class BeslutteVedtakStegTest {
 
         assertThat(nesteSteg).isEqualTo(StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)
         assertThat(taskSlot[0].type).isEqualTo(FerdigstillOppgaveTask.TYPE)
-        // assertThat(taskSlot[1].type).isEqualTo(PollStatusFraIverksettTask.TYPE)
+
+        verify(exactly = 1) { iverksettService.iverksettBehandlingFørsteGang(behandlingId) }
         // assertThat(taskSlot[2].type).isEqualTo(BehandlingsstatistikkTask.TYPE)
         // assertThat(objectMapper.readValue<BehandlingsstatistikkTaskPayload>(taskSlot[2].payload).hendelse)
         //    .isEqualTo(Hendelse.BESLUTTET)
@@ -124,8 +128,6 @@ class BeslutteVedtakStegTest {
                 BehandlingResultat.INNVILGET,
             )
         }
-        // verify(exactly = 1) { iverksett.iverksett(any(), any()) }
-        // verify(exactly = 0) { iverksett.iverksettUtenBrev(any()) }
     }
 
     @Test
@@ -142,6 +144,7 @@ class BeslutteVedtakStegTest {
         assertThat(taskSlot[0].type).isEqualTo(FerdigstillOppgaveTask.TYPE)
         assertThat(taskSlot[1].type).isEqualTo(OpprettOppgaveTask.TYPE)
         assertThat(taskData.oppgave.oppgavetype).isEqualTo(Oppgavetype.BehandleUnderkjentVedtak)
+        verify(exactly = 0) { iverksettService.iverksettBehandlingFørsteGang(any()) }
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en behandling blir iverksatt, iverksettes andeler tom forrige måned.
Andeler for gjeldende måned og neste blir iverksatte i denne månedsjobben.

`IverksettMånedTask` kjører månedlig og lager `HentStatusFraIverksettingTask` for hvert behandling som har andeler som skal iverksettes
`HentStatusFraIverksettingTask`  kaller på iverksetting

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17603