### PR TITLE
Skal bruke eksternId i ForrigeIverksettingDto på lik måte som behandl…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -155,6 +155,8 @@ class BehandlingService(
     fun hentSaksbehandling(eksternBehandlingId: Long): Saksbehandling =
         behandlingRepository.finnSaksbehandling(eksternBehandlingId)
 
+    fun hentEksternBehandlingId(behandlingId: UUID) = eksternBehandlingIdRepository.findByBehandlingId(behandlingId)
+
     fun hentBehandlingPåEksternId(eksternBehandlingId: Long): Behandling = behandlingRepository.finnMedEksternId(
         eksternBehandlingId,
     ) ?: error("Kan ikke finne behandling med eksternId=$eksternBehandlingId")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDto.kt
@@ -25,7 +25,7 @@ data class VedtaksdetaljerDto(
 )
 
 data class ForrigeIverksettingDto(
-    val behandlingId: UUID,
+    val behandlingId: Long,
     val iverksettingId: UUID,
 )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -236,5 +236,8 @@ class IverksettService(
             .mapNotNull { it.iverksetting }
             .maxByOrNull { it.iverksettingTidspunkt }
             ?.iverksettingId
-            ?.let { ForrigeIverksettingDto(behandlingId = behandlingId, iverksettingId = it) }
+            ?.let {
+                val eksternBehandlingId = behandlingService.hentEksternBehandlingId(behandlingId).id
+                ForrigeIverksettingDto(behandlingId = eksternBehandlingId, iverksettingId = it)
+            }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettDtoMapperTest.kt
@@ -73,7 +73,7 @@ class IverksettDtoMapperTest {
 
     @Test
     fun `skal mappe forrigeIverksetting`() {
-        val forrigeIverksetting = ForrigeIverksettingDto(UUID.randomUUID(), UUID.randomUUID())
+        val forrigeIverksetting = ForrigeIverksettingDto(11L, UUID.randomUUID())
         val dto = IverksettDtoMapper.map(
             behandling = behandling,
             andelerTilkjentYtelse = listOf(andel.copy(beløp = 0)),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
@@ -131,10 +131,8 @@ class IverksettServiceTest : IntegrationTest() {
                 forrigeBehandlingId = behandling.id,
             )
 
-        val tilkjentYtelse =
-            tilkjentYtelse(behandlingId = behandling.id, andeler = lagAndeler(behandling))
-        val tilkjentYtelse2 =
-            tilkjentYtelse(behandlingId = behandling2.id, andeler = lagAndeler(behandling2))
+        val tilkjentYtelse = tilkjentYtelse(behandlingId = behandling.id, andeler = lagAndeler(behandling))
+        val tilkjentYtelse2 = tilkjentYtelse(behandlingId = behandling2.id, andeler = lagAndeler(behandling2))
 
         @BeforeEach
         fun setUp() {
@@ -173,7 +171,8 @@ class IverksettServiceTest : IntegrationTest() {
 
             iverksettingDto.assertUtbetalingerInneholder(forrigeMåned, nåværendeMåned, nesteMåned)
 
-            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId)
+                .isEqualTo(hentEksternBehandlingId(behandling))
             assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(behandling.id)
         }
 
@@ -194,7 +193,8 @@ class IverksettServiceTest : IntegrationTest() {
 
             iverksettingDto.assertUtbetalingerInneholder(forrigeMåned, nåværendeMåned)
 
-            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId)
+                .isEqualTo(hentEksternBehandlingId(behandling))
             assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(behandling.id)
         }
 
@@ -219,7 +219,8 @@ class IverksettServiceTest : IntegrationTest() {
 
             iverksettingDto.assertUtbetalingerInneholder(forrigeMåned, nåværendeMåned)
 
-            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId)
+                .isEqualTo(hentEksternBehandlingId(behandling))
             assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(iverksettingIdBehandling1)
         }
 
@@ -246,7 +247,8 @@ class IverksettServiceTest : IntegrationTest() {
 
             iverksettingDto.assertUtbetalingerInneholder(forrigeMåned, nåværendeMåned, nesteMåned)
 
-            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId).isEqualTo(behandling2.id)
+            assertThat(iverksettingDto.captured.forrigeIverksetting?.behandlingId)
+                .isEqualTo(hentEksternBehandlingId(behandling2))
             assertThat(iverksettingDto.captured.forrigeIverksetting?.iverksettingId).isEqualTo(behandling2.id)
         }
 
@@ -375,6 +377,9 @@ class IverksettServiceTest : IntegrationTest() {
             ),
         )
     }
+
+    private fun hentEksternBehandlingId(behandling: Behandling) =
+        testoppsettService.hentSaksbehandling(behandling.id).eksternId
 
     private fun hentAndeler(behandling: Behandling): Set<AndelTilkjentYtelse> {
         return tilkjentYtelseRepository.findByBehandlingId(behandling.id)!!.andelerTilkjentYtelse


### PR DESCRIPTION
…ingId i iverksetting då behandlingId som er UUID er for lang id i oppdrag

### Hvorfor er denne endringen nødvendig? ✨
Skulle vært en del av 
* https://github.com/navikt/tilleggsstonader-sak/pull/260

> Vi sendte tidligere behandlingId som UUID, men pga begrensninger i økonomi skal verdiet ha en makslengde på 30 tegn. Bruker då i stedet eksternBehandlingId, som også familie gjør.

Litt småhackig sjekk i testene.. 

Funnet av Øyvind https://nav-it.slack.com/archives/C06PRML2V7C/p1713775097120239