### PR TITLE
Henter fakta fra arena for å vise dato til når det finnes vedtak i Ar…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240522090805_0e9c7a6"
 val tilleggsstønaderLibsVersion = "2024.05.27-10.56.b9a67bfd6080"
-val tilleggsstønaderKontrakterVersion = "2024.05.30-13.50.30622be4473d"
+val tilleggsstønaderKontrakterVersion = "2024.06.03-12.20.c0262a00841a"
 val tokenSupportVersion = "4.1.7"
 val wiremockVersion = "3.6.0"
 val mockkVersion = "1.13.11"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
@@ -18,6 +18,7 @@ data class BehandlingFaktaDto(
     val aktivitet: FaktaAktivtet,
     val barn: List<FaktaBarn>,
     val dokumentasjon: FaktaDokumentasjon?,
+    val arena: ArenaFakta?,
 )
 
 data class FaktaHovedytelse(
@@ -88,4 +89,13 @@ data class SøknadsgrunnlagBarn(
     val type: TypeBarnepass,
     val startetIFemte: JaNei?,
     val årsak: ÅrsakBarnepass?,
+)
+
+/**
+ * @param finnesVedtak true hvis man har vedtak for gitt stønadstype med eller uten utfall.
+ * I tillfelle man ennå ikke vedtatt vedtaket så er ikke utfall satt
+ */
+data class ArenaFakta(
+    val finnesVedtak: Boolean,
+    val vedtakTom: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaDto.kt
@@ -91,11 +91,6 @@ data class SøknadsgrunnlagBarn(
     val årsak: ÅrsakBarnepass?,
 )
 
-/**
- * @param finnesVedtak true hvis man har vedtak for gitt stønadstype med eller uten utfall.
- * I tillfelle man ennå ikke vedtatt vedtaket så er ikke utfall satt
- */
 data class ArenaFakta(
-    val finnesVedtak: Boolean,
     val vedtakTom: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.behandling.fakta
 
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlagsdata
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
@@ -18,6 +19,7 @@ class BehandlingFaktaService(
     private val søknadService: SøknadService,
     private val barnService: BarnService,
     private val faktaArbeidOgOppholdMapper: FaktaArbeidOgOppholdMapper,
+    private val arenaService: ArenaService,
 ) {
 
     fun hentFakta(
@@ -31,7 +33,13 @@ class BehandlingFaktaService(
             aktivitet = mapAktivitet(søknad),
             barn = mapBarn(grunnlagsdata, søknad, behandlingId),
             dokumentasjon = søknad?.let { mapDokumentasjon(it, grunnlagsdata) },
+            arena = arenaFakta(behandlingId),
         )
+    }
+
+    // TODO flytte til grunnlag - dette skal kun være her for å teste at det vises riktig i frontend
+    private fun arenaFakta(behandlingId: UUID): ArenaFakta {
+        return FaktaArenaMapper.mapFaktaArena(arenaService.hentStatus(behandlingId))
     }
 
     private fun mapAktivitet(søknad: SøknadBarnetilsyn?) =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapper.kt
@@ -1,0 +1,15 @@
+package no.nav.tilleggsstonader.sak.behandling.fakta
+
+import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
+import no.nav.tilleggsstonader.sak.util.isEqualOrAfter
+import java.time.LocalDate
+
+object FaktaArenaMapper {
+
+    fun mapFaktaArena(status: ArenaStatusDto): ArenaFakta = with(status.vedtak) {
+        ArenaFakta(
+            finnesVedtak = harVedtak || harVedtakUtenUtfall,
+            vedtakTom = vedtakTom?.takeIf { it.isEqualOrAfter(LocalDate.now().minusMonths(3)) },
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapper.kt
@@ -8,7 +8,6 @@ object FaktaArenaMapper {
 
     fun mapFaktaArena(status: ArenaStatusDto): ArenaFakta = with(status.vedtak) {
         ArenaFakta(
-            finnesVedtak = harVedtak || harVedtakUtenUtfall,
             vedtakTom = vedtakTom?.takeIf { it.isEqualOrAfter(LocalDate.now().minusMonths(3)) },
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaService.kt
@@ -4,15 +4,23 @@ import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
 import no.nav.tilleggsstonader.kontrakter.felles.IdenterRequest
 import no.nav.tilleggsstonader.kontrakter.felles.IdenterStønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
 class ArenaService(
     private val arenaClient: ArenaClient,
     private val personService: PersonService,
+    private val behandlingService: BehandlingService,
 ) {
+
+    fun hentStatus(behandlingId: UUID): ArenaStatusDto {
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+        return hentStatus(saksbehandling.ident, saksbehandling.stønadstype)
+    }
 
     fun hentStatus(ident: String, stønadstype: Stønadstype): ArenaStatusDto {
         val identer = personService.hentPersonIdenter(ident).identer()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaServiceTest.kt
@@ -4,6 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KodeverkServiceUtil.mockedKodeverkService
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.arenaStatusDto
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.util.FileUtil.assertFileIsEqual
@@ -29,11 +31,14 @@ internal class BehandlingFaktaServiceTest {
     val søknadService = mockk<SøknadService>()
     val barnService = mockk<BarnService>()
     val faktaArbeidOgOppholdMapper = FaktaArbeidOgOppholdMapper(mockedKodeverkService())
+    val arenaService = mockk<ArenaService>()
+
     val service = BehandlingFaktaService(
         grunnlagsdataService,
         søknadService,
         barnService,
         faktaArbeidOgOppholdMapper,
+        arenaService,
     )
 
     val behandlingId = UUID.randomUUID()
@@ -41,6 +46,7 @@ internal class BehandlingFaktaServiceTest {
     @BeforeEach
     fun setUp() {
         every { barnService.finnBarnPåBehandling(any()) } returns emptyList()
+        every { arenaService.hentStatus(any()) } returns arenaStatusDto()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapperTest.kt
@@ -1,0 +1,55 @@
+package no.nav.tilleggsstonader.sak.behandling.fakta
+
+import no.nav.tilleggsstonader.sak.behandling.fakta.FaktaArenaMapper.mapFaktaArena
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.arenaStatusDto
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.vedtakStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class FaktaArenaMapperTest {
+
+    @Nested
+    inner class FinnesVedtak {
+
+        @Test
+        fun `finnes ikke vedtak hvis harVedtak=false og harVedtakUtenUtfall=false`() {
+            assertThat(mapFaktaArena(arenaStatusDto()).finnesVedtak).isFalse
+        }
+
+        @Test
+        fun `finnes vedtak hvis harVedtak eller harVedtakUtenUtfall er true`() {
+            listOf(
+                Pair(true, false),
+                Pair(false, true),
+                Pair(true, true),
+            ).forEach {
+                val vedtakStatus = vedtakStatus(harVedtak = it.first, harVedtakUtenUtfall = it.second)
+                assertThat(mapFaktaArena(arenaStatusDto(vedtakStatus)).finnesVedtak).isTrue
+            }
+        }
+    }
+
+    @Nested
+    inner class VedtakTom {
+        @Test
+        fun `skal mappe vedtakTom fra vedtakStatus`() {
+            listOf(LocalDate.now(), null).forEach {
+                assertThat(mapFaktaArena(arenaStatusDto(vedtakStatus(vedtakTom = it))).vedtakTom)
+                    .isEqualTo(it)
+            }
+        }
+
+        @Test
+        fun `skal mappe vedtakTom hvis det er innen 3mnd då det ikke er interessant å vise vedtak som slutter før 3mnd bak i tiden`() {
+            val dato3mndsiden = LocalDate.now().minusMonths(3)
+
+            assertThat(mapFaktaArena(arenaStatusDto(vedtakStatus(vedtakTom = dato3mndsiden.minusDays(1)))).vedtakTom).isNull()
+
+            listOf(dato3mndsiden, dato3mndsiden.plusDays(1)).forEach {
+                assertThat(mapFaktaArena(arenaStatusDto(vedtakStatus(vedtakTom = it))).vedtakTom).isEqualTo(it)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/FaktaArenaMapperTest.kt
@@ -11,27 +11,6 @@ import java.time.LocalDate
 class FaktaArenaMapperTest {
 
     @Nested
-    inner class FinnesVedtak {
-
-        @Test
-        fun `finnes ikke vedtak hvis harVedtak=false og harVedtakUtenUtfall=false`() {
-            assertThat(mapFaktaArena(arenaStatusDto()).finnesVedtak).isFalse
-        }
-
-        @Test
-        fun `finnes vedtak hvis harVedtak eller harVedtakUtenUtfall er true`() {
-            listOf(
-                Pair(true, false),
-                Pair(false, true),
-                Pair(true, true),
-            ).forEach {
-                val vedtakStatus = vedtakStatus(harVedtak = it.first, harVedtakUtenUtfall = it.second)
-                assertThat(mapFaktaArena(arenaStatusDto(vedtakStatus)).finnesVedtak).isTrue
-            }
-        }
-    }
-
-    @Nested
     inner class VedtakTom {
         @Test
         fun `skal mappe vedtakTom fra vedtakStatus`() {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/ArenaClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/ArenaClientConfig.kt
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
+import java.time.LocalDate
 
 @Configuration
 @Profile("mock-arena")
@@ -30,7 +31,12 @@ class ArenaClientConfig {
             clearMocks(client)
             every { client.hentStatus(any()) } returns ArenaStatusDto(
                 SakStatus(harAktivSakUtenVedtak = false),
-                VedtakStatus(harVedtak = false, harAktivtVedtak = false, harVedtakUtenUtfall = false),
+                VedtakStatus(
+                    harVedtak = false,
+                    harAktivtVedtak = false,
+                    harVedtakUtenUtfall = false,
+                    vedtakTom = LocalDate.now().minusDays(10),
+                ),
             )
             every { client.harSaker(any()) } returns ArenaStatusHarSakerDto(true)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaStatusDtoUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaStatusDtoUtil.kt
@@ -1,0 +1,29 @@
+package no.nav.tilleggsstonader.sak.opplysninger.arena
+
+import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
+import no.nav.tilleggsstonader.kontrakter.arena.SakStatus
+import no.nav.tilleggsstonader.kontrakter.arena.VedtakStatus
+import java.time.LocalDate
+
+object ArenaStatusDtoUtil {
+
+    fun arenaStatusDto(
+        vedtakStatus: VedtakStatus = vedtakStatus(),
+        sakStatus: SakStatus = SakStatus(false),
+    ) = ArenaStatusDto(
+        sak = sakStatus,
+        vedtak = vedtakStatus,
+    )
+
+    fun vedtakStatus(
+        harVedtak: Boolean = false,
+        harAktivtVedtak: Boolean = false,
+        harVedtakUtenUtfall: Boolean = false,
+        vedtakTom: LocalDate? = null,
+    ) = VedtakStatus(
+        harVedtak = harVedtak,
+        harAktivtVedtak = harAktivtVedtak,
+        harVedtakUtenUtfall = harVedtakUtenUtfall,
+        vedtakTom = vedtakTom,
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/VilkårGrunnlagUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/VilkårGrunnlagUtil.kt
@@ -22,6 +22,7 @@ object VilkårGrunnlagUtil {
             barn = barn,
             dokumentasjon = null,
             søknadMottattTidspunkt = null,
+            arena = null,
         )
 
     fun grunnlagBarn(

--- a/src/test/resources/vilkår/vilkårGrunnlagDto.json
+++ b/src/test/resources/vilkår/vilkårGrunnlagDto.json
@@ -54,5 +54,9 @@
         "dokumentInfoId" : "688ad1dc-e35e-4ab8-a534-17c6e691463f"
       } ]
     } ]
+  },
+  "arena" : {
+    "finnesVedtak" : false,
+    "vedtakTom" : null
   }
 }

--- a/src/test/resources/vilkår/vilkårGrunnlagDto.json
+++ b/src/test/resources/vilkår/vilkårGrunnlagDto.json
@@ -56,7 +56,6 @@
     } ]
   },
   "arena" : {
-    "finnesVedtak" : false,
     "vedtakTom" : null
   }
 }


### PR DESCRIPTION
…ena.

### Hvorfor er denne endringen nødvendig? ✨

For å unngå at saksbehandler legger inn overlappende vedtak er det ønskelig å vise informasjon om at det finnes vedtak i Arena.

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/362

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21211
