### PR TITLE
Fjerner steg om publisering av vedtakshendelser og tenker dette kan g…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
@@ -75,11 +75,6 @@ enum class StegType(
         tillattFor = BehandlerRolle.SYSTEM,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.IVERKSETTER_VEDTAK),
     ),
-    PUBLISER_VEDTAKSHENDELSE(
-        rekkefølge = 8,
-        tillattFor = BehandlerRolle.SYSTEM,
-        gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.FERDIGSTILT),
-    ),
     BEHANDLING_FERDIGSTILT(
         rekkefølge = 9,
         tillattFor = BehandlerRolle.SYSTEM,
@@ -108,12 +103,7 @@ enum class StegType(
             SEND_TIL_BESLUTTER -> BESLUTTE_VEDTAK
             BESLUTTE_VEDTAK -> JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV
             JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV -> FERDIGSTILLE_BEHANDLING
-            /*
-            VENTE_PÅ_STATUS_FRA_UTBETALING -> LAG_SAKSBEHANDLINGSBLANKETT
-            LAG_SAKSBEHANDLINGSBLANKETT -> FERDIGSTILLE_BEHANDLING
-             */
-            FERDIGSTILLE_BEHANDLING -> PUBLISER_VEDTAKSHENDELSE
-            PUBLISER_VEDTAKSHENDELSE -> BEHANDLING_FERDIGSTILT
+            FERDIGSTILLE_BEHANDLING -> BEHANDLING_FERDIGSTILT
             BEHANDLING_FERDIGSTILT -> BEHANDLING_FERDIGSTILT
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkControllerTest.kt
@@ -83,8 +83,7 @@ internal class BehandlingshistorikkControllerTest : IntegrationTest() {
         leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(4), StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)
         // leggInnHistorikk(behandling, "6", LocalDateTime.now().plusDays(5), StegType.LAG_SAKSBEHANDLINGSBLANKETT)
         leggInnHistorikk(behandling, "7", LocalDateTime.now().plusDays(6), StegType.FERDIGSTILLE_BEHANDLING)
-        leggInnHistorikk(behandling, "8", LocalDateTime.now().plusDays(7), StegType.PUBLISER_VEDTAKSHENDELSE)
-        leggInnHistorikk(behandling, "9", LocalDateTime.now().plusDays(8), StegType.BEHANDLING_FERDIGSTILT)
+        leggInnHistorikk(behandling, "8", LocalDateTime.now().plusDays(7), StegType.BEHANDLING_FERDIGSTILT)
         behandlingRepository.update(
             behandling.copy(
                 resultat = BehandlingResultat.INNVILGET,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
@@ -56,6 +56,8 @@ class StegServiceTest(
     val vilkårperiodeRepository: VilkårperiodeRepository,
     @Autowired
     val vilkårRepository: VilkårRepository,
+    @Autowired
+    val ferdigstillBehandlingSteg: FerdigstillBehandlingSteg,
 ) : IntegrationTest() {
 
     val stegForBeslutter = object : BehandlingSteg<String> {
@@ -216,6 +218,23 @@ class StegServiceTest(
 
             stegService.resetSteg(behandling.id, steg = StegType.VILKÅR)
             assertThat(behandlingRepository.findByIdOrThrow(behandling.id).steg).isEqualTo(StegType.VILKÅR)
+        }
+    }
+
+    @Nested
+    inner class StegFlyt {
+
+        @Test
+        fun `skal endre steg til ferdigstilt etter ferdigstilling`() {
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(
+                behandling(
+                    status = BehandlingStatus.IVERKSETTER_VEDTAK,
+                    steg = StegType.FERDIGSTILLE_BEHANDLING,
+                ),
+            )
+            val oppdatertBehandling = stegService.håndterSteg(behandlingId = behandling.id, ferdigstillBehandlingSteg)
+            assertThat(oppdatertBehandling.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+            assertThat(oppdatertBehandling.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
         }
     }
 


### PR DESCRIPTION
…jøres i FERDIGSTILLE_BEHANDLING i stedet då man likevel bare skal lage tasks på å eks sende noe på kafka eller liknende som burde skje async

### Hvorfor er denne endringen nødvendig? ✨
Dette er ikke helt som vi først tenke i oppgaven. Men når jeg tok tak i den innså jeg at det er enklere å bare gjøre håndtering av publisering av hendelser direkt inne i FerdigstillBehandlingSteg, eks ved å opprette en task som legger noe på kafka.,

Hvis vi har behov for et eget steg for det kan vi gjør det ved behov.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20372