### PR TITLE
✨ Skal oppdatere beskrivelsen på oppgave med kommentar fra saksbehandle…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtil.kt
@@ -13,12 +13,14 @@ object SettPåVentBeskrivelseUtil {
         oppgave: Oppgave,
         frist: LocalDate,
         tidspunkt: LocalDateTime = LocalDateTime.now(),
+        kommentar: String?,
     ): String {
         val tilordnetSaksbehandlerBeskrivelse =
             utledTilordnetSaksbehandlerBeskrivelse(oppgave, "")
         return utledBeskrivelsePrefix(tidspunkt) +
             utledOppgavefristBeskrivelse(oppgave, frist).påNyRadEllerTomString() +
             tilordnetSaksbehandlerBeskrivelse.påNyRadEllerTomString() +
+            kommentar.påNyRadEllerTomString() +
             nåværendeBeskrivelse(oppgave)
     }
 
@@ -26,13 +28,15 @@ object SettPåVentBeskrivelseUtil {
         oppgave: Oppgave,
         frist: LocalDate,
         tidspunkt: LocalDateTime = LocalDateTime.now(),
+        endretKommentar: String?,
     ): String {
         val fristBeskrivelse = utledOppgavefristBeskrivelse(oppgave, frist)
-        if (fristBeskrivelse.isEmpty()) {
+        if (fristBeskrivelse.isEmpty() && endretKommentar.isNullOrBlank()) {
             return oppgave.beskrivelse ?: ""
         }
         return utledBeskrivelsePrefix(tidspunkt) +
             fristBeskrivelse.påNyRadEllerTomString() +
+            endretKommentar.påNyRadEllerTomString() +
             nåværendeBeskrivelse(oppgave)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
@@ -82,6 +82,7 @@ class SettPåVentService(
         if (harEndretÅrsaker(settPåVent, dto)) {
             opprettHistorikkInnslag(behandling, StegUtfall.SATT_PÅ_VENT, mapOf("årsaker" to dto.årsaker))
         }
+
         settPåVentRepository.update(settPåVent.copy(årsaker = dto.årsaker, kommentar = dto.kommentar))
 
         val oppgaveResponse = oppdaterOppgave(settPåVent, dto)
@@ -100,6 +101,9 @@ class SettPåVentService(
         dto: OppdaterSettPåVentDto,
     ) = !settPåVent.årsaker.containsAll(dto.årsaker) ||
         settPåVent.årsaker.size != dto.årsaker.size
+
+    private fun harEndretKommentar(settPåVent: SettPåVent, dto: OppdaterSettPåVentDto) =
+        settPåVent.kommentar != dto.kommentar
 
     private fun hentOppgave(behandlingId: UUID): Oppgave {
         val oppgave = hentBehandleSakOppgave(behandlingId)
@@ -137,7 +141,11 @@ class SettPåVentService(
             versjon = oppgave.versjon,
             tilordnetRessurs = "",
             fristFerdigstillelse = dto.frist,
-            beskrivelse = SettPåVentBeskrivelseUtil.settPåVent(oppgave, dto.frist),
+            beskrivelse = SettPåVentBeskrivelseUtil.settPåVent(
+                oppgave = oppgave,
+                frist = dto.frist,
+                kommentar = dto.kommentar,
+            ),
             mappeId = Optional.of(mappeId),
         )
         return oppgaveService.oppdaterOppgave(oppdatertOppgave)
@@ -152,7 +160,11 @@ class SettPåVentService(
             id = settPåVent.oppgaveId,
             versjon = dto.oppgaveVersjon,
             fristFerdigstillelse = dto.frist,
-            beskrivelse = SettPåVentBeskrivelseUtil.oppdaterSettPåVent(oppgave, dto.frist),
+            beskrivelse = SettPåVentBeskrivelseUtil.oppdaterSettPåVent(
+                oppgave,
+                dto.frist,
+                endretKommentar = if (harEndretKommentar(settPåVent, dto)) dto.kommentar else null,
+            ),
         )
         return oppgaveService.oppdaterOppgave(oppdatertOppgave)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtilTest.kt
@@ -34,6 +34,27 @@ class SettPåVentBeskrivelseUtilTest {
                 Oppgave(id = 0, versjon = 0, beskrivelse = "tidligere beskrivelse", tilordnetRessurs = "a100"),
                 LocalDate.of(2023, 1, 1),
                 tidspunkt,
+                "Kommentar fra saksbehandler",
+            )
+            assertThat(beskrivelse).isEqualTo(
+                """
+                --- 05.03.2024 18:00 a100 (a100) ---
+                Oppgave endret frist fra <ingen> til 01.01.2023
+                Oppgave flyttet fra saksbehandler a100 til <ingen>
+                Kommentar fra saksbehandler
+                
+                tidligere beskrivelse
+                """.trimIndent(),
+            )
+        }
+
+        @Test
+        fun `skal oppdatere beskrivelse med ny info og beholde eksisterende beskrivelse - uten kommentar`() {
+            val beskrivelse = SettPåVentBeskrivelseUtil.settPåVent(
+                Oppgave(id = 0, versjon = 0, beskrivelse = "tidligere beskrivelse", tilordnetRessurs = "a100"),
+                LocalDate.of(2023, 1, 1),
+                tidspunkt,
+                null,
             )
             assertThat(beskrivelse).isEqualTo(
                 """
@@ -56,11 +77,13 @@ class SettPåVentBeskrivelseUtilTest {
                 Oppgave(id = 0, versjon = 0, beskrivelse = "tidligere beskrivelse"),
                 LocalDate.of(2023, 1, 1),
                 tidspunkt,
+                "Endret kommentar fra saksbehandler",
             )
             assertThat(beskrivelse).isEqualTo(
                 """
                 --- 05.03.2024 18:00 a100 (a100) ---
                 Oppgave endret frist fra <ingen> til 01.01.2023
+                Endret kommentar fra saksbehandler
 
                 tidligere beskrivelse
                 """.trimIndent(),
@@ -68,12 +91,32 @@ class SettPåVentBeskrivelseUtilTest {
         }
 
         @Test
-        fun `uendret frist`() {
+        fun `uendret frist - endret kommentar`() {
             val frist = LocalDate.of(2023, 1, 1)
             val beskrivelse = SettPåVentBeskrivelseUtil.oppdaterSettPåVent(
                 Oppgave(id = 0, versjon = 0, beskrivelse = "tidligere beskrivelse", fristFerdigstillelse = frist),
                 frist,
                 tidspunkt,
+                "Ny kommentar",
+            )
+            assertThat(beskrivelse).isEqualTo(
+                """
+                --- 05.03.2024 18:00 a100 (a100) ---
+                Ny kommentar
+                
+                tidligere beskrivelse
+                """.trimIndent(),
+            )
+        }
+
+        @Test
+        fun `uendret frist og kommentar`() {
+            val frist = LocalDate.of(2023, 1, 1)
+            val beskrivelse = SettPåVentBeskrivelseUtil.oppdaterSettPåVent(
+                Oppgave(id = 0, versjon = 0, beskrivelse = "tidligere beskrivelse", fristFerdigstillelse = frist),
+                frist,
+                tidspunkt,
+                null,
             )
             assertThat(beskrivelse).isEqualTo(
                 """

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentServiceTest.kt
@@ -78,7 +78,7 @@ class SettPåVentServiceTest : IntegrationTest() {
                 }
 
                 with(oppgaveService.hentOppgave(oppgaveId!!)) {
-                    assertThat(beskrivelse).doesNotContain("ny beskrivelse")
+                    assertThat(beskrivelse).contains("ny beskrivelse")
                     assertThat(fristFerdigstillelse).isEqualTo(settPåVentDto.frist)
                     assertThat(tilordnetRessurs).isNull()
                     assertThat(mappeId?.getOrNull()).isEqualTo(MAPPE_ID_PÅ_VENT.toLong())


### PR DESCRIPTION
…r når sak settes på vent

### Hvorfor er denne endringen nødvendig? ✨
Når en sak settes på vent ønsker vi at kommentar fra saksbehandler også legges i beskrivelsen til behandle sak-oppgaven, så dette også er synlig i gosys/oppgavebenk. Etter ønske og diskusjon med Tone/Marie.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20796