### PR TITLE
♻️ Refaktor. Trekker ut kode fra AutomatiskJournalføringService som også

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -284,4 +284,9 @@ class BehandlingService(
             ),
         )
     }
+
+    fun utledNesteBehandlingstype(fagsakId: UUID): BehandlingType {
+        val behandlinger = hentBehandlinger(fagsakId)
+        return if (behandlinger.all { it.resultat == BehandlingResultat.HENLAGT }) BehandlingType.FØRSTEGANGSBEHANDLING else BehandlingType.REVURDERING
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
@@ -5,100 +5,72 @@ import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
-import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.sak.journalføring.HåndterSøknadRequest
-import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService.Companion.MASKINELL_JOURNALFOERENDE_ENHET
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
-import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
-import no.nav.tilleggsstonader.sak.behandling.domain.Journalposttype
-import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.journalføring.JournalføringService
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
-import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
-import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 @Service
 class AutomatiskJournalføringService(
-    private val fagsakService: FagsakService,
     private val personService: PersonService,
-    private val arbeidsfordelingService: ArbeidsfordelingService,
     private val journalpostService: JournalpostService,
-    private val behandlingService: BehandlingService,
-    private val søknadService: SøknadService,
     private val taskService: TaskService,
-    private val barnService: BarnService,
-    private val grunnlagsdataService: GrunnlagsdataService,
+    private val journalføringService: JournalføringService,
+    private val fagsakService: FagsakService,
+    private val behandlingService: BehandlingService,
+    private val unleashService: UnleashService,
 ) {
-
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     @Transactional
     fun håndterSøknad(request: HåndterSøknadRequest) {
         val personIdent = request.personIdent
         val stønadstype = request.stønadstype
 
-        if (kanOppretteBehandling(personIdent, stønadstype)) {
-            automatiskJournalførTilBehandling(
+        if (kanAutomatiskJournalføre(personIdent, stønadstype)) {
+            journalføringService.journalførTilNyBehandling(
                 journalpostId = request.journalpostId,
                 personIdent = personIdent,
                 stønadstype = stønadstype,
+                oppgaveBeskrivelse = "Automatisk journalført søknad",
             )
         } else {
             håndterSøknadSomIkkeKanAutomatiskJournalføres(request)
         }
     }
 
-    private fun automatiskJournalførTilBehandling(
-        journalpostId: String,
-        personIdent: String,
-        stønadstype: Stønadstype,
-    ) {
-        val journalpost = journalpostService.hentJournalpost(journalpostId)
-        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent, stønadstype)
-        val nesteBehandlingstype = utledNesteBehandlingstype(behandlingService.hentBehandlinger(fagsak.id))
-        val journalførendeEnhet =
-            arbeidsfordelingService.hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(fagsak.hentAktivIdent())
+    fun kanAutomatiskJournalføre(personIdent: String, stønadstype: Stønadstype): Boolean {
+        val allePersonIdenter = personService.hentPersonIdenter(personIdent).identer()
+        val fagsak = fagsakService.finnFagsak(allePersonIdenter, stønadstype)
 
-        validerKanAutomatiskJournalføre(personIdent, stønadstype, journalpost)
+        return if (fagsak == null) {
+            true
+        } else {
+            val nesteBehandlingstype = behandlingService.utledNesteBehandlingstype(fagsak.id)
 
-        val behandling = opprettBehandlingOgPopulerGrunnlagsdataForAutomatiskJournalførtSøknad(
-            behandlingstype = nesteBehandlingstype,
-            fagsak = fagsak,
-            journalpost = journalpost,
-        )
+            if (nesteBehandlingstype === BehandlingType.REVURDERING && !unleashService.isEnabled(Toggle.AUTOMATISK_JOURNALFORING_REVURDERING)) {
+                return false
+            }
 
-        journalpostService.oppdaterOgFerdigstillJournalpostMaskinelt(
-            journalpost = journalpost,
-            journalførendeEnhet = journalførendeEnhet,
-            fagsak = fagsak,
-        )
+            val behandlinger = behandlingService.hentBehandlinger(fagsak.id)
+            !harÅpenBehandling(behandlinger)
+        }
+    }
 
-        opprettBehandleSakOppgaveTask(
-            OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData(
-                behandlingId = behandling.id,
-                saksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker(),
-                beskrivelse = "Automatisk journalført søknad",
-            ),
-        )
+    private fun harÅpenBehandling(behandlinger: List<Behandling>): Boolean {
+        return behandlinger.any { !it.erAvsluttet() }
     }
 
     private fun håndterSøknadSomIkkeKanAutomatiskJournalføres(request: HåndterSøknadRequest) {
@@ -123,40 +95,6 @@ class AutomatiskJournalføringService(
         return "Må behandles i ny løsning - $dokumentTittel"
     }
 
-    fun kanOppretteBehandling(ident: String, stønadstype: Stønadstype): Boolean {
-        val allePersonIdenter = personService.hentPersonIdenter(ident).identer()
-        val fagsak = fagsakService.finnFagsak(allePersonIdenter, stønadstype)
-        val behandlinger = fagsak?.let { behandlingService.hentBehandlinger(fagsak.id) } ?: emptyList()
-
-        return if (!harÅpenBehandling(behandlinger)) {
-            secureLogger.info("Kan automatisk journalføre for fagsak: ${fagsak?.id}")
-            true
-        } else {
-            secureLogger.info("Kan ikke automatisk journalføre for fagsak: ${fagsak?.id}")
-            false
-        }
-    }
-
-    private fun validerKanAutomatiskJournalføre(
-        personIdent: String,
-        stønadstype: Stønadstype,
-        journalpost: Journalpost,
-    ) {
-        val allePersonIdenter = personService.hentPersonIdenter(personIdent).identer()
-
-        feilHvisIkke(kanOppretteBehandling(personIdent, stønadstype)) {
-            "Kan ikke opprette førstegangsbehandling for $stønadstype da det allerede finnes en behandling i infotrygd eller ny løsning"
-        }
-
-        feilHvis(journalpost.bruker == null) {
-            "Journalposten mangler bruker. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
-        }
-
-        feilHvis(journalpost.journalstatus != Journalstatus.MOTTATT) {
-            "Journalposten har ugyldig journalstatus ${journalpost.journalstatus}. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
-        }
-    }
-
     private fun fagsakPersonOgJournalpostBrukerErSammePerson(
         allePersonIdenter: Set<String>,
         gjeldendePersonIdent: String,
@@ -169,54 +107,4 @@ class AutomatiskJournalføringService(
 
     private fun hentAktørIderForPerson(personIdent: String) =
         personService.hentAktørIder(personIdent).identer()
-
-    private fun utledNesteBehandlingstype(behandlinger: List<Behandling>): BehandlingType {
-        return if (behandlinger.all { it.resultat == BehandlingResultat.HENLAGT }) BehandlingType.FØRSTEGANGSBEHANDLING else BehandlingType.REVURDERING
-    }
-
-    private fun harÅpenBehandling(behandlinger: List<Behandling>): Boolean {
-        return behandlinger.any { !it.erAvsluttet() }
-    }
-
-    private fun opprettBehandlingOgPopulerGrunnlagsdataForAutomatiskJournalførtSøknad(
-        behandlingstype: BehandlingType,
-        fagsak: Fagsak,
-        journalpost: Journalpost,
-    ): Behandling {
-        val behandling = behandlingService.opprettBehandling(
-            behandlingType = behandlingstype,
-            fagsakId = fagsak.id,
-            behandlingsårsak = BehandlingÅrsak.SØKNAD,
-        )
-
-        lagreSøknad(journalpost, behandling.id)
-        behandlingService.leggTilBehandlingsjournalpost(journalpost.journalpostId, Journalposttype.I, behandling.id)
-
-        /* TODO: Opprett statistikkinnslag */
-
-        /* TODO: Opprett grunnlagsdata
-          val grunnlagsdata = grunnlagsdataService.opprettGrunlagsdata(behandling.id)
-         */
-
-        val barn = søknadService.hentSøknadBarnetilsyn(behandling.id)?.barn?.map {
-            BehandlingBarn(
-                behandlingId = behandling.id,
-                ident = it.ident,
-                søknadBarnId = it.id,
-            )
-        } ?: error("Søknad mangler barn")
-
-        barnService.opprettBarn(barn)
-
-        return behandling
-    }
-
-    private fun lagreSøknad(journalpost: Journalpost, behandlingId: UUID) {
-        val søknad = journalpostService.hentSøknadFraJournalpost(journalpost)
-        søknadService.lagreSøknad(behandlingId, journalpost, søknad)
-    }
-
-    private fun opprettBehandleSakOppgaveTask(opprettOppgaveTaskData: OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData) {
-        taskService.save(OpprettOppgaveForOpprettetBehandlingTask.opprettTask(opprettOppgaveTaskData))
-    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -5,4 +5,5 @@ import no.nav.tilleggsstonader.libs.unleash.ToggleId
 enum class Toggle(override val toggleId: String) : ToggleId {
     SØKNAD_ROUTING_TILSYN_BARN("sak.soknad-routing.tilsyn-barn"),
     KAN_OPPRETTE_BEHANDLING("sak.kan-opprette-behandling"),
+    AUTOMATISK_JOURNALFORING_REVURDERING("sak.automatisk-jfr-revurdering"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
@@ -1,0 +1,140 @@
+package no.nav.tilleggsstonader.sak.journalføring
+
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.behandling.domain.Journalposttype
+import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class JournalføringService(
+    private val behandlingService: BehandlingService,
+    private val fagsakService: FagsakService,
+    private val journalpostService: JournalpostService,
+    private val søknadService: SøknadService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val taskService: TaskService,
+    private val barnService: BarnService,
+) {
+    fun journalførTilNyBehandling(
+        journalpostId: String,
+        personIdent: String,
+        stønadstype: Stønadstype,
+        oppgaveBeskrivelse: String,
+    ) {
+        val journalpost = journalpostService.hentJournalpost(journalpostId)
+        val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent, stønadstype)
+        val nesteBehandlingstype = behandlingService.utledNesteBehandlingstype(fagsak.id)
+        val journalførendeEnhet =
+            arbeidsfordelingService.hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(fagsak.hentAktivIdent())
+
+        validerKanOppretteBehandling(personIdent, stønadstype, journalpost)
+
+        val behandling = opprettBehandlingOgPopulerGrunnlagsdataForSøknad(
+            behandlingstype = nesteBehandlingstype,
+            fagsak = fagsak,
+            journalpost = journalpost,
+        )
+
+        if (journalpost.harStrukturertSøknad()) {
+            lagreSøknadOgBarn(journalpost, behandling)
+        }
+
+        ferdigstillJournalpost(journalpost, journalførendeEnhet, fagsak)
+
+        opprettBehandleSakOppgaveTask(
+            OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData(
+                behandlingId = behandling.id,
+                saksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker(),
+                beskrivelse = oppgaveBeskrivelse,
+            ),
+        )
+    }
+
+    private fun ferdigstillJournalpost(
+        journalpost: Journalpost,
+        journalførendeEnhet: String,
+        fagsak: Fagsak,
+    ) {
+        journalpostService.oppdaterOgFerdigstillJournalpostMaskinelt(
+            journalpost = journalpost,
+            journalførendeEnhet = journalførendeEnhet,
+            fagsak = fagsak,
+        )
+    }
+
+    private fun opprettBehandlingOgPopulerGrunnlagsdataForSøknad(
+        behandlingstype: BehandlingType,
+        fagsak: Fagsak,
+        journalpost: Journalpost,
+    ): Behandling {
+        val behandling = behandlingService.opprettBehandling(
+            behandlingType = behandlingstype,
+            fagsakId = fagsak.id,
+            behandlingsårsak = BehandlingÅrsak.SØKNAD,
+        )
+
+        behandlingService.leggTilBehandlingsjournalpost(journalpost.journalpostId, Journalposttype.I, behandling.id)
+
+        /* TODO: Opprett statistikkinnslag */
+
+        /* TODO: Opprett grunnlagsdata
+          val grunnlagsdata = grunnlagsdataService.opprettGrunlagsdata(behandling.id)
+         */
+        return behandling
+    }
+
+    private fun lagreSøknadOgBarn(
+        journalpost: Journalpost,
+        behandling: Behandling,
+    ) {
+        lagreSøknad(journalpost, behandling.id)
+        val barn = søknadService.hentSøknadBarnetilsyn(behandling.id)?.barn?.map {
+            BehandlingBarn(
+                behandlingId = behandling.id,
+                ident = it.ident,
+                søknadBarnId = it.id,
+            )
+        } ?: error("Søknad mangler barn")
+
+        barnService.opprettBarn(barn)
+    }
+
+    private fun lagreSøknad(journalpost: Journalpost, behandlingId: UUID) {
+        val søknad = journalpostService.hentSøknadFraJournalpost(journalpost)
+        søknadService.lagreSøknad(behandlingId, journalpost, søknad)
+    }
+
+    private fun opprettBehandleSakOppgaveTask(opprettOppgaveTaskData: OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData) {
+        taskService.save(OpprettOppgaveForOpprettetBehandlingTask.opprettTask(opprettOppgaveTaskData))
+    }
+
+    private fun validerKanOppretteBehandling(
+        personIdent: String,
+        stønadstype: Stønadstype,
+        journalpost: Journalpost,
+    ) {
+        feilHvis(journalpost.bruker == null) {
+            "Journalposten mangler bruker. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
+        }
+
+        feilHvis(journalpost.journalstatus != Journalstatus.MOTTATT) {
+            "Journalposten har ugyldig journalstatus ${journalpost.journalstatus}. Kan ikke automatisk journalføre ${journalpost.journalpostId}"
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
@@ -225,4 +225,48 @@ internal class BehandlingServiceTest {
             ),
         )
     }
+
+    @Nested
+    inner class UtledNesteBehandlingstype {
+
+        @Test
+        internal fun `skal returnere revurdering hvis det finnes en førstegangsbehandling`() {
+            val fagsak = fagsak()
+            every {
+                behandlingRepository.findByFagsakId(fagsak.id)
+            } returns listOf(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING, resultat = BehandlingResultat.INNVILGET))
+
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.REVURDERING)
+        }
+
+        @Test
+        internal fun `skal returnere førstegangsbehandling hvis det ikke finnes en førstegangsbehandling`() {
+            val fagsak = fagsak()
+            every {
+                behandlingRepository.findByFagsakId(fagsak.id)
+            } returns emptyList()
+
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
+        }
+
+        @Test
+        internal fun `skal returnere førstegangsbehandling hvis det finnes en førstegangsbehandling som er henlagt`() {
+            val fagsak = fagsak()
+            every {
+                behandlingRepository.findByFagsakId(fagsak.id)
+            } returns listOf(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING, resultat = BehandlingResultat.HENLAGT))
+
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
+        }
+
+        @Test
+        internal fun `skal returnere revurdering hvis det finnes en førstegangsbehandling som ikke er ferdigstilt`() {
+            val fagsak = fagsak()
+            every {
+                behandlingRepository.findByFagsakId(fagsak.id)
+            } returns listOf(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING, status = BehandlingStatus.UTREDES, resultat = BehandlingResultat.IKKE_SATT))
+
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.REVURDERING)
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringServiceTest.kt
@@ -1,9 +1,8 @@
 package no.nav.tilleggsstonader.sak.ekstern.journalføring
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -26,9 +25,9 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
-import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
+import no.nav.tilleggsstonader.sak.journalføring.JournalføringService
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
@@ -41,7 +40,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SøknadBarnetilsy
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -57,17 +55,16 @@ internal class AutomatiskJournalføringServiceTest {
     val søknadService: SøknadService = mockk()
     val taskService: TaskService = mockk()
     val barnService: BarnService = mockk()
+    val journalføringService: JournalføringService = mockk()
 
     val automatiskJournalføringService = AutomatiskJournalføringService(
-        behandlingService = behandlingService,
-        fagsakService = fagsakService,
         personService = personService,
-        arbeidsfordelingService = arbeidsfordelingService,
         journalpostService = journalpostService,
-        grunnlagsdataService = grunnlagsdataService,
-        søknadService = søknadService,
-        barnService = barnService,
         taskService = taskService,
+        journalføringService = journalføringService,
+        fagsakService = fagsakService,
+        behandlingService = behandlingService,
+        unleashService = mockUnleashService(),
     )
 
     val enhet = ArbeidsfordelingService.ENHET_NASJONAL_NAY.enhetId
@@ -109,13 +106,14 @@ internal class AutomatiskJournalføringServiceTest {
         every { barnService.opprettBarn(any()) } returns mockk()
         every { personService.hentAktørIder(any()) } returns PdlIdenter(listOf(PdlIdent(aktørId, false)))
         every { taskService.save(capture(taskSlot)) } returns mockk()
+        every { behandlingService.utledNesteBehandlingstype(fagsak.id) } returns BehandlingType.FØRSTEGANGSBEHANDLING
     }
 
     @Test
     internal fun `kan ikke opprette behandling hvis det eksisterer en åpen behandling i ny løsning`() {
         every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(behandling(status = BehandlingStatus.UTREDES))
         val kanOppretteBehandling =
-            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+            automatiskJournalføringService.kanAutomatiskJournalføre(personIdent, Stønadstype.BARNETILSYN)
         assertThat(kanOppretteBehandling).isFalse
     }
 
@@ -123,7 +121,7 @@ internal class AutomatiskJournalføringServiceTest {
     internal fun `kan opprette behandling hvis det ikke finnes innslag i ny løsning`() {
         every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf()
         val kanOppretteBehandling =
-            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+            automatiskJournalføringService.kanAutomatiskJournalføre(personIdent, Stønadstype.BARNETILSYN)
         assertThat(kanOppretteBehandling).isTrue
     }
 
@@ -136,7 +134,7 @@ internal class AutomatiskJournalføringServiceTest {
             ),
         )
         val kanOppretteBehandling =
-            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+            automatiskJournalføringService.kanAutomatiskJournalføre(personIdent, Stønadstype.BARNETILSYN)
         assertThat(kanOppretteBehandling).isTrue
     }
 
@@ -150,48 +148,15 @@ internal class AutomatiskJournalføringServiceTest {
             behandling(resultat = BehandlingResultat.AVSLÅTT, status = BehandlingStatus.FERDIGSTILT),
         )
         val kanOppretteBehandling =
-            automatiskJournalføringService.kanOppretteBehandling(personIdent, Stønadstype.BARNETILSYN)
+            automatiskJournalføringService.kanAutomatiskJournalføre(personIdent, Stønadstype.BARNETILSYN)
         assertThat(kanOppretteBehandling).isTrue
     }
 
     @Test
-    internal fun `skal ikke kunne automatisk journalføre hvis journalpostens bruker mangler`() {
-        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = null)
-        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
-
-        assertThatThrownBy {
-            automatiskJournalføringService.håndterSøknad(
-                HåndterSøknadRequest(
-                    personIdent,
-                    journalpostId,
-                    Stønadstype.BARNETILSYN,
-                ),
-            )
-        }.hasMessageContaining("Journalposten mangler bruker")
-    }
-
-    @Test
     internal fun `skal kunne automatisk journalføre`() {
-        val aktørIdBruker = Bruker(
-            id = aktørId,
-            type = BrukerIdType.AKTOERID,
-        )
-        val journalpostMedAktørId = journalpost.copy(bruker = aktørIdBruker)
-        every { journalpostService.hentJournalpost(journalpostId) } returns journalpostMedAktørId
-        every { journalpostService.oppdaterOgFerdigstillJournalpostMaskinelt(any(), any(), any()) } just Runs
-        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
-
         every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
-        every { behandlingService.leggTilBehandlingsjournalpost(any(), any(), any()) } just Runs
-        every {
-            behandlingService.opprettBehandling(
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                fagsakId = fagsak.id,
-                behandlingsårsak = BehandlingÅrsak.SØKNAD,
-            )
-        } returns behandling(fagsak = fagsak)
-        every { journalpostService.hentSøknadFraJournalpost(any()) } returns mockk()
-        every { søknadService.lagreSøknad(any(), any(), any()) } returns mockk()
+
+        justRun { journalføringService.journalførTilNyBehandling(journalpostId, personIdent, Stønadstype.BARNETILSYN, any()) }
 
         automatiskJournalføringService.håndterSøknad(
             HåndterSøknadRequest(
@@ -202,14 +167,13 @@ internal class AutomatiskJournalføringServiceTest {
         )
 
         verify(exactly = 1) {
-            behandlingService.opprettBehandling(
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
-                fagsakId = fagsak.id,
-                behandlingsårsak = BehandlingÅrsak.SØKNAD,
+            journalføringService.journalførTilNyBehandling(
+                journalpostId,
+                personIdent,
+                Stønadstype.BARNETILSYN,
+                "Automatisk journalført søknad",
             )
         }
-
-        assertThat(taskSlot.captured.type).isEqualTo(OpprettOppgaveForOpprettetBehandlingTask.TYPE)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
@@ -1,0 +1,134 @@
+package no.nav.tilleggsstonader.sak.journalføring
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.DokumentInfo
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class JournalføringServiceTest {
+
+    val behandlingService = mockk<BehandlingService>()
+    val fagsakService = mockk<FagsakService>()
+    val journalpostService = mockk<JournalpostService>()
+    val søknadService = mockk<SøknadService>()
+    val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
+    val taskService = mockk<TaskService>()
+    val barnService = mockk<BarnService>()
+
+    val journalføringService = JournalføringService(
+        behandlingService,
+        fagsakService,
+        journalpostService,
+        søknadService,
+        arbeidsfordelingService,
+        taskService,
+        barnService,
+    )
+
+    val enhet = ArbeidsfordelingService.ENHET_NASJONAL_NAY.enhetId
+    val personIdent = "123456789"
+    val aktørId = "9876543210127"
+    val tidligerePersonIdent = "9123456789"
+    val fagsak = fagsak()
+    val journalpostId = "1"
+    val journalpost = Journalpost(
+        journalpostId = journalpostId,
+        journalposttype = Journalposttype.I,
+        journalstatus = Journalstatus.MOTTATT,
+        dokumenter = listOf(DokumentInfo("", brevkode = "1")),
+        bruker = Bruker(personIdent, BrukerIdType.FNR),
+        journalforendeEnhet = "123",
+    )
+
+    val taskSlot = slot<Task>()
+
+    @BeforeEach
+    fun setUp() {
+        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+        every { fagsakService.hentEllerOpprettFagsak(any(), any()) } returns fagsak
+        every { behandlingService.utledNesteBehandlingstype(fagsak.id) } returns BehandlingType.FØRSTEGANGSBEHANDLING
+        every { arbeidsfordelingService.hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(any()) } returns enhet
+        every { taskService.save(capture(taskSlot)) } returns mockk()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        taskSlot.clear()
+    }
+
+    @Test
+    internal fun `skal ikke kunne journalføre hvis journalpostens bruker mangler`() {
+        every { journalpostService.hentJournalpost(journalpostId) } returns journalpost.copy(bruker = null)
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+
+        Assertions.assertThatThrownBy {
+            journalføringService.journalførTilNyBehandling(
+                journalpostId,
+                personIdent,
+                Stønadstype.BARNETILSYN,
+                "oppgaveBeskrivelse",
+            )
+        }.hasMessageContaining("Journalposten mangler bruker")
+    }
+
+    @Test
+    internal fun `skal kunne journalføre og opprette behandling`() {
+        val aktørIdBruker = Bruker(
+            id = aktørId,
+            type = BrukerIdType.AKTOERID,
+        )
+        val journalpostMedAktørId = journalpost.copy(bruker = aktørIdBruker)
+        every { journalpostService.hentJournalpost(journalpostId) } returns journalpostMedAktørId
+        every { journalpostService.oppdaterOgFerdigstillJournalpostMaskinelt(any(), any(), any()) } just Runs
+        every { fagsakService.finnFagsak(any(), any()) } returns fagsak
+
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+        every { behandlingService.leggTilBehandlingsjournalpost(any(), any(), any()) } just Runs
+        every {
+            behandlingService.opprettBehandling(
+                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                fagsakId = fagsak.id,
+                behandlingsårsak = BehandlingÅrsak.SØKNAD,
+            )
+        } returns behandling(fagsak = fagsak)
+        every { journalpostService.hentSøknadFraJournalpost(any()) } returns mockk()
+        every { søknadService.lagreSøknad(any(), any(), any()) } returns mockk()
+
+        journalføringService.journalførTilNyBehandling(journalpostId, personIdent, Stønadstype.BARNETILSYN, "beskrivelse")
+
+        verify(exactly = 1) {
+            behandlingService.opprettBehandling(
+                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
+                fagsakId = fagsak.id,
+                behandlingsårsak = BehandlingÅrsak.SØKNAD,
+            )
+        }
+
+        Assertions.assertThat(taskSlot.captured.type).isEqualTo(OpprettOppgaveForOpprettetBehandlingTask.TYPE)
+    }
+}


### PR DESCRIPTION
… skal brukes til manuell journalføring til egen JournalføringService

### Hvorfor er denne endringen nødvendig? ✨
Automatisk og manuell journalføring er avhengig av en del felles kode. Trekker dette ut i en en JournalføringsService. Denne PRen skal være en ren refaktorering og ikke gjør noen funksjonelle endringer (med unntak av featuretoggling av revurderinger)

Kode for manuell journalføring bygger på dette og kommer i en egen PR.
