### PR TITLE
♻️ Fjern begrunnelse DelvilkårVilkårperiode

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtak.kt
@@ -57,7 +57,6 @@ data class DelvilkårVilkårperiode(
 
 data class VurderingVilkårperiode(
     val svar: String?,
-    val begrunnelse: String?,
     val resultat: ResultatDelvilkårperiode,
 )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakService.kt
@@ -102,7 +102,6 @@ class InterntVedtakService(
         return VurderingVilkårperiode(
             svar = vurdering.svar?.name,
             resultat = vurdering.resultat,
-            begrunnelse = vurdering.begrunnelse,
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -150,6 +150,9 @@ class VilkårperiodeService(
                 )
             }
         }
+
+//        oppdatert.validerBegrunnelserDelvilkår()
+
         return vilkårperiodeRepository.update(oppdatert)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -150,9 +150,6 @@ class VilkårperiodeService(
                 )
             }
         }
-
-//        oppdatert.validerBegrunnelserDelvilkår()
-
         return vilkårperiodeRepository.update(oppdatert)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -106,15 +106,11 @@ enum class ResultatVilkårperiode {
 sealed class DelvilkårVilkårperiode {
     data class Vurdering(
         val svar: SvarJaNei?,
-        val begrunnelse: String? = null,
         val resultat: ResultatDelvilkårperiode,
     ) {
         init {
-            feilHvis(svar == SvarJaNei.JA_IMPLISITT && begrunnelse != null) {
-                "Kan ikke ha begrunnelse når svar=$svar"
-            }
-            feilHvis(resultat == ResultatDelvilkårperiode.IKKE_AKTUELT && (svar != null || begrunnelse != null)) {
-                "Ugyldig resultat=$resultat når svar=$svar begrunnelseErNull=${begrunnelse == null}"
+            feilHvis(resultat == ResultatDelvilkårperiode.IKKE_AKTUELT && (svar != null)) {
+                "Ugyldig resultat=$resultat når svar=$svar"
             }
         }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -47,7 +47,27 @@ data class Vilkårperiode(
             "Ugyldig kombinasjon type=${type.javaClass.simpleName} detaljer=${delvilkår.javaClass.simpleName}"
         }
 
+        validerBegrunnelserDelvilkår()
+
         validerSlettefelter()
+    }
+
+    fun validerBegrunnelserDelvilkår() {
+        validerBegrunnelserDelvilkårMålgruppe()
+
+        brukerfeilHvis(delvilkår is DelvilkårAktivitet && delvilkår.lønnet.resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT && begrunnelse.isNullOrBlank()) {
+            "Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid"
+        }
+    }
+
+    private fun validerBegrunnelserDelvilkårMålgruppe() {
+        brukerfeilHvis(delvilkår is DelvilkårMålgruppe && delvilkår.medlemskap.resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT && begrunnelse.isNullOrBlank()) {
+            "Mangler begrunnelse for ikke oppfylt medlemskap"
+        }
+
+        brukerfeilHvis(delvilkår is DelvilkårMålgruppe && delvilkår.dekketAvAnnetRegelverk.resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT && begrunnelse.isNullOrBlank()) {
+            "Mangler begrunnelse for utgifter dekt av annet regelverk"
+        }
     }
 
     private fun validerSlettefelter() {
@@ -110,17 +130,7 @@ enum class ResultatDelvilkårperiode {
 data class DelvilkårMålgruppe(
     val medlemskap: Vurdering,
     val dekketAvAnnetRegelverk: Vurdering,
-) : DelvilkårVilkårperiode() {
-    init {
-        brukerfeilHvis(medlemskap.resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT && medlemskap.begrunnelse.isNullOrBlank()) {
-            "Mangler begrunnelse for ikke oppfylt medlemskap"
-        }
-
-        brukerfeilHvis(dekketAvAnnetRegelverk.resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT && dekketAvAnnetRegelverk.begrunnelse.isNullOrBlank()) {
-            "Mangler begrunnelse for utgifter dekt av annet regelverk"
-        }
-    }
-}
+) : DelvilkårVilkårperiode()
 
 data class DelvilkårAktivitet(
     val lønnet: Vurdering,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -75,10 +75,7 @@ fun DelvilkårVilkårperiode.tilDto() = when (this) {
 fun DelvilkårVilkårperiode.Vurdering.tilDto() =
     this.takeIf { resultat != ResultatDelvilkårperiode.IKKE_AKTUELT }
         ?.let {
-            VurderingDto(
-                svar = svar,
-                begrunnelse = begrunnelse,
-            )
+            VurderingDto(svar = svar)
         }
 
 data class Datoperiode(
@@ -134,7 +131,6 @@ data class DelvilkårAktivitetDto(
 
 data class VurderingDto(
     val svar: SvarJaNei? = null,
-    val begrunnelse: String? = null,
 )
 
 data class SlettVikårperiode(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppe.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppe.kt
@@ -121,7 +121,6 @@ object EvalueringMålgruppe {
     val IMPLISITT_OPPFYLT_MÅLGRUPPE =
         Vurdering(
             svar = SvarJaNei.JA_IMPLISITT,
-            begrunnelse = null,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiode.kt
@@ -32,7 +32,6 @@ object EvalueringVilkårperiode {
     fun VurderingDto?.tilVurdering(resultat: ResultatDelvilkårperiode) =
         DelvilkårVilkårperiode.Vurdering(
             svar = this?.svar,
-            begrunnelse = this?.begrunnelse,
             resultat = resultat,
         )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
@@ -95,7 +95,6 @@ class InterntVedtakServiceTest {
                 delvilkår = delvilkårAktivitet(
                     lønnet = vurdering(
                         SvarJaNei.JA,
-                        "begrunnelse lønnet",
                         resultat = ResultatDelvilkårperiode.IKKE_OPPFYLT,
                     ),
                 ),
@@ -159,7 +158,7 @@ class InterntVedtakServiceTest {
 
     /**
      * Kommenter ut Disabled for å oppdatere html og pdf ved endringer i htmlify.
-     * Endre SKAL_SKRIVE_TIL_FIL til true
+     * Endre SKAL_SKRIVE_TIL_FIL i fileUtil til true
      * Formatter htmlfil etter generering for å unngå stor diff
      */
     @Disabled
@@ -221,7 +220,6 @@ class InterntVedtakServiceTest {
             assertThat(begrunnelse).isEqualTo("målgruppe aap")
             with(delvilkår.medlemskap!!) {
                 assertThat(svar).isEqualTo(SvarJaNei.JA_IMPLISITT.name)
-                assertThat(begrunnelse).isNull()
                 assertThat(resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
             }
             assertThat(delvilkår.lønnet).isNull()
@@ -241,12 +239,10 @@ class InterntVedtakServiceTest {
             assertThat(begrunnelse).isEqualTo("aktivitet abd")
             with(delvilkår.lønnet!!) {
                 assertThat(svar).isEqualTo(SvarJaNei.JA.name)
-                assertThat(begrunnelse).isEqualTo("begrunnelse lønnet")
                 assertThat(resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
             }
             with(delvilkår.mottarSykepenger!!) {
                 assertThat(svar).isEqualTo(SvarJaNei.NEI.name)
-                assertThat(begrunnelse).isNull()
                 assertThat(resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
             }
             assertThat(delvilkår.medlemskap).isNull()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -132,28 +132,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     ),
                 )
             }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt medlemskap")
-
-            assertThatThrownBy {
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeMålgruppe(
-                        type = MålgruppeType.AAP,
-                        begrunnelse = "",
-                        dekkesAvAnnetRegelverk = VurderingDto(SvarJaNei.JA),
-                        behandlingId = behandling.id,
-                    ),
-                )
-            }.hasMessageContaining("Mangler begrunnelse for utgifter dekt av annet regelverk")
-
-            assertThatThrownBy {
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeAktivitet(
-                        begrunnelse = "",
-                        lønnet = VurderingDto(SvarJaNei.JA),
-                        behandlingId = behandling.id,
-                    ),
-
-                )
-            }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid")
         }
 
         @Test
@@ -170,17 +148,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     ),
                 )
             }.hasMessageContaining("Mangler begrunnelse for utgifter dekt av annet regelverk")
-
-            assertThatThrownBy {
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeAktivitet(
-                        begrunnelse = "",
-                        lønnet = VurderingDto(SvarJaNei.JA),
-                        behandlingId = behandling.id,
-                    ),
-
-                )
-            }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid")
         }
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -61,7 +61,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         fun `skal opprette periode for målgruppe manuelt`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val opprettVilkårperiode = opprettVilkårperiodeMålgruppe(
-                medlemskap = VurderingDto(SvarJaNei.NEI, "begrunnelse medlemskap"),
+                medlemskap = VurderingDto(SvarJaNei.NEI),
                 begrunnelse = "begrunnelse målgruppe",
                 behandlingId = behandling.id,
             )
@@ -75,7 +75,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
             assertThat(vilkårperiode.resultat).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
             assertThat(vilkårperiode.medlemskap.svar).isEqualTo(SvarJaNei.NEI)
-            assertThat(vilkårperiode.medlemskap.begrunnelse).isEqualTo("begrunnelse medlemskap")
             assertThat(vilkårperiode.medlemskap.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
             assertThat(vilkårperiode.dekketAvAnnetRegelverk.svar).isNull()
             assertThat(vilkårperiode.dekketAvAnnetRegelverk.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_AKTUELT)
@@ -85,8 +84,8 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         fun `skal opprette periode for aktivitet manuelt`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val opprettVilkårperiode = opprettVilkårperiodeAktivitet(
-                lønnet = VurderingDto(SvarJaNei.NEI, "begrunnelse lønnet"),
-                mottarSykepenger = VurderingDto(SvarJaNei.NEI, "begrunnelse sykepenger"),
+                lønnet = VurderingDto(SvarJaNei.NEI),
+                mottarSykepenger = VurderingDto(SvarJaNei.NEI),
                 begrunnelse = "begrunnelse aktivitet",
                 behandlingId = behandling.id,
             )
@@ -100,11 +99,9 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
             assertThat(vilkårperiode.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
             assertThat(vilkårperiode.lønnet.svar).isEqualTo(SvarJaNei.NEI)
-            assertThat(vilkårperiode.lønnet.begrunnelse).isEqualTo("begrunnelse lønnet")
             assertThat(vilkårperiode.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
 
             assertThat(vilkårperiode.mottarSykepenger.svar).isEqualTo(SvarJaNei.NEI)
-            assertThat(vilkårperiode.mottarSykepenger.begrunnelse).isEqualTo("begrunnelse sykepenger")
             assertThat(vilkårperiode.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
         }
 
@@ -224,10 +221,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 tom = nyttDato,
                 begrunnelse = "Oppdatert begrunnelse",
                 delvilkår = DelvilkårMålgruppeDto(
-                    medlemskap = VurderingDto(
-                        SvarJaNei.JA,
-                        begrunnelse = "ny begrunnelse",
-                    ),
+                    medlemskap = VurderingDto(SvarJaNei.JA),
                     dekketAvAnnetRegelverk = null,
                 ),
             )
@@ -240,7 +234,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             assertThat(oppdatertPeriode.tom).isEqualTo(nyttDato)
             assertThat(oppdatertPeriode.begrunnelse).isEqualTo("Oppdatert begrunnelse")
             assertThat(oppdatertPeriode.medlemskap.svar).isEqualTo(SvarJaNei.JA)
-            assertThat(oppdatertPeriode.medlemskap.begrunnelse).isEqualTo("ny begrunnelse")
             assertThat(oppdatertPeriode.medlemskap.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
         }
 
@@ -261,7 +254,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             val oppdatering = vilkårperiode.tilOppdatering().copy(
                 begrunnelse = "Oppdatert begrunnelse",
                 delvilkår = DelvilkårMålgruppeDto(
-                    medlemskap = VurderingDto(SvarJaNei.NEI, "ny begrunnelse"),
+                    medlemskap = VurderingDto(SvarJaNei.NEI),
                     dekketAvAnnetRegelverk = null,
                 ),
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -48,11 +48,9 @@ object VilkårperiodeTestUtil {
 
     fun vurdering(
         svar: SvarJaNei? = SvarJaNei.JA_IMPLISITT,
-        begrunnelse: String? = null,
         resultat: ResultatDelvilkårperiode = ResultatDelvilkårperiode.OPPFYLT,
     ) = Vurdering(
         svar = svar,
-        begrunnelse = begrunnelse,
         resultat = resultat,
     )
 
@@ -88,12 +86,10 @@ object VilkårperiodeTestUtil {
     fun delvilkårAktivitet(
         lønnet: Vurdering = vurdering(
             svar = SvarJaNei.NEI,
-            begrunnelse = null,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
         mottarSykepenger: Vurdering = vurdering(
             svar = SvarJaNei.NEI,
-            begrunnelse = null,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
     ) = DelvilkårAktivitet(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/DelvilkårVilkårperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/DelvilkårVilkårperiodeTest.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
 
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
@@ -11,26 +10,12 @@ class DelvilkårVilkårperiodeTest {
     @Nested
     inner class VurderingDelvilkår {
 
-        @Test
-        fun `kan ikke ha begrunnelse sammen når svar=JA_IMPLISITT`() {
-            assertThatThrownBy {
-                DelvilkårVilkårperiode.Vurdering(SvarJaNei.JA_IMPLISITT, "", ResultatDelvilkårperiode.OPPFYLT)
-            }.hasMessageContaining("Kan ikke ha begrunnelse når svar=JA_IMPLISITT")
-        }
-
-        @Test
-        fun `kan ikke ha begrunnelse sammen med resultat=IKKE_AKTUELT`() {
-            assertThatThrownBy {
-                DelvilkårVilkårperiode.Vurdering(null, "", ResultatDelvilkårperiode.IKKE_AKTUELT)
-            }.hasMessageContaining("Ugyldig resultat=IKKE_AKTUELT når svar=null begrunnelseErNull=false")
-        }
-
         @ParameterizedTest
         @EnumSource(value = SvarJaNei::class)
         fun `kan ikke ha svar når resultat=IKKE_AKTUELT`(svar: SvarJaNei) {
             assertThatThrownBy {
-                DelvilkårVilkårperiode.Vurdering(svar, null, ResultatDelvilkårperiode.IKKE_AKTUELT)
-            }.hasMessageContaining("Ugyldig resultat=IKKE_AKTUELT når svar=$svar begrunnelseErNull=true")
+                DelvilkårVilkårperiode.Vurdering(svar, ResultatDelvilkårperiode.IKKE_AKTUELT)
+            }.hasMessageContaining("Ugyldig resultat=IKKE_AKTUELT når svar=$svar")
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
@@ -40,6 +40,7 @@ class VilkårperiodeDtoTest {
         )
         fun `skal returnere delvilkår hvis resultat != IKKE_AKTUELT`(resultat: ResultatDelvilkårperiode) {
             val målgruppe = målgruppe(
+                begrunnelse = if (resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT) "begrunnelse" else null,
                 delvilkår = DelvilkårMålgruppe(
                     medlemskap = DelvilkårVilkårperiode.Vurdering(
                         svar = null,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
@@ -44,12 +44,10 @@ class VilkårperiodeDtoTest {
                 delvilkår = DelvilkårMålgruppe(
                     medlemskap = DelvilkårVilkårperiode.Vurdering(
                         svar = null,
-                        begrunnelse = if (resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT) "begrunnelse" else null,
                         resultat = resultat,
                     ),
                     dekketAvAnnetRegelverk = DelvilkårVilkårperiode.Vurdering(
                         svar = null,
-                        begrunnelse = if (resultat == ResultatDelvilkårperiode.IKKE_OPPFYLT) "begrunnelse" else null,
                         resultat = resultat,
                     ),
                 ),
@@ -67,12 +65,10 @@ class VilkårperiodeDtoTest {
                 delvilkår = DelvilkårMålgruppe(
                     medlemskap = DelvilkårVilkårperiode.Vurdering(
                         svar = null,
-                        begrunnelse = null,
                         resultat = ResultatDelvilkårperiode.IKKE_AKTUELT,
                     ),
                     dekketAvAnnetRegelverk = DelvilkårVilkårperiode.Vurdering(
                         svar = null,
-                        begrunnelse = null,
                         resultat = ResultatDelvilkårperiode.IKKE_AKTUELT,
                     ),
                 ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
@@ -178,19 +178,6 @@ class EvalueringMålgruppeTest {
             }
 
             @NedsattArbeidsevneParameterizedTest
-            fun `skal kaste feil ved svar ja og manglende begrunnelse`(type: MålgruppeType) {
-                assertThatThrownBy {
-                    utledResultat(
-                        type,
-                        delvilkårMålgruppeDto(
-                            medlemskap = oppfyltMedlemskap(type),
-                            dekketAvAnnetRegelverk = VurderingDto(svar = SvarJaNei.JA),
-                        ),
-                    )
-                }.hasMessageContaining("Mangler begrunnelse for utgifter dekt av annet regelverk")
-            }
-
-            @NedsattArbeidsevneParameterizedTest
             fun `manglende svar skal mappes til ikke vurdert for nedsatt arbeidsevne`(type: MålgruppeType) {
                 val resultat = utledResultat(
                     type,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringMålgruppeTest.kt
@@ -19,7 +19,7 @@ class EvalueringMålgruppeTest {
 
     val jaVurdering = VurderingDto(SvarJaNei.JA)
     val implisittVurdering = VurderingDto(SvarJaNei.JA_IMPLISITT)
-    val neiVurdering = VurderingDto(SvarJaNei.NEI, "begrunnelse")
+    val neiVurdering = VurderingDto(SvarJaNei.NEI)
     val svarManglerVurdering = VurderingDto(null)
 
     @Nested
@@ -169,7 +169,7 @@ class EvalueringMålgruppeTest {
                     type,
                     delvilkårMålgruppeDto(
                         medlemskap = oppfyltMedlemskap(type),
-                        dekketAvAnnetRegelverk = VurderingDto(svar = SvarJaNei.JA, begrunnelse = "begrunnelse"),
+                        dekketAvAnnetRegelverk = VurderingDto(svar = SvarJaNei.JA),
                     ),
                 )
 

--- a/src/test/resources/interntVedtak/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/internt_vedtak.json
@@ -21,7 +21,6 @@
     "delvilkår" : {
       "medlemskap" : {
         "svar" : "JA_IMPLISITT",
-        "begrunnelse" : null,
         "resultat" : "OPPFYLT"
       },
       "lønnet" : null,
@@ -38,7 +37,6 @@
     "delvilkår" : {
       "medlemskap" : {
         "svar" : "JA_IMPLISITT",
-        "begrunnelse" : null,
         "resultat" : "OPPFYLT"
       },
       "lønnet" : null,
@@ -57,12 +55,10 @@
       "medlemskap" : null,
       "lønnet" : {
         "svar" : "JA",
-        "begrunnelse" : "begrunnelse lønnet",
         "resultat" : "IKKE_OPPFYLT"
       },
       "mottarSykepenger" : {
         "svar" : "NEI",
-        "begrunnelse" : null,
         "resultat" : "OPPFYLT"
       }
     },
@@ -78,12 +74,10 @@
       "medlemskap" : null,
       "lønnet" : {
         "svar" : "NEI",
-        "begrunnelse" : null,
         "resultat" : "OPPFYLT"
       },
       "mottarSykepenger" : {
         "svar" : "NEI",
-        "begrunnelse" : null,
         "resultat" : "OPPFYLT"
       }
     },


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal kun være en begrunnelse pr. Vilkårperiode. Denne PRen flytter valideringen av påkrevd begrunnelse til Vilkårperioden. Feks. var det tidligere påkrevd at dersom delvilkåret dekketAvAnnetRegelverk ikke var oppfylt, skulle man ha en begrunnelse på den vurderingen. Nå blir det påkrevd med begrunnelse på Vilkårperioden i stedenfor.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20573

**Kommer senere**
- Obligatorisk begrunnelse når medlemskap har vært vurdert av saksbehandler
- Obligatorisk begrunnelse for målgruppe nedsatt arbeidsevne