### PR TITLE
SettPåVent skal vise informasjon hvem som satte behandlingen på vent

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentDto.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.behandling.vent
 
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class SettPåVentDto(
     val årsaker: List<ÅrsakSettPåVent>,
@@ -29,6 +30,9 @@ data class StatusPåVentDto(
     val årsaker: List<ÅrsakSettPåVent>,
     val kommentar: String?,
     val datoSattPåVent: LocalDate,
+    val opprettetAv: String,
+    val endretAv: String?,
+    val endretTid: LocalDateTime?,
     val frist: LocalDate?,
     val oppgaveVersjon: Int,
 )


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det var også ønskelig å vise hvem som endret på infoen. Blir litt krøll fordi endretTid og opprettet tid nesten er lik, men ikke eksakt. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21469

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/389