### PR TITLE
Hent aktiviteter i beregning

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/InnvilgelseTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/InnvilgelseTilsynBarnDto.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Aktivitet
 import java.math.BigDecimal
 import java.time.YearMonth
 import java.util.UUID
@@ -39,11 +40,16 @@ data class Beregningsresultat(
 data class Beregningsgrunnlag(
     val måned: YearMonth,
     val makssats: Int,
-    val stønadsperioder: List<StønadsperiodeDto>,
+    val stønadsperioderGrunnlag: List<StønadsperiodeGrunnlag>,
     val utgifter: List<UtgiftBarn>,
-    val antallDagerTotal: Int,
     val utgifterTotal: Int,
     val antallBarn: Int,
+)
+
+data class StønadsperiodeGrunnlag(
+    val stønadsperiode: StønadsperiodeDto,
+    val aktiviteter: List<Aktivitet>,
+    val antallDager: Int,
 )
 
 data class UtgiftBarn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -59,12 +59,12 @@ class TilsynBarnBeregnYtelseSteg(
         beregningsresultat: BeregningsresultatTilsynBarnDto,
     ) {
         val andelerTilkjentYtelse = beregningsresultat.perioder.flatMap {
-            it.grunnlag.stønadsperioder.map { stønadsperiode ->
+            it.grunnlag.stønadsperioderGrunnlag.map { stønadsperiodeMedAktivitet ->
                 AndelTilkjentYtelse(
                     // TODO hvordan burde vi egentligen gjøre med decimaler?
                     beløp = it.dagsats.setScale(0, RoundingMode.HALF_UP).toInt(),
-                    fom = stønadsperiode.fom,
-                    tom = stønadsperiode.tom,
+                    fom = stønadsperiodeMedAktivitet.stønadsperiode.fom,
+                    tom = stønadsperiodeMedAktivitet.stønadsperiode.tom,
                     satstype = Satstype.DAG, // TODO
                     type = TypeAndel.TILSYN_BARN_AAP, // TODO
                     kildeBehandlingId = saksbehandling.id,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregningService.kt
@@ -11,6 +11,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiod
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Aktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.tilAktivitet
 import org.springframework.stereotype.Service
@@ -114,8 +115,8 @@ class TilsynBarnBeregningService(
     }
 
     private fun finnAktiviteter(behandlingId: UUID): List<Aktivitet> {
-        val vilkårsperioder = vilkårperiodeRepository.findByBehandlingId(behandlingId)
-        return vilkårsperioder.tilAktivitet()
+        return vilkårperiodeRepository.findByBehandlingIdAndResultat(behandlingId, ResultatVilkårperiode.OPPFYLT)
+            .tilAktivitet()
     }
 
     /**

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import org.springframework.data.annotation.Id
@@ -152,3 +153,25 @@ data class Vilkårperioder(
     val målgrupper: List<Vilkårperiode>,
     val aktiviteter: List<Vilkårperiode>,
 )
+
+data class Aktivitet(
+    val type: AktivitetType,
+    override val fom: LocalDate,
+    override val tom: LocalDate,
+    val aktivitetsdager: Int,
+) : Periode<LocalDate>
+
+fun List<Vilkårperiode>.tilAktivitet(): List<Aktivitet> {
+    return this.mapNotNull {
+        if (it.type is AktivitetType) {
+            Aktivitet(
+                type = it.type,
+                fom = it.fom,
+                tom = it.tom,
+                aktivitetsdager = it.aktivitetsdager ?: error("Aktivitetsdager mangler på periode ${it.id}"),
+            )
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/VilkårperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/VilkårperiodeRepository.kt
@@ -9,4 +9,6 @@ import java.util.UUID
 interface VilkårperiodeRepository : RepositoryInterface<Vilkårperiode, UUID>, InsertUpdateRepository<Vilkårperiode> {
 
     fun findByBehandlingId(behandlingId: UUID): List<Vilkårperiode>
+
+    fun findByBehandlingIdAndResultat(behandlingId: UUID, resultat: ResultatVilkårperiode): List<Vilkårperiode>
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
@@ -14,7 +14,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
-import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
@@ -23,6 +22,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnBeregnYtelseSteg
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.Utgift
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchIllegalStateException

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -40,7 +40,14 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårAktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -231,6 +238,44 @@ fun stønadsperiode(
     tom = tom,
     målgruppe = målgruppe,
     aktivitet = aktivitet,
+)
+
+fun aktivitet(
+    behandlingId: UUID,
+    fom: LocalDate,
+    tom: LocalDate,
+    type: AktivitetType = AktivitetType.TILTAK,
+    aktivitetsdager: Int = 5,
+    begrunnelse: String? = null,
+    delvilkår: DelvilkårAktivitet = delvilkårAktivitet(),
+    kilde: KildeVilkårsperiode = KildeVilkårsperiode.MANUELL,
+    resultatVilkårperiode: ResultatVilkårperiode = ResultatVilkårperiode.OPPFYLT,
+): Vilkårperiode = Vilkårperiode(
+    behandlingId = behandlingId,
+    type = type,
+    fom = fom,
+    tom = tom,
+    aktivitetsdager = aktivitetsdager,
+    begrunnelse = begrunnelse,
+    kilde = kilde,
+    resultat = resultatVilkårperiode,
+    delvilkår = delvilkår,
+)
+
+fun delvilkårAktivitet(
+    lønnet: DelvilkårVilkårperiode.Vurdering = vurdering(svar = SvarJaNei.NEI),
+    mottarSykepenger: DelvilkårVilkårperiode.Vurdering = vurdering(svar = SvarJaNei.NEI),
+) = DelvilkårAktivitet(
+    lønnet = lønnet,
+    mottarSykepenger = mottarSykepenger,
+)
+
+fun vurdering(
+    resultat: ResultatDelvilkårperiode = ResultatDelvilkårperiode.OPPFYLT,
+    svar: SvarJaNei = SvarJaNei.JA,
+): DelvilkårVilkårperiode.Vurdering = DelvilkårVilkårperiode.Vurdering(
+    resultat = resultat,
+    svar = svar,
 )
 
 fun vilkår(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -40,14 +40,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårAktivitet
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -238,44 +231,6 @@ fun stønadsperiode(
     tom = tom,
     målgruppe = målgruppe,
     aktivitet = aktivitet,
-)
-
-fun aktivitet(
-    behandlingId: UUID,
-    fom: LocalDate,
-    tom: LocalDate,
-    type: AktivitetType = AktivitetType.TILTAK,
-    aktivitetsdager: Int = 5,
-    begrunnelse: String? = null,
-    delvilkår: DelvilkårAktivitet = delvilkårAktivitet(),
-    kilde: KildeVilkårsperiode = KildeVilkårsperiode.MANUELL,
-    resultatVilkårperiode: ResultatVilkårperiode = ResultatVilkårperiode.OPPFYLT,
-): Vilkårperiode = Vilkårperiode(
-    behandlingId = behandlingId,
-    type = type,
-    fom = fom,
-    tom = tom,
-    aktivitetsdager = aktivitetsdager,
-    begrunnelse = begrunnelse,
-    kilde = kilde,
-    resultat = resultatVilkårperiode,
-    delvilkår = delvilkår,
-)
-
-fun delvilkårAktivitet(
-    lønnet: DelvilkårVilkårperiode.Vurdering = vurdering(svar = SvarJaNei.NEI),
-    mottarSykepenger: DelvilkårVilkårperiode.Vurdering = vurdering(svar = SvarJaNei.NEI),
-) = DelvilkårAktivitet(
-    lønnet = lønnet,
-    mottarSykepenger = mottarSykepenger,
-)
-
-fun vurdering(
-    resultat: ResultatDelvilkårperiode = ResultatDelvilkårperiode.OPPFYLT,
-    svar: SvarJaNei = SvarJaNei.JA,
-): DelvilkårVilkårperiode.Vurdering = DelvilkårVilkårperiode.Vurdering(
-    resultat = resultat,
-    svar = svar,
 )
 
 fun vilkår(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
@@ -23,6 +23,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDt
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
@@ -47,7 +48,8 @@ class StepDefinitions {
 
     private val logger = LoggerFactory.getLogger(javaClass)
     val stønadsperiodeRepository = mockk<StønadsperiodeRepository>()
-    val service = TilsynBarnBeregningService(stønadsperiodeRepository)
+    val vilkårperiodeRepository = mockk<VilkårperiodeRepository>()
+    val service = TilsynBarnBeregningService(stønadsperiodeRepository, vilkårperiodeRepository)
 
     var exception: Exception? = null
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriInt
 import no.nav.tilleggsstonader.sak.cucumber.parseÅrMåned
 import no.nav.tilleggsstonader.sak.cucumber.parseÅrMånedEllerDato
+import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
@@ -27,6 +28,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeR
 import org.assertj.core.api.Assertions.assertThat
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
 
@@ -61,6 +63,13 @@ class StepDefinitions {
     @Gitt("følgende støndsperioder")
     fun `følgende støndsperioder`(dataTable: DataTable) {
         every { stønadsperiodeRepository.findAllByBehandlingId(behandlingId) } returns mapStønadsperider(dataTable)
+        every { vilkårperiodeRepository.findByBehandlingId(behandlingId) } returns listOf(
+            aktivitet(
+                behandlingId,
+                LocalDate.now(),
+                LocalDate.now(),
+            ),
+        )
     }
 
     private fun mapStønadsperider(dataTable: DataTable) = dataTable.mapRad { rad ->

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
@@ -24,6 +24,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDt
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.slf4j.LoggerFactory
@@ -63,7 +64,12 @@ class StepDefinitions {
     @Gitt("følgende støndsperioder")
     fun `følgende støndsperioder`(dataTable: DataTable) {
         every { stønadsperiodeRepository.findAllByBehandlingId(behandlingId) } returns mapStønadsperider(dataTable)
-        every { vilkårperiodeRepository.findByBehandlingId(behandlingId) } returns listOf(
+        every {
+            vilkårperiodeRepository.findByBehandlingIdAndResultat(
+                behandlingId,
+                ResultatVilkårperiode.OPPFYLT,
+            )
+        } returns listOf(
             aktivitet(
                 behandlingId,
                 LocalDate.now(),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
@@ -17,11 +17,11 @@ import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriInt
 import no.nav.tilleggsstonader.sak.cucumber.parseÅrMåned
 import no.nav.tilleggsstonader.sak.cucumber.parseÅrMånedEllerDato
-import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
-import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
@@ -14,6 +13,7 @@ import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
+import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
@@ -13,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -34,6 +36,8 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
     val tilkjentYtelseRepository: TilkjentYtelseRepository,
     @Autowired
     val stønadsperiodeRepository: StønadsperiodeRepository,
+    @Autowired
+    val vilkårperiodeRepository: VilkårperiodeRepository,
 ) : IntegrationTest() {
 
     val behandling = behandling()
@@ -41,6 +45,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
     val barn = BehandlingBarn(behandlingId = behandling.id, ident = "123")
     val stønadsperiode =
         stønadsperiode(behandlingId = behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
+    val aktivitet = aktivitet(behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
 
     val januar = YearMonth.of(2023, 1)
     val februar = YearMonth.of(2023, 2)
@@ -60,6 +65,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
         @Test
         fun `skal lagre vedtak`() {
             stønadsperiodeRepository.insert(stønadsperiode)
+            vilkårperiodeRepository.insert(aktivitet)
 
             val vedtakDto = innvilgelseDto(
                 utgifter = mapOf(barn(barn.id, Utgift(januar, januar, 100))),
@@ -108,6 +114,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
                     stønadsperiode4,
                 ),
             )
+            vilkårperiodeRepository.insert(aktivitet(behandling.id, fom = januar.atDay(1), tom = april.atEndOfMonth()))
 
             val vedtakDto = innvilgelseDto(
                 mapOf(
@@ -150,6 +157,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
         @Test
         fun `skal validere at barn finnes på behandlingen`() {
             stønadsperiodeRepository.insert(stønadsperiode)
+            vilkårperiodeRepository.insert(aktivitet)
 
             val vedtak = innvilgelseDto(
                 utgifter = mapOf(barn(UUID.randomUUID(), Utgift(januar, januar, utgift))),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
@@ -43,11 +44,20 @@ class TilsynBarnBeregnYtelseStegTest {
     fun setUp() {
         every { barnService.finnBarnPåBehandling(saksbehandling.id) } returns listOf(barn)
         every { repository.insert(any()) } answers { firstArg() }
+        val fom = LocalDate.of(2023, 1, 1)
+        val tom = LocalDate.of(2023, 1, 31)
         every { stønadsperiodeService.findAllByBehandlingId(saksbehandling.id) } returns listOf(
             stønadsperiode(
                 behandlingId = saksbehandling.id,
-                fom = LocalDate.of(2023, 1, 1),
-                tom = LocalDate.of(2023, 1, 31),
+                fom = fom,
+                tom = tom,
+            ),
+        )
+        every { vilkårperiodeRepository.findByBehandlingId(saksbehandling.id) } returns listOf(
+            aktivitet(
+                behandlingId = saksbehandling.id,
+                fom = fom,
+                tom = tom,
             ),
         )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -24,9 +25,10 @@ class TilsynBarnBeregnYtelseStegTest {
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>(relaxed = true)
     private val simuleringService = mockk<SimuleringService>(relaxed = true)
     private val stønadsperiodeService = mockk<StønadsperiodeRepository>(relaxed = true)
+    private val vilkårperiodeRepository = mockk<VilkårperiodeRepository>(relaxed = true)
 
     val steg = TilsynBarnBeregnYtelseSteg(
-        tilsynBarnBeregningService = TilsynBarnBeregningService(stønadsperiodeService),
+        tilsynBarnBeregningService = TilsynBarnBeregningService(stønadsperiodeService, vilkårperiodeRepository),
         vedtakRepository = repository,
         barnService = barnService,
         tilkjentytelseService = tilkjentYtelseService,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -8,12 +8,12 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
-import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -53,7 +54,7 @@ class TilsynBarnBeregnYtelseStegTest {
                 tom = tom,
             ),
         )
-        every { vilkårperiodeRepository.findByBehandlingId(saksbehandling.id) } returns listOf(
+        every { vilkårperiodeRepository.findByBehandlingIdAndResultat(saksbehandling.id, ResultatVilkårperiode.OPPFYLT) } returns listOf(
             aktivitet(
                 behandlingId = saksbehandling.id,
                 fom = fom,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -7,11 +7,11 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailException
-import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -7,10 +7,12 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailException
+import no.nav.tilleggsstonader.sak.util.aktivitet
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -28,11 +30,15 @@ class TilsynBarnVedtakControllerTest(
     val barnRepository: BarnRepository,
     @Autowired
     val stønadsperiodeRepository: StønadsperiodeRepository,
+    @Autowired
+    val vilkårperiodeRepository: VilkårperiodeRepository,
 ) : IntegrationTest() {
 
     val behandling = behandling(steg = StegType.BEREGNE_YTELSE, status = BehandlingStatus.UTREDES)
     val barn = BehandlingBarn(behandlingId = behandling.id, ident = "123")
-    val stønadsperiode = stønadsperiode(behandlingId = behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
+    val stønadsperiode =
+        stønadsperiode(behandlingId = behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
+    val aktivitet = aktivitet(behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
 
     @BeforeEach
     fun setUp() {
@@ -40,6 +46,7 @@ class TilsynBarnVedtakControllerTest(
         testoppsettService.opprettBehandlingMedFagsak(behandling)
         barnRepository.insert(barn)
         stønadsperiodeRepository.insert(stønadsperiode)
+        vilkårperiodeRepository.insert(aktivitet)
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å kunne finne ut antall aktivitetsdager må man finne aktivitetene som er relevante for en stønadsperiode. De relevante aktivitetene lagres nå ned per stønadsperiode i beregningsgrunnlaget. Det blir altså et `beregningsgrunnlag` per måned og hver av disse har en liste med `StønadsperiodeGrunnlag` som inneholder stønadsperioden, relevante aktiviteter og antall dager. 

**Greit å være klar over**
- Antall dager er ikke tilpasset aktivitetsdager. Denne returnerer fortsatt virkedager per stønadsperiode, men summeringen skjer utenfor. 
- Cucumbertester er kun tilpasset så det opprettes aktiviteter av riktig type med samme lengde som stønadsperioden. Dette fikses når aktivitetene faktisk skal brukes til å beregne dager. Nå sjekkes det bare at det finnes aktiviteter som matcher (noe det burde gjøre fordi det valideres når det legges inn i inngangsvilkår)

