### PR TITLE
Vedtaksstatistikk skal ha et felt om endret_tid som er siste tidspunk…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/Vedtaksstatistikk.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/Vedtaksstatistikk.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.StønadstypeDvh.BARNETILSYN
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
@@ -56,9 +57,16 @@ data class Vedtaksstatistikk(
     @Column("arsaker_avslag")
     val årsakerAvslag: ÅrsakAvslagDvh.JsonWrapper? = null,
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
+    val endretTid: LocalDateTime = opprettetTid,
     // TODO: Legg inn årsak til revurdering når revurdering kommer i løsningen
     // TODO: EØS-informasjon når det kommer støtte for det i løsningen
-)
+) {
+    init {
+        feilHvis(endretTid < opprettetTid) {
+            "EndretTid=$endretTid kan ikke være før opprettetTid=$opprettetTid"
+        }
+    }
+}
 
 enum class StønadstypeDvh {
     BARNETILSYN,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/Vedtaksstatistikk.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/Vedtaksstatistikk.kt
@@ -21,6 +21,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkår
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
 import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -28,6 +29,10 @@ import java.util.UUID
 
 // TODO: Vurder om dette bør flyttes til kontrakter
 
+/**
+ * @param endretTid skal oppdateres i tilfelle man må patche data på en behandling.
+ * Man skal då beholde den samme raden for å beholde opprettet_tid, men oppdatere felter og oppdatere
+ */
 data class Vedtaksstatistikk(
     @Id
     val id: UUID = UUID.randomUUID(),
@@ -57,6 +62,7 @@ data class Vedtaksstatistikk(
     @Column("arsaker_avslag")
     val årsakerAvslag: ÅrsakAvslagDvh.JsonWrapper? = null,
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
+    @LastModifiedDate
     val endretTid: LocalDateTime = opprettetTid,
     // TODO: Legg inn årsak til revurdering når revurdering kommer i løsningen
     // TODO: EØS-informasjon når det kommer støtte for det i løsningen

--- a/src/main/resources/db/migration/V42__vedtakstatistikk_endret_tid.sql
+++ b/src/main/resources/db/migration/V42__vedtakstatistikk_endret_tid.sql
@@ -1,0 +1,6 @@
+ALTER TABLE vedtaksstatistikk
+    ADD COLUMN endret_tid TIMESTAMP(3);
+
+UPDATE vedtaksstatistikk SET endret_tid = opprettet_tid;
+
+ALTER TABLE vedtaksstatistikk ALTER COLUMN endret_tid SET NOT NULL;


### PR DESCRIPTION
…tet dataen ble endret, i tilfelle data må patches

### Hvorfor er denne endringen nødvendig? ✨
Har patchet data i vedtaks- og andelstabellen pga feil dato som ble satt.
Vi må patche dataen vi har sendt til DVH. Av den grunnen har vi bestemt at vi legger på et felt "endret_tid" som oppdateres hvis man patcher data i DVH. Då kan de lese den dataen på nytt. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21276
