### PR TITLE
Behandlingstype kan utledes fra hvilke behandlinger som finnes fra fø…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
@@ -1,10 +1,22 @@
 package no.nav.tilleggsstonader.sak.behandling
 
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType.FØRSTEGANGSBEHANDLING
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType.REVURDERING
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import java.util.UUID
 
 object BehandlingUtil {
+
+    fun utledBehandlingType(tidligereBehandlinger: List<Behandling>): BehandlingType {
+        return if (tidligereBehandlinger.any { it.resultat != BehandlingResultat.HENLAGT }) {
+            REVURDERING
+        } else {
+            FØRSTEGANGSBEHANDLING
+        }
+    }
 
     fun validerBehandlingIdErLik(behandlingIdParam: UUID, behandlingIdRequest: UUID) =
         feilHvis(behandlingIdParam != behandlingIdRequest) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettBehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettBehandlingUtil.kt
@@ -20,24 +20,16 @@ object OpprettBehandlingUtil {
     fun validerKanOppretteNyBehandling(
         behandlingType: BehandlingType,
         tidligereBehandlinger: List<Behandling>,
-        erMigrering: Boolean = false,
     ) {
         val sisteBehandling = tidligereBehandlinger
             .filter { it.resultat != BehandlingResultat.HENLAGT }
             .sisteFerdigstilteBehandling()
 
         validerTidligereBehandlingerErFerdigstilte(tidligereBehandlinger)
-        validerMigreringErRevurdering(behandlingType, erMigrering)
 
         when (behandlingType) {
             FØRSTEGANGSBEHANDLING -> validerKanOppretteFørstegangsbehandling(sisteBehandling)
-            REVURDERING -> validerKanOppretteRevurdering(sisteBehandling, erMigrering)
-        }
-    }
-
-    private fun validerMigreringErRevurdering(behandlingType: BehandlingType, erMigrering: Boolean) {
-        feilHvis(erMigrering && behandlingType != REVURDERING) {
-            "Det er ikke mulig å lage en migrering av annet enn revurdering"
+            REVURDERING -> validerKanOppretteRevurdering(sisteBehandling)
         }
     }
 
@@ -60,15 +52,9 @@ object OpprettBehandlingUtil {
         }
     }
 
-    private fun validerKanOppretteRevurdering(sisteBehandling: Behandling?, erMigrering: Boolean) {
-        if (sisteBehandling == null && !erMigrering) {
+    private fun validerKanOppretteRevurdering(sisteBehandling: Behandling?) {
+        if (sisteBehandling == null) {
             throw ApiFeil("Det finnes ikke en tidligere behandling på fagsaken", HttpStatus.BAD_REQUEST)
-        }
-        if (erMigrering && sisteBehandling != null) {
-            throw ApiFeil(
-                "Det er ikke mulig å opprette en migrering når det finnes en behandling fra før",
-                HttpStatus.BAD_REQUEST,
-            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettTestBehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettTestBehandlingController.kt
@@ -31,7 +31,6 @@ import no.nav.tilleggsstonader.libs.utils.osloNow
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
@@ -75,7 +74,6 @@ class OpprettTestBehandlingController(
 
     private fun lagBehandling(fagsak: Fagsak): Behandling =
         behandlingService.opprettBehandling(
-            behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
             fagsakId = fagsak.id,
             behandlingsårsak = BehandlingÅrsak.SØKNAD,
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
@@ -11,7 +11,6 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandling.domain.Journalposttype
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
@@ -35,7 +34,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Service
-open class JournalføringService(
+class JournalføringService(
     private val behandlingService: BehandlingService,
     private val fagsakService: FagsakService,
     private val journalpostService: JournalpostService,
@@ -99,12 +98,10 @@ open class JournalføringService(
     ) {
         val journalpost = journalpostService.hentJournalpost(journalpostId)
         val fagsak = hentEllerOpprettFagsakIEgenTransaksjon(personIdent, stønadstype)
-        val nesteBehandlingstype = behandlingService.utledNesteBehandlingstype(fagsak.id)
 
         validerKanOppretteBehandling(journalpost, personIdent)
 
         val behandling = opprettBehandlingOgPopulerGrunnlagsdataForJournalpost(
-            behandlingstype = nesteBehandlingstype,
             fagsak = fagsak,
             journalpost = journalpost,
             behandlingÅrsak = behandlingÅrsak,
@@ -167,13 +164,11 @@ open class JournalføringService(
     }
 
     private fun opprettBehandlingOgPopulerGrunnlagsdataForJournalpost(
-        behandlingstype: BehandlingType,
         fagsak: Fagsak,
         journalpost: Journalpost,
         behandlingÅrsak: BehandlingÅrsak,
     ): Behandling {
         val behandling = behandlingService.opprettBehandling(
-            behandlingType = behandlingstype,
             fagsakId = fagsak.id,
             behandlingsårsak = behandlingÅrsak,
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceIntegrationTest.kt
@@ -35,23 +35,10 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
         )
         assertThatThrownBy {
             behandlingService.opprettBehandling(
-                BehandlingType.REVURDERING,
                 fagsak.id,
                 behandlingsårsak = behandlingÅrsak,
             )
         }.hasMessage("Det finnes en behandling på fagsaken som ikke er ferdigstilt")
-    }
-
-    @Test
-    internal fun `opprettBehandling - skal ikke være mulig å opprette en revurdering om det ikke finnes en behandling fra før`() {
-        val fagsak = testoppsettService.lagreFagsak(fagsak())
-        assertThatThrownBy {
-            behandlingService.opprettBehandling(
-                BehandlingType.REVURDERING,
-                fagsak.id,
-                behandlingsårsak = behandlingÅrsak,
-            )
-        }.hasMessage("Det finnes ikke en tidligere behandling på fagsaken")
     }
 
     @Test
@@ -159,7 +146,6 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
             testoppsettService.lagre(behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT))
             assertThatThrownBy {
                 behandlingService.opprettBehandling(
-                    BehandlingType.FØRSTEGANGSBEHANDLING,
                     fagsak.id,
                     behandlingsårsak = behandlingÅrsak,
                 )
@@ -172,7 +158,6 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
             testoppsettService.lagre(behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT))
             assertThatThrownBy {
                 behandlingService.opprettBehandling(
-                    BehandlingType.REVURDERING,
                     fagsak.id,
                     behandlingsårsak = behandlingÅrsak,
                 )
@@ -187,7 +172,6 @@ internal class BehandlingServiceIntegrationTest : IntegrationTest() {
                 behandling(fagsak, BehandlingStatus.SATT_PÅ_VENT, type = BehandlingType.REVURDERING),
             )
             behandlingService.opprettBehandling(
-                BehandlingType.REVURDERING,
                 fagsak.id,
                 behandlingsårsak = behandlingÅrsak,
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
@@ -90,8 +90,6 @@ internal class BehandlingServiceTest {
                 stegType = StegType.VILKÅR,
                 behandlingsårsak = BehandlingÅrsak.PAPIRSØKNAD,
                 kravMottatt = osloDateNow().plusDays(1),
-                erMigrering = false,
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 fagsakId = UUID.randomUUID(),
             )
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
@@ -19,7 +19,6 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
@@ -80,7 +79,6 @@ class JournalføringServiceTest {
     fun setUp() {
         every { fagsakService.finnFagsak(any(), any()) } returns fagsak
         every { fagsakService.hentEllerOpprettFagsak(any(), any()) } returns fagsak
-        every { behandlingService.utledNesteBehandlingstype(fagsak.id) } returns BehandlingType.FØRSTEGANGSBEHANDLING
         every { taskService.save(capture(taskSlot)) } returns mockk()
         every { personService.hentPersonIdenter(personIdent) } returns PdlIdenter(listOf(PdlIdent(personIdent, false)))
         justRun { oppgaveService.ferdigstillOppgave(any()) }
@@ -118,7 +116,6 @@ class JournalføringServiceTest {
         every { behandlingService.leggTilBehandlingsjournalpost(any(), any(), any()) } just Runs
         every {
             behandlingService.opprettBehandling(
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 fagsakId = fagsak.id,
                 behandlingsårsak = BehandlingÅrsak.SØKNAD,
             )
@@ -137,7 +134,6 @@ class JournalføringServiceTest {
 
         verify(exactly = 1) {
             behandlingService.opprettBehandling(
-                behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                 fagsakId = fagsak.id,
                 behandlingsårsak = BehandlingÅrsak.SØKNAD,
             )


### PR DESCRIPTION
…r i stedet for å sende med den til behandlingService

### Hvorfor er denne endringen nødvendig? ✨
Ønsker å gjøre den før vi begynner med å opprette ny behandling

I stedet for å sende med "behandlingType" så kan vi utlede den i stedet. Forenkler en del av koden.
Fjernet også "erMigrering" som ikke er i bruk 

