### PR TITLE
Skal fjerne tildelt ressurs når man oppdaterer sett på vent

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtil.kt
@@ -32,8 +32,11 @@ object SettPåVentBeskrivelseUtil {
         if (fristBeskrivelse.isEmpty()) {
             return oppgave.beskrivelse ?: ""
         }
+        val tilordnetSaksbehandlerBeskrivelse =
+            utledTilordnetSaksbehandlerBeskrivelse(oppgave, "")
         return utledBeskrivelsePrefix(tidspunkt) +
             fristBeskrivelse.påNyRadEllerTomString() +
+            tilordnetSaksbehandlerBeskrivelse.påNyRadEllerTomString() +
             nåværendeBeskrivelse(oppgave)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
@@ -178,6 +178,7 @@ class SettPåVentService(
             versjon = dto.oppgaveVersjon,
             fristFerdigstillelse = dto.frist,
             beskrivelse = SettPåVentBeskrivelseUtil.oppdaterSettPåVent(oppgave, dto.frist),
+            tilordnetRessurs = "",
         )
         return oppgaveService.oppdaterOppgave(oppdatertOppgave)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtilTest.kt
@@ -81,6 +81,22 @@ class SettPåVentBeskrivelseUtilTest {
                 """.trimIndent(),
             )
         }
+
+        @Test
+        fun `skal fjerne saksbehandler på oppgaven når man oppdaterer sett på vent`() {
+            val beskrivelse = SettPåVentBeskrivelseUtil.oppdaterSettPåVent(
+                Oppgave(id = 0, versjon = 0, tilordnetRessurs = "a100"),
+                LocalDate.of(2023, 1, 1),
+                tidspunkt,
+            )
+            assertThat(beskrivelse).isEqualTo(
+                """
+                --- 05.03.2024 18:00 a100 (a100) ---
+                Oppgave endret frist fra <ingen> til 01.01.2023
+                Oppgave flyttet fra saksbehandler a100 til <ingen>
+                """.trimIndent(),
+            )
+        }
     }
 
     @Nested


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21460

❗ Sånn som det er nå kan man oppdatere selv om en annen står på oppgaven - og då fjerner den andre personen - er det ønskelig? 