### PR TITLE
Flyttet arena-fakta til grunnlag

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaService.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.behandling.fakta
 
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
-import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlagsdata
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
@@ -19,7 +18,6 @@ class BehandlingFaktaService(
     private val søknadService: SøknadService,
     private val barnService: BarnService,
     private val faktaArbeidOgOppholdMapper: FaktaArbeidOgOppholdMapper,
-    private val arenaService: ArenaService,
 ) {
 
     fun hentFakta(
@@ -33,13 +31,16 @@ class BehandlingFaktaService(
             aktivitet = mapAktivitet(søknad),
             barn = mapBarn(grunnlagsdata, søknad, behandlingId),
             dokumentasjon = søknad?.let { mapDokumentasjon(it, grunnlagsdata) },
-            arena = arenaFakta(behandlingId),
+            arena = arenaFakta(grunnlagsdata),
         )
     }
 
-    // TODO flytte til grunnlag - dette skal kun være her for å teste at det vises riktig i frontend
-    private fun arenaFakta(behandlingId: UUID): ArenaFakta {
-        return FaktaArenaMapper.mapFaktaArena(arenaService.hentStatus(behandlingId))
+    private fun arenaFakta(grunnlagsdata: Grunnlagsdata): ArenaFakta? {
+        return grunnlagsdata.grunnlag.arena?.let {
+            ArenaFakta(
+                vedtakTom = it.vedtakTom,
+            )
+        }
     }
 
     private fun mapAktivitet(søknad: SøknadBarnetilsyn?) =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaService.kt
@@ -4,24 +4,18 @@ import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
 import no.nav.tilleggsstonader.kontrakter.felles.IdenterRequest
 import no.nav.tilleggsstonader.kontrakter.felles.IdenterStønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class ArenaService(
     private val arenaClient: ArenaClient,
     private val personService: PersonService,
-    private val behandlingService: BehandlingService,
 ) {
 
-    fun hentStatus(behandlingId: UUID): ArenaStatusDto {
-        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
-        return hentStatus(saksbehandling.ident, saksbehandling.stønadstype)
-    }
-
+    @Cacheable("arena-status-ident")
     fun hentStatus(ident: String, stønadstype: Stønadstype): ArenaStatusDto {
         val identer = personService.hentPersonIdenter(ident).identer()
         return arenaClient.hentStatus(IdenterStønadstype(identer, stønadstype))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagArenaMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagArenaMapper.kt
@@ -1,13 +1,13 @@
-package no.nav.tilleggsstonader.sak.behandling.fakta
+package no.nav.tilleggsstonader.sak.opplysninger.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
 import no.nav.tilleggsstonader.sak.util.isEqualOrAfter
 import java.time.LocalDate
 
-object FaktaArenaMapper {
+object GrunnlagArenaMapper {
 
-    fun mapFaktaArena(status: ArenaStatusDto): ArenaFakta = with(status.vedtak) {
-        ArenaFakta(
+    fun mapFaktaArena(status: ArenaStatusDto): GrunnlagArena = with(status.vedtak) {
+        GrunnlagArena(
             vedtakTom = vedtakTom?.takeIf { it.isEqualOrAfter(LocalDate.now().minusMonths(3)) },
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagPatchController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagPatchController.kt
@@ -1,0 +1,37 @@
+package no.nav.tilleggsstonader.sak.opplysninger.grunnlag
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/api/grunnlag/patch"])
+@ProtectedWithClaims(issuer = "azuread")
+class GrunnlagPatchController(
+    private val behandlingRepository: BehandlingRepository,
+    private val grunnlagsdataRepository: GrunnlagsdataRepository,
+    private val arenaService: ArenaService,
+) {
+
+    @PostMapping
+    fun patchGrunnlag() {
+        behandlingRepository.findAll()
+            .filter { setOf(BehandlingStatus.UTREDES, BehandlingStatus.OPPRETTET, BehandlingStatus.SATT_PÅ_VENT).contains(it.status) }
+            .forEach {
+                val grunnlag = grunnlagsdataRepository.findByIdOrThrow(it.id)
+                if (grunnlag.grunnlag.arena == null) {
+                    val saksbehandling = behandlingRepository.finnSaksbehandling(it.id)
+                    val statusArena = arenaService.hentStatus(saksbehandling.ident, saksbehandling.stønadstype)
+                    val grunnlagArena = GrunnlagArenaMapper.mapFaktaArena(statusArena)
+
+                    val oppdatertGrunnlag = grunnlag.grunnlag.copy(arena = grunnlagArena)
+                    grunnlagsdataRepository.update(grunnlag.copy(grunnlag = oppdatertGrunnlag))
+                }
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/Grunnlagsdata.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/Grunnlagsdata.kt
@@ -18,6 +18,11 @@ data class Grunnlag(
     val navn: Navn,
     val fødsel: Fødsel?,
     val barn: List<GrunnlagBarn>,
+    val arena: GrunnlagArena? = null,
+)
+
+data class GrunnlagArena(
+    val vedtakTom: LocalDate?,
 )
 
 data class Fødsel(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagsdataService.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
 import no.nav.tilleggsstonader.sak.opplysninger.dto.SøkerMedBarn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gjeldende
@@ -19,6 +20,7 @@ class GrunnlagsdataService(
     private val barnService: BarnService,
     private val personService: PersonService,
     private val grunnlagsdataRepository: GrunnlagsdataRepository,
+    private val arenaService: ArenaService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -53,7 +55,13 @@ class GrunnlagsdataService(
             navn = person.søker.navn.gjeldende().tilNavn(),
             fødsel = mapFødsel(person),
             barn = mapBarn(behandling, person),
+            arena = hentGrunnlagArena(behandling),
         )
+    }
+
+    private fun hentGrunnlagArena(behandling: Saksbehandling): GrunnlagArena {
+        val statusArena = arenaService.hentStatus(behandling.ident, behandling.stønadstype)
+        return GrunnlagArenaMapper.mapFaktaArena(statusArena)
     }
 
     private fun mapFødsel(person: SøkerMedBarn): Fødsel {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaServiceTest.kt
@@ -4,8 +4,6 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KodeverkServiceUtil.mockedKodeverkService
-import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
-import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.arenaStatusDto
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.util.FileUtil.assertFileIsEqual
@@ -31,14 +29,12 @@ internal class BehandlingFaktaServiceTest {
     val søknadService = mockk<SøknadService>()
     val barnService = mockk<BarnService>()
     val faktaArbeidOgOppholdMapper = FaktaArbeidOgOppholdMapper(mockedKodeverkService())
-    val arenaService = mockk<ArenaService>()
 
     val service = BehandlingFaktaService(
         grunnlagsdataService,
         søknadService,
         barnService,
         faktaArbeidOgOppholdMapper,
-        arenaService,
     )
 
     val behandlingId = UUID.randomUUID()
@@ -46,7 +42,6 @@ internal class BehandlingFaktaServiceTest {
     @BeforeEach
     fun setUp() {
         every { barnService.finnBarnPåBehandling(any()) } returns emptyList()
-        every { arenaService.hentStatus(any()) } returns arenaStatusDto()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagArenaMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagArenaMapperTest.kt
@@ -1,14 +1,14 @@
-package no.nav.tilleggsstonader.sak.behandling.fakta
+package no.nav.tilleggsstonader.sak.opplysninger.grunnlag
 
-import no.nav.tilleggsstonader.sak.behandling.fakta.FaktaArenaMapper.mapFaktaArena
 import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.arenaStatusDto
 import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.vedtakStatus
+import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagArenaMapper.mapFaktaArena
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-class FaktaArenaMapperTest {
+class GrunnlagArenaMapperTest {
 
     @Nested
     inner class VedtakTom {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagPatchControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagPatchControllerTest.kt
@@ -1,0 +1,55 @@
+package no.nav.tilleggsstonader.sak.opplysninger.grunnlag
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.util.GrunnlagsdataUtil.grunnlagsdataDomain
+import no.nav.tilleggsstonader.sak.util.GrunnlagsdataUtil.lagGrunnlagsdata
+import no.nav.tilleggsstonader.sak.util.behandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class GrunnlagPatchControllerTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var grunnlagPatchController: GrunnlagPatchController
+
+    @Autowired
+    lateinit var grunnlagRepository: GrunnlagsdataRepository
+
+    @Test
+    fun `skal legge inn arena-grunnlag på behandlinger som mangler`() {
+        val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling(), opprettGrunnlagsdata = false)
+
+        grunnlagRepository.insert(
+            grunnlagsdataDomain(
+                behandlingId = behandling.id,
+                grunnlag = lagGrunnlagsdata(arena = null),
+            ),
+        )
+        grunnlagPatchController.patchGrunnlag()
+
+        val oppdatertGrunnlag = grunnlagRepository.findByIdOrThrow(behandling.id)
+        assertThat(oppdatertGrunnlag.grunnlag.arena?.vedtakTom).isNotNull()
+    }
+
+    @Test
+    fun `skal ikke legge inn arena-grunnlag på bnehandling med feil status`() {
+        val behandling = testoppsettService.opprettBehandlingMedFagsak(
+            behandling(status = BehandlingStatus.FERDIGSTILT),
+            opprettGrunnlagsdata = false,
+        )
+
+        grunnlagRepository.insert(
+            grunnlagsdataDomain(
+                behandlingId = behandling.id,
+                grunnlag = lagGrunnlagsdata(arena = null),
+            ),
+        )
+        grunnlagPatchController.patchGrunnlag()
+
+        val oppdatertGrunnlag = grunnlagRepository.findByIdOrThrow(behandling.id)
+        assertThat(oppdatertGrunnlag.grunnlag.arena?.vedtakTom).isNull()
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagsdataServiceTest.kt
@@ -5,6 +5,8 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.arenaStatusDto
 import no.nav.tilleggsstonader.sak.opplysninger.dto.SøkerMedBarn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.fødsel
@@ -26,12 +28,14 @@ class GrunnlagsdataServiceTest {
     val barnService = mockk<BarnService>()
     val personService = mockk<PersonService>()
     val grunnlagsdataRepository = mockk<GrunnlagsdataRepository>()
+    val arenaService = mockk<ArenaService>()
 
     val service = GrunnlagsdataService(
         behandlingService = behandlingService,
         barnService = barnService,
         personService = personService,
         grunnlagsdataRepository = grunnlagsdataRepository,
+        arenaService = arenaService,
     )
 
     val behandling = saksbehandling()
@@ -61,6 +65,7 @@ class GrunnlagsdataServiceTest {
         every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
         every { barnService.finnBarnPåBehandling(behandling.id) } returns emptyList()
         every { personService.hentPersonMedBarn(behandling.ident) } returns søkerMedBarn
+        every { arenaService.hentStatus(any(), any()) } returns arenaStatusDto()
     }
 
     @Nested

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/GrunnlagsdataUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/GrunnlagsdataUtil.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.util
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Fødsel
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlag
+import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagArena
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagBarn
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlagsdata
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Navn
@@ -22,10 +23,12 @@ object GrunnlagsdataUtil {
         navn: Navn = lagNavn(),
         fødsel: Fødsel? = Fødsel(fødselsdato = LocalDate.of(2000, 1, 1), fødselsår = 2000),
         barn: List<GrunnlagBarn> = listOf(lagGrunnlagsdataBarn()),
+        arena: GrunnlagArena? = GrunnlagArena(vedtakTom = LocalDate.of(2024, 1, 1)),
     ) = Grunnlag(
         navn = navn,
         fødsel = fødsel,
         barn = barn,
+        arena = arena,
     )
 
     fun lagGrunnlagsdataBarn(

--- a/src/test/resources/vilkår/vilkårGrunnlagDto.json
+++ b/src/test/resources/vilkår/vilkårGrunnlagDto.json
@@ -56,6 +56,6 @@
     } ]
   },
   "arena" : {
-    "vedtakTom" : null
+    "vedtakTom" : "2024-01-01"
   }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For å kunne vise dataen i frontend på lik måte som det ble vist når behandlingen ble behandlet

Koblet til 
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21211

Bygger videre på
* https://github.com/navikt/tilleggsstonader-sak/pull/335