### PR TITLE
Vise klagebehandling etter opprettelse

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageClient.kt
@@ -24,7 +24,7 @@ class KlageClient(
 
     private val hentKlagebehandlinger =
         UriComponentsBuilder.fromUri(klageUri).pathSegment(
-            "api/behandling/${Fagsystem.TILLEGGSSTONADER}",
+            "api/ekstern/behandling/${Fagsystem.TILLEGGSSTONADER}",
         ).build().toUri()
 
     fun opprettKlage(opprettKlagebehandlingRequest: OpprettKlagebehandlingRequest) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageController.kt
@@ -34,9 +34,9 @@ class KlageController(
     }
 
     @GetMapping("/fagsak-person/{fagsakPersonId}")
-    fun hentKlagebehandlinger(@PathVariable fagsakPersonId: UUID): Ressurs<KlagebehandlingerDto> {
+    fun hentKlagebehandlinger(@PathVariable fagsakPersonId: UUID): KlagebehandlingerDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(klageService.hentBehandlinger(fagsakPersonId))
+        return klageService.hentBehandlinger(fagsakPersonId)
     }
 
     @GetMapping("/ekstern-fagsak/{eksternFagsakId}/vedtak")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/dto/KlagebehandlingerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/dto/KlagebehandlingerDto.kt
@@ -3,7 +3,5 @@ package no.nav.tilleggsstonader.sak.klage.dto
 import no.nav.tilleggsstonader.kontrakter.klage.KlagebehandlingDto
 
 data class KlagebehandlingerDto(
-    val overgangsstønad: List<KlagebehandlingDto>,
     val barnetilsyn: List<KlagebehandlingDto>,
-    val skolepenger: List<KlagebehandlingDto>,
 )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageClientMock.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageClientMock.kt
@@ -1,0 +1,44 @@
+package no.nav.tilleggsstonader.sak.klage
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.klage.BehandlingResultat
+import no.nav.tilleggsstonader.kontrakter.klage.BehandlingStatus
+import no.nav.tilleggsstonader.kontrakter.klage.KlagebehandlingDto
+import no.nav.tilleggsstonader.kontrakter.klage.Årsak
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Configuration
+class KlageClientMock {
+    @Profile("mock-klage")
+    @Bean
+    @Primary
+    fun klageClient(): KlageClient {
+        val mockk = mockk<KlageClient>()
+        justRun { mockk.opprettKlage(any()) }
+        every { mockk.hentKlagebehandlinger(any()) } answers {
+            firstArg<Set<Long>>().associateWith {
+                listOf(
+                    KlagebehandlingDto(
+                        id = UUID.randomUUID(),
+                        fagsakId = UUID.randomUUID(),
+                        status = BehandlingStatus.FERDIGSTILT,
+                        opprettet = LocalDateTime.now(),
+                        mottattDato = LocalDate.now(),
+                        resultat = BehandlingResultat.IKKE_MEDHOLD,
+                        årsak = Årsak.FEIL_I_LOVANDVENDELSE,
+                        vedtaksdato = LocalDateTime.now(),
+                    ),
+                )
+            }
+        }
+        return mockk
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
@@ -81,7 +81,6 @@ internal class KlageServiceTest {
             assertThat(request.fagsystem).isEqualTo(Fagsystem.TILLEGGSSTONADER)
             assertThat(request.klageMottatt).isEqualTo(klageMottattTidspunkt)
             assertThat(request.behandlendeEnhet).isEqualTo(arbeidsfordelingEnhetNr)
-            assertThat(request.klageGjelderTilbakekreving).isEqualTo(false)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
@@ -1,0 +1,282 @@
+package no.nav.tilleggsstonader.sak.klage
+
+import io.mockk.*
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.klage.dto.OpprettKlageDto
+import no.nav.tilleggsstonader.kontrakter.klage.BehandlingEventType
+import no.nav.tilleggsstonader.kontrakter.klage.BehandlingResultat
+import no.nav.tilleggsstonader.kontrakter.klage.BehandlingStatus
+import no.nav.tilleggsstonader.kontrakter.klage.KlagebehandlingDto
+import no.nav.tilleggsstonader.kontrakter.klage.KlageinstansResultatDto
+import no.nav.tilleggsstonader.kontrakter.klage.OpprettKlagebehandlingRequest
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.Arbeidsfordelingsenhet
+import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Month
+import java.util.UUID
+
+internal class KlageServiceTest {
+    private val fagsakService = mockk<FagsakService>()
+
+    private val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
+
+    private val klageClient = mockk<KlageClient>()
+
+    private val klageService =
+        KlageService(
+            fagsakService,
+            arbeidsfordelingService,
+            klageClient,
+        )
+
+    private val fagsakId = UUID.randomUUID()
+    private val fagsakPersonId = UUID.randomUUID()
+    private val eksternFagsakId = EksternFagsakId(1L, fagsakId)
+    private val personIdent = "12345678910"
+    private val arbeidsfordelingEnhetNr = "1"
+    private val fagsak = fagsak(id = fagsakId, fagsakPersonId = fagsakPersonId, eksternId = eksternFagsakId)
+
+    private val opprettKlageSlot = slot<OpprettKlagebehandlingRequest>()
+
+    @BeforeEach
+    internal fun setUp() {
+        opprettKlageSlot.clear()
+        every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+        every { fagsakService.hentAktivIdent(fagsak.id) } returns personIdent
+        every { arbeidsfordelingService.hentNavEnhet(any()) } returns Arbeidsfordelingsenhet(
+            arbeidsfordelingEnhetNr,
+            "NAV arbeid og ytelser"
+        )
+        justRun { klageClient.opprettKlage(capture(opprettKlageSlot)) }
+    }
+
+    @Nested
+    inner class OpprettKlage {
+        @Test
+        internal fun `skal mappe riktige verdier ved manuelt opprettet klage`() {
+            val klageMottattTidspunkt = LocalDate.now()
+            klageService.opprettKlage(fagsak.id, OpprettKlageDto(klageMottattTidspunkt))
+
+            val request = opprettKlageSlot.captured
+
+            assertThat(request.ident).isEqualTo("15")
+            assertThat(request.stønadstype).isEqualTo(Stønadstype.BARNETILSYN)
+            assertThat(request.eksternFagsakId).isEqualTo(eksternFagsakId.id.toString())
+            assertThat(request.fagsystem).isEqualTo(Fagsystem.TILLEGGSSTONADER)
+            assertThat(request.klageMottatt).isEqualTo(klageMottattTidspunkt)
+            assertThat(request.behandlendeEnhet).isEqualTo(arbeidsfordelingEnhetNr)
+            assertThat(request.klageGjelderTilbakekreving).isEqualTo(false)
+        }
+    }
+
+    @Nested
+    inner class Validering {
+        @Test
+        internal fun `skal ikke kunne opprette klage med krav mottatt frem i tid`() {
+            val opprettKlageDto = OpprettKlageDto(mottattDato = LocalDate.now().plusDays(1))
+            val feil = assertThrows<ApiFeil> { klageService.opprettKlage(UUID.randomUUID(), opprettKlageDto) }
+
+            assertThat(feil.feil).contains("Kan ikke opprette klage med krav mottatt frem i tid for fagsak=")
+        }
+
+        @Test
+        internal fun `skal ikke kunne opprette dersom enhetId ikke finnes`() {
+            val opprettKlageDto = OpprettKlageDto(mottattDato = LocalDate.now())
+
+            every { arbeidsfordelingService.hentNavEnhet(any()) } returns null
+
+            val feil = assertThrows<ApiFeil> { klageService.opprettKlage(fagsak.id, opprettKlageDto) }
+
+            assertThat(feil.feil).isEqualTo("Finner ikke behandlende enhet for personen")
+        }
+    }
+
+    @Nested
+    inner class Mapping {
+
+        @Test
+        internal fun `henter 0 behandlinger fra tilleggsstonader-klage med eksternFagsakId`() {
+            val eksternFagsakIdSlot = slot<Set<Long>>()
+            val fagsaker = fagsaker()
+
+            every { fagsakService.finnFagsakerForFagsakPersonId(fagsakPersonId) } returns fagsaker
+            every { klageClient.hentKlagebehandlinger(capture(eksternFagsakIdSlot)) } returns emptyMap()
+
+            klageService.hentBehandlinger(fagsakPersonId)
+            assertThat(eksternFagsakIdSlot.captured).containsExactlyInAnyOrder(eksternFagsakId.id)
+        }
+
+        @Test
+        internal fun `skal mappe fagsakId til riktig stønadstype`() {
+            val fagsaker = fagsaker()
+            val klageBehandlingerDto = klageBehandlingerDto()
+
+            every { fagsakService.finnFagsakerForFagsakPersonId(fagsakPersonId) } returns fagsaker
+            every { klageClient.hentKlagebehandlinger(listOf(eksternFagsakId.id).toSet()) } returns klageBehandlingerDto
+
+            val klager = klageService.hentBehandlinger(fagsakPersonId)
+
+            assertThat(klager.barnetilsyn.single()).isEqualTo(klageBehandlingerDto[eksternFagsakId.id]!!.single())
+        }
+
+        @Test
+        internal fun `skal returnere tomme lister dersom eksternFagsakId ikke eksisterer`() {
+            every { fagsakService.finnFagsakerForFagsakPersonId(fagsakPersonId) } returns Fagsaker(null)
+
+            val klager = klageService.hentBehandlinger(fagsakPersonId)
+
+            assertThat(klager.barnetilsyn).isEmpty()
+            verify(exactly = 0) { klageClient.hentKlagebehandlinger(any()) }
+        }
+
+        @Test
+        internal fun `Hent klage - skal bruke vedtaksdato fra kabal hvis resultat IKKE_MEDHOLD og avsluttet i kabal`() {
+            val fagsaker = fagsaker()
+
+            val tidsPunktAvsluttetIKabal = LocalDateTime.of(2022, Month.OCTOBER, 1, 0, 0)
+            val tidspunktAvsluttetIFamilieKlage = LocalDateTime.of(2022, Month.AUGUST, 1, 0, 0)
+
+            val klagebehandlingAvsluttetKabal =
+                klageBehandlingDto(
+                    resultat = BehandlingResultat.IKKE_MEDHOLD,
+                    klageinstansResultat =
+                    listOf(
+                        KlageinstansResultatDto(
+                            type = BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET,
+                            utfall = null,
+                            mottattEllerAvsluttetTidspunkt = tidsPunktAvsluttetIKabal,
+                            journalpostReferanser = listOf(),
+                            årsakFeilregistrert = null,
+                        ),
+                    ),
+                    vedtaksdato = tidspunktAvsluttetIFamilieKlage,
+                )
+
+            every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
+            every { klageClient.hentKlagebehandlinger(any()) } returns mapOf(
+                eksternFagsakId.id to listOf(
+                    klagebehandlingAvsluttetKabal
+                )
+            )
+
+            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+
+            assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidsPunktAvsluttetIKabal)
+        }
+
+        @Test
+        internal fun `Hent klage - hvis resultat fra kabal ikke foreligger enda skal vedtaksdato være null behandlingsresultat er IKKE_MEDHOLD`() {
+            val fagsaker = fagsaker()
+            val tidspunktAvsluttetFamilieKlage = LocalDateTime.of(2022, Month.AUGUST, 1, 0, 0)
+
+            val klagebehandlingIkkeAvsluttetKabal =
+                klageBehandlingDto(
+                    resultat = BehandlingResultat.IKKE_MEDHOLD,
+                    klageinstansResultat = emptyList(),
+                    vedtaksdato = tidspunktAvsluttetFamilieKlage,
+                )
+
+            every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
+            every { klageClient.hentKlagebehandlinger(any()) } returns
+                    mapOf(eksternFagsakId.id to listOf(klagebehandlingIkkeAvsluttetKabal))
+
+            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+
+            assertThat(klager.barnetilsyn.first().vedtaksdato).isNull()
+        }
+
+        @Test
+        internal fun `Hent klage - skal bruke vedtaksdato fra klageløsning dersom behandling ikke er oversendt kabal`() {
+            val fagsaker = fagsaker()
+            val tidspunktAvsluttetFamilieKlage = LocalDateTime.of(2022, Month.AUGUST, 1, 0, 0)
+
+            every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
+            every { klageClient.hentKlagebehandlinger(any()) } returns
+                    mapOf(
+                        eksternFagsakId.id to
+                                listOf(
+                                    klageBehandlingDto(
+                                        resultat = BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+                                        klageinstansResultat = emptyList(),
+                                        vedtaksdato = tidspunktAvsluttetFamilieKlage,
+                                    ),
+                                ),
+                    )
+
+            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+
+            assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidspunktAvsluttetFamilieKlage)
+        }
+
+        @Test
+        internal fun `Hent klage - skal bruke vedtaksdato fra kabal dersom behandlingen er feilregistrert i kabal`() {
+            val fagsaker = fagsaker()
+
+            val tidsPunktAvsluttetIKabal = LocalDateTime.of(2022, Month.OCTOBER, 1, 0, 0)
+            val tidspunktAvsluttetIFamilieKlage = LocalDateTime.of(2022, Month.AUGUST, 1, 0, 0)
+
+            val årsakFeilregistrert = "Klage registrert på feil vedtak"
+            val klagebehandlingAvsluttetKabal =
+                klageBehandlingDto(
+                    resultat = BehandlingResultat.IKKE_MEDHOLD,
+                    klageinstansResultat =
+                    listOf(
+                        KlageinstansResultatDto(
+                            type = BehandlingEventType.BEHANDLING_FEILREGISTRERT,
+                            utfall = null,
+                            mottattEllerAvsluttetTidspunkt = tidsPunktAvsluttetIKabal,
+                            journalpostReferanser = listOf(),
+                            årsakFeilregistrert = årsakFeilregistrert,
+                        ),
+                    ),
+                    vedtaksdato = tidspunktAvsluttetIFamilieKlage,
+                )
+
+            every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
+            every { klageClient.hentKlagebehandlinger(any()) } returns
+                    mapOf(eksternFagsakId.id to listOf(klagebehandlingAvsluttetKabal))
+
+            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+
+            assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidsPunktAvsluttetIKabal)
+            assertThat(klager.barnetilsyn.first().klageinstansResultat.first().årsakFeilregistrert).isEqualTo(
+                årsakFeilregistrert
+            )
+        }
+
+        private fun fagsaker() = Fagsaker(fagsak)
+
+        private fun klageBehandlingDto(
+            resultat: BehandlingResultat? = null,
+            vedtaksdato: LocalDateTime? = null,
+            klageinstansResultat: List<KlageinstansResultatDto> = emptyList(),
+        ) = KlagebehandlingDto(
+            id = UUID.randomUUID(),
+            fagsakId = UUID.randomUUID(),
+            status = BehandlingStatus.UTREDES,
+            opprettet = LocalDateTime.now(),
+            mottattDato = LocalDate.now().minusDays(1),
+            resultat = resultat,
+            årsak = null,
+            vedtaksdato = vedtaksdato,
+            klageinstansResultat = klageinstansResultat,
+        )
+
+        private fun klageBehandlingerDto() =
+            mapOf(
+                eksternFagsakId.id to listOf(klageBehandlingDto())
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
@@ -1,12 +1,12 @@
 package no.nav.tilleggsstonader.sak.klage
 
-import io.mockk.*
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
-import no.nav.tilleggsstonader.sak.klage.dto.OpprettKlageDto
 import no.nav.tilleggsstonader.kontrakter.klage.BehandlingEventType
 import no.nav.tilleggsstonader.kontrakter.klage.BehandlingResultat
 import no.nav.tilleggsstonader.kontrakter.klage.BehandlingStatus
@@ -15,7 +15,11 @@ import no.nav.tilleggsstonader.kontrakter.klage.KlageinstansResultatDto
 import no.nav.tilleggsstonader.kontrakter.klage.OpprettKlagebehandlingRequest
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.Arbeidsfordelingsenhet
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.klage.dto.OpprettKlageDto
 import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -57,7 +61,7 @@ internal class KlageServiceTest {
         every { fagsakService.hentAktivIdent(fagsak.id) } returns personIdent
         every { arbeidsfordelingService.hentNavEnhet(any()) } returns Arbeidsfordelingsenhet(
             arbeidsfordelingEnhetNr,
-            "NAV arbeid og ytelser"
+            "NAV arbeid og ytelser",
         )
         justRun { klageClient.opprettKlage(capture(opprettKlageSlot)) }
     }
@@ -167,8 +171,8 @@ internal class KlageServiceTest {
             every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
             every { klageClient.hentKlagebehandlinger(any()) } returns mapOf(
                 eksternFagsakId.id to listOf(
-                    klagebehandlingAvsluttetKabal
-                )
+                    klagebehandlingAvsluttetKabal,
+                ),
             )
 
             val klager = klageService.hentBehandlinger(UUID.randomUUID())
@@ -190,7 +194,7 @@ internal class KlageServiceTest {
 
             every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
             every { klageClient.hentKlagebehandlinger(any()) } returns
-                    mapOf(eksternFagsakId.id to listOf(klagebehandlingIkkeAvsluttetKabal))
+                mapOf(eksternFagsakId.id to listOf(klagebehandlingIkkeAvsluttetKabal))
 
             val klager = klageService.hentBehandlinger(UUID.randomUUID())
 
@@ -204,16 +208,16 @@ internal class KlageServiceTest {
 
             every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
             every { klageClient.hentKlagebehandlinger(any()) } returns
-                    mapOf(
-                        eksternFagsakId.id to
-                                listOf(
-                                    klageBehandlingDto(
-                                        resultat = BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
-                                        klageinstansResultat = emptyList(),
-                                        vedtaksdato = tidspunktAvsluttetFamilieKlage,
-                                    ),
-                                ),
-                    )
+                mapOf(
+                    eksternFagsakId.id to
+                        listOf(
+                            klageBehandlingDto(
+                                resultat = BehandlingResultat.IKKE_MEDHOLD_FORMKRAV_AVVIST,
+                                klageinstansResultat = emptyList(),
+                                vedtaksdato = tidspunktAvsluttetFamilieKlage,
+                            ),
+                        ),
+                )
 
             val klager = klageService.hentBehandlinger(UUID.randomUUID())
 
@@ -246,13 +250,13 @@ internal class KlageServiceTest {
 
             every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
             every { klageClient.hentKlagebehandlinger(any()) } returns
-                    mapOf(eksternFagsakId.id to listOf(klagebehandlingAvsluttetKabal))
+                mapOf(eksternFagsakId.id to listOf(klagebehandlingAvsluttetKabal))
 
             val klager = klageService.hentBehandlinger(UUID.randomUUID())
 
             assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidsPunktAvsluttetIKabal)
             assertThat(klager.barnetilsyn.first().klageinstansResultat.first().årsakFeilregistrert).isEqualTo(
-                årsakFeilregistrert
+                årsakFeilregistrert,
             )
         }
 
@@ -276,7 +280,7 @@ internal class KlageServiceTest {
 
         private fun klageBehandlingerDto() =
             mapOf(
-                eksternFagsakId.id to listOf(klageBehandlingDto())
+                eksternFagsakId.id to listOf(klageBehandlingDto()),
             )
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tilhørende [frontend PR](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/366)

Skal kunne hente alle klagebehandlinger for en person fra tilleggstonader-klage. Klagebehandlingene skal presenteres i fagsaksoversikten etter at man har opprettet en klage manuelt, se bilde:

<img width="1772" alt="Skjermbilde 2024-06-04 kl  12 18 21" src="https://github.com/navikt/tilleggsstonader-sak/assets/32769446/6f8a3c4c-3ed2-4c33-ab41-0bacabdbedfc">
