### PR TITLE
Lag eget endepunkt for å lage avslag vedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
@@ -1,6 +1,13 @@
 package no.nav.tilleggsstonader.sak.vedtak
 
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+
 enum class TypeVedtak {
     INNVILGELSE,
     AVSLAG,
+}
+
+fun TypeVedtak.tilBehandlingResult(): BehandlingResultat = when(this) {
+    TypeVedtak.INNVILGELSE -> BehandlingResultat.INNVILGET
+    TypeVedtak.AVSLAG -> BehandlingResultat.AVSLÅTT
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
@@ -1,6 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak
 
 enum class TypeVedtak {
-    INNVILGET,
-    AVSLÅTT,
+    INNVILGELSE,
+    AVSLAG,
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
@@ -2,4 +2,5 @@ package no.nav.tilleggsstonader.sak.vedtak
 
 enum class TypeVedtak {
     INNVILGET,
+    AVSLÅTT,
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/TypeVedtak.kt
@@ -7,7 +7,7 @@ enum class TypeVedtak {
     AVSLAG,
 }
 
-fun TypeVedtak.tilBehandlingResult(): BehandlingResultat = when(this) {
+fun TypeVedtak.tilBehandlingResult(): BehandlingResultat = when (this) {
     TypeVedtak.INNVILGELSE -> BehandlingResultat.INNVILGET
     TypeVedtak.AVSLAG -> BehandlingResultat.AVSLÅTT
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakController.kt
@@ -5,8 +5,6 @@ import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
 
 @ProtectedWithClaims(issuer = "azuread")
@@ -14,8 +12,7 @@ abstract class VedtakController<DTO, DOMENE>(
     private val tilgangService: TilgangService,
     private val vedtakService: VedtakService<DTO, DOMENE>,
 ) {
-    @PostMapping("{behandlingId}")
-    fun lagreVedtak(@PathVariable behandlingId: UUID, @RequestBody vedtak: DTO) {
+    fun lagreVedtak(behandlingId: UUID, vedtak: DTO) {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
         vedtakService.håndterSteg(behandlingId, vedtak)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -48,7 +48,7 @@ class TilsynBarnBeregnYtelseSteg(
                 vedtakRepository.insert(
                     VedtakTilsynBarn(
                         behandlingId = saksbehandling.id,
-                        type = TypeVedtak.AVSLÅTT,
+                        type = TypeVedtak.AVSLAG,
                         avslagBegrunnelse = vedtak.begrunnelse,
                     ),
                 )
@@ -106,7 +106,7 @@ class TilsynBarnBeregnYtelseSteg(
     ): VedtakTilsynBarn {
         return VedtakTilsynBarn(
             behandlingId = behandling.id,
-            type = TypeVedtak.INNVILGET,
+            type = TypeVedtak.INNVILGELSE,
             vedtak = VedtaksdataTilsynBarn(
                 utgifter = vedtak.utgifter,
             ),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregningService.kt
@@ -8,6 +8,12 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilAkt
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilDagerPerUke
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilUke
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilÅrMåned
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beløpsperiode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beregningsgrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.BeregningsresultatTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.StønadsperiodeGrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -2,6 +2,10 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.vedtak.VedtakController
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.BeregningsresultatTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnDto
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -14,16 +18,32 @@ import java.util.UUID
 class TilsynBarnVedtakController(
     private val tilsynBarnBeregningService: TilsynBarnBeregningService,
     tilgangService: TilgangService,
-    tilsynBarnVedtakService: TilsynBarnVedtakService,
-) : VedtakController<InnvilgelseTilsynBarnDto, VedtakTilsynBarn>(
+    private val tilsynBarnVedtakService: TilsynBarnVedtakService,
+) : VedtakController<VedtakTilsynBarnDto, VedtakTilsynBarn>(
     tilgangService,
     tilsynBarnVedtakService,
 ) {
 
+    @PostMapping("{behandlingId}")
+    fun innvilge(
+        @PathVariable behandlingId: UUID,
+        @RequestBody vedtak: InnvilgelseTilsynBarnRequest,
+    ) {
+        lagreVedtak(behandlingId, vedtak.tilDto())
+    }
+
+    @PostMapping("{behandlingId}/avslag")
+    fun avslå(
+        @PathVariable behandlingId: UUID,
+        @RequestBody vedtak: AvslagRequest,
+    ) {
+        lagreVedtak(behandlingId, vedtak.tilDto())
+    }
+
     @PostMapping("{behandlingId}/beregn")
     fun beregn(
         @PathVariable behandlingId: UUID,
-        @RequestBody vedtak: InnvilgelseTilsynBarnDto,
+        @RequestBody vedtak: InnvilgelseTilsynBarnRequest,
     ): BeregningsresultatTilsynBarnDto {
         return tilsynBarnBeregningService.beregn(behandlingId, vedtak.utgifter)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
@@ -25,7 +25,7 @@ class TilsynBarnVedtakService(
                 },
             )
 
-            TypeVedtak.AVSLAG -> return AvslagTilsynBarnDto(begrunnelse = vedtak.avslagBegrunnelse!!)
+            TypeVedtak.AVSLAG -> return AvslagTilsynBarnDto(begrunnelse = vedtak.avslagBegrunnelse ?: error("Mangler begrunnelse i avslag"))
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
@@ -1,7 +1,12 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.BeregningsresultatTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnDto
 import org.springframework.stereotype.Service
 
 @Service
@@ -9,14 +14,18 @@ class TilsynBarnVedtakService(
     repository: TilsynBarnVedtakRepository,
     stegService: StegService,
     tilsynBarnBeregnYtelseSteg: TilsynBarnBeregnYtelseSteg,
-) : VedtakService<InnvilgelseTilsynBarnDto, VedtakTilsynBarn>(stegService, tilsynBarnBeregnYtelseSteg, repository) {
+) : VedtakService<VedtakTilsynBarnDto, VedtakTilsynBarn>(stegService, tilsynBarnBeregnYtelseSteg, repository) {
 
-    override fun mapTilDto(vedtak: VedtakTilsynBarn): InnvilgelseTilsynBarnDto {
-        return InnvilgelseTilsynBarnDto(
-            utgifter = vedtak.vedtak.utgifter,
-            beregningsresultat = vedtak.beregningsresultat?.let {
-                BeregningsresultatTilsynBarnDto(perioder = it.perioder)
-            },
-        )
+    override fun mapTilDto(vedtak: VedtakTilsynBarn): VedtakTilsynBarnDto {
+        when (vedtak.type) {
+            TypeVedtak.INNVILGET -> return InnvilgelseTilsynBarnDto(
+                utgifter = vedtak.vedtak?.utgifter ?: error("Mangler utgifter i vedtak"),
+                beregningsresultat = vedtak.beregningsresultat?.let {
+                    BeregningsresultatTilsynBarnDto(perioder = it.perioder)
+                },
+            )
+
+            TypeVedtak.AVSLÅTT -> return AvslagTilsynBarnDto(begrunnelse = vedtak.avslagBegrunnelse!!)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
@@ -18,14 +18,14 @@ class TilsynBarnVedtakService(
 
     override fun mapTilDto(vedtak: VedtakTilsynBarn): VedtakTilsynBarnDto {
         when (vedtak.type) {
-            TypeVedtak.INNVILGET -> return InnvilgelseTilsynBarnDto(
+            TypeVedtak.INNVILGELSE -> return InnvilgelseTilsynBarnDto(
                 utgifter = vedtak.vedtak?.utgifter ?: error("Mangler utgifter i vedtak"),
                 beregningsresultat = vedtak.beregningsresultat?.let {
                     BeregningsresultatTilsynBarnDto(perioder = it.perioder)
                 },
             )
 
-            TypeVedtak.AVSLÅTT -> return AvslagTilsynBarnDto(begrunnelse = vedtak.avslagBegrunnelse!!)
+            TypeVedtak.AVSLAG -> return AvslagTilsynBarnDto(begrunnelse = vedtak.avslagBegrunnelse!!)
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBeregningUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBeregningUtil.kt
@@ -2,6 +2,8 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.splitPerMåned
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.UtgiftBarn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakTilsynBarn.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakTilsynBarn.kt
@@ -2,6 +2,8 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Embedded
 import java.util.UUID
@@ -15,8 +17,9 @@ data class VedtakTilsynBarn(
     @Id
     val behandlingId: UUID,
     val type: TypeVedtak,
-    val vedtak: VedtaksdataTilsynBarn,
-    val beregningsresultat: VedtaksdataBeregningsresultat?,
+    val vedtak: VedtaksdataTilsynBarn? = null,
+    val beregningsresultat: VedtaksdataBeregningsresultat? = null,
+    val avslagBegrunnelse: String? = null,
 
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
@@ -25,6 +28,10 @@ data class VedtakTilsynBarn(
         when (type) {
             TypeVedtak.INNVILGET -> {
                 require(beregningsresultat != null) { "Mangler beregningsresultat for type=$type" }
+                require(vedtak != null) { "Mangler vedtak for type=$type" }
+            }
+            TypeVedtak.AVSLÅTT -> {
+                require(avslagBegrunnelse != null) { "Avslag må begrunnes" }
             }
         }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakTilsynBarn.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakTilsynBarn.kt
@@ -26,11 +26,11 @@ data class VedtakTilsynBarn(
 ) {
     init {
         when (type) {
-            TypeVedtak.INNVILGET -> {
+            TypeVedtak.INNVILGELSE -> {
                 require(beregningsresultat != null) { "Mangler beregningsresultat for type=$type" }
                 require(vedtak != null) { "Mangler vedtak for type=$type" }
             }
-            TypeVedtak.AVSLÅTT -> {
+            TypeVedtak.AVSLAG -> {
                 require(avslagBegrunnelse != null) { "Avslag må begrunnes" }
             }
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/AvslagTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/AvslagTilsynBarnDto.kt
@@ -1,0 +1,13 @@
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto
+
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+
+data class AvslagTilsynBarnDto(
+    val begrunnelse: String,
+) : VedtakTilsynBarnDto(TypeVedtak.AVSLÅTT)
+
+data class AvslagRequest(
+    val begrunnelse: String,
+) {
+    fun tilDto() = AvslagTilsynBarnDto(begrunnelse)
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/AvslagTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/AvslagTilsynBarnDto.kt
@@ -4,7 +4,7 @@ import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 
 data class AvslagTilsynBarnDto(
     val begrunnelse: String,
-) : VedtakTilsynBarnDto(TypeVedtak.AVSLÅTT)
+) : VedtakTilsynBarnDto(TypeVedtak.AVSLAG)
 
 data class AvslagRequest(
     val begrunnelse: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
@@ -1,6 +1,7 @@
-package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
@@ -15,7 +16,14 @@ import java.util.UUID
 data class InnvilgelseTilsynBarnDto(
     val utgifter: Map<UUID, List<Utgift>>,
     val beregningsresultat: BeregningsresultatTilsynBarnDto?,
-)
+) : VedtakTilsynBarnDto(TypeVedtak.INNVILGET)
+
+data class InnvilgelseTilsynBarnRequest(
+    val utgifter: Map<UUID, List<Utgift>>,
+    val beregningsresultat: BeregningsresultatTilsynBarnDto?,
+) {
+    fun tilDto() = InnvilgelseTilsynBarnDto(utgifter, beregningsresultat)
+}
 
 data class Utgift(
     override val fom: YearMonth,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 data class InnvilgelseTilsynBarnDto(
     val utgifter: Map<UUID, List<Utgift>>,
     val beregningsresultat: BeregningsresultatTilsynBarnDto?,
-) : VedtakTilsynBarnDto(TypeVedtak.INNVILGET)
+) : VedtakTilsynBarnDto(TypeVedtak.INNVILGELSE)
 
 data class InnvilgelseTilsynBarnRequest(
     val utgifter: Map<UUID, List<Utgift>>,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/VedtakTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/VedtakTilsynBarnDto.kt
@@ -1,0 +1,12 @@
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+@JsonSubTypes(
+    JsonSubTypes.Type(InnvilgelseTilsynBarnDto::class, name = "INNVILGELSE"),
+    JsonSubTypes.Type(AvslagTilsynBarnDto::class, name = "AVSLAG"),
+)
+sealed class VedtakTilsynBarnDto(open val type: TypeVedtak)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -87,6 +87,11 @@ class BeslutteVedtakSteg(
                     BehandlingResultat.INNVILGET,
                 )
             }
+
+            TypeVedtak.AVSLÅTT -> behandlingService.oppdaterResultatPåBehandling(
+                behandlingId,
+                BehandlingResultat.AVSLÅTT,
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
@@ -17,7 +16,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.IverksettService
-import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
 import no.nav.tilleggsstonader.sak.vedtak.tilBehandlingResult
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -19,6 +19,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.IverksettService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
+import no.nav.tilleggsstonader.sak.vedtak.tilBehandlingResult
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
 import org.springframework.stereotype.Service
 
@@ -80,19 +81,10 @@ class BeslutteVedtakSteg(
     private fun oppdaterResultatPåBehandling(saksbehandling: Saksbehandling) {
         val behandlingId = saksbehandling.id
         val resultat = vedtaksresultatService.hentVedtaksresultat(saksbehandling)
-        when (resultat) {
-            TypeVedtak.INNVILGELSE -> {
-                behandlingService.oppdaterResultatPåBehandling(
-                    behandlingId,
-                    BehandlingResultat.INNVILGET,
-                )
-            }
-
-            TypeVedtak.AVSLAG -> behandlingService.oppdaterResultatPåBehandling(
-                behandlingId,
-                BehandlingResultat.AVSLÅTT,
-            )
-        }
+        behandlingService.oppdaterResultatPåBehandling(
+            behandlingId = behandlingId,
+            behandlingResultat = resultat.tilBehandlingResult(),
+        )
     }
 
     private fun opprettBehandleUnderkjentVedtakOppgave(saksbehandling: Saksbehandling, navIdent: String) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakSteg.kt
@@ -81,14 +81,14 @@ class BeslutteVedtakSteg(
         val behandlingId = saksbehandling.id
         val resultat = vedtaksresultatService.hentVedtaksresultat(saksbehandling)
         when (resultat) {
-            TypeVedtak.INNVILGET -> {
+            TypeVedtak.INNVILGELSE -> {
                 behandlingService.oppdaterResultatPåBehandling(
                     behandlingId,
                     BehandlingResultat.INNVILGET,
                 )
             }
 
-            TypeVedtak.AVSLÅTT -> behandlingService.oppdaterResultatPåBehandling(
+            TypeVedtak.AVSLAG -> behandlingService.oppdaterResultatPåBehandling(
                 behandlingId,
                 BehandlingResultat.AVSLÅTT,
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterSteg.kt
@@ -87,7 +87,7 @@ class SendTilBeslutterSteg(
 
     private fun validerRiktigTilstandVedInvilgelse(saksbehandling: Saksbehandling) {
         val vedtaksresultat = vedtaksresultatService.hentVedtaksresultat(saksbehandling)
-        if (vedtaksresultat == TypeVedtak.INNVILGET) {
+        if (vedtaksresultat == TypeVedtak.INNVILGELSE) {
             brukerfeilHvisIkke(vilkårService.erAlleVilkårOppfylt(saksbehandling.id)) {
                 "Kan ikke innvilge hvis ikke alle vilkår er oppfylt for behandlingId: ${saksbehandling.id}"
             }

--- a/src/main/resources/db/migration/V37__vedtak_tilsynbarn_avslag.sql
+++ b/src/main/resources/db/migration/V37__vedtak_tilsynbarn_avslag.sql
@@ -1,0 +1,5 @@
+ALTER TABLE vedtak_tilsyn_barn
+    ALTER
+        COLUMN vedtak DROP
+        NOT NULL,
+    ADD COLUMN avslag_begrunnelse VARCHAR NULL;

--- a/src/main/resources/db/migration/V37__vedtak_tilsynbarn_avslag.sql
+++ b/src/main/resources/db/migration/V37__vedtak_tilsynbarn_avslag.sql
@@ -3,3 +3,7 @@ ALTER TABLE vedtak_tilsyn_barn
         COLUMN vedtak DROP
         NOT NULL,
     ADD COLUMN avslag_begrunnelse VARCHAR NULL;
+
+UPDATE vedtak_tilsyn_barn
+SET type = 'INNVILGELSE'
+WHERE type = 'INNVILGET';

--- a/src/main/resources/db/migration/V37__vedtak_tilsynbarn_avslag.sql
+++ b/src/main/resources/db/migration/V37__vedtak_tilsynbarn_avslag.sql
@@ -1,7 +1,5 @@
 ALTER TABLE vedtak_tilsyn_barn
-    ALTER
-        COLUMN vedtak DROP
-        NOT NULL,
+    ALTER COLUMN vedtak DROP NOT NULL,
     ADD COLUMN avslag_begrunnelse VARCHAR NULL;
 
 UPDATE vedtak_tilsyn_barn

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
@@ -27,9 +27,9 @@ import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import no.nav.tilleggsstonader.sak.statistikk.task.BehandlingsstatistikkTask
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.InnvilgelseTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakController
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.Utgift
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.TotrinnskontrollController
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.TotrinnkontrollStatus

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegServiceTest.kt
@@ -18,9 +18,9 @@ import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.InnvilgelseTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnBeregnYtelseSteg
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.Utgift
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/StepDefinitions.kt
@@ -16,6 +16,9 @@ import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriInt
 import no.nav.tilleggsstonader.sak.cucumber.parseÅrMåned
 import no.nav.tilleggsstonader.sak.cucumber.parseÅrMånedEllerDato
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beløpsperiode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.BeregningsresultatTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
@@ -94,7 +95,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
             val vedtak = repository.findByIdOrThrow(saksbehandling.id)
 
             assertThat(vedtak.behandlingId).isEqualTo(saksbehandling.id)
-            assertThat(vedtak.type).isEqualTo(TypeVedtak.INNVILGET)
+            assertThat(vedtak.type).isEqualTo(TypeVedtak.INNVILGELSE)
             assertThat(vedtak.vedtak).isEqualTo(
                 VedtaksdataTilsynBarn(
                     utgifter = vedtakDto.utgifter,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -20,7 +21,6 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresult
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -101,16 +101,5 @@ class TilsynBarnBeregnYtelseStegTest {
         verify(exactly = 0) {
             simuleringService.hentOgLagreSimuleringsresultat(any())
         }
-    }
-
-    @Test
-    fun `skal kaste feil hvis vedtaket inneholder beregningsresultat`() {
-        val vedtak = innvilgelseDto(
-            utgifter = mapOf(barn(barn.id, Utgift(måned, måned, 100))),
-            beregningsresultat = BeregningsresultatTilsynBarnDto(emptyList()),
-        )
-        assertThatThrownBy {
-            steg.utførSteg(saksbehandling, vedtak)
-        }.hasMessageContaining("Kan ikke sende inn beregningsresultat")
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -1,5 +1,8 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.BeregningsresultatTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import java.util.UUID
 
 object TilsynBarnTestUtil {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -10,7 +10,14 @@ import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailExce
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -74,25 +81,40 @@ class TilsynBarnVedtakControllerTest(
     }
 
     @Test
-    fun `utgifter på vedtaket skal være likt det man sender inn`() {
-        val vedtak = lagVedtak()
-        lagreVedtak(behandling, vedtak)
+    fun `Ved innvilgelse skal utgifter på vedtaket være likt det man sender inn`() {
+        val vedtak = lagInnvilgeVedtak()
+        innvilgeVedtak(behandling, vedtak)
 
         val lagretDto = hentVedtak(behandling.id).body!!
 
-        assertThat(lagretDto.utgifter).isEqualTo(vedtak.utgifter)
+        assertThat((lagretDto as InnvilgelseTilsynBarnDto).utgifter).isEqualTo(vedtak.utgifter)
+        assertThat(lagretDto.type).isEqualTo(TypeVedtak.INNVILGET)
     }
 
-    private fun lagVedtak() = InnvilgelseTilsynBarnDto(
+    @Test
+    fun `skal lagre og hente avslag`() {
+        val vedtak = AvslagRequest(
+            begrunnelse = "begrunnelse",
+        )
+
+        avslåVedtak(behandling, vedtak)
+
+        val lagretDto = hentVedtak(behandling.id).body!!
+
+        assertThat((lagretDto as AvslagTilsynBarnDto).begrunnelse).isEqualTo(vedtak.begrunnelse)
+        assertThat(lagretDto.type).isEqualTo(TypeVedtak.AVSLÅTT)
+    }
+
+    private fun lagInnvilgeVedtak() = InnvilgelseTilsynBarnRequest(
         utgifter = mapOf(
             barn(barn.id, Utgift(YearMonth.of(2023, 1), YearMonth.of(2023, 1), 100)),
         ),
         beregningsresultat = null,
     )
 
-    private fun lagreVedtak(
+    private fun innvilgeVedtak(
         behandling: Behandling,
-        vedtak: InnvilgelseTilsynBarnDto,
+        vedtak: InnvilgelseTilsynBarnRequest,
     ) {
         restTemplate.exchange<Map<String, Any>?>(
             localhost("api/vedtak/tilsyn-barn/${behandling.id}"),
@@ -101,8 +123,19 @@ class TilsynBarnVedtakControllerTest(
         )
     }
 
+    private fun avslåVedtak(
+        behandling: Behandling,
+        vedtak: AvslagRequest,
+    ) {
+        restTemplate.exchange<Map<String, Any>?>(
+            localhost("api/vedtak/tilsyn-barn/${behandling.id}/avslag"),
+            HttpMethod.POST,
+            HttpEntity(vedtak, headers),
+        )
+    }
+
     private fun hentVedtak(behandlingId: UUID) =
-        restTemplate.exchange<InnvilgelseTilsynBarnDto>(
+        restTemplate.exchange<VedtakTilsynBarnDto>(
             localhost("api/vedtak/tilsyn-barn/$behandlingId"),
             HttpMethod.GET,
             HttpEntity(null, headers),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -88,7 +88,7 @@ class TilsynBarnVedtakControllerTest(
         val lagretDto = hentVedtak(behandling.id).body!!
 
         assertThat((lagretDto as InnvilgelseTilsynBarnDto).utgifter).isEqualTo(vedtak.utgifter)
-        assertThat(lagretDto.type).isEqualTo(TypeVedtak.INNVILGET)
+        assertThat(lagretDto.type).isEqualTo(TypeVedtak.INNVILGELSE)
     }
 
     @Test
@@ -102,7 +102,7 @@ class TilsynBarnVedtakControllerTest(
         val lagretDto = hentVedtak(behandling.id).body!!
 
         assertThat((lagretDto as AvslagTilsynBarnDto).begrunnelse).isEqualTo(vedtak.begrunnelse)
-        assertThat(lagretDto.type).isEqualTo(TypeVedtak.AVSLÅTT)
+        assertThat(lagretDto.type).isEqualTo(TypeVedtak.AVSLAG)
     }
 
     private fun lagInnvilgeVedtak() = InnvilgelseTilsynBarnRequest(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakRepositoryTest.kt
@@ -22,14 +22,14 @@ class TilsynBarnVedtakRepositoryTest : IntegrationTest() {
         tilsynBarnVedtakRepository.insert(
             VedtakTilsynBarn(
                 behandlingId = behandling.id,
-                type = TypeVedtak.INNVILGET,
+                type = TypeVedtak.INNVILGELSE,
                 vedtak = vedtak,
                 beregningsresultat = beregningsresultat,
             ),
         )
 
         val lagretVedtak = tilsynBarnVedtakRepository.findByIdOrThrow(behandling.id)
-        assertThat(lagretVedtak.type).isEqualTo(TypeVedtak.INNVILGET)
+        assertThat(lagretVedtak.type).isEqualTo(TypeVedtak.INNVILGELSE)
         assertThat(lagretVedtak.vedtak).isEqualTo(vedtak)
         assertThat(lagretVedtak.beregningsresultat).isEqualTo(beregningsresultat)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakServiceTest.kt
@@ -32,7 +32,7 @@ class TilsynBarnVedtakServiceTest {
 
     @Test
     fun `skal mappe avslått vedtak til dto`() {
-        val vedtak = VedtakTilsynBarn(behandlingId = UUID.randomUUID(), type = TypeVedtak.AVSLÅTT, avslagBegrunnelse = "begrunnelse")
+        val vedtak = VedtakTilsynBarn(behandlingId = UUID.randomUUID(), type = TypeVedtak.AVSLAG, avslagBegrunnelse = "begrunnelse")
 
         val dto = tilsynBarnVedtakService.mapTilDto(vedtak) as AvslagTilsynBarnDto
 
@@ -42,7 +42,7 @@ class TilsynBarnVedtakServiceTest {
 
     private fun vedtak() = VedtakTilsynBarn(
         behandlingId = UUID.randomUUID(),
-        type = TypeVedtak.INNVILGET,
+        type = TypeVedtak.INNVILGELSE,
         vedtak = VedtaksdataTilsynBarn(
             utgifter = mapOf(
                 TilsynBarnTestUtil.barn(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakServiceTest.kt
@@ -2,6 +2,12 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beløpsperiode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beregningsgrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -15,13 +21,23 @@ class TilsynBarnVedtakServiceTest {
     private val tilsynBarnVedtakService = TilsynBarnVedtakService(mockk(), mockk(), mockk())
 
     @Test
-    fun `skal mappe vedtak til dto`() {
+    fun `skal mappe innvilget vedtak til dto`() {
         val vedtak = vedtak()
 
-        val dto = tilsynBarnVedtakService.mapTilDto(vedtak)
+        val dto = tilsynBarnVedtakService.mapTilDto(vedtak) as InnvilgelseTilsynBarnDto
 
-        assertThat(dto.utgifter).isEqualTo(vedtak.vedtak.utgifter)
+        assertThat(dto.utgifter).isEqualTo(vedtak.vedtak?.utgifter)
         assertThat(dto.beregningsresultat!!.perioder).isEqualTo(vedtak.beregningsresultat!!.perioder)
+    }
+
+    @Test
+    fun `skal mappe avslått vedtak til dto`() {
+        val vedtak = VedtakTilsynBarn(behandlingId = UUID.randomUUID(), type = TypeVedtak.AVSLÅTT, avslagBegrunnelse = "begrunnelse")
+
+        val dto = tilsynBarnVedtakService.mapTilDto(vedtak) as AvslagTilsynBarnDto
+
+        assertThat(dto.begrunnelse).isEqualTo(vedtak.avslagBegrunnelse)
+        assertThat(dto.type).isEqualTo(vedtak.type)
     }
 
     private fun vedtak() = VedtakTilsynBarn(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/BeslutteVedtakStegTest.kt
@@ -97,7 +97,7 @@ class BeslutteVedtakStegTest {
         // every { iverksettingDtoMapper.tilDto(any(), any()) } returns mockk()
         // every { iverksett.iverksett(any(), any()) } just Runs
         // every { iverksett.iverksettUtenBrev(any()) } just Runs
-        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGET
+        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGELSE
         // every { vedtaksresultatService.oppdaterBeslutter(any(), any()) } just Runs
         every { behandlingService.oppdaterResultatPåBehandling(any(), any()) } answers {
             behandling(fagsak, id = behandlingId, resultat = secondArg())

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/SendTilBeslutterStegTest.kt
@@ -116,7 +116,7 @@ class SendTilBeslutterStegTest {
         // every { tilbakekrevingService.harSaksbehandlerTattStillingTilTilbakekreving(any()) } returns true
         // every { tilbakekrevingService.finnesÅpenTilbakekrevingsBehandling(any()) } returns true
 
-        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGET
+        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGELSE
         mockBrukerContext(saksbehandlerNavn)
     }
 
@@ -199,7 +199,7 @@ class SendTilBeslutterStegTest {
 
     @Test
     internal fun `skal ikke hente brev når man håndterer behandling med årsak korrigering uten brev`() {
-        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGET
+        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns TypeVedtak.INNVILGELSE
         val behandling = behandling.copy(årsak = BehandlingÅrsak.KORRIGERING_UTEN_BREV)
 
         beslutteVedtakSteg.validerSteg(behandling)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når bruker ikke oppfyller vilkårene må man kunne avslå!

### Hva er gjort?
Har endret den abstrakte controlleren slik at endepunktet for å lagre kun er en funksjon. Så i controlleren for barnetilsyn er det laget et endepunkt for å innvilge og et for å avslå, med egne request typer slik at frontend ikke trenger å bry seg om de generiske klassene. 

Hører sammen med [PR 313 i sak-frontend](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/313)

**PS** 
Nå er TilsynBarn brukt på alle filnavnene her, ville ikke endre dette fordi det ville blitt vanskelig å se hva som var nytt 😢 