### PR TITLE
✨ Skal kunne hente journalpost med tilhørende personident og navn

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostController.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.journalføring
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.journalføring.dto.JournalpostResponse
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.http.MediaType
@@ -25,5 +26,17 @@ class JournalpostController(
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.ACCESS)
 
         return journalpostService.hentDokument(journalpost, dokumentInfoId)
+    }
+
+    @GetMapping("/{journalpostId}")
+    fun hentJournalPost(@PathVariable journalpostId: String): JournalpostResponse {
+        val (journalpost, personIdent) = journalpostService.finnJournalpostOgPersonIdent(journalpostId)
+        tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.ACCESS)
+        return JournalpostResponse(
+            journalpost,
+            personIdent,
+            journalpostService.hentBrukersNavn(journalpost, personIdent),
+            journalpost.harStrukturertSøknad(),
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
@@ -15,6 +15,8 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gjeldende
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.visningsnavn
 import no.nav.tilleggsstonader.sak.vedlegg.VedleggRequest
 import org.springframework.stereotype.Service
 
@@ -112,6 +114,18 @@ class JournalpostService(private val journalpostClient: JournalpostClient, priva
         } ?: error("Kan ikke hente journalpost=$journalpostId uten bruker")
         return Pair(journalpost, personIdent)
     }
+
+    fun hentBrukersNavn(
+        journalpost: Journalpost,
+        personIdent: String,
+    ): String {
+        return journalpost.avsenderMottaker
+            ?.takeIf { it.erLikBruker }?.navn
+            ?: hentNavnFraPdl(personIdent)
+    }
+
+    private fun hentNavnFraPdl(personIdent: String) =
+        personService.hentPersonKortBolk(listOf(personIdent)).getValue(personIdent).navn.gjeldende().visningsnavn()
 
     fun hentDokument(
         journalpost: Journalpost,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/dto/JournalpostResponse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/dto/JournalpostResponse.kt
@@ -1,0 +1,10 @@
+package no.nav.tilleggsstonader.sak.journalføring.dto
+
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+
+data class JournalpostResponse(
+    val journalpost: Journalpost,
+    val personIdent: String,
+    val navn: String,
+    val harStrukturertSøknad: Boolean,
+)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostServiceTest.kt
@@ -7,6 +7,8 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
 import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdent
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
 import no.nav.tilleggsstonader.sak.util.dokumentInfo
 import no.nav.tilleggsstonader.sak.util.dokumentvariant
 import no.nav.tilleggsstonader.sak.util.journalpost
@@ -24,6 +26,22 @@ class JournalpostServiceTest() {
     @Nested
     inner class FinnJournalpostOgPersonIdent {
         val journalpostId = "123"
+        val aktørId = "11111111111"
+        val personIdentFraPdl = "12345678901"
+
+        @Test
+        internal fun `skal hente journalpost med personident utledet fra pdl`() {
+            every {
+                personService.hentPersonIdenter(aktørId)
+            } returns PdlIdenter(listOf(PdlIdent(personIdentFraPdl, false)))
+
+            every { journalpostClient.hentJournalpost(any()) } returns journalpost(journalpostId = journalpostId, bruker = Bruker(type = BrukerIdType.AKTOERID, id = aktørId))
+
+            val (journalpost, personIdent) = journalpostService.finnJournalpostOgPersonIdent(journalpostId)
+
+            assertThat(personIdent).isEqualTo(personIdentFraPdl)
+            assertThat(journalpost.journalpostId).isEqualTo(journalpostId)
+        }
 
         @Test
         fun `skal kaste feil om journalpost ikke har bruker`() {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved manuell journalføring skal man kunne hente en journalpost, med navn og ident.