### PR TITLE
Iverksetting må bruke ekstern behandlingId

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/HentStatusFraIverksettingTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/HentStatusFraIverksettingTask.kt
@@ -27,20 +27,32 @@ class HentStatusFraIverksettingTask(
         iverksettStatusService.hentStatusOgOppdaterAndeler(
             eksternFagsakId = taskData.eksternFagsakId,
             behandlingId = taskData.behandlingId,
+            eksternBehandlingId = taskData.eksternBehandlingId,
             iverksettingId = taskData.iverksettingId,
         )
     }
 
     companion object {
 
-        fun opprettTask(eksternFagsakId: Long, behandlingId: UUID, iverksettingId: UUID): Task {
-            val taskData = TaskData(eksternFagsakId = eksternFagsakId, behandlingId = behandlingId, iverksettingId = iverksettingId)
+        fun opprettTask(
+            eksternFagsakId: Long,
+            behandlingId: UUID,
+            eksternBehandlingId: Long,
+            iverksettingId: UUID,
+        ): Task {
+            val taskData = TaskData(
+                eksternFagsakId = eksternFagsakId,
+                behandlingId = behandlingId,
+                eksternBehandlingId = eksternBehandlingId,
+                iverksettingId = iverksettingId,
+            )
             return Task(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(taskData),
                 properties = Properties().apply {
                     setProperty("eksternFagsakId", eksternFagsakId.toString())
                     setProperty("behandlingId", behandlingId.toString())
+                    setProperty("eksternBehandlingId", eksternBehandlingId.toString())
                     setProperty("iverksettingId", iverksettingId.toString())
                 },
             ).copy(triggerTid = LocalDateTime.now().plusSeconds(31))
@@ -52,6 +64,7 @@ class HentStatusFraIverksettingTask(
     private data class TaskData(
         val eksternFagsakId: Long,
         val behandlingId: UUID,
+        val eksternBehandlingId: Long,
         val iverksettingId: UUID,
     )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettClient.kt
@@ -38,13 +38,13 @@ class IverksettClient(
         }
     }
 
-    fun hentStatus(sakId: Long, behandlingId: UUID, iverksettingId: UUID): IverksettStatus {
+    fun hentStatus(eksternFagsakId: Long, eksternBehandlingId: Long, iverksettingId: UUID): IverksettStatus {
         val url = UriComponentsBuilder.fromUri(uri)
             .pathSegment("api", "iverksetting", "{sakId}", "{behandlingId}", "{iverksettingId}", "status")
             .encode().toUriString()
         val uriVariables = mapOf(
-            "sakId" to sakId,
-            "behandlingId" to behandlingId,
+            "sakId" to eksternFagsakId,
+            "behandlingId" to eksternBehandlingId,
             "iverksettingId" to iverksettingId,
         )
         return getForEntity<IverksettStatus>(url, uriVariables = uriVariables)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDto.kt
@@ -10,7 +10,7 @@ import java.util.UUID
  */
 data class IverksettDto(
     val sakId: String,
-    val behandlingId: UUID,
+    val behandlingId: String,
     val iverksettingId: UUID,
     val personident: String,
     val vedtak: VedtaksdetaljerDto,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoMapper.kt
@@ -22,7 +22,7 @@ object IverksettDtoMapper {
         }
         return IverksettDto(
             sakId = behandling.eksternFagsakId.toString(),
-            behandlingId = behandling.id,
+            behandlingId = behandling.eksternId.toString(),
             iverksettingId = iverksettingId,
             personident = behandling.ident,
             forrigeIverksetting = forrigeIverksetting,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -199,6 +199,7 @@ class IverksettService(
             HentStatusFraIverksettingTask.opprettTask(
                 eksternFagsakId = behandling.eksternFagsakId,
                 behandlingId = behandling.id,
+                eksternBehandlingId = behandling.eksternId,
                 iverksettingId = iverksettingId,
             ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelseRepository
@@ -153,7 +154,7 @@ class IverksettService(
                         iverksetting = iverksetting,
                     )
                 } else {
-                    feilHvis(it.statusIverksetting != StatusIverksetting.OK) {
+                    feilHvisIkke(it.statusIverksetting.erOk()) {
                         "Kan ikke iverksette behandling=${tilkjentYtelse.behandlingId} iverksetting=$iverksettingId " +
                             "når det finnes tidligere andeler med annen status enn OK/UBEHANDLET"
                     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettStatusService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettStatusService.kt
@@ -21,8 +21,8 @@ class IverksettStatusService(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    fun hentStatusOgOppdaterAndeler(eksternFagsakId: Long, behandlingId: UUID, iverksettingId: UUID) {
-        val status = iverksettClient.hentStatus(eksternFagsakId, behandlingId, iverksettingId)
+    fun hentStatusOgOppdaterAndeler(eksternFagsakId: Long, behandlingId: UUID, eksternBehandlingId: Long, iverksettingId: UUID) {
+        val status = iverksettClient.hentStatus(eksternFagsakId, eksternBehandlingId, iverksettingId)
         val statusIverksetting = when (status) {
             IverksettStatus.OK -> StatusIverksetting.OK
             IverksettStatus.OK_UTEN_UTBETALING -> StatusIverksetting.OK_UTEN_UTBETALING

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -86,4 +86,7 @@ enum class StatusIverksetting {
     OK,
     OK_UTEN_UTBETALING,
     UAKTUELL,
+    ;
+
+    fun erOk() = this == StatusIverksetting.OK || this == StatusIverksetting.OK_UTEN_UTBETALING
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettClientTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettClientTest.kt
@@ -49,15 +49,15 @@ class IverksettClientTest {
     @Test
     fun `skal hente status for gitt behandlingId og iverksettingId`() {
         val eksternFagsakId = 10L
-        val behandlingId = UUID.randomUUID()
+        val eksternBehandlingId = 11L
         val iverksettingId = UUID.randomUUID()
         val json = objectMapper.writeValueAsString("OK")
         wiremockServerItem.stubFor(
-            get(WireMock.urlEqualTo("/api/iverksetting/$eksternFagsakId/$behandlingId/$iverksettingId/status"))
+            get(WireMock.urlEqualTo("/api/iverksetting/$eksternFagsakId/$eksternBehandlingId/$iverksettingId/status"))
                 .willReturn(okJson(json)),
         )
 
-        assertThat(client.hentStatus(eksternFagsakId, behandlingId, iverksettingId)).isEqualTo(IverksettStatus.OK)
+        assertThat(client.hentStatus(eksternFagsakId, eksternBehandlingId, iverksettingId)).isEqualTo(IverksettStatus.OK)
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoMapperTest.kt
@@ -39,7 +39,7 @@ class IverksettDtoMapperTest {
 
         assertThat(dto.iverksettingId).isEqualTo(iverksettingId)
         assertThat(dto.sakId).isEqualTo("200")
-        assertThat(dto.behandlingId).isEqualTo(behandling.id)
+        assertThat(dto.behandlingId).isEqualTo(behandling.eksternId.toString())
         assertThat(dto.iverksettingId).isEqualTo(iverksettingId)
         assertThat(dto.personident).isEqualTo("ident1")
         assertThat(dto.forrigeIverksetting).isNull()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoUtil.kt
@@ -9,13 +9,14 @@ object IverksettDtoUtil {
     fun iverksettDto(
         sakId: String = "fagsakId",
         behandlingId: UUID = UUID.randomUUID(),
+        eksternBehandlingId: Long = 1,
         iverksettingId: UUID = behandlingId,
         personident: String = "123",
         vedtak: VedtaksdetaljerDto = vedtaksdetaljerDto(),
         forrigeIverksetting: ForrigeIverksettingDto? = null,
     ) = IverksettDto(
         sakId = sakId,
-        behandlingId = behandlingId,
+        behandlingId = eksternBehandlingId.toString(),
         iverksettingId = iverksettingId,
         personident = personident,
         vedtak = vedtak,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
@@ -105,10 +105,12 @@ class IverksettServiceTest : IntegrationTest() {
 
     private fun assertHarOpprettetTaskForÅSjekkeStatus(fagsak: Fagsak, behandling: Behandling) {
         val task = taskService.finnTasksMedStatus(Status.entries, HentStatusFraIverksettingTask.TYPE).single()
+        val eksternBehandlingId = testoppsettService.hentSaksbehandling(behandling.id).eksternId
         assertThat(objectMapper.readValue<Map<String, Any>>(task.payload)).isEqualTo(
             mapOf(
                 "eksternFagsakId" to fagsak.eksternId.id.toInt(),
                 "behandlingId" to behandling.id.toString(),
+                "eksternBehandlingId" to eksternBehandlingId.toInt(),
                 "iverksettingId" to behandling.id.toString(),
             ),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
@@ -32,6 +32,8 @@ class TestoppsettService(
 
     fun hentBehandling(behandlingId: UUID) = behandlingRepository.findByIdOrThrow(behandlingId)
 
+    fun hentSaksbehandling(behandlingId: UUID) = behandlingRepository.finnSaksbehandling(behandlingId)
+
     fun opprettBehandlingMedFagsak(
         behandling: Behandling,
         stønadstype: Stønadstype = Stønadstype.BARNETILSYN,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Endringer i kontraktet mot iverksetting.
Vi sendte tidligere behandlingId som UUID, men pga begrensninger i økonomi skal verdiet ha en makslengde på 30 tegn. Bruker då i stedet eksternBehandlingId, som også familie gjør.

https://nav-it.slack.com/archives/C060V3ADLTD/p1712578706155069

Iverksetting som gått ok https://tilleggsstonader-prosessering.intern.dev.nav.no/service/tilleggsstonader-sak/gruppert?statusFilter=ALLE&callId=efc21fd4-1089-458d-a692-4ca8cf7963f0

Edit:
Virker dog som at noe feiler med status, men gjetter på at feilen er hos iverksetting
https://logs.adeo.no/s/nav-logs-legacy/app/r/s/7xLKm