### PR TITLE
✨Lagt til kodeverk for å kunne hente landkoder og poststed

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -87,6 +87,7 @@ spec:
         - host: pdl-api-q1.dev-fss-pub.nais.io
         - host: tilleggsstonader-arena.dev-fss-pub.nais.io
         - host: tilleggsstonader-unleash-api.nav.cloud.nais.io
+        - host: kodeverk-api.nav.no
 
   envFrom:
     - secret: tilleggsstonader-sak-unleash-api-token

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -83,6 +83,8 @@ spec:
           namespace: teamfamilie
         - application: dp-iverksett
           namespace: teamdagpenger
+        - application: kodeverk-api
+          namespace: team-rocket
       external:
         - host: pdl-api.prod-fss-pub.nais.io
         - host: tilleggsstonader-arena.prod-fss-pub.nais.io

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkClient.kt
@@ -1,0 +1,32 @@
+package no.nav.tilleggsstonader.sak.opplysninger.kodeverk
+
+import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
+import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Component
+class KodeverkClient(
+    @Value("\${clients.kodeverk.uri}")
+    private val uri: URI,
+    @Qualifier("azureClientCredential") restTemplate: RestTemplate,
+) :
+    AbstractRestClient(restTemplate) {
+
+    fun hentPostnummer(): KodeverkDto =
+        getForEntity(kodeverkUri, null, mapOf("kodeverksnavn" to "Postnummer"))
+
+    fun hentLandkoder(): KodeverkDto =
+        getForEntity(kodeverkUri, null, mapOf("kodeverksnavn" to "Landkoder"))
+
+    private val kodeverkUri = UriComponentsBuilder.fromUri(uri)
+        .pathSegment("api", "v1", "kodeverk", "{kodeverksnavn}", "koder", "betydninger")
+        .queryParam("ekskluderUgyldige", "true") // henter ikke historikk
+        .queryParam("spraak", "nb")
+        .encode()
+        .toUriString()
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkInitializer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkInitializer.kt
@@ -1,0 +1,61 @@
+package no.nav.tilleggsstonader.sak.opplysninger.kodeverk
+
+import no.nav.tilleggsstonader.libs.log.mdc.MDCConstants
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.cache.CacheManager
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Henter kodeverk på nytt hver natt kl 1. Dette for å unngå at vi må hente det synkront når noen trenger dataen.
+ * Disse blir cachet i [CachedKodeverkService]
+ */
+@Component
+@Profile("!integrasjonstest")
+class KodeverkInitializer(
+    private val kodeverkService: CachedKodeverkService,
+    @Qualifier("kodeverkCache")
+    private val cacheManager: CacheManager,
+) : ApplicationListener<ApplicationReadyEvent> {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = HVER_DAG_KL_01)
+    fun syncKodeverk() {
+        logger.info("Kjører schedulert jobb for å hente kodeverk")
+        cacheManager.cacheNames.stream().forEach { cacheManager.getCache(it)?.clear() }
+        sync()
+    }
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        sync()
+    }
+
+    private fun sync() {
+        syncKodeverk("Poststed", kodeverkService::hentPoststed)
+        syncKodeverk("Landkoder", kodeverkService::hentLandkoder)
+    }
+
+    private fun syncKodeverk(navn: String, henter: () -> Unit) {
+        try {
+            MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
+            logger.info("Henter kodeverk=$navn")
+            henter.invoke()
+            logger.info("Hentet kodeverk=$navn")
+        } catch (e: Exception) {
+            logger.warn("Feilet henting av kodeverk=$navn ${e.message}")
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    companion object {
+        private const val HVER_DAG_KL_01 = "0 0 1 * * *"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkService.kt
@@ -1,0 +1,50 @@
+package no.nav.tilleggsstonader.sak.opplysninger.kodeverk
+
+import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
+import no.nav.tilleggsstonader.kontrakter.kodeverk.hentGjeldende
+import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+
+/**
+ * Henter cachade verdier fra kodeverk. Kodeverk inneholder mapping av div verdier til norsk tekst av verdiet.
+ * Eks inneholder kodeverk mapping fra postnummer 0010 til Oslo
+ */
+@Service
+class KodeverkService(
+    private val cachedKodeverkService: CachedKodeverkService,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    fun hentPoststed(postnummer: String?) = hentKodeverdi("poststed", postnummer) {
+        cachedKodeverkService.hentPoststed().hentGjeldende(it)
+    }
+
+    fun hentLandkode(landkode: String?) =
+        hentKodeverdi("landkode", landkode) {
+            cachedKodeverkService.hentLandkoder().hentGjeldende(it)
+        }
+
+    private fun hentKodeverdi(type: String, kode: String?, hentKodeverdiFunction: Function1<String, String?>): String {
+        return try {
+            kode?.let(hentKodeverdiFunction) ?: kode ?: ""
+        } catch (e: Exception) {
+            // Ikke la feil kodeverk stoppe henting av data
+            logger.error("Feilet henting av $type til $kode message=${e.message} cause=${e.cause?.message}")
+            ""
+        }
+    }
+}
+
+@Service
+@CacheConfig(cacheManager = "kodeverkCache")
+class CachedKodeverkService(
+    private val kodeverkClient: KodeverkClient,
+) {
+    @Cacheable("poststed", sync = true)
+    fun hentPoststed(): KodeverkDto = kodeverkClient.hentPostnummer()
+
+    @Cacheable("landkoder", sync = true)
+    fun hentLandkoder(): KodeverkDto = kodeverkClient.hentLandkoder()
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,3 +13,5 @@ clients:
   pdl:
     uri: https://pdl-api-q1.${CLIENT_ENV}-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.pdl.pdl-api-q1/.default
+  kodeverk:
+    uri: https://kodeverk-api.nav.no

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -112,6 +112,16 @@ no.nav.security.jwt:
         client-secret: ${AZURE_APP_CLIENT_SECRET}
         client-auth-method: client_secret_basic
 
+    kodeverk-client_credentials:
+      resource-url: ${clients.kodeverk.uri}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: client_credentials
+      scope: ${clients.kodeverk.scope}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
+
     iverksetting:
       resource-url: ${clients.iverksetting.uri}
       token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
@@ -151,3 +161,6 @@ clients:
   iverksetting:
     uri: http://dp-iverksett.teamdagpenger
     scope: api://${CLIENT_ENV}-gcp.teamdagpenger.dp-iverksett/.default
+  kodeverk:
+    uri: http://kodeverk-api.team-rocket
+    scope: api://${CLIENT_ENV}-gcp.team-rocket.kodeverk-api/.default

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -73,6 +73,7 @@ class DefaultRestTemplateConfiguration {
     "mock-htmlify",
     "mock-arena",
     "mock-aktivitet",
+    "mock-kodeverk",
 )
 @EnableMockOAuth2Server
 abstract class IntegrationTest {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
@@ -29,4 +29,5 @@ fun appLocal(): SpringApplicationBuilder =
             "mock-htmlify",
             "mock-arena",
             "mock-aktivitet",
+            "mock-kodeverk",
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/KodeverkClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/KodeverkClientConfig.kt
@@ -1,0 +1,42 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.mocks
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.kodeverk.BeskrivelseDto
+import no.nav.tilleggsstonader.kontrakter.kodeverk.BetydningDto
+import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
+import no.nav.tilleggsstonader.sak.opplysninger.kodeverk.KodeverkClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import java.time.LocalDate
+
+@Configuration
+@Profile("mock-kodeverk")
+class KodeverkClientConfig {
+
+    @Bean
+    fun kodeverkClient(): KodeverkClient {
+        val client = mockk<KodeverkClient>()
+        every { client.hentPostnummer() } returns KodeverkDto(
+            mapOf(
+                "Postnummer" to listOf(
+                    BeskrivelseDto("0010", "Oslo"),
+                ).map { betydning(it) },
+            ),
+        )
+        every { client.hentLandkoder() } returns KodeverkDto(
+            mapOf(
+                "Landkoder" to listOf(
+                    BeskrivelseDto("SWE", "Sverige"),
+                    BeskrivelseDto("FIN", "Finland"),
+                ).map { betydning(it) },
+            ),
+        )
+
+        return client
+    }
+
+    private fun betydning(it: BeskrivelseDto) =
+        BetydningDto(LocalDate.now().minusYears(1), LocalDate.now().plusYears(1), mapOf("nb" to it))
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/KodeverkClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/KodeverkClientConfig.kt
@@ -19,23 +19,19 @@ class KodeverkClientConfig {
     fun kodeverkClient(): KodeverkClient {
         val client = mockk<KodeverkClient>()
         every { client.hentPostnummer() } returns KodeverkDto(
-            mapOf(
-                "Postnummer" to listOf(
-                    BeskrivelseDto("0010", "Oslo"),
-                ).map { betydning(it) },
-            ),
+            listOf("0010" to "Oslo").tilBetydninger(),
         )
         every { client.hentLandkoder() } returns KodeverkDto(
-            mapOf(
-                "Landkoder" to listOf(
-                    BeskrivelseDto("SWE", "Sverige"),
-                    BeskrivelseDto("FIN", "Finland"),
-                ).map { betydning(it) },
-            ),
+            listOf(
+                "SWE" to "Sverige",
+                "FIN" to "Finland",
+            ).tilBetydninger(),
         )
-
         return client
     }
+
+    private fun List<Pair<String, String>>.tilBetydninger() =
+        this.associate { it.first to listOf(betydning(BeskrivelseDto(it.second, it.second))) }
 
     private fun betydning(it: BeskrivelseDto) =
         BetydningDto(LocalDate.now().minusYears(1), LocalDate.now().plusYears(1), mapOf("nb" to it))

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/CachedKodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/CachedKodeverkServiceTest.kt
@@ -1,0 +1,43 @@
+package no.nav.tilleggsstonader.sak.opplysninger.kodeverk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.annotation.Cacheable
+import java.lang.reflect.Modifier
+import kotlin.reflect.KClass
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.jvm.javaMethod
+
+internal class CachedKodeverkServiceTest {
+
+    // for å unngå at en metode som ikke @Cacheable kaller på en metode som er @Cacheable
+    @Test
+    internal fun `alle public metoder må være cacheable`() {
+        assertThat(sjekkAllePublicErCacheable(CachedKodeverkService::class)).isTrue()
+    }
+
+    @Test
+    internal fun `alle public metoder må være cacheable testklasse`() {
+        open class CachedKlasse {
+
+            @Cacheable
+            open fun med() = true
+
+            fun uten() = false
+        }
+
+        open class CachedKlasseMedPrivat {
+
+            @Cacheable
+            open fun med() = true
+
+            private fun uten() = false
+        }
+        assertThat(sjekkAllePublicErCacheable(CachedKlasse::class)).isFalse()
+        assertThat(sjekkAllePublicErCacheable(CachedKlasseMedPrivat::class)).isTrue()
+    }
+
+    private fun sjekkAllePublicErCacheable(kClass: KClass<*>) = kClass.declaredMemberFunctions
+        .filter { Modifier.isPublic(it.javaMethod!!.modifiers) }
+        .none { it.annotations.none { innerIt -> innerIt.annotationClass == Cacheable::class } }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/kodeverk/KodeverkServiceIntegrationTest.kt
@@ -1,0 +1,28 @@
+package no.nav.tilleggsstonader.sak.opplysninger.kodeverk
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class KodeverkServiceIntegrationTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var kodeverkService: KodeverkService
+
+    @Test
+    fun `skal mapppe landkode til land`() {
+        assertThat(kodeverkService.hentLandkode("SWE")).isEqualTo("Sverige")
+        assertThat(kodeverkService.hentLandkode("FIN")).isEqualTo("Finland")
+    }
+
+    @Test
+    fun `skal mappe ikke-eksisterende landkode til koden`() {
+        assertThat(kodeverkService.hentLandkode("EKSISTERER_IKKE")).isEqualTo("EKSISTERER_IKKE")
+    }
+
+    @Test
+    fun `skal mappe landkode null til tom streng`() {
+        assertThat(kodeverkService.hentLandkode(null)).isEqualTo("")
+    }
+}


### PR DESCRIPTION
Landkoder skal brukes til land fra søknaden.
Samme kode som i søknad-api

### Hvorfor er denne endringen nødvendig? ✨
Ønsker å hente landkoder fra kodeverk for å kunne mappe alpha-3 koder til norske landkoder i
* https://github.com/navikt/tilleggsstonader-sak/pull/251