### PR TITLE
Kaster feil hvis man oppretter AndelTilkjentYtelse med fom som er lør…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain
 
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.util.erLørdagEllerSøndag
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.annotation.Version
@@ -41,6 +42,9 @@ data class AndelTilkjentYtelse(
     init {
         feilHvis(YearMonth.from(fom) != YearMonth.from(tom)) {
             "For å unngå at man iverksetter frem i tiden skal perioder kun løpe over 1 måned"
+        }
+        feilHvis(satstype == Satstype.DAG && fom.erLørdagEllerSøndag()) {
+            "Dagsats som begynner en lørdag eller søndag vil ikke bli utbetalt"
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
@@ -5,11 +5,13 @@ import no.nav.tilleggsstonader.libs.utils.osloNow
 import no.nav.tilleggsstonader.sak.util.DatoFormat.DATE_FORMAT_NORSK
 import no.nav.tilleggsstonader.sak.util.DatoUtil.dagensDato
 import no.nav.tilleggsstonader.sak.util.DatoUtil.dagensDatoMedTid
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Period
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
 
 object DatoFormat {
 
@@ -83,3 +85,11 @@ fun LocalDateTime.harGåttAntallTimer(timer: Int) =
 fun dagensDatoMedTidNorskFormat(): String = dagensDatoMedTid().medGosysTid()
 
 fun LocalDateTime.medGosysTid(): String = this.format(DatoFormat.GOSYS_DATE_TIME)
+
+fun LocalDate.erLørdagEllerSøndag() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY
+
+fun LocalDate.datoEllerNesteMandagHvisLørdagEllerSøndag() = if (this.erLørdagEllerSøndag()) {
+    with(TemporalAdjusters.next(DayOfWeek.MONDAY))
+} else {
+    this
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -18,6 +18,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.springframework.stereotype.Service
+import java.time.DayOfWeek
 import java.time.LocalDate
 
 @Service
@@ -90,11 +91,16 @@ class TilsynBarnBeregnYtelseSteg(
     ) {
         val andelerTilkjentYtelse = beregningsresultat.perioder.flatMap {
             it.beløpsperioder.map { beløpsperiode ->
+                val satstype = Satstype.DAG
+                val day = beløpsperiode.dato.dayOfWeek
+                feilHvis(day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY) {
+                    "Skal ikke opprette perioder som begynner på en helgdag for satstype=$satstype"
+                }
                 AndelTilkjentYtelse(
                     beløp = beløpsperiode.beløp,
                     fom = beløpsperiode.dato,
                     tom = beløpsperiode.dato,
-                    satstype = Satstype.DAG,
+                    satstype = satstype,
                     type = beløpsperiode.målgruppe.tilTypeAndel(),
                     kildeBehandlingId = saksbehandling.id,
                 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregningService.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.erSortert
 import no.nav.tilleggsstonader.kontrakter.felles.overlapper
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilAktiviteterPerMånedPerType
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilDagerPerUke
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBeregningUtil.tilUke
@@ -73,7 +74,7 @@ class TilsynBarnBeregningService(
     private fun lagBeløpsperioder(dagsats: BigDecimal, it: Beregningsgrunnlag): List<Beløpsperiode> {
         return it.stønadsperioderGrunnlag.map {
             Beløpsperiode(
-                dato = it.stønadsperiode.fom,
+                dato = it.stønadsperiode.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
                 beløp = beregnBeløp(dagsats, it.antallDager),
                 målgruppe = it.stønadsperiode.målgruppe,
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjen
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.TotrinnInternStatus
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.domain.TotrinnskontrollRepository
@@ -386,7 +387,7 @@ class IverksettServiceTest : IntegrationTest() {
     }
 
     private fun Collection<AndelTilkjentYtelse>.forMåned(yearMonth: YearMonth) =
-        this.single { it.fom == yearMonth.atDay(1) }
+        this.single { it.fom == yearMonth.atDay(1).datoEllerNesteMandagHvisLørdagEllerSøndag() }
 
     fun AndelTilkjentYtelse.assertHarStatusOgId(statusIverksetting: StatusIverksetting, iverksettingId: UUID? = null) {
         assertThat(this.statusIverksetting).isEqualTo(statusIverksetting)
@@ -412,7 +413,7 @@ class IverksettServiceTest : IntegrationTest() {
 
     private fun lagAndel(behandling: Behandling, måned: YearMonth, beløp: Int = 10) = andelTilkjentYtelse(
         kildeBehandlingId = behandling.id,
-        fom = måned.atDay(1),
+        fom = måned.atDay(1).datoEllerNesteMandagHvisLørdagEllerSøndag(),
         tom = måned.atEndOfMonth(),
         beløp = beløp,
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepositoryTest.kt
@@ -37,14 +37,14 @@ class AndelTilkjentYtelseRepositoryTest : IntegrationTest() {
         val andel1 = andelTilkjentYtelse(
             kildeBehandlingId = behandling.id,
             beløp = 100,
-            fom = LocalDate.of(2023, 1, 1),
-            tom = LocalDate.of(2023, 1, 1),
+            fom = LocalDate.of(2023, 1, 2),
+            tom = LocalDate.of(2023, 1, 2),
         )
         val andel2 = andelTilkjentYtelse(
             kildeBehandlingId = behandling.id,
             beløp = 200,
-            fom = LocalDate.of(2023, 1, 1),
-            tom = LocalDate.of(2023, 1, 1),
+            fom = LocalDate.of(2023, 1, 2),
+            tom = LocalDate.of(2023, 1, 2),
         )
         tilkjentYtelseRepository.insert(
             TilkjentYtelse(
@@ -77,8 +77,8 @@ class AndelTilkjentYtelseRepositoryTest : IntegrationTest() {
         val andel1 = andelTilkjentYtelse(
             kildeBehandlingId = behandling.id,
             beløp = 100,
-            fom = LocalDate.of(2023, 1, 1),
-            tom = LocalDate.of(2023, 1, 1),
+            fom = LocalDate.of(2023, 1, 2),
+            tom = LocalDate.of(2023, 1, 2),
         )
         tilkjentYtelseRepository.insert(
             TilkjentYtelse(
@@ -156,8 +156,8 @@ class AndelTilkjentYtelseRepositoryTest : IntegrationTest() {
             val andel1 = andelTilkjentYtelse(
                 kildeBehandlingId = behandling.id,
                 beløp = 100,
-                fom = LocalDate.of(2023, 1, 1),
-                tom = LocalDate.of(2023, 1, 1),
+                fom = LocalDate.of(2023, 1, 2),
+                tom = LocalDate.of(2023, 1, 2),
                 statusIverksetting = statusIverksetting,
             )
             tilkjentYtelseRepository.insert(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.util
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.YearMonth
 
 class DatoUtilTest {
 
@@ -26,5 +27,21 @@ class DatoUtilTest {
     fun `antallÅrSiden skal returnere 1 hvis vi sender inn gårsdagens dato for ett år siden`() {
         val gårsdagensDatoIFjor = osloDateNow().minusYears(1).minusDays(1)
         assertThat(antallÅrSiden(gårsdagensDatoIFjor)).isEqualTo(1)
+    }
+
+    @Test
+    fun `nesteMandagHvisHelg skal håndtere dagens dato hvis lørdag eller søndag`() {
+        val april = YearMonth.of(2024, 4)
+        listOf(
+            april.atDay(1) to april.atDay(1),
+            april.atDay(2) to april.atDay(2),
+            april.atDay(3) to april.atDay(3),
+            april.atDay(4) to april.atDay(4),
+            april.atDay(5) to april.atDay(5),
+            april.atDay(6) to april.atDay(8),
+            april.atDay(7) to april.atDay(8),
+        ).forEach {
+            assertThat(it.first.datoEllerNesteMandagHvisLørdagEllerSøndag()).isEqualTo(it.second)
+        }
     }
 }

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_helgdager.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_helgdager.feature
@@ -1,0 +1,60 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Beregning - Håndtering av helgdager
+
+  Scenario: Håndtering av periode som starter en søndag
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 01.01.2023 | 31.01.2023 | UTDANNING | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 01.01.2023 | 31.01.2023 | UTDANNING | 5               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2023 | 01.2023 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 01.2023 | 29.53   | 22           | 1000   | 650         |
+
+    Så forvent følgende stønadsperiodeGrunnlag for: 01.2023
+      | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |
+      | 01.01.2023 | 31.01.2023 | AAP       | UTDANNING | 1                  | 22           |
+
+    Så forvent følgende beløpsperioder for: 01.2023
+      | Dato       | Beløp | Målgruppe |
+      # 01.01.2023 er en søndag, lager en beløpsperiode som er
+      | 02.01.2023 | 650   | AAP       |
+
+  Scenario: Håndtering av periode som starter en lørdag
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 01.04.2023 | 30.04.2023 | UTDANNING | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 01.04.2023 | 30.04.2023 | UTDANNING | 5               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 04.2023 | 04.2023 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 04.2023 | 29.53   | 20           | 1000   | 591         |
+
+    Så forvent følgende stønadsperiodeGrunnlag for: 04.2023
+      | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |
+      | 01.04.2023 | 30.04.2023 | AAP       | UTDANNING | 1                  | 20           |
+
+    Så forvent følgende beløpsperioder for: 04.2023
+      | Dato       | Beløp | Målgruppe |
+      # 01.04.2023 er en lørdag, lager en beløpsperiode som er
+      | 03.04.2023 | 591   | AAP       |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/fullAktivitet/flere_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/fullAktivitet/flere_stønadsperioder.feature
@@ -30,7 +30,8 @@ Egenskap: Beregning - Flere stønadsperioder med full aktivitet
 
     Så forvent følgende beløpsperioder for: 01.2023
       | Dato       | Beløp | Målgruppe       |
-      | 01.01.2023 | 236   | OVERGANGSSTØNAD |
+      # dato skal egentligen være 01.01.2023 men er en søndag
+      | 02.01.2023 | 236   | OVERGANGSSTØNAD |
       | 12.01.2023 | 413   | AAP             |
 
   Scenario: Flere stønadsperioder innenfor samme måned - ulike aktiviteter:
@@ -63,5 +64,5 @@ Egenskap: Beregning - Flere stønadsperioder med full aktivitet
 
     Så forvent følgende beløpsperioder for: 01.2023
       | Dato       | Beløp | Målgruppe       |
-      | 01.01.2023 | 236   | OVERGANGSSTØNAD |
+      | 02.01.2023 | 236   | OVERGANGSSTØNAD |
       | 12.01.2023 | 413   | AAP             |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/komplisert_case.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/komplisert_case.feature
@@ -45,7 +45,7 @@ Egenskap: Beregning - Komplisert scenario
 
     Så forvent følgende beløpsperioder for: 01.2023
       | Dato       | Beløp | Målgruppe |
-      | 01.01.2023 | 413   | AAP       |
+      | 02.01.2023 | 413   | AAP       |
 
     Så forvent følgende stønadsperiodeGrunnlag for: 02.2023
       | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |
@@ -71,7 +71,7 @@ Egenskap: Beregning - Komplisert scenario
 
     Så forvent følgende beløpsperioder for: 04.2023
       | Dato       | Beløp | Målgruppe       |
-      | 01.04.2023 | 1181  | OVERGANGSSTØNAD |
+      | 03.04.2023 | 1181  | OVERGANGSSTØNAD |
 
     Så forvent følgende stønadsperiodeGrunnlag for: 05.2023
       | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |


### PR DESCRIPTION
…dag eller søndag

### Hvorfor er denne endringen nødvendig? ✨
Vi skal ikke opprette andeler som begynner på en lørdag eller søndag då det ikke blir utbetalt noe for slike perioder.
Beregning utleder "riktig dag" når man beregner beløpsperiode. Hvis stønadsperioden begynner en søndag så blir datoet neste dag, som er en mandag.

Vi må også patche data som finnes i databasen.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21215
