### PR TITLE
Send til beslutter og Angre send til beslutter skal sjekke at det ikk…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
@@ -119,7 +119,7 @@ class AngreSendTilBeslutterService(
             behandlingId = saksbehandling.id,
             oppgavetype = Oppgavetype.GodkjenneVedtak,
         ) ?: throw ApiFeil(
-            feil = "Systemet har ikke rukket å opprette godkjenne vedtak oppgaven enda. Prøv igjen om litt.",
+            feil = "Systemet har ikke rukket å opprette Godkjenne Vedtak oppgaven enda. Prøv igjen om litt.",
             httpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterService.kt
@@ -111,6 +111,10 @@ class AngreSendTilBeslutterService(
     private fun validerOppgave(
         saksbehandling: Saksbehandling,
     ) {
+        brukerfeilHvis(oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(saksbehandling.id) != null) {
+            "Systemet har ikke rukket å ferdigstille forrige behandle sak oppgave. Prøv igjen om litt."
+        }
+
         val oppgave = oppgaveService.hentOppgaveSomIkkeErFerdigstilt(
             behandlingId = saksbehandling.id,
             oppgavetype = Oppgavetype.GodkjenneVedtak,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
@@ -11,7 +11,6 @@ import no.nav.tilleggsstonader.sak.brev.VedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
@@ -46,7 +45,7 @@ class SendTilBeslutterSteg(
          */
         validerRiktigTilstandVedInvilgelse(saksbehandling)
         validerSaksbehandlersignatur(saksbehandling)
-        validerAtDetFinnesOppgave(saksbehandling)
+        validerOppgaver(saksbehandling)
     }
 
     override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
@@ -105,9 +104,12 @@ class SendTilBeslutterSteg(
         }
     }
 
-    private fun validerAtDetFinnesOppgave(saksbehandling: Saksbehandling) {
-        feilHvis(oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(saksbehandling.id) == null) {
-            "Oppgaven for behandlingen er ikke tilgjengelig. Vennligst vent og prøv igjen om litt."
+    private fun validerOppgaver(saksbehandling: Saksbehandling) {
+        brukerfeilHvis(oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(saksbehandling.id) == null) {
+            "Oppgaven for behandlingen er ikke tilgjengelig. Prøv igjen om litt."
+        }
+        brukerfeilHvis(oppgaveService.hentOppgaveSomIkkeErFerdigstilt(saksbehandling.id, Oppgavetype.GodkjenneVedtak) != null) {
+            "Systemet har ikke rukket å ferdigstille godkjenne vedtak-oppgaven. Prøv igjen om litt."
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
@@ -109,7 +109,7 @@ class SendTilBeslutterSteg(
             "Oppgaven for behandlingen er ikke tilgjengelig. Prøv igjen om litt."
         }
         brukerfeilHvis(oppgaveService.hentOppgaveSomIkkeErFerdigstilt(saksbehandling.id, Oppgavetype.GodkjenneVedtak) != null) {
-            "Systemet har ikke rukket å ferdigstille godkjenne vedtak-oppgaven. Prøv igjen om litt."
+            "Det finnes en Godkjenne Vedtak oppgave systemet må ferdigstille før behandlingen kan sendes til beslutter. Prøv igjen om litt"
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/AngreSendTilBeslutterServiceTest.kt
@@ -144,7 +144,7 @@ class AngreSendTilBeslutterServiceTest {
                 catchThrowableOfType<ApiFeil> {
                     service.angreSendTilBeslutter(behandling.id)
                 },
-            ).hasMessageContaining("Systemet har ikke rukket å opprette godkjenne vedtak oppgaven enda.")
+            ).hasMessageContaining("Systemet har ikke rukket å opprette Godkjenne Vedtak oppgaven enda")
         }
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
@@ -170,7 +170,7 @@ class SendTilBeslutterStegTest {
 
         val feil = catchThrowableOfType<ApiFeil> { beslutteVedtakSteg.validerSteg(behandling) }
         assertThat(feil.feil)
-            .contains("Systemet har ikke rukket å ferdigstille godkjenne vedtak-oppgaven.")
+            .contains("Det finnes en Godkjenne Vedtak oppgave systemet må ferdigstille før behandlingen kan sendes til beslutter.")
     }
 
     @Test


### PR DESCRIPTION
…e finnes oppgaver som ikke er ferdigstilte

### Hvorfor er denne endringen nødvendig? ✨
Når man sender til beslutter så finnes det en liten risiko at "Godkjenne vedtak"-oppgaven ennå ikke er ferdigstilt. 
Det finnes også en risiko at man trykker på "Angre send til beslutter" når oppgaven for behandle sak ennå ikke er ferdigstilt. Dette skal håndtere de 2 situasjonene 

### Valdieringer av oppgaver, (nytt) er det som er lagt til. Første punkt fantes fra tidligere

Angre send til beslutter
* Sjekker at "godkjenn vedtak"-oppgaven finnes
* Sjekker at "behandle sak"-oppgaven er ferdigstilt (nytt)

Send til beslutter
* Sjekker at "behandle sak"-oppgaven finnes
* Sjekker at "godkjenne vedtak"-oppgave er ferdigstilt (nytt)

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20633
