### PR TITLE
Fjerner metode i client som ikke bruker template og bruker metode for…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostClient.kt
@@ -1,18 +1,14 @@
 package no.nav.tilleggsstonader.sak.journalføring
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.OppdaterJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.OppdaterJournalpostResponse
 import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
-import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
 import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.JournalposterForBrukerRequest
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
-import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
 import no.nav.tilleggsstonader.libs.log.NavHttpHeaders
 import org.springframework.beans.factory.annotation.Qualifier
@@ -87,11 +83,6 @@ class JournalpostClient(
         )
     }
 
-    fun hentSøknadTilsynBarn(journalpostId: String, dokumentId: String): Søknadsskjema<SøknadsskjemaBarnetilsyn> {
-        val data = getForEntity<ByteArray>(jsonDokumentUri(journalpostId, dokumentId).toString())
-        return objectMapper.readValue(data)
-    }
-
     fun distribuerJournalpost(request: DistribuerJournalpostRequest, saksbehandler: String? = null): String {
         return postForEntity<String>(
             dokdistUri.toString(),
@@ -130,11 +121,6 @@ class JournalpostClient(
             httpHeaders.set(NavHttpHeaders.NAV_USER_ID.asString(), saksbehandler)
         }
         return httpHeaders
-    }
-
-    private fun jsonDokumentUri(journalpostId: String, dokumentInfoId: String): URI {
-        return UriComponentsBuilder.fromUri(journalpostUri).pathSegment("hentdokument", journalpostId, dokumentInfoId)
-            .queryParam("variantFormat", Dokumentvariantformat.ORIGINAL).build().toUri()
     }
 
     private fun journalpostIdUriVariables(journalpostId: String): Map<String, String> =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostService.kt
@@ -1,9 +1,11 @@
 package no.nav.tilleggsstonader.sak.journalføring
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
 import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
 import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
 import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
@@ -114,7 +116,12 @@ class JournalpostService(private val journalpostClient: JournalpostClient, priva
 
     fun hentSøknadFraJournalpost(søknadJournalpost: Journalpost): Søknadsskjema<SøknadsskjemaBarnetilsyn> {
         val dokumentinfo = JournalføringHelper.plukkUtOriginaldokument(søknadJournalpost, DokumentBrevkode.BARNETILSYN)
-        return journalpostClient.hentSøknadTilsynBarn(søknadJournalpost.journalpostId, dokumentinfo.dokumentInfoId)
+        val data = journalpostClient.hentDokument(
+            journalpostId = søknadJournalpost.journalpostId,
+            dokumentInfoId = dokumentinfo.dokumentInfoId,
+            Dokumentvariantformat.ORIGINAL,
+        )
+        return objectMapper.readValue(data)
     }
 
     fun finnJournalpostOgPersonIdent(journalpostId: String): Pair<Journalpost, String> {


### PR DESCRIPTION
… å hente dokument, som finnes fra før, direkte fra service

### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig å bruke uri-template for kall, hvis ikke så får vi metrics på hver endepunkt man kaller
Se forskjell på
![image](https://github.com/navikt/tilleggsstonader-sak/assets/937168/a9058ba2-3fcf-45c3-9d38-de1191d4d5f7)
