### PR TITLE
✨ Begrunnelse skal være obligatorisk når medlemskap er vurdert til ikke oppfylt

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 @Table("vilkar_periode")
 data class Vilkårperiode(
@@ -108,7 +109,13 @@ enum class ResultatDelvilkårperiode {
 
 data class DelvilkårMålgruppe(
     val medlemskap: Vurdering,
-) : DelvilkårVilkårperiode()
+) : DelvilkårVilkårperiode() {
+    init {
+        brukerfeilHvis(medlemskap.resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT && medlemskap.begrunnelse == null) {
+            "Mangler begrunnelse for ikke oppfylt medlemskap"
+        }
+    }
+}
 
 data class DelvilkårAktivitet(
     val lønnet: Vurdering,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
@@ -42,7 +42,7 @@ class VilkårperiodeDtoTest {
                 delvilkår = DelvilkårMålgruppe(
                     medlemskap = DelvilkårVilkårperiode.Vurdering(
                         svar = null,
-                        begrunnelse = null,
+                        begrunnelse = if (resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT) "begrunnelse" else null,
                         resultat = resultat,
                     ),
                 ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
@@ -18,7 +18,7 @@ class EvalueringMålgruppeTest {
 
     val svarJa = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.JA))
     val svarImplisitt = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.JA_IMPLISITT))
-    val svarNei = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.NEI))
+    val svarNei = DelvilkårMålgruppeDto(VurderingDto(SvarJaNei.NEI, "begrunnelse"))
     val svarMangler = DelvilkårMålgruppeDto(VurderingDto(null))
 
     @Nested


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler skal ikke kunne vurdere medlemskap til ikke oppfylt, uten å oppgi en begrunnelse.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-18537

![image](https://github.com/navikt/tilleggsstonader-sak/assets/21220467/2383ae26-1b1c-492e-bb1a-9c3e86c58df5)

