### PR TITLE
🐛 Fikse mapping av dokumentasjon-id til vedlegg

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
@@ -66,21 +66,21 @@ class BehandlingFaktaService(
         if (søknad != null) {
             validerFinnesGrunnlagsdataForAlleBarnISøknad(grunnlagsdata, søknadBarnPåIdent)
         }
-        val barnPåBehandling = barnService.finnBarnPåBehandling(behandlingId).associateBy { it.ident }
+        val grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn.associateBy { it.ident }
 
-        return grunnlagsdata.grunnlagsdata.barn.map { barn ->
-            val behandlingBarn = barnPåBehandling[barn.ident]
-                ?: error("Finner ikke barn med ident=${barn.ident} på behandling=$behandlingId")
+        return barnService.finnBarnPåBehandling(behandlingId).map { behandlingBarn ->
+            val barnGrunnlagsdata = grunnlagsdataBarn[behandlingBarn.ident]
+                ?: error("Finner ikke barn med ident=${behandlingBarn.ident} på behandling=$behandlingId")
 
             FaktaBarn(
-                ident = barn.ident,
+                ident = behandlingBarn.ident,
                 barnId = behandlingBarn.id,
                 registergrunnlag = RegistergrunnlagBarn(
-                    navn = barn.navn.visningsnavn(),
-                    alder = barn.alder,
-                    dødsdato = barn.dødsdato,
+                    navn = barnGrunnlagsdata.navn.visningsnavn(),
+                    alder = barnGrunnlagsdata.alder,
+                    dødsdato = barnGrunnlagsdata.dødsdato,
                 ),
-                søknadgrunnlag = søknadBarnPåIdent[barn.ident]?.let { søknadBarn ->
+                søknadgrunnlag = søknadBarnPåIdent[behandlingBarn.ident]?.let { søknadBarn ->
                     SøknadsgrunnlagBarn(
                         type = søknadBarn.data.type,
                         startetIFemte = søknadBarn.data.startetIFemte,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapper.kt
@@ -29,7 +29,9 @@ object DokumentasjonMapper {
 
     private fun mapVedleggPåId(journalpost: Journalpost): Map<String, Dokument> {
         return journalpost.dokumenter?.mapNotNull { dokumentInfo ->
-            dokumentInfo.tittel?.let { it to Dokument(dokumentInfoId = dokumentInfo.dokumentInfoId) }
-        }?.toMap() ?: emptyMap()
+            dokumentInfo.dokumentvarianter?.mapNotNull {
+                it.filnavn?.let { it to Dokument(dokumentInfoId = dokumentInfo.dokumentInfoId) }
+            }
+        }?.flatten()?.toMap() ?: emptyMap()
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapperTest.kt
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.UUID
+import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.Dokument as DokumentDomain
 
 class DokumentasjonMapperTest {
 
@@ -38,13 +39,13 @@ class DokumentasjonMapperTest {
             Dokumentasjon(
                 type = Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE,
                 harSendtInn = false,
-                dokumenter = listOf(no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.Dokument("vedlegg1")),
+                dokumenter = listOf(DokumentDomain("vedlegg1")),
                 identBarn = null,
             ),
             Dokumentasjon(
                 type = Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE,
                 harSendtInn = true,
-                dokumenter = listOf(no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.Dokument("vedlegg2")),
+                dokumenter = listOf(DokumentDomain("vedlegg2")),
                 identBarn = "barnId",
             ),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/JournalpostUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/JournalpostUtil.kt
@@ -1,6 +1,8 @@
 package no.nav.tilleggsstonader.sak.util
 
 import no.nav.tilleggsstonader.kontrakter.journalpost.DokumentInfo
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariant
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
@@ -20,9 +22,10 @@ object JournalpostUtil {
 
     fun lagDokument(
         dokumentInfoId: String = UUID.randomUUID().toString(),
-        tittel: String,
+        filnavn: String,
     ) = DokumentInfo(
         dokumentInfoId = dokumentInfoId,
-        tittel = tittel,
+        tittel = "tittel",
+        dokumentvarianter = listOf(Dokumentvariant(Dokumentvariantformat.ARKIV, filnavn, true)),
     )
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
1. Id't til dokumentet ligger som filnavn inne i dokumentvarianter. Fikset mapping av riktig felt her.
2. Når man henter fakta så skal man utgå fra barn på behandlingen og ikke grunnlagsdata. Grunnlagsdata kan inneholde barn som ikke er med i behandlingen. 