### PR TITLE
Åpne opp for brukere utenfor nicedevice/SKSS

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -11,6 +11,7 @@ spec:
   image: {{image}}
   ingresses:
     - https://tilleggsstonader-sak.intern.dev.nav.no
+    - https://tilleggsstonader-sak.ansatt.dev.nav.no
   liveness:
     path: /internal/status/isAlive
     initialDelay: 30

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -8,9 +8,10 @@ metadata:
 
 spec:
   port: 8080
-  image: {{ image }}
+  image: { { image } }
   ingresses:
     - https://tilleggsstonader-sak.intern.nav.no
+    - https://tilleggsstonader-sak.ansatt.nav.no
   liveness:
     path: /internal/status/isAlive
     initialDelay: 30


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ansatte som ikke er utviklere mister tilgangen til saksbehandlingsløsningen.

Denne endringen vil åpne opp for saksbehandlere på mobilitetsløsninger uten naisdevice eller Chrome SKSS.

- Ingresser på *.ansatt.nav.no  / *.ansatt.dev.nav.no eksponeres til internett, men bak innlogging med compliant device.

- Ingresser på *.intern.nav.no / *.intern.dev.nav.no er kun tilgjengelige på interne nettverk. Man må altså ha tilgang til disse, f.eks. via Chrome SKSS eller via naisdevice.

ROS: https://apps.powerapps.com/play/f8517640-ea01-46e2-9c09-be6b05013566?app=567&ID=1670