### PR TITLE
Steg "VILKÅR" skal loggføres i database-tabell "behandlingshistorikk"…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -30,9 +30,4 @@ class VilkårSteg(
     }
 
     override fun stegType(): StegType = StegType.VILKÅR
-
-    /**
-     * håndteres av [VilkårStegService]
-     */
-    override fun settInnHistorikk(): Boolean = false
 }


### PR DESCRIPTION
…. Loggføringen skjer i fanen "PASS AV BARN" i saksbehandlings-GUI

### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig at man har historikk for VILKÅR-steget i behandlingshistorikken