### PR TITLE
Fjerner boolean flagg "harSendtInn" fra "Dokumentasjon"-domene-objekt

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
@@ -47,7 +47,6 @@ data class FaktaDokumentasjon(
 
 data class Dokumentasjon(
     val type: String,
-    val harSendtInn: Boolean,
     val dokumenter: List<Dokument>,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val identBarn: String? = null,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
@@ -97,7 +97,6 @@ class BehandlingFaktaService(
             val navnBarn = dokumentasjon.identBarn?.let { navn[it] }?.let { " - $it" } ?: ""
             Dokumentasjon(
                 type = dokumentasjon.type.tittel + navnBarn,
-                harSendtInn = dokumentasjon.harSendtInn,
                 dokumenter = dokumentasjon.dokumenter.map { Dokument(it.dokumentInfoId) },
                 identBarn = dokumentasjon.identBarn,
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/domain/Søknad.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/domain/Søknad.kt
@@ -70,7 +70,6 @@ data class AktivitetAvsnitt(
 
 data class Dokumentasjon(
     val type: Vedleggstype,
-    val harSendtInn: Boolean,
     val dokumenter: List<Dokument>,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val identBarn: String? = null,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapper.kt
@@ -16,7 +16,6 @@ object DokumentasjonMapper {
         return skjema.dokumentasjon.map {
             Dokumentasjon(
                 type = it.type,
-                harSendtInn = it.harSendtInn,
                 dokumenter = it.opplastedeVedlegg.map { dokument ->
                     val dokumentId = dokument.id
                     vedlegg[dokumentId.toString()]

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaServiceTest.kt
@@ -104,7 +104,7 @@ internal class BehandlingFaktaServiceTest {
 
         @Test
         fun `skal mappe dokumentasjon`() {
-            val dokumentasjon = lagDokumentasjon(harSendtInn = false)
+            val dokumentasjon = lagDokumentasjon()
             every { grunnlagsdataService.hentFraRegister(behandlingId) } returns
                 grunnlagsdataMedMetadata(grunnlagsdata = lagGrunnlagsdata(barn = emptyList()))
             every { søknadService.hentSøknadBarnetilsyn(behandlingId) } returns søknadBarnetilsyn(
@@ -118,7 +118,6 @@ internal class BehandlingFaktaServiceTest {
             assertThat(fakta.dokumentasjon?.journalpostId).contains("journalpostId2")
             with(fakta.dokumentasjon!!.dokumentasjon.single()) {
                 assertThat(type).isEqualTo(dokumentasjon.type.tittel)
-                assertThat(harSendtInn).isFalse()
                 assertThat(dokumenter.map { it.dokumentInfoId })
                     .containsExactlyElementsOf(dokumentasjon.dokumenter.map { it.dokumentInfoId })
                 assertThat(identBarn).isNull()
@@ -144,7 +143,6 @@ internal class BehandlingFaktaServiceTest {
 
             with(fakta.dokumentasjon!!.dokumentasjon.single()) {
                 assertThat(type).isEqualTo("${dokumentasjon.type.tittel} - Fornavn barn1")
-                assertThat(harSendtInn).isTrue()
                 assertThat(identBarn).isEqualTo("1")
             }
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/DokumentasjonMapperTest.kt
@@ -38,13 +38,11 @@ class DokumentasjonMapperTest {
         assertThat(data).containsExactlyInAnyOrder(
             Dokumentasjon(
                 type = Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE,
-                harSendtInn = false,
                 dokumenter = listOf(DokumentDomain("vedlegg1")),
                 identBarn = null,
             ),
             Dokumentasjon(
                 type = Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE,
-                harSendtInn = true,
                 dokumenter = listOf(DokumentDomain("vedlegg2")),
                 identBarn = "barnId",
             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadBarnetilsynUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadBarnetilsynUtil.kt
@@ -66,11 +66,9 @@ object SøknadBarnetilsynUtil {
     )
 
     fun lagDokumentasjon(
-        harSendtInn: Boolean = true,
         identBarn: String? = null,
     ): Dokumentasjon = Dokumentasjon(
         type = Vedleggstype.UTGIFTER_PASS_ANNET,
-        harSendtInn = harSendtInn,
         dokumenter = listOf(
             Dokument("688ad1dc-e35e-4ab8-a534-17c6e691463f"),
         ),

--- a/src/test/resources/vilkår/vilkårGrunnlagDto.json
+++ b/src/test/resources/vilkår/vilkårGrunnlagDto.json
@@ -29,7 +29,6 @@
     "journalpostId" : "testId",
     "dokumentasjon" : [ {
       "type" : "Dokumentasjon av utgifter for pass av barn",
-      "harSendtInn" : true,
       "dokumenter" : [ {
         "dokumentInfoId" : "688ad1dc-e35e-4ab8-a534-17c6e691463f"
       } ]


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi skal ikke lenger ta stilling til valget i Frontend, så det er ikke behov for å lagre denne informasjonen lenger.