### PR TITLE
VilkårperioderGrunnlag skal kun inneholde aktiviteter som er stønadsb…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -121,7 +121,7 @@ class VilkårperiodeService(
             ident = behandlingService.hentSaksbehandling(behandlingId).ident,
             fom = fom,
             tom = tom,
-        ),
+        ).filter { it.erStønadsberettiget == true },
     )
 
     private fun hentGrunnlagYtelse(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/AktivitetClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/AktivitetClientConfig.kt
@@ -1,12 +1,10 @@
 package no.nav.tilleggsstonader.sak.infrastruktur.mocks
 
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
-import no.nav.tilleggsstonader.kontrakter.aktivitet.Kilde
-import no.nav.tilleggsstonader.kontrakter.aktivitet.StatusAktivitet
-import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetClient
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -20,26 +18,14 @@ class AktivitetClientConfig {
     @Primary
     fun aktivitetClient(): AktivitetClient {
         val client = mockk<AktivitetClient>()
-
-        every { client.hentAktiviteter(any(), any(), any()) } returns
-            listOf(
-                AktivitetArenaDto(
-                    id = "123",
-                    fom = osloDateNow(),
-                    tom = osloDateNow().plusMonths(1),
-                    type = "TYPE",
-                    typeNavn = "Type navn",
-                    status = StatusAktivitet.AKTUELL,
-                    statusArena = "AKTUL",
-                    antallDagerPerUke = 5,
-                    prosentDeltakelse = 100.toBigDecimal(),
-                    erStønadsberettiget = true,
-                    erUtdanning = false,
-                    arrangør = "Arrangør",
-                    kilde = Kilde.ARENA,
-                ),
-            )
-
+        resetMock(client)
         return client
+    }
+
+    companion object {
+        fun resetMock(client: AktivitetClient) {
+            clearMocks(client)
+            every { client.hentAktiviteter(any(), any(), any()) } returns listOf(aktivitetArenaDto())
+        }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/ArenaKontraktUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/ArenaKontraktUtil.kt
@@ -1,0 +1,40 @@
+package no.nav.tilleggsstonader.sak.opplysninger.aktivitet
+
+import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import no.nav.tilleggsstonader.kontrakter.aktivitet.Kilde
+import no.nav.tilleggsstonader.kontrakter.aktivitet.StatusAktivitet
+import no.nav.tilleggsstonader.libs.utils.osloDateNow
+import java.math.BigDecimal
+import java.time.LocalDate
+
+object ArenaKontraktUtil {
+    fun aktivitetArenaDto(
+        id: String = "123",
+        fom: LocalDate = osloDateNow(),
+        tom: LocalDate? = osloDateNow().plusMonths(1),
+        type: String = "TYPE",
+        typeNavn: String = "Type navn",
+        status: StatusAktivitet? = StatusAktivitet.AKTUELL,
+        statusArena: String? = "AKTUL",
+        antallDagerPerUke: Int? = 5,
+        prosentDeltakelse: BigDecimal? = 100.toBigDecimal(),
+        erStønadsberettiget: Boolean? = true,
+        erUtdanning: Boolean? = false,
+        arrangør: String? = "Arrangør",
+        kilde: Kilde = Kilde.ARENA,
+    ) = AktivitetArenaDto(
+        id = id,
+        fom = fom,
+        tom = tom,
+        type = type,
+        typeNavn = typeNavn,
+        status = status,
+        statusArena = statusArena,
+        antallDagerPerUke = antallDagerPerUke,
+        prosentDeltakelse = prosentDeltakelse,
+        erStønadsberettiget = erStønadsberettiget,
+        erUtdanning = erUtdanning,
+        arrangør = arrangør,
+        kilde = kilde,
+    )
+}


### PR DESCRIPTION
…erettiget då alle andre skaper en del støy. Og de vises under personoversikten

### Hvorfor er denne endringen nødvendig? ✨
Ikke opprettet oppgave på denne. Dette var etter diskusjon med T og Ø.

Nå lagres kun aktiviteter som gir rett på stønaden ned i grunnlaget. Hvis de ønsker å eks avslå fordi man er på en aktivitet som ikke finnes med så vises den vanligvis i personoversikten. 