### PR TITLE
Vi skal iverksette første i måneden for å iverksette i forskudd.

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettBehandlingMånedTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettBehandlingMånedTask.kt
@@ -34,7 +34,11 @@ class IverksettBehandlingMånedTask(
 
         validerErSisteBehandling(taskData.behandlingId)
 
-        iverksettService.iverksett(taskData.behandlingId, UUID.fromString(iverksettingId), taskData.måned)
+        val måned = taskData.måned
+        feilHvis(måned > YearMonth.now()) {
+            "Kan ikke iverksette for måned=$måned som er frem i tiden"
+        }
+        iverksettService.iverksett(taskData.behandlingId, UUID.fromString(iverksettingId), måned)
     }
 
     private fun validerErSisteBehandling(behandlingId: UUID) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettMånedTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettMånedTask.kt
@@ -51,7 +51,7 @@ class IverksettMånedTask(
             }
 
             return Task(TYPE, måned.toString()).copy(metadataWrapper = PropertiesWrapper(properties))
-                .medTriggerTid(måned.atEndOfMonth().atTime(6, 4)) // TODO når skal vi iverksette
+                .medTriggerTid(måned.atDay(1).atTime(6, 4))
         }
 
         const val TYPE = "IverksettMåned"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -69,13 +69,13 @@ class IverksettService(
     }
 
     private fun andelerForFørsteIverksettingAvBehandling(tilkjentYtelse: TilkjentYtelse): Collection<AndelTilkjentYtelse> {
-        val nullMåned = YearMonth.now()
-        val andelerTilIverksetting = finnAndelerTilIverksetting(tilkjentYtelse, tilkjentYtelse.behandlingId, nullMåned)
+        val måned = YearMonth.now()
+        val andelerTilIverksetting = finnAndelerTilIverksetting(tilkjentYtelse, tilkjentYtelse.behandlingId, måned)
 
         return andelerTilIverksetting.ifEmpty {
             val iverksetting = Iverksetting(tilkjentYtelse.behandlingId, LocalDateTime.now())
 
-            listOf(tilkjentYtelseService.leggTilNullAndel(tilkjentYtelse, iverksetting, nullMåned))
+            listOf(tilkjentYtelseService.leggTilNullAndel(tilkjentYtelse, iverksetting, måned))
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -69,7 +69,7 @@ class IverksettService(
     }
 
     private fun andelerForFørsteIverksettingAvBehandling(tilkjentYtelse: TilkjentYtelse): Collection<AndelTilkjentYtelse> {
-        val nullMåned = YearMonth.now().minusMonths(1)
+        val nullMåned = YearMonth.now()
         val andelerTilIverksetting = finnAndelerTilIverksetting(tilkjentYtelse, tilkjentYtelse.behandlingId, nullMåned)
 
         return andelerTilIverksetting.ifEmpty {
@@ -89,9 +89,7 @@ class IverksettService(
      * Når man iverksetter samme behandling neste gang skal man bruke inneværende måned for å iverksette aktuell måned
      */
     @Transactional
-    fun iverksett(behandlingId: UUID, iverksettingId: UUID, måned: YearMonth = YearMonth.now()) {
-        validerIkkeFremITid(måned)
-
+    fun iverksett(behandlingId: UUID, iverksettingId: UUID, måned: YearMonth) {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         if (!behandling.resultat.skalIverksettes) {
             logger.info("Iverksetter ikke behandling=$behandlingId med status=${behandling.status}")
@@ -110,12 +108,6 @@ class IverksettService(
         )
         opprettHentStatusFraIverksettingTask(behandling, iverksettingId)
         iverksettClient.iverksett(dto)
-    }
-
-    private fun validerIkkeFremITid(måned: YearMonth) {
-        feilHvis(måned > YearMonth.now()) {
-            "Kan ikke iverksette for måned=$måned som er frem i tiden"
-        }
     }
 
     private fun markerAndelerFraForrieBehandlingSomUaktuelle(behandling: Saksbehandling) {


### PR DESCRIPTION
Det betyder også at vi skal iverksette inneværende måneden direkte. 
Har flyttet valideringen for at man ikke iverksetter frem i tiden til tasken for å kunne iverksette neste måned i testene.
For at testene skal gi mening har jeg lagt til en til andel for `nestNesteMåned`. Dette for å kunne iverksette "neste måned" og verifisere at `nestNesteMåned` ikke blir iverksatt.

### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17603

Besluttning:
https://nav-it.slack.com/archives/C06LM8VDX6J/p1709192911427739
