### PR TITLE
Fjern sykepenger som delvilkår på aktivitet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtak.kt
@@ -52,7 +52,6 @@ data class Vilkårperiode(
 data class DelvilkårVilkårperiode(
     val medlemskap: VurderingVilkårperiode?,
     val lønnet: VurderingVilkårperiode?,
-    val mottarSykepenger: VurderingVilkårperiode?,
 )
 
 data class VurderingVilkårperiode(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakService.kt
@@ -87,11 +87,9 @@ class InterntVedtakService(
     private fun mapDelvilkår(delvilkår: DelvilkårVilkårperiodeDomain): DelvilkårVilkårperiode {
         val medlemskap = if (delvilkår is DelvilkårMålgruppe) mapVurdering(delvilkår.medlemskap) else null
         val lønnet = if (delvilkår is DelvilkårAktivitet) mapVurdering(delvilkår.lønnet) else null
-        val mottarSykepenger = if (delvilkår is DelvilkårAktivitet) mapVurdering(delvilkår.mottarSykepenger) else null
         return DelvilkårVilkårperiode(
             medlemskap = medlemskap,
             lønnet = lønnet,
-            mottarSykepenger = mottarSykepenger,
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -138,7 +138,6 @@ data class DelvilkårMålgruppe(
 
 data class DelvilkårAktivitet(
     val lønnet: Vurdering,
-    val mottarSykepenger: Vurdering,
 ) : DelvilkårVilkårperiode()
 
 enum class SvarJaNei {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -67,7 +67,6 @@ fun DelvilkårVilkårperiode.tilDto() = when (this) {
 
     is DelvilkårAktivitet -> DelvilkårAktivitetDto(
         lønnet = lønnet.tilDto(),
-        mottarSykepenger = mottarSykepenger.tilDto(),
     )
 }
 
@@ -126,7 +125,6 @@ data class DelvilkårMålgruppeDto(
 
 data class DelvilkårAktivitetDto(
     val lønnet: VurderingDto?,
-    val mottarSykepenger: VurderingDto?,
 ) : DelvilkårVilkårperiodeDto()
 
 data class VurderingDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringAktivitet.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringAktivitet.kt
@@ -3,12 +3,10 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårAktivitet
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.DelvilkårVilkårperiode.Vurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatDelvilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.DelvilkårAktivitetDto
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringVilkårperiode.tilVurdering
 
 object EvalueringAktivitet {
@@ -16,62 +14,45 @@ object EvalueringAktivitet {
         type: AktivitetType,
         delvilkår: DelvilkårAktivitetDto,
     ): ResultatEvaluering {
-        val oppdatertDelvilkår = utledVurderingerDelvilkår(type, delvilkår)
-        val resultatAktivitet = utledResultatVilkårperiode(oppdatertDelvilkår)
-        return ResultatEvaluering(oppdatertDelvilkår, resultatAktivitet)
+        return when (type) {
+            AktivitetType.UTDANNING, AktivitetType.REELL_ARBEIDSSØKER -> ikkeVurdertLønnet(type, delvilkår)
+            AktivitetType.TILTAK -> utledResultat(delvilkår)
+        }
     }
 
-    private fun utledVurderingerDelvilkår(
-        type: AktivitetType,
-        delvilkår: DelvilkårAktivitetDto,
-    ): DelvilkårAktivitet {
-        val vurderingLønnet = vurderingLønnet(type, delvilkår.lønnet)
-        val vurderingMottarSykepenger = vurderingMottarSykepenger(delvilkår.mottarSykepenger)
+    private fun utledResultat(delvilkår: DelvilkårAktivitetDto): ResultatEvaluering {
+        val lønnet = delvilkår.lønnet
+        val vurderingLønnet = lønnet.tilVurdering(utledResultatLønnet(lønnet?.svar))
+        val resultat = utledResultatVilkårperiode(vurderingLønnet.resultat)
 
-        return DelvilkårAktivitet(
-            lønnet = vurderingLønnet,
-            mottarSykepenger = vurderingMottarSykepenger,
+        return ResultatEvaluering(
+            delvilkår = DelvilkårAktivitet(lønnet = vurderingLønnet),
+            resultat = resultat,
         )
     }
 
     private fun utledResultatVilkårperiode(
-        delvilkår: DelvilkårAktivitet,
+        resultatLønnet: ResultatDelvilkårperiode,
     ): ResultatVilkårperiode {
-        val vurderingLønnet = delvilkår.lønnet
-        val vurderingMottarSykepenger = delvilkår.mottarSykepenger
-        val resultater = listOf(
-            vurderingLønnet.resultat,
-            vurderingMottarSykepenger.resultat,
-        ).filterNot { it == ResultatDelvilkårperiode.IKKE_AKTUELT }
-
-        return when {
-            resultater.contains(ResultatDelvilkårperiode.IKKE_VURDERT) -> ResultatVilkårperiode.IKKE_VURDERT
-            resultater.contains(ResultatDelvilkårperiode.IKKE_OPPFYLT) -> ResultatVilkårperiode.IKKE_OPPFYLT
-            resultater.all { it == ResultatDelvilkårperiode.OPPFYLT } -> ResultatVilkårperiode.OPPFYLT
-            else ->
-                error(
-                    "Ugyldig resultat resultatLønnet=$vurderingLønnet" +
-                        " resultatMottarSykepenger=$vurderingMottarSykepenger",
-                )
+        return when (resultatLønnet) {
+            ResultatDelvilkårperiode.IKKE_VURDERT -> ResultatVilkårperiode.IKKE_VURDERT
+            ResultatDelvilkårperiode.IKKE_OPPFYLT -> ResultatVilkårperiode.IKKE_OPPFYLT
+            ResultatDelvilkårperiode.OPPFYLT -> ResultatVilkårperiode.OPPFYLT
+            else -> error("Ugyldig resultat=$resultatLønnet for tiltak er lønnet")
         }
     }
 
-    private fun vurderingLønnet(type: AktivitetType, vurderingDto: VurderingDto?): Vurdering {
-        return when (type) {
-            AktivitetType.TILTAK -> vurderingDto.tilVurdering(utledResultatLønnet(vurderingDto?.svar))
-
-            AktivitetType.UTDANNING,
-            AktivitetType.REELL_ARBEIDSSØKER,
-            -> ikkeVurdertLønnet(type, vurderingDto)
+    private fun ikkeVurdertLønnet(type: AktivitetType, delvilkår: DelvilkårAktivitetDto): ResultatEvaluering {
+        val lønnet = delvilkår.lønnet
+        feilHvis(lønnet?.svar != null) {
+            "Ugyldig svar=${lønnet?.svar} for lønnet for $type"
         }
-    }
-
-    private fun ikkeVurdertLønnet(type: AktivitetType, vurderingDto: VurderingDto?): Vurdering {
-        val svar = vurderingDto?.svar
-        feilHvis(svar != null) {
-            "Ugyldig svar=$svar for lønnet for $type"
-        }
-        return vurderingDto.tilVurdering(ResultatDelvilkårperiode.IKKE_AKTUELT)
+        return ResultatEvaluering(
+            delvilkår = DelvilkårAktivitet(
+                lønnet = lønnet.tilVurdering(ResultatDelvilkårperiode.IKKE_AKTUELT),
+            ),
+            resultat = ResultatVilkårperiode.OPPFYLT,
+        )
     }
 
     private fun utledResultatLønnet(svar: SvarJaNei?) = when (svar) {
@@ -79,15 +60,5 @@ object EvalueringAktivitet {
         SvarJaNei.NEI -> ResultatDelvilkårperiode.OPPFYLT
         null -> ResultatDelvilkårperiode.IKKE_VURDERT
         SvarJaNei.JA_IMPLISITT -> error("Svar=$svar er ikke gyldig svar for lønnet")
-    }
-
-    private fun vurderingMottarSykepenger(vurderingDto: VurderingDto?): Vurdering =
-        vurderingDto.tilVurdering(utledResultatMottarSykepenger(vurderingDto?.svar))
-
-    private fun utledResultatMottarSykepenger(svar: SvarJaNei?) = when (svar) {
-        SvarJaNei.JA -> ResultatDelvilkårperiode.IKKE_OPPFYLT
-        SvarJaNei.NEI -> ResultatDelvilkårperiode.OPPFYLT
-        null -> ResultatDelvilkårperiode.IKKE_VURDERT
-        SvarJaNei.JA_IMPLISITT -> error("Svar=$svar er ikke gyldig svar for mottarSykepenger")
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
@@ -223,7 +223,6 @@ class InterntVedtakServiceTest {
                 assertThat(resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
             }
             assertThat(delvilkår.lønnet).isNull()
-            assertThat(delvilkår.mottarSykepenger).isNull()
         }
     }
 
@@ -240,10 +239,6 @@ class InterntVedtakServiceTest {
             with(delvilkår.lønnet!!) {
                 assertThat(svar).isEqualTo(SvarJaNei.JA.name)
                 assertThat(resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
-            }
-            with(delvilkår.mottarSykepenger!!) {
-                assertThat(svar).isEqualTo(SvarJaNei.NEI.name)
-                assertThat(resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
             }
             assertThat(delvilkår.medlemskap).isNull()
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeControllerTest.kt
@@ -77,7 +77,6 @@ class StønadsperiodeControllerTest : IntegrationTest() {
                 tom = dagensDato,
                 delvilkår = DelvilkårAktivitetDto(
                     lønnet = VurderingDto(SvarJaNei.NEI),
-                    mottarSykepenger = VurderingDto(SvarJaNei.NEI),
                 ),
                 behandlingId = behandling.id,
                 aktivitetsdager = 5,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -245,14 +245,13 @@ class StønadsperiodeServiceTest : IntegrationTest() {
         fom: LocalDate = this.FOM,
         tom: LocalDate = this.TOM,
         lønnet: SvarJaNei? = SvarJaNei.NEI,
-        mottarSykepenger: SvarJaNei? = SvarJaNei.NEI,
         behandlingId: UUID = UUID.randomUUID(),
         aktivitetsdager: Int = 5,
     ) = LagreVilkårperiode(
         type = type,
         fom = fom,
         tom = tom,
-        delvilkår = DelvilkårAktivitetDto(VurderingDto(lønnet), VurderingDto(mottarSykepenger)),
+        delvilkår = DelvilkårAktivitetDto(VurderingDto(lønnet)),
         behandlingId = behandlingId,
         aktivitetsdager = aktivitetsdager,
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeExtensions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeExtensions.kt
@@ -19,9 +19,6 @@ object VilkårperiodeExtensions {
     val Vilkårperiode.lønnet: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårAktivitet).lønnet
 
-    val Vilkårperiode.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
-
     val VilkårperiodeDto.medlemskap: VurderingDto?
         get() = (this.delvilkår as DelvilkårMålgruppeDto).medlemskap
 
@@ -31,9 +28,6 @@ object VilkårperiodeExtensions {
     val VilkårperiodeDto.lønnet: VurderingDto?
         get() = (this.delvilkår as DelvilkårAktivitetDto).lønnet
 
-    val VilkårperiodeDto.mottarSykepenger: VurderingDto?
-        get() = (this.delvilkår as DelvilkårAktivitetDto).mottarSykepenger
-
     val ResultatEvaluering.medlemskap: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårMålgruppe).medlemskap
 
@@ -42,7 +36,4 @@ object VilkårperiodeExtensions {
 
     val ResultatEvaluering.lønnet: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårAktivitet).lønnet
-
-    val ResultatEvaluering.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -13,7 +13,6 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDt
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.dekketAvAnnetRegelverk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.lønnet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.medlemskap
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.mottarSykepenger
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.opprettVilkårperiodeAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.opprettVilkårperiodeMålgruppe
@@ -85,7 +84,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val opprettVilkårperiode = opprettVilkårperiodeAktivitet(
                 lønnet = VurderingDto(SvarJaNei.NEI),
-                mottarSykepenger = VurderingDto(SvarJaNei.NEI),
                 begrunnelse = "begrunnelse aktivitet",
                 behandlingId = behandling.id,
             )
@@ -100,9 +98,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             assertThat(vilkårperiode.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
             assertThat(vilkårperiode.lønnet.svar).isEqualTo(SvarJaNei.NEI)
             assertThat(vilkårperiode.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
-
-            assertThat(vilkårperiode.mottarSykepenger.svar).isEqualTo(SvarJaNei.NEI)
-            assertThat(vilkårperiode.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
         }
 
         @Test
@@ -299,7 +294,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 begrunnelse = "",
                 delvilkår = DelvilkårAktivitetDto(
                     lønnet = VurderingDto(SvarJaNei.JA),
-                    mottarSykepenger = VurderingDto(SvarJaNei.JA),
                 ),
             )
             assertThatThrownBy {
@@ -363,7 +357,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 is DelvilkårAktivitet -> (this.delvilkår as DelvilkårAktivitet).let {
                     DelvilkårAktivitetDto(
                         lønnet = VurderingDto(it.lønnet.svar),
-                        mottarSykepenger = VurderingDto(it.mottarSykepenger.svar),
                     )
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -40,7 +40,10 @@ object VilkårperiodeTestUtil {
         aktivitetsdager = null,
     )
 
-    fun delvilkårMålgruppe(medlemskap: Vurdering = vurdering(), dekkesAvAnnetRegelverk: Vurdering = vurdering(svar = SvarJaNei.NEI)) =
+    fun delvilkårMålgruppe(
+        medlemskap: Vurdering = vurdering(),
+        dekkesAvAnnetRegelverk: Vurdering = vurdering(svar = SvarJaNei.NEI),
+    ) =
         DelvilkårMålgruppe(
             medlemskap = medlemskap,
             dekketAvAnnetRegelverk = dekkesAvAnnetRegelverk,
@@ -88,18 +91,12 @@ object VilkårperiodeTestUtil {
             svar = SvarJaNei.NEI,
             resultat = ResultatDelvilkårperiode.OPPFYLT,
         ),
-        mottarSykepenger: Vurdering = vurdering(
-            svar = SvarJaNei.NEI,
-            resultat = ResultatDelvilkårperiode.OPPFYLT,
-        ),
     ) = DelvilkårAktivitet(
         lønnet = lønnet,
-        mottarSykepenger = mottarSykepenger,
     )
 
     fun delvilkårAktivitetDto() = DelvilkårAktivitetDto(
         lønnet = VurderingDto(SvarJaNei.NEI),
-        mottarSykepenger = VurderingDto(SvarJaNei.NEI),
     )
 
     fun opprettVilkårperiodeMålgruppe(
@@ -124,7 +121,6 @@ object VilkårperiodeTestUtil {
         fom: LocalDate = LocalDate.now(),
         tom: LocalDate = LocalDate.now(),
         lønnet: VurderingDto? = null,
-        mottarSykepenger: VurderingDto? = null,
         begrunnelse: String? = null,
         behandlingId: UUID = UUID.randomUUID(),
         aktivitetsdager: Int = 5,
@@ -132,7 +128,7 @@ object VilkårperiodeTestUtil {
         type = type,
         fom = fom,
         tom = tom,
-        delvilkår = DelvilkårAktivitetDto(lønnet, mottarSykepenger),
+        delvilkår = DelvilkårAktivitetDto(lønnet),
         begrunnelse = begrunnelse,
         behandlingId = behandlingId,
         aktivitetsdager = aktivitetsdager,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringAktivitetTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringAktivitetTest.kt
@@ -22,113 +22,53 @@ class EvalueringAktivitetTest {
     inner class Tiltak {
 
         @Test
-        fun `hvis ikke lønnet og ikke mottar sykepenger så er resultatet oppfylt`() {
+        fun `hvis tiltak ikke er lønnet skal resultatet være oppfylt`() {
             val resultat = utledResultat(
                 AktivitetType.TILTAK,
-                delvilkårAktivitetDto(lønnet = SvarJaNei.NEI, mottarSykepenger = SvarJaNei.NEI),
+                delvilkårAktivitetDto(lønnet = SvarJaNei.NEI),
             )
             assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
             assertThat(resultat.lønnet.svar).isEqualTo(SvarJaNei.NEI)
-
-            assertThat(resultat.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
-            assertThat(resultat.mottarSykepenger.svar).isEqualTo(SvarJaNei.NEI)
 
             assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
         }
 
         @Test
-        fun `hvis både lønnet og mottar sykepener mangler vurdering så blir resultatet IKKE_VURDERT`() {
+        fun `hvis tiltak er lønnet skal resultat være ikke oppfylt`() {
             val resultat = utledResultat(
                 AktivitetType.TILTAK,
-                delvilkårAktivitetDto(lønnet = null, mottarSykepenger = null),
+                delvilkårAktivitetDto(lønnet = SvarJaNei.JA),
+            )
+            assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
+            assertThat(resultat.lønnet.svar).isEqualTo(SvarJaNei.JA)
+
+            assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+        }
+
+        @Test
+        fun `hvis svar på lønnet mangler blir resultatet IKKE_VURDERT`() {
+            val resultat = utledResultat(
+                AktivitetType.TILTAK,
+                delvilkårAktivitetDto(lønnet = null),
             )
             assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_VURDERT)
             assertThat(resultat.lønnet.svar).isNull()
 
-            assertThat(resultat.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_VURDERT)
-            assertThat(resultat.mottarSykepenger.svar).isNull()
-
             assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
-        }
-
-        @Test
-        fun `skal vurdere lønnet alene`() {
-            val resultat = utledResultat(
-                AktivitetType.TILTAK,
-                delvilkårAktivitetDto(lønnet = SvarJaNei.NEI, mottarSykepenger = null),
-            )
-            assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
-            assertThat(resultat.lønnet.svar).isEqualTo(SvarJaNei.NEI)
-
-            assertThat(resultat.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_VURDERT)
-            assertThat(resultat.mottarSykepenger.svar).isNull()
-
-            assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
-        }
-
-        @Test
-        fun `skal vurdere mottar sykepenger alene`() {
-            val resultat = utledResultat(
-                AktivitetType.TILTAK,
-                delvilkårAktivitetDto(lønnet = null, mottarSykepenger = SvarJaNei.JA),
-            )
-            assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_VURDERT)
-            assertThat(resultat.lønnet.svar).isEqualTo(null)
-
-            assertThat(resultat.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
-            assertThat(resultat.mottarSykepenger.svar).isEqualTo(SvarJaNei.JA)
-            assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
-        }
-
-        @Test
-        fun `hvis en ikke er oppfylt så er resultatet ikke oppfylt`() {
-            val gyldigeSvarForAktivitet = SvarJaNei.entries.filter { it != SvarJaNei.JA_IMPLISITT }
-            gyldigeSvarForAktivitet.forEach {
-                assertThat(
-                    utledResultat(
-                        AktivitetType.TILTAK,
-                        delvilkårAktivitetDto(lønnet = SvarJaNei.JA, mottarSykepenger = it),
-                    ).resultat,
-                ).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
-
-                assertThat(
-                    utledResultat(
-                        AktivitetType.TILTAK,
-                        delvilkårAktivitetDto(lønnet = it, mottarSykepenger = SvarJaNei.JA),
-                    ).resultat,
-                ).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
-            }
         }
     }
 
     @Nested
     inner class UtdanningEllerReellArbeidssøker {
         @ReellArbeidssøkerEllerUtdanningParameterizedTest
-        fun `mottar sykepenger skal mappes til IKKE_OPPFYLT`(type: AktivitetType) {
-            val delvilkår = delvilkårAktivitetDto(mottarSykepenger = SvarJaNei.JA)
-            val resultat = utledResultat(type, delvilkår)
-
-            assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
-
-            assertThat(resultat.lønnet.svar).isEqualTo(null)
-            assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_AKTUELT)
-
-            assertThat(resultat.mottarSykepenger.svar).isEqualTo(SvarJaNei.JA)
-            assertThat(resultat.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
-        }
-
-        @ReellArbeidssøkerEllerUtdanningParameterizedTest
-        fun `mottar ikke sykepenger skal mappes til OPPFYLT`(type: AktivitetType) {
-            val delvilkår = delvilkårAktivitetDto(mottarSykepenger = SvarJaNei.NEI)
+        fun `skal bli oppfylt uten svar på lønnet `(type: AktivitetType) {
+            val delvilkår = delvilkårAktivitetDto()
             val resultat = utledResultat(type, delvilkår)
 
             assertThat(resultat.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
 
             assertThat(resultat.lønnet.svar).isEqualTo(null)
             assertThat(resultat.lønnet.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_AKTUELT)
-
-            assertThat(resultat.mottarSykepenger.svar).isEqualTo(SvarJaNei.NEI)
-            assertThat(resultat.mottarSykepenger.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
         }
 
         @ParameterizedTest
@@ -150,37 +90,18 @@ class EvalueringAktivitetTest {
                     type = AktivitetType.TILTAK,
                     delvilkår = DelvilkårAktivitetDto(
                         lønnet = VurderingDto(SvarJaNei.JA_IMPLISITT),
-                        mottarSykepenger = null,
                     ),
                 )
             }.hasMessageContaining("Svar=JA_IMPLISITT er ikke gyldig svar for lønnet")
-        }
-
-        @ParameterizedTest
-        @EnumSource(value = AktivitetType::class)
-        fun `ja implisitt er ikke et gyldig svar for mottar sykepenger`(type: AktivitetType) {
-            assertThatThrownBy {
-                utledResultat(
-                    type = type,
-                    delvilkår = DelvilkårAktivitetDto(
-                        lønnet = null,
-                        mottarSykepenger = VurderingDto(SvarJaNei.JA_IMPLISITT),
-                    ),
-                )
-            }.hasMessageContaining("Svar=JA_IMPLISITT er ikke gyldig svar for mottarSykepenger")
         }
     }
 
     private fun delvilkårAktivitetDto(
         lønnet: SvarJaNei? = null,
-        mottarSykepenger: SvarJaNei? = null,
-    ) = DelvilkårAktivitetDto(lønnet = VurderingDto(lønnet), mottarSykepenger = VurderingDto(mottarSykepenger))
+    ) = DelvilkårAktivitetDto(lønnet = VurderingDto(lønnet))
 
     private val ResultatEvaluering.lønnet: DelvilkårVilkårperiode.Vurdering
         get() = (this.delvilkår as DelvilkårAktivitet).lønnet
-
-    private val ResultatEvaluering.mottarSykepenger: DelvilkårVilkårperiode.Vurdering
-        get() = (this.delvilkår as DelvilkårAktivitet).mottarSykepenger
 }
 
 @ParameterizedTest

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/evaluering/EvalueringVilkårperiodeTest.kt
@@ -25,7 +25,7 @@ class EvalueringVilkårperiodeTest {
 
         val resultatAktivitet = evaulerVilkårperiode(
             AktivitetType.TILTAK,
-            DelvilkårAktivitetDto(VurderingDto(SvarJaNei.NEI), VurderingDto(SvarJaNei.NEI)),
+            DelvilkårAktivitetDto(VurderingDto(SvarJaNei.NEI)),
         )
         assertThat(resultatAktivitet.resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
     }
@@ -33,7 +33,7 @@ class EvalueringVilkårperiodeTest {
     @Test
     fun `skal kaste feil hvis delvilkår ikke matcher type`() {
         assertThatThrownBy {
-            evaulerVilkårperiode(MålgruppeType.AAP, DelvilkårAktivitetDto(VurderingDto(null), VurderingDto(null)))
+            evaulerVilkårperiode(MålgruppeType.AAP, DelvilkårAktivitetDto(VurderingDto(null)))
         }.hasMessageContaining("Ugyldig kombinasjon")
 
         assertThatThrownBy {

--- a/src/test/resources/interntVedtak/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/internt_vedtak.json
@@ -23,8 +23,7 @@
         "svar" : "JA_IMPLISITT",
         "resultat" : "OPPFYLT"
       },
-      "lønnet" : null,
-      "mottarSykepenger" : null
+      "lønnet" : null
     },
     "kilde" : "SYSTEM",
     "resultat" : "OPPFYLT",
@@ -39,8 +38,7 @@
         "svar" : "JA_IMPLISITT",
         "resultat" : "OPPFYLT"
       },
-      "lønnet" : null,
-      "mottarSykepenger" : null
+      "lønnet" : null
     },
     "kilde" : "SYSTEM",
     "resultat" : "OPPFYLT",
@@ -56,10 +54,6 @@
       "lønnet" : {
         "svar" : "JA",
         "resultat" : "IKKE_OPPFYLT"
-      },
-      "mottarSykepenger" : {
-        "svar" : "NEI",
-        "resultat" : "OPPFYLT"
       }
     },
     "kilde" : "SYSTEM",
@@ -73,10 +67,6 @@
     "delvilkår" : {
       "medlemskap" : null,
       "lønnet" : {
-        "svar" : "NEI",
-        "resultat" : "OPPFYLT"
-      },
-      "mottarSykepenger" : {
         "svar" : "NEI",
         "resultat" : "OPPFYLT"
       }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Sykepenger skal bli egen målgruppe og ikke lenger være et delvilkår på aktitvitet.

Skrev om `EvalueringAktivitet` litt fordi det var litt overkill med ekstra funksjoner når det bare var en ting som skulle vurderes.

Hører sammen med [PR 307 i sak-frontend](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/307)