### PR TITLE
✨ Perioder for ytelse inn i VilkårperiodeGrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetService.kt
@@ -21,8 +21,7 @@ class AktivitetService(
         ).sortedByDescending { it.fom }
     }
 
-    fun hentAktiviteterForGrunnlagsdata(fagsakPersonId: UUID, fom: LocalDate, tom: LocalDate): List<AktivitetArenaDto> {
-        val ident = fagsakPersonService.hentAktivIdent(fagsakPersonId)
+    fun hentAktiviteterForGrunnlagsdata(ident: String, fom: LocalDate, tom: LocalDate): List<AktivitetArenaDto> {
         return aktivitetClient.hentAktiviteter(
             ident = ident,
             fom = fom,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseController.kt
@@ -24,12 +24,4 @@ class YtelseController(
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return aktivitetService.hentYtelser(fagsakPersonId)
     }
-
-    @GetMapping("/behandling/{behandlingId}")
-    fun hentYtelserForBehandling(
-        @PathVariable behandlingId: UUID,
-    ): YtelserRegisterDto {
-        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        return aktivitetService.hentYtelserForBehandling(behandlingId)
-    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
@@ -1,12 +1,18 @@
 package no.nav.tilleggsstonader.sak.opplysninger.ytelse
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.ytelse.HentetInformasjon
+import no.nav.tilleggsstonader.kontrakter.ytelse.StatusHentetInformasjon
 import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
+import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderDto
 import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderRequest
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelserRegisterDtoMapper.tilDto
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -17,11 +23,7 @@ class YtelseService(
 ) {
     fun hentYtelser(fagsakPersonId: UUID): YtelserRegisterDto {
         val ident = fagsakPersonService.hentAktivIdent(fagsakPersonId)
-        val typer = listOf(
-            TypeYtelsePeriode.AAP,
-            TypeYtelsePeriode.ENSLIG_FORSØRGER,
-            TypeYtelsePeriode.OMSTILLINGSSTØNAD,
-        )
+        val typer = finnRelevanteYtelsesTyper(Stønadstype.BARNETILSYN)
 
         return ytelseClient.hentYtelser(
             YtelsePerioderRequest(
@@ -33,21 +35,44 @@ class YtelseService(
         ).tilDto()
     }
 
-    fun hentYtelserForBehandling(behandlingId: UUID): YtelserRegisterDto {
-        val ident = behandlingService.hentSaksbehandling(behandlingId).ident
-        val typer = listOf(
-            TypeYtelsePeriode.AAP,
-            TypeYtelsePeriode.ENSLIG_FORSØRGER,
-            TypeYtelsePeriode.OMSTILLINGSSTØNAD,
-        )
+    fun hentYtelseForGrunnlag(
+        behandlingId: UUID,
+        fom: LocalDate,
+        tom: LocalDate,
+    ): YtelsePerioderDto {
+        val behandling = behandlingService.hentSaksbehandling(behandlingId)
+        val typer = finnRelevanteYtelsesTyper(behandling.stønadstype)
 
-        return ytelseClient.hentYtelser(
-            YtelsePerioderRequest(
-                ident = ident,
-                fom = osloDateNow().minusMonths(3),
-                tom = osloDateNow().plusYears(1),
-                typer = typer,
-            ),
-        ).tilDto()
+        val resultat =
+            ytelseClient.hentYtelser(
+                YtelsePerioderRequest(
+                    ident = behandling.ident,
+                    fom = fom,
+                    tom = tom,
+                    typer = typer,
+                ),
+            )
+
+        validerResultat(resultat.hentetInformasjon)
+
+        return resultat
     }
+
+    private fun validerResultat(hentetInformasjon: List<HentetInformasjon>) {
+        val test = hentetInformasjon.filter { it.status != StatusHentetInformasjon.OK }
+
+        feilHvis(test.isNotEmpty()) {
+            "Feil ved henting av ytelser fra andre systemer: ${test.joinToString(", ") { it.type.name }}. Prøv å laste inn siden på nytt."
+        }
+    }
+
+    private fun finnRelevanteYtelsesTyper(type: Stønadstype) =
+        when (type) {
+            Stønadstype.BARNETILSYN ->
+                listOf(
+                    TypeYtelsePeriode.AAP,
+                    TypeYtelsePeriode.ENSLIG_FORSØRGER,
+                    TypeYtelsePeriode.OMSTILLINGSSTØNAD,
+                )
+        }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -30,6 +30,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperioderRes
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringVilkårperiode.evaulerVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagAktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagDomain
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagRepository
@@ -79,21 +80,29 @@ class VilkårperiodeService(
         }
     }
 
-    private fun opprettGrunnlagsdata(behandlingId: UUID) = vilkårperioderGrunnlagRepository.insert(
-        VilkårperioderGrunnlagDomain(
-            behandlingId = behandlingId,
-            grunnlag = VilkårperioderGrunnlag(
-                aktivitet = GrunnlagAktivitet(
-                    aktivitetService.hentAktiviteterForGrunnlagsdata(
-                        behandlingService.hentSaksbehandling(behandlingId).fagsakPersonId,
-                        fom = LocalDate.now().minusMonths(3),
-                        tom = LocalDate.now().plusYears(1),
+    private fun opprettGrunnlagsdata(behandlingId: UUID): VilkårperioderGrunnlagDomain {
+        val fom = LocalDate.now().minusMonths(3)
+        val tom = LocalDate.now().plusYears(1)
+        return vilkårperioderGrunnlagRepository.insert(
+            VilkårperioderGrunnlagDomain(
+                behandlingId = behandlingId,
+                grunnlag = VilkårperioderGrunnlag(
+                    aktivitet = GrunnlagAktivitet(
+                        aktiviteter = aktivitetService.hentAktiviteterForGrunnlagsdata(
+                            behandlingService.hentSaksbehandling(behandlingId).fagsakPersonId,
+                            fom = fom,
+                            tom = tom,
+                        ),
+                        hentetInformasjon = HentetInformasjon(
+                            fom = fom,
+                            tom = tom,
+                            tidspunktHentet = LocalDateTime.now(),
+                        ),
                     ),
-                    tidspunktHentet = LocalDateTime.now(),
                 ),
             ),
-        ),
-    )
+        )
+    }
 
     fun hentVilkårperioderDto(behandlingId: UUID): VilkårperioderDto {
         return hentVilkårperioder(behandlingId).tilDto()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -86,21 +86,38 @@ class VilkårperiodeService(
         return vilkårperioderGrunnlagRepository.insert(
             VilkårperioderGrunnlagDomain(
                 behandlingId = behandlingId,
-                grunnlag = VilkårperioderGrunnlag(
-                    aktivitet = GrunnlagAktivitet(
-                        aktiviteter = aktivitetService.hentAktiviteterForGrunnlagsdata(
-                            behandlingService.hentSaksbehandling(behandlingId).fagsakPersonId,
-                            fom = fom,
-                            tom = tom,
-                        ),
-                        hentetInformasjon = HentetInformasjon(
-                            fom = fom,
-                            tom = tom,
-                            tidspunktHentet = LocalDateTime.now(),
-                        ),
-                    ),
-                ),
+                grunnlag = grunnlag,
             ),
+        )
+    }
+
+    private fun hentGrunnlagAktvititet(
+        behandlingId: UUID,
+        fom: LocalDate,
+        tom: LocalDate,
+    ) = GrunnlagAktivitet(
+        aktiviteter = aktivitetService.hentAktiviteterForGrunnlagsdata(
+            ident = behandlingService.hentSaksbehandling(behandlingId).ident,
+            fom = fom,
+            tom = tom,
+        ),
+    )
+
+    private fun hentGrunnlagYtelse(
+        behandlingId: UUID,
+        fom: LocalDate,
+        tom: LocalDate,
+    ): GrunnlagYtelse {
+        val ytelserFraRegister = ytelseService.hentYtelseForGrunnlag(behandlingId, fom, tom)
+
+        return GrunnlagYtelse(
+            perioder = ytelserFraRegister.perioder.map {
+                PeriodeGrunnlagYtelse(
+                    type = it.type,
+                    fom = it.fom,
+                    tom = it.tom,
+                )
+            },
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -9,6 +9,8 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetService
+import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
+import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeValideringUtil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
@@ -30,7 +32,9 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperioderRes
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.evaluering.EvalueringVilkårperiode.evaulerVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagAktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtelse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagDomain
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagRepository
@@ -39,6 +43,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.YearMonth
 import java.util.UUID
 
 @Service
@@ -48,6 +53,8 @@ class VilkårperiodeService(
     private val stønadsperiodeRepository: StønadsperiodeRepository,
     private val vilkårperioderGrunnlagRepository: VilkårperioderGrunnlagRepository,
     private val aktivitetService: AktivitetService,
+    private val ytelseService: YtelseService,
+    private val søknadService: SøknadService,
 ) {
 
     fun hentVilkårperioder(behandlingId: UUID): Vilkårperioder {
@@ -81,8 +88,22 @@ class VilkårperiodeService(
     }
 
     private fun opprettGrunnlagsdata(behandlingId: UUID): VilkårperioderGrunnlagDomain {
-        val fom = LocalDate.now().minusMonths(3)
-        val tom = LocalDate.now().plusYears(1)
+        val søknad = søknadService.hentSøknadBarnetilsyn(behandlingId)
+        val utgangspunktDato = søknad?.mottattTidspunkt ?: LocalDateTime.now()
+
+        val fom = YearMonth.from(utgangspunktDato).minusMonths(3).atDay(1)
+        val tom = YearMonth.from(utgangspunktDato).plusYears(1).atEndOfMonth()
+
+        val grunnlag = VilkårperioderGrunnlag(
+            aktivitet = hentGrunnlagAktvititet(behandlingId, fom, tom),
+            ytelse = hentGrunnlagYtelse(behandlingId, fom, tom),
+            hentetInformasjon = HentetInformasjon(
+                fom = fom,
+                tom = tom,
+                tidspunktHentet = LocalDateTime.now(),
+            ),
+        )
+
         return vilkårperioderGrunnlagRepository.insert(
             VilkårperioderGrunnlagDomain(
                 behandlingId = behandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -23,5 +24,11 @@ data class VilkårperioderGrunnlagDomain(
 
 data class GrunnlagAktivitet(
     val aktiviteter: List<AktivitetArenaDto>,
+    val hentetInformasjon: HentetInformasjon,
+)
+
+data class HentetInformasjon(
+    val fom: LocalDate,
+    val tom: LocalDate,
     val tidspunktHentet: LocalDateTime,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
@@ -1,16 +1,20 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 data class VilkårperioderGrunnlag(
     val aktivitet: GrunnlagAktivitet,
+    // TODO: Burde hete målgruppegrunnlag? Selv om det er ytelser inni er det grunnlaget for målgruppe
+    val ytelse: GrunnlagYtelse?,
+    val hentetInformasjon: HentetInformasjon?,
 )
 
 @Table("vilkarperioder_grunnlag")
@@ -24,7 +28,16 @@ data class VilkårperioderGrunnlagDomain(
 
 data class GrunnlagAktivitet(
     val aktiviteter: List<AktivitetArenaDto>,
-    val hentetInformasjon: HentetInformasjon,
+)
+
+data class GrunnlagYtelse(
+    val perioder: List<PeriodeGrunnlagYtelse>,
+)
+
+data class PeriodeGrunnlagYtelse(
+    val type: TypeYtelsePeriode,
+    val fom: LocalDate,
+    val tom: LocalDate?,
 )
 
 data class HentetInformasjon(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
@@ -25,23 +25,3 @@ data class GrunnlagAktivitet(
     val aktiviteter: List<AktivitetArenaDto>,
     val tidspunktHentet: LocalDateTime,
 )
-
-data class VilkårperioderGrunnlagDto(
-    val aktivitet: GrunnlagAktivitetDto,
-)
-
-data class GrunnlagAktivitetDto(
-    val aktiviteter: List<AktivitetArenaDto>,
-    val tidspunktHentet: LocalDateTime,
-)
-
-fun VilkårperioderGrunnlag.tilDto() =
-    VilkårperioderGrunnlagDto(
-        aktivitet = this.aktivitet.tilDto(),
-    )
-
-fun GrunnlagAktivitet.tilDto() =
-    GrunnlagAktivitetDto(
-        aktiviteter = this.aktiviteter,
-        tidspunktHentet = this.tidspunktHentet,
-    )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
@@ -1,28 +1,30 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class VilkårperioderGrunnlagDto(
     val aktivitet: GrunnlagAktivitetDto,
+    val ytelse: GrunnlagYtelseDto?,
+    val hentetInformasjon: HentetInformasjonDto?,
 )
 
 data class GrunnlagAktivitetDto(
     val aktiviteter: List<AktivitetArenaDto>,
-    val hentetInformasjon: HentetInformasjonDto,
+    val tidspunktHentet: LocalDateTime,
 )
 
-fun VilkårperioderGrunnlag.tilDto() =
-    VilkårperioderGrunnlagDto(
-        aktivitet = this.aktivitet.tilDto(),
-    )
+data class GrunnlagYtelseDto(
+    val perioder: List<PeriodeGrunnlagYtelseDto>,
+)
 
-fun GrunnlagAktivitet.tilDto() =
-    GrunnlagAktivitetDto(
-        aktiviteter = this.aktiviteter,
-        hentetInformasjon = this.hentetInformasjon.tilDto(),
-    )
+data class PeriodeGrunnlagYtelseDto(
+    val type: TypeYtelsePeriode,
+    val fom: LocalDate,
+    val tom: LocalDate?,
+)
 
 data class HentetInformasjonDto(
     val fom: LocalDate,
@@ -30,8 +32,34 @@ data class HentetInformasjonDto(
     val tidspunktHentet: LocalDateTime,
 )
 
-fun HentetInformasjon.tilDto() = HentetInformasjonDto(
-    fom = this.fom,
-    tom = this.tom,
-    tidspunktHentet = this.tidspunktHentet,
-)
+fun VilkårperioderGrunnlag.tilDto() =
+    VilkårperioderGrunnlagDto(
+        aktivitet = this.aktivitet.tilDto(),
+        ytelse = this.ytelse?.tilDto(),
+        hentetInformasjon = this.hentetInformasjon?.tilDto(),
+    )
+
+fun GrunnlagAktivitet.tilDto() =
+    GrunnlagAktivitetDto(
+        aktiviteter = this.aktiviteter,
+        tidspunktHentet = LocalDateTime.now(), // TODO: Fjern felt etter patching. Kun lagt til for å ikke knekke frontend midletidig
+    )
+
+fun GrunnlagYtelse.tilDto() =
+    GrunnlagYtelseDto(
+        perioder = this.perioder.map { it.tilDto() },
+    )
+
+fun PeriodeGrunnlagYtelse.tilDto() =
+    PeriodeGrunnlagYtelseDto(
+        type = this.type,
+        fom = this.fom,
+        tom = this.tom,
+    )
+
+fun HentetInformasjon.tilDto() =
+    HentetInformasjonDto(
+        fom = this.fom,
+        tom = this.tom,
+        tidspunktHentet = this.tidspunktHentet,
+    )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
@@ -1,0 +1,24 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
+
+import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import java.time.LocalDateTime
+
+data class VilkårperioderGrunnlagDto(
+    val aktivitet: GrunnlagAktivitetDto,
+)
+
+data class GrunnlagAktivitetDto(
+    val aktiviteter: List<AktivitetArenaDto>,
+    val tidspunktHentet: LocalDateTime,
+)
+
+fun VilkårperioderGrunnlag.tilDto() =
+    VilkårperioderGrunnlagDto(
+        aktivitet = this.aktivitet.tilDto(),
+    )
+
+fun GrunnlagAktivitet.tilDto() =
+    GrunnlagAktivitetDto(
+        aktiviteter = this.aktiviteter,
+        tidspunktHentet = this.tidspunktHentet,
+    )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class VilkårperioderGrunnlagDto(
@@ -9,7 +10,7 @@ data class VilkårperioderGrunnlagDto(
 
 data class GrunnlagAktivitetDto(
     val aktiviteter: List<AktivitetArenaDto>,
-    val tidspunktHentet: LocalDateTime,
+    val hentetInformasjon: HentetInformasjonDto,
 )
 
 fun VilkårperioderGrunnlag.tilDto() =
@@ -20,5 +21,17 @@ fun VilkårperioderGrunnlag.tilDto() =
 fun GrunnlagAktivitet.tilDto() =
     GrunnlagAktivitetDto(
         aktiviteter = this.aktiviteter,
-        tidspunktHentet = this.tidspunktHentet,
+        hentetInformasjon = this.hentetInformasjon.tilDto(),
     )
+
+data class HentetInformasjonDto(
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val tidspunktHentet: LocalDateTime,
+)
+
+fun HentetInformasjon.tilDto() = HentetInformasjonDto(
+    fom = this.fom,
+    tom = this.tom,
+    tidspunktHentet = this.tidspunktHentet,
+)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -620,7 +620,12 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
             val response = vilkårperiodeService.hentVilkårperioderResponse(behandling.id)
 
-            assertThat(vilkårperioderGrunnlagRepository.findByBehandlingId(behandling.id)!!.grunnlag.tilDto()).isEqualTo(response.grunnlag)
+            assertThat(vilkårperioderGrunnlagRepository.findByBehandlingId(behandling.id)!!.grunnlag.tilDto())
+                .usingRecursiveComparison()
+                .ignoringFields("aktivitet.tidspunktHentet") // TODO: Fjern når tidspunktHentet er fjernet
+                .isEqualTo(response.grunnlag)
+            assertThat(response.grunnlag!!.aktivitet.aktiviteter).isNotEmpty
+            assertThat(response.grunnlag!!.ytelse?.perioder).isNotEmpty
         }
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagRepositoryTest.kt
@@ -40,7 +40,11 @@ internal class VilkårperioderGrunnlagRepositoryTest : IntegrationTest() {
                         kilde = Kilde.ARENA,
                     ),
                 ),
-                tidspunktHentet = LocalDateTime.now(),
+                hentetInformasjon = HentetInformasjon(
+                    fom = LocalDate.now().minusMonths(3),
+                    tom = LocalDate.now().plusYears(1),
+                    tidspunktHentet = LocalDateTime.now(),
+                )
             ),
         )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagRepositoryTest.kt
@@ -3,10 +3,10 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
 import no.nav.tilleggsstonader.kontrakter.aktivitet.Kilde
 import no.nav.tilleggsstonader.kontrakter.aktivitet.StatusAktivitet
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.util.behandling
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,32 +21,44 @@ internal class VilkårperioderGrunnlagRepositoryTest : IntegrationTest() {
     internal fun `skal kunne lagre grunnlag for vilkårsperioder`() {
         val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling = behandling())
 
-        val grunnlagJson = VilkårperioderGrunnlag(
-            aktivitet = GrunnlagAktivitet(
-                aktiviteter = listOf(
-                    AktivitetArenaDto(
-                        id = "123",
-                        fom = LocalDate.now(),
-                        tom = LocalDate.now().plusMonths(1),
-                        type = "TYPE",
-                        typeNavn = "Type navn",
-                        status = StatusAktivitet.AKTUELL,
-                        statusArena = "AKTUL",
-                        antallDagerPerUke = 5,
-                        prosentDeltakelse = 100.toBigDecimal(),
-                        erStønadsberettiget = true,
-                        erUtdanning = false,
-                        arrangør = "Arrangør",
-                        kilde = Kilde.ARENA,
+        val grunnlagJson =
+            VilkårperioderGrunnlag(
+                aktivitet =
+                GrunnlagAktivitet(
+                    aktiviteter = listOf(
+                        AktivitetArenaDto(
+                            id = "123",
+                            fom = LocalDate.now(),
+                            tom = LocalDate.now().plusMonths(1),
+                            type = "TYPE",
+                            typeNavn = "Type navn",
+                            status = StatusAktivitet.AKTUELL,
+                            statusArena = "AKTUL",
+                            antallDagerPerUke = 5,
+                            prosentDeltakelse = 100.toBigDecimal(),
+                            erStønadsberettiget = true,
+                            erUtdanning = false,
+                            arrangør = "Arrangør",
+                            kilde = Kilde.ARENA,
+                        ),
+                    ),
+                ),
+                ytelse = GrunnlagYtelse(
+                    perioder =
+                    listOf(
+                        PeriodeGrunnlagYtelse(
+                            type = TypeYtelsePeriode.AAP,
+                            fom = LocalDate.now(),
+                            tom = LocalDate.now().plusDays(1),
+                        ),
                     ),
                 ),
                 hentetInformasjon = HentetInformasjon(
                     fom = LocalDate.now().minusMonths(3),
                     tom = LocalDate.now().plusYears(1),
                     tidspunktHentet = LocalDateTime.now(),
-                )
-            ),
-        )
+                ),
+            )
 
         vilkårperioderGrunnlagRepository.insert(
             VilkårperioderGrunnlagDomain(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å gjøre det lettere for SB ønsker man å vise perioder med ytelser. Dette må lagres ned i grunnlag slik at man senere vet akkurat hva SB har sett. 

Er et par TODO kommentarer som fjernes etter at vilkårperiodegrunnlag slettes på eksisterende behandlinger.

### Hva håndteres _ikke_
- Rehenting av ytelser som feiler. Hvis feil oppstår kastes det bare en feil og sb må refreshe siden for å prøve igjen. Da vil systemet prøve å hente på nytt og siden ikke noe eksisterer vil det skje. 