### PR TITLE
Lagt til orderBy og order til henting av oppgaver for å fikse paginer…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240214140223_83c31de"
 val tilleggsstønaderLibsVersion = "2024.05.08-08.38.544e65c0c5a6"
-val tilleggsstønaderKontrakterVersion = "2024.05.13-15.21.90cbfb23b578"
+val tilleggsstønaderKontrakterVersion = "2024.05.21-17.41.d2a32e2a25bf"
 val tokenSupportVersion = "4.1.4"
 val wiremockVersion = "3.5.2"
 val mockkVersion = "1.13.10"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
@@ -253,6 +253,7 @@ class OppgaveService(
                 tema = Tema.TSO,
                 oppgavetype = Oppgavetype.BehandleSak,
                 limit = limit,
+                offset = 0,
                 opprettetTomTidspunkt = opprettetTomTidspunktPåBehandleSakOppgave,
             ),
         )
@@ -262,6 +263,7 @@ class OppgaveService(
                 tema = Tema.TSO,
                 oppgavetype = Oppgavetype.BehandleUnderkjentVedtak,
                 limit = limit,
+                offset = 0,
             ),
         )
 
@@ -270,6 +272,7 @@ class OppgaveService(
                 tema = Tema.TSO,
                 oppgavetype = Oppgavetype.GodkjenneVedtak,
                 limit = limit,
+                offset = 0,
             ),
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/FinnOppgaveRequestDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/FinnOppgaveRequestDto.kt
@@ -4,6 +4,8 @@ import no.nav.tilleggsstonader.kontrakter.felles.Behandlingstema
 import no.nav.tilleggsstonader.kontrakter.felles.Tema
 import no.nav.tilleggsstonader.kontrakter.oppgave.FinnOppgaveRequest
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
+import no.nav.tilleggsstonader.kontrakter.oppgave.Sorteringsfelt
+import no.nav.tilleggsstonader.kontrakter.oppgave.Sorteringsrekkefølge
 import java.time.LocalDate
 
 data class FinnOppgaveRequestDto(
@@ -24,6 +26,8 @@ data class FinnOppgaveRequestDto(
     val ident: String?,
     val limit: Long = 150, // TODO slett når frontend implementert limit og offset
     val offset: Long = 0, // TODO slett når frontend implementert limit og offset
+    val orderBy: Sorteringsfelt = Sorteringsfelt.OPPRETTET_TIDSPUNKT, // TODO slett når frontend implementert
+    val order: Sorteringsrekkefølge = Sorteringsrekkefølge.ASC, // TODO slett når frontend implementert
 ) {
 
     fun tilFinnOppgaveRequest(aktørid: String? = null): FinnOppgaveRequest =
@@ -55,5 +59,7 @@ data class FinnOppgaveRequestDto(
             mappeId = this.mappeId,
             limit = this.limit,
             offset = this.offset,
+            sorteringsrekkefolge = order,
+            sorteringsfelt = orderBy,
         )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientConfig.kt
@@ -49,7 +49,9 @@ class OppgaveClientConfig {
                 .filter { oppgave -> request.oppgavetype?.let { oppgave.oppgavetype == it.value } ?: true }
                 .filter { oppgave -> request.behandlingstype?.let { oppgave.behandlingstype == it.value } ?: true }
                 .toList()
-            FinnOppgaveResponseDto(antallTreffTotalt = oppgavelager.size.toLong(), oppgaver = oppgaver)
+            val toIndex = minOf((request.offset + request.limit).toInt(), oppgaver.size)
+            val paginerteOppgaver = oppgaver.subList(request.offset.toInt(), toIndex)
+            FinnOppgaveResponseDto(antallTreffTotalt = oppgaver.size.toLong(), oppgaver = paginerteOppgaver)
         }
 
         every { oppgaveClient.finnOppgaveMedId(any()) } answers {


### PR DESCRIPTION
…ing i frontend

### Hvorfor er denne endringen nødvendig? ✨
Ønsker at frontend paginerer med rest-kall for å endre side, og at man ikke henter 150 oppgaver fra oppgave, som den sen selv paginerer.
Ulempen er at sortering på eks opprettetTid ikke virker nå når man kun henter 150 oppgaver av idag 186, då sortering gjøres i frontend. Då vil det være 36 som ikke er med i uttrekket og vil aldri vises. 

Litt koblet til https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20858