### PR TITLE
Valider at utgifter som sendes inn kun tihører barn med oppfylte vilkår

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OppdaterVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
@@ -323,6 +324,10 @@ class VilkårService(
         val stønadstype = fagsakService.hentFagsakForBehandling(behandlingId).stønadstype
         val lagretVilkårsett = vilkårRepository.findByBehandlingId(behandlingId)
         return OppdaterVilkår.erAlleVilkårOppfylt(lagretVilkårsett, stønadstype)
+    }
+
+    fun hentOppfyltePassBarnVilkår(behandlingId: UUID): List<Vilkår> {
+        return vilkårRepository.findByBehandlingId(behandlingId).filter { it.resultat == Vilkårsresultat.OPPFYLT && it.type == VilkårType.PASS_BARN }
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
@@ -129,7 +129,7 @@ class StegServiceTest(
         }
 
         @Test
-        internal fun `skal feile håndtering av ny søknad hvis en behandling er ferdigstilt`() {
+        internal fun `skal ikke kunne beregne ytelse dersom behandling er ferdigstilt`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(
                 behandling(steg = StegType.BEHANDLING_FERDIGSTILT),
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -9,8 +9,12 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
+import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -32,6 +36,8 @@ class TilsynBarnVedtakControllerTest(
     val stønadsperiodeRepository: StønadsperiodeRepository,
     @Autowired
     val vilkårperiodeRepository: VilkårperiodeRepository,
+    @Autowired
+    val vilkårRepository: VilkårRepository,
 ) : IntegrationTest() {
 
     val behandling = behandling(steg = StegType.BEREGNE_YTELSE, status = BehandlingStatus.UTREDES)
@@ -39,6 +45,7 @@ class TilsynBarnVedtakControllerTest(
     val stønadsperiode =
         stønadsperiode(behandlingId = behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
     val aktivitet = aktivitet(behandling.id, fom = LocalDate.of(2023, 1, 1), tom = LocalDate.of(2023, 1, 31))
+    val vilkår = vilkår(behandlingId = behandling.id, barnId = barn.id, type = VilkårType.PASS_BARN, resultat = Vilkårsresultat.OPPFYLT)
 
     @BeforeEach
     fun setUp() {
@@ -47,6 +54,7 @@ class TilsynBarnVedtakControllerTest(
         barnRepository.insert(barn)
         stønadsperiodeRepository.insert(stønadsperiode)
         vilkårperiodeRepository.insert(aktivitet)
+        vilkårRepository.insert(vilkår)
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke kunne sende inn utgifter for barn som ikke har oppfylt vilkår `pass barn` slik at disse ikke tas med i beregningen. 

Gjenstår å fikse frontend så utgifter som evt er lagret fra tidligere ikke sendes inn på nytt ved lagring av vedtak