### PR TITLE
✨ Skal ferdigstille behandle sak oppgaver ved henlegging

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/HenleggService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/HenleggService.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.behandling
 
+import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -9,7 +11,7 @@ import java.util.UUID
 @Service
 class HenleggService(
     private val behandlingService: BehandlingService,
-    // private val oppgaveService: OppgaveService,
+    private val oppgaveService: OppgaveService,
 ) {
 
     @Transactional
@@ -20,17 +22,13 @@ class HenleggService(
     }
 
     private fun ferdigstillOppgaveTask(behandling: Behandling) {
-        /*
         oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(
             behandlingId = behandling.id,
             Oppgavetype.BehandleSak,
-            ignorerFeilregistrert = true,
         )
         oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(
             behandlingId = behandling.id,
             Oppgavetype.BehandleUnderkjentVedtak,
-            ignorerFeilregistrert = true,
         )
-         */
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
@@ -146,11 +146,6 @@ class OppgaveService(
         ferdigstillOppgaveOgSettOppgaveDomainTilFerdig(oppgave)
     }
 
-    /**
-     * @param ignorerFeilregistrert ignorerer oppgaver som allerede er feilregistrerte
-     * Den burde kun settes til true for lukking av oppgaver koblet til henleggelse
-     * Oppgaver skal ikke være lukket når denne kalles, då det er ef-sak som burde lukke oppgaver som vi har opprettet
-     */
     fun ferdigstillOppgaveHvisOppgaveFinnes(
         behandlingId: UUID,
         oppgavetype: Oppgavetype,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en behandling henlegges skal vi ferdigstille oppgavene på den.

Bør vi kaste feil hvis det ikke finnes noen oppgave? Gjør ikke dette i EF