### PR TITLE
Dp-iverksett har en ny status for iverksettinger uten andeler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDto.kt
@@ -64,5 +64,6 @@ enum class IverksettStatus {
     SENDT_TIL_OPPDRAG,
     FEILET_MOT_OPPDRAG,
     OK,
+    OK_UTEN_UTBETALING,
     IKKE_PAABEGYNT,
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -82,5 +82,6 @@ enum class StatusIverksetting {
     UBEHANDLET,
     SENDT,
     OK,
+    OK_UTEN_UTBETALING,
     UAKTUELL,
 }


### PR DESCRIPTION
Har lagt til validering av den for å verifisere at den virker som forventet

### Hvorfor er denne endringen nødvendig? ✨
DP-iverksett har lagt til en ny status for de iverksettinger som ikke har noen andeler.
Når vi iverksetter frem i tiden sender vi ikke noen andeler til dp

Burde vi lagre ned liknende status hos oss? Eller skal vi kun ha `OK` som `StatusIverksetting` som lagres ned på andelen? 