### PR TITLE
Skal ikke kunne opprette grunnlag som veileder.

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -7,7 +7,7 @@ jobs:
   ktlint:
     name: Ktlint
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     permissions:
       contents: read
     steps:

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -8,9 +8,12 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseService
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeValideringUtil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
@@ -55,6 +58,7 @@ class VilkårperiodeService(
     private val aktivitetService: AktivitetService,
     private val ytelseService: YtelseService,
     private val søknadService: SøknadService,
+    private val tilgangService: TilgangService,
 ) {
 
     fun hentVilkårperioder(behandlingId: UUID): Vilkårperioder {
@@ -88,6 +92,10 @@ class VilkårperiodeService(
     }
 
     private fun opprettGrunnlagsdata(behandlingId: UUID): VilkårperioderGrunnlagDomain {
+        feilHvisIkke(tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER)) {
+            "Behandlingen er ikke påbegynt. Kan ikke opprette vilkårperiode hvis man ikke er saksbehandler"
+        }
+
         val søknad = søknadService.hentSøknadBarnetilsyn(behandlingId)
         val utgangspunktDato = søknad?.mottattTidspunkt ?: LocalDateTime.now()
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingControllerTest.kt
@@ -2,19 +2,20 @@ package no.nav.tilleggsstonader.sak.behandling
 
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.sak.IntegrationTest
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.HenlagtÅrsak
 import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -24,9 +25,6 @@ import org.springframework.web.client.exchange
 import java.util.UUID
 
 internal class BehandlingControllerTest : IntegrationTest() {
-
-    @Autowired
-    private lateinit var behandlingRepository: BehandlingRepository
 
     @BeforeEach
     fun setUp() {
@@ -62,6 +60,37 @@ internal class BehandlingControllerTest : IntegrationTest() {
         assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(respons.body!!.resultat).isEqualTo(BehandlingResultat.HENLAGT)
         assertThat(respons.body!!.henlagtÅrsak).isEqualTo(HenlagtÅrsak.FEILREGISTRERT)
+    }
+
+    @Nested
+    inner class OpprettelseAvGrunnlagsdata {
+        val behandling = behandling()
+
+        @BeforeEach
+        fun setUp() {
+            testoppsettService.opprettBehandlingMedFagsak(behandling, opprettGrunnlagsdata = false)
+        }
+
+        @Test
+        fun `behandlingStatus=OPPRETTET og veileder skal ikke hentes då det opprettes grunnlag`() {
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.veilederRolle))
+
+            val exception = catchProblemDetailException { hentBehandling(behandling.id) }
+            assertThat(exception.detail.detail).contains("Behandlingen er ikke påbegynt")
+        }
+
+        @Test
+        fun `behandlingStatus=UTREDES og veilder skal kunne hente behandlingen hvis statusen er annet enn UTREDES`() {
+            testoppsettService.oppdater(behandling.copy(status = BehandlingStatus.UTREDES))
+            headers.setBearerAuth(onBehalfOfToken(role = rolleConfig.veilederRolle))
+
+            hentBehandling(behandling.id)
+        }
+
+        @Test
+        fun `behandlingStatus=OPPRETTET skal kunne opprette grunnlag hvis bruker er saksbehandler`() {
+            hentBehandling(behandling.id)
+        }
     }
 
     private fun hentBehandling(id: UUID): ResponseEntity<BehandlingDto> {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
@@ -71,6 +71,10 @@ class TestoppsettService(
         return dbBehandling
     }
 
+    fun oppdater(behandling: Behandling): Behandling {
+        return behandlingRepository.update(behandling)
+    }
+
     fun opprettGrunnlagsdata(behandlingId: UUID) {
         grunnlagsdataService.opprettGrunnlagsdataHvisDetIkkeEksisterer(behandlingId)
     }


### PR DESCRIPTION
Trenger kanskje egentlige noe smartere oppsett i frontend sånn at dette aldri skjer, men foreløpig er det en grei løsning

### Hvorfor er denne endringen nødvendig? ✨
Hvis man går inn på en behandling som veileder så skal man ikke opprette grunnlagsdata.
Av den grunnen kaster vi feil for "enkleste" løsningen nå.

Dette håndterer at man går inn på en behandling via behandlingsoversikten eller via lenke.
Man kaster då feil og det vises i saksbehandlingen. 

2 ulike feil
* Opprettelse av grunnlag fra hentBehandling - `brukerFeil`
* Opprettelse av vilkårperiodegrunnlag -> skal egentligen ikke skje `feil` - dette skal ikke gjøres før hentBehandling

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21398

Skal få testet den lokalt men opprettelse av saksbehandler har problemer i IDA.

