### PR TITLE
Fjerner felter fra PDL som vi ikke bruker eller har behandlingsgrunnlag til

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/SøkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/SøkService.kt
@@ -7,7 +7,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
 import no.nav.tilleggsstonader.sak.opplysninger.dto.NavnDto
-import no.nav.tilleggsstonader.sak.opplysninger.mapper.KjønnMapper
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gjeldende
@@ -60,7 +59,6 @@ class SøkService(
 
         return Søkeresultat(
             personIdent = gjeldendePersonIdent,
-            kjønn = KjønnMapper.tilKjønn(person.kjønn.first().kjønn),
             visningsnavn = NavnDto.fraNavn(person.navn.gjeldende()).visningsnavn,
             fagsakPersonId = fagsakPerson?.id,
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/Søkeresultat.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/Søkeresultat.kt
@@ -1,12 +1,10 @@
 package no.nav.tilleggsstonader.sak.fagsak.søk
 
-import no.nav.tilleggsstonader.sak.opplysninger.dto.Kjønn
 import java.util.UUID
 
 data class Søkeresultat(
     val personIdent: String,
     val visningsnavn: String,
-    val kjønn: Kjønn,
     val fagsakPersonId: UUID?,
 )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
@@ -105,14 +105,6 @@ enum class Folkeregisterpersonstatus(private val pdlStatus: String, val visnings
     }
 }
 
-@Suppress("unused") // Kopi fra PDL
-enum class Kjønn {
-
-    KVINNE,
-    MANN,
-    UKJENT,
-}
-
 data class NavnDto(
     val fornavn: String,
     val mellomnavn: String?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
@@ -27,20 +27,12 @@ enum class OppholdType {
     UKJENT,
 }
 
-data class DeltBostedDto(
-    val startdatoForKontrakt: LocalDate,
-    val sluttdatoForKontrakt: LocalDate?,
-    val historisk: Boolean,
-)
-
 data class BarnDto(
     val personIdent: String,
     val navn: String,
     val annenForelder: AnnenForelderMinimumDto?,
     val adresse: List<AdresseDto>,
     val borHosSøker: Boolean,
-    val deltBosted: List<DeltBostedDto>,
-    val harDeltBostedNå: Boolean,
     val fødselsdato: LocalDate?,
     val dødsdato: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
@@ -50,37 +50,6 @@ data class AnnenForelderMinimumDto(
     val bostedsadresse: String?,
 )
 
-data class SivilstandDto(
-    val type: Sivilstandstype,
-    val gyldigFraOgMed: LocalDate?,
-    val relatertVedSivilstand: String?,
-    val navn: String?,
-    val dødsdato: LocalDate?,
-    val erGjeldende: Boolean,
-)
-
-@Suppress("unused") // Kopi fra PDL
-enum class Sivilstandstype {
-
-    UOPPGITT,
-    UGIFT,
-    GIFT,
-    ENKE_ELLER_ENKEMANN,
-    SKILT,
-    SEPARERT,
-    REGISTRERT_PARTNER,
-    SEPARERT_PARTNER,
-    SKILT_PARTNER,
-    GJENLEVENDE_PARTNER,
-    ;
-
-    fun erGift(): Boolean = this == REGISTRERT_PARTNER || this == GIFT
-    fun erUgiftEllerUoppgitt(): Boolean = this == UGIFT || this == UOPPGITT
-    fun erSeparert(): Boolean = this == SEPARERT_PARTNER || this == SEPARERT
-    fun erEnkeEllerEnkemann(): Boolean = this == ENKE_ELLER_ENKEMANN || this == GJENLEVENDE_PARTNER
-    fun erSkilt(): Boolean = this == SKILT || this == SKILT_PARTNER
-}
-
 data class AdresseDto(
     val visningsadresse: String?,
     val type: AdresseType,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/mapper/KjønnMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/mapper/KjønnMapper.kt
@@ -1,9 +1,0 @@
-package no.nav.tilleggsstonader.sak.opplysninger.mapper
-
-import no.nav.tilleggsstonader.sak.opplysninger.dto.Kjønn
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KjønnType
-
-object KjønnMapper {
-
-    fun tilKjønn(kjønn: KjønnType): Kjønn = kjønn.let { Kjønn.valueOf(it.name) }
-}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
@@ -109,7 +109,6 @@ data class PdlSøker(
     val navn: List<Navn>,
     val opphold: List<Opphold>,
     val oppholdsadresse: List<Oppholdsadresse>,
-    val sivilstand: List<Sivilstand>,
     val statsborgerskap: List<Statsborgerskap>,
     val innflyttingTilNorge: List<InnflyttingTilNorge>,
     val utflyttingFraNorge: List<UtflyttingFraNorge>,
@@ -326,27 +325,6 @@ enum class Oppholdstillatelse {
     MIDLERTIDIG,
     PERMANENT,
     OPPLYSNING_MANGLER,
-}
-
-data class Sivilstand(
-    val type: Sivilstandstype,
-    val gyldigFraOgMed: LocalDate?,
-    val relatertVedSivilstand: String?,
-    val bekreftelsesdato: LocalDate?,
-    val metadata: Metadata,
-)
-
-enum class Sivilstandstype {
-    UOPPGITT,
-    UGIFT,
-    GIFT,
-    ENKE_ELLER_ENKEMANN,
-    SKILT,
-    SEPARERT,
-    REGISTRERT_PARTNER,
-    SEPARERT_PARTNER,
-    SKILT_PARTNER,
-    GJENLEVENDE_PARTNER,
 }
 
 data class InnflyttingTilNorge(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
@@ -90,11 +90,6 @@ data class PdlPersonKort(
     @JsonProperty("doedsfall") val dødsfall: List<Dødsfall>,
 )
 
-data class PdlSøkerKort(
-    @JsonProperty("kjoenn") val kjønn: List<Kjønn>,
-    val navn: List<Navn>,
-)
-
 data class PdlSøker(
     val adressebeskyttelse: List<Adressebeskyttelse>,
     override val bostedsadresse: List<Bostedsadresse>,
@@ -104,7 +99,6 @@ data class PdlSøker(
     @JsonProperty("foedsel") override val fødsel: List<Fødsel>,
     val folkeregisterpersonstatus: List<Folkeregisterpersonstatus>,
     val fullmakt: List<Fullmakt>,
-    @JsonProperty("kjoenn") val kjønn: List<Kjønn>,
     val kontaktadresse: List<Kontaktadresse>,
     val navn: List<Navn>,
     val opphold: List<Opphold>,
@@ -284,14 +278,6 @@ data class Fullmakt(
 enum class MotpartsRolle {
     FULLMAKTSGIVER,
     FULLMEKTIG,
-}
-
-data class Kjønn(@JsonProperty("kjoenn") val kjønn: KjønnType)
-
-enum class KjønnType {
-    KVINNE,
-    MANN,
-    UKJENT,
 }
 
 data class Navn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
@@ -122,7 +122,6 @@ data class PdlSøker(
 data class PdlPersonForelderBarn(
     val adressebeskyttelse: List<Adressebeskyttelse>,
     override val bostedsadresse: List<Bostedsadresse>,
-    val deltBosted: List<DeltBosted>,
     @JsonProperty("doedsfall") val dødsfall: List<Dødsfall>,
     val forelderBarnRelasjon: List<ForelderBarnRelasjon>,
     @JsonProperty("foedsel") override val fødsel: List<Fødsel>,
@@ -139,14 +138,6 @@ data class PdlAnnenForelder(
 ) : PdlPerson
 
 data class Metadata(val historisk: Boolean)
-
-data class DeltBosted(
-    val startdatoForKontrakt: LocalDate,
-    val sluttdatoForKontrakt: LocalDate?,
-    val vegadresse: Vegadresse?,
-    val ukjentBosted: UkjentBosted?,
-    val metadata: Metadata,
-)
 
 data class Folkeregistermetadata(
     val gyldighetstidspunkt: LocalDateTime?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPersonUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPersonUtil.kt
@@ -21,8 +21,6 @@ fun List<Bostedsadresse>.gjeldende(): Bostedsadresse? = this.find { !it.metadata
 fun List<Oppholdsadresse>.gjeldende(): Oppholdsadresse? = this.find { !it.metadata.historisk }
 fun List<Sivilstand>.gjeldende(): Sivilstand = this.find { !it.metadata.historisk } ?: this.first()
 fun List<Fødsel>.gjeldende(): Fødsel = this.first()
-fun List<DeltBosted>.gjeldende(): DeltBosted? = this.find { !it.metadata.historisk }
-
 fun List<Folkeregisterpersonstatus>.gjeldende(): Folkeregisterpersonstatus? = this.find { !it.metadata.historisk }
 fun List<Dødsfall>.gjeldende(): Dødsfall? = this.firstOrNull()
 fun List<Adressebeskyttelse>.gjeldende(): Adressebeskyttelse? = this.find { !it.metadata.historisk }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPersonUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPersonUtil.kt
@@ -19,7 +19,6 @@ fun Personnavn.visningsnavn(): String {
 fun List<Navn>.gjeldende(): Navn = this.single()
 fun List<Bostedsadresse>.gjeldende(): Bostedsadresse? = this.find { !it.metadata.historisk }
 fun List<Oppholdsadresse>.gjeldende(): Oppholdsadresse? = this.find { !it.metadata.historisk }
-fun List<Sivilstand>.gjeldende(): Sivilstand = this.find { !it.metadata.historisk } ?: this.first()
 fun List<Fødsel>.gjeldende(): Fødsel = this.first()
 fun List<Folkeregisterpersonstatus>.gjeldende(): Folkeregisterpersonstatus? = this.find { !it.metadata.historisk }
 fun List<Dødsfall>.gjeldende(): Dødsfall? = this.firstOrNull()

--- a/src/main/resources/pdl/forelder_barn.graphql
+++ b/src/main/resources/pdl/forelder_barn.graphql
@@ -46,26 +46,6 @@ query($identer: [ID!]!){
                     bostedskommune
                 }
             }
-            deltBosted (historikk: true){
-                startdatoForKontrakt
-                sluttdatoForKontrakt
-                vegadresse {
-                    husnummer
-                    husbokstav
-                    bruksenhetsnummer
-                    adressenavn
-                    kommunenummer
-                    tilleggsnavn
-                    postnummer
-                    matrikkelId
-                }
-                ukjentBosted {
-                    bostedskommune
-                }
-                metadata {
-                    historisk
-                }
-            }
             doedsfall {
                 doedsdato
             }

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -82,9 +82,6 @@ query($ident: ID!){
             motpartsRolle
             omraader
         }
-        kjoenn {
-            kjoenn
-        }
         navn {
             fornavn
             mellomnavn

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -188,15 +188,6 @@ query($ident: ID!){
                 historisk
             }
         }
-        sivilstand(historikk: true) {
-            type
-            gyldigFraOgMed
-            relatertVedSivilstand
-            bekreftelsesdato
-            metadata {
-                historisk
-            }
-        }
         statsborgerskap {
             land
             gyldigFraOgMed

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/PdlClientConfig.kt
@@ -17,7 +17,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Folkeregisterpersonstatu
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.ForelderBarnRelasjon
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Fullmakt
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KjønnType
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktadresseType
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.MotpartsRolle
@@ -35,7 +34,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Vegadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.VergeEllerFullmektig
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.VergemaalEllerFremtidsfullmakt
 import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.fødsel
-import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.lagKjønn
 import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.lagNavn
 import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.metadataGjeldende
 import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.pdlBarn
@@ -163,7 +161,6 @@ class PdlClientConfig {
                     ),
                 ),
                 fullmakt = fullmakter(),
-                kjønn = lagKjønn(KjønnType.KVINNE),
                 kontaktadresse = kontaktadresse(),
                 navn = listOf(lagNavn()),
                 opphold = listOf(Opphold(Oppholdstillatelse.PERMANENT, startdato, null)),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/PdlClientConfig.kt
@@ -29,8 +29,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdent
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlPersonForelderBarn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlPersonKort
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstand
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstandstype
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Statsborgerskap
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.UtflyttingFraNorge
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Vegadresse
@@ -170,7 +168,6 @@ class PdlClientConfig {
                 navn = listOf(lagNavn()),
                 opphold = listOf(Opphold(Oppholdstillatelse.PERMANENT, startdato, null)),
                 oppholdsadresse = listOf(),
-                sivilstand = sivilstand(),
                 statsborgerskap = statsborgerskap(),
                 innflyttingTilNorge = listOf(InnflyttingTilNorge("SWE", "Stockholm", folkeregistermetadata)),
                 utflyttingFraNorge = listOf(
@@ -275,17 +272,6 @@ class PdlClientConfig {
                     land = "SWE",
                     gyldigFraOgMed = startdato.minusYears(3),
                     gyldigTilOgMed = startdato,
-                ),
-            )
-
-        private fun sivilstand(): List<Sivilstand> =
-            listOf(
-                Sivilstand(
-                    type = Sivilstandstype.GIFT,
-                    gyldigFraOgMed = startdato,
-                    relatertVedSivilstand = "11111122222",
-                    bekreftelsesdato = LocalDate.of(2020, 1, 1),
-                    metadata = metadataGjeldende,
                 ),
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/PdlClientConfig.kt
@@ -8,7 +8,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.PdlNotFoundException
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Bostedsadresse
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.DeltBosted
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Dødsfall
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Familierelasjonsrolle
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Folkeregisteridentifikator
@@ -21,7 +20,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KjønnType
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktadresseType
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Metadata
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.MotpartsRolle
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Navn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Opphold
@@ -195,22 +193,6 @@ class PdlClientConfig {
             mapOf(
                 barnFnr to pdlBarn(
                     bostedsadresse = bostedsadresse(),
-                    deltBosted = listOf(
-                        DeltBosted(
-                            LocalDate.of(2023, 1, 1),
-                            LocalDate.of(2053, 1, 1),
-                            null,
-                            null,
-                            Metadata(false),
-                        ),
-                        DeltBosted(
-                            LocalDate.of(2020, 1, 1),
-                            LocalDate.of(2023, 3, 31),
-                            null,
-                            null,
-                            Metadata(true),
-                        ),
-                    ),
                     forelderBarnRelasjon = familierelasjonerBarn(),
                     fødsel = fødsel(),
                     navn = lagNavn("Barn", null, "Barnesen"),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlPersonUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlPersonUtilTest.kt
@@ -4,8 +4,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Bostedsadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Metadata
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Navn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Oppholdsadresse
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstand
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstandstype
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Vegadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gjeldende
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.visningsnavn
@@ -61,17 +59,6 @@ internal class PdlPersonUtilTest {
         assertThat(adresser.gjeldende()!!.vegadresse!!.husnummer).isEqualTo(gjeldendeAdresse.vegadresse!!.husnummer)
 
         assertThat(historiskeAdresser.gjeldende()).isNull()
-    }
-
-    @Test
-    internal fun `skal finne riktig gjeldende sivilstand`() {
-        val sivilstander = listOf(
-            Sivilstand(Sivilstandstype.UGIFT, null, null, null, Metadata(true)),
-            Sivilstand(Sivilstandstype.GIFT, null, null, null, Metadata(true)),
-            Sivilstand(Sivilstandstype.SEPARERT, null, null, null, Metadata(false)),
-        )
-
-        assertThat(sivilstander.gjeldende().type).isEqualTo(Sivilstandstype.SEPARERT)
     }
 
     private fun vegadresse(gate: String, nr: String, historisk: Boolean): Bostedsadresse {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
@@ -14,8 +14,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.ForelderBarnRelasjon
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Fullmakt
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Fødsel
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kjønn
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KjønnType
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktadresseType
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Matrikkeladresse
@@ -145,7 +143,6 @@ object PdlTestdata {
                         listOf(""),
                     ),
                 ),
-                listOf(Kjønn(KjønnType.KVINNE)),
                 listOf(
                     Kontaktadresse(
                         "",

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.opplysninger.pdl
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Bostedsadresse
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.DeltBosted
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Dødsfall
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Familierelasjonsrolle
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Folkeregisteridentifikator
@@ -202,15 +201,6 @@ object PdlTestdata {
                     PdlPersonForelderBarn(
                         adressebeskyttelse,
                         bostedsadresse,
-                        listOf(
-                            DeltBosted(
-                                LocalDate.now(),
-                                LocalDate.now(),
-                                vegadresse,
-                                UkjentBosted(""),
-                                metadataGjeldende,
-                            ),
-                        ),
                         dødsfall,
                         familierelasjon,
                         fødsel,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
@@ -39,8 +39,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PersonSøkTreff
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Personnavn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PostadresseIFrittFormat
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Postboksadresse
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstand
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstandstype
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Statsborgerskap
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.UkjentBosted
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.UtenlandskAdresse
@@ -164,15 +162,6 @@ object PdlTestdata {
                 navn,
                 opphold,
                 oppholdsadresse,
-                listOf(
-                    Sivilstand(
-                        Sivilstandstype.GIFT,
-                        LocalDate.now(),
-                        "",
-                        LocalDate.now(),
-                        metadataGjeldende,
-                    ),
-                ),
                 statsborgerskap,
                 innflyttingTilNorge,
                 utflyttingFraNorge,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -492,7 +492,6 @@ fun søker(): Søker =
         listOf(),
         listOf(),
         listOf(),
-        KjønnType.KVINNE,
         listOf(),
         Navn("fornavn", null, "etternavn", Metadata(false)),
         listOf(),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -483,7 +483,7 @@ fun barnMedIdent(fnr: String, navn: String, fødsel: Fødsel = fødsel(LocalDate
 
 /*
 
-fun søker(sivilstand: List<SivilstandMedNavn> = emptyList()): Søker =
+fun søker(): Søker =
     Søker(
         adressebeskyttelse = Adressebeskyttelse(AdressebeskyttelseGradering.UGRADERT, Metadata(false)),
         bostedsadresse = listOf(),
@@ -497,7 +497,6 @@ fun søker(sivilstand: List<SivilstandMedNavn> = emptyList()): Søker =
         Navn("fornavn", null, "etternavn", Metadata(false)),
         listOf(),
         listOf(),
-        sivilstand = sivilstand,
         listOf(),
         listOf(),
         listOf(),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -466,7 +466,6 @@ fun barnMedIdent(fnr: String, navn: String, fødsel: Fødsel = fødsel(LocalDate
     BarnMedIdent(
         adressebeskyttelse = emptyList(),
         bostedsadresse = emptyList(),
-        deltBosted = emptyList(),
         dødsfall = emptyList(),
         forelderBarnRelasjon = emptyList(),
         fødsel = listOf(fødsel),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
@@ -20,7 +20,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Oppholdsadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlPersonForelderBarn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlPersonKort
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlSøker
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Sivilstand
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Statsborgerskap
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.UkjentBosted
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.UtflyttingFraNorge
@@ -61,7 +60,6 @@ object PdlTestdataHelper {
         navn: List<Navn> = listOf(lagNavn()),
         opphold: List<Opphold> = emptyList(),
         oppholdsadresse: List<Oppholdsadresse> = emptyList(),
-        sivilstand: List<Sivilstand> = emptyList(),
         statsborgerskap: List<Statsborgerskap> = emptyList(),
         innflyttingTilNorge: List<InnflyttingTilNorge> = emptyList(),
         utflyttingFraNorge: List<UtflyttingFraNorge> = emptyList(),
@@ -82,7 +80,6 @@ object PdlTestdataHelper {
             navn = navn,
             opphold = opphold,
             oppholdsadresse = oppholdsadresse,
-            sivilstand = sivilstand,
             statsborgerskap = statsborgerskap,
             innflyttingTilNorge = innflyttingTilNorge,
             utflyttingFraNorge = utflyttingFraNorge,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
@@ -10,8 +10,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.ForelderBarnRelasjon
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Fullmakt
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Fødsel
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kjønn
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KjønnType
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Metadata
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Navn
@@ -30,8 +28,6 @@ object PdlTestdataHelper {
 
     val metadataGjeldende = Metadata(historisk = false)
     val metadataHistorisk = Metadata(historisk = true)
-
-    fun lagKjønn(kjønnType: KjønnType = KjønnType.KVINNE) = Kjønn(kjønnType)
 
     fun lagNavn(
         fornavn: String = "Fornavn",
@@ -55,7 +51,6 @@ object PdlTestdataHelper {
         fødsel: List<Fødsel> = emptyList(),
         folkeregisterpersonstatus: List<Folkeregisterpersonstatus> = emptyList(),
         fullmakt: List<Fullmakt> = emptyList(),
-        kjønn: Kjønn? = null,
         kontaktadresse: List<Kontaktadresse> = emptyList(),
         navn: List<Navn> = listOf(lagNavn()),
         opphold: List<Opphold> = emptyList(),
@@ -75,7 +70,6 @@ object PdlTestdataHelper {
             fødsel = fødsel,
             folkeregisterpersonstatus = folkeregisterpersonstatus,
             fullmakt = fullmakt,
-            kjønn = listOfNotNull(kjønn),
             kontaktadresse = kontaktadresse,
             navn = navn,
             opphold = opphold,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.util
 
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Bostedsadresse
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.DeltBosted
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Dødsfall
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Folkeregisteridentifikator
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.FolkeregisteridentifikatorStatus
@@ -93,7 +92,6 @@ object PdlTestdataHelper {
     fun pdlBarn(
         adressebeskyttelse: List<Adressebeskyttelse> = emptyList(),
         bostedsadresse: List<Bostedsadresse> = emptyList(),
-        deltBosted: List<DeltBosted> = emptyList(),
         dødsfall: List<Dødsfall> = emptyList(),
         forelderBarnRelasjon: List<ForelderBarnRelasjon> = emptyList(),
         fødsel: Fødsel? = null,
@@ -102,7 +100,6 @@ object PdlTestdataHelper {
         PdlPersonForelderBarn(
             adressebeskyttelse = adressebeskyttelse,
             bostedsadresse = bostedsadresse,
-            deltBosted = deltBosted,
             dødsfall = dødsfall,
             forelderBarnRelasjon = forelderBarnRelasjon,
             fødsel = listOfNotNull(fødsel),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det fantes en oppgave på det tidligere men fant den ikke. Forstyrrer mye i loggene. 

For å fjerne warnings som
> Advarsel ved henting av class no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlPersonForelderBarn fra PDL: [PdlWarning(details={missing=[DELT_BOSTED_V1]}, id=tilgangsstyring, message=Behandling mangler opplysningstyper, query=hentPersonBolk)]
