### PR TITLE
Oppgave skal inneholde informasjon om hvem som sendte behandlingen ti…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveDomain.kt
@@ -18,3 +18,16 @@ data class OppgaveDomain(
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
 )
+
+/**
+ *
+ * @param sendtTilTotrinnskontrollAv brukes for at saksbehandler ikke skal plukke behandlinger man selv sendt til totrinnskontroll
+
+ * !!NOTER: Denne blir cachet i [OppgaveService.finnOppgaveMetadata]
+ * så hvis noe legges til som kan endre seg, eks en status, så må cache fjernes
+ */
+data class OppgaveMetadata(
+    val gsakOppgaveId: Long,
+    val behandlingId: UUID,
+    val sendtTilTotrinnskontrollAv: String?,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
@@ -32,6 +32,7 @@ interface OppgaveRepository : RepositoryInterface<OppgaveDomain, UUID>, InsertUp
         FROM oppgave o
         LEFT JOIN totrinnskontroll t ON t.behandling_id = o.behandling_id AND t.status = 'KAN_FATTE_VEDTAK'
         WHERE gsak_oppgave_id IN (:oppgaveIder)
+        AND o.behandling_id IS NOT NULL
         """,
     )
     fun finnOppgaveMetadata(oppgaveIder: Collection<Long>): List<OppgaveMetadata>

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepository.kt
@@ -27,8 +27,12 @@ interface OppgaveRepository : RepositoryInterface<OppgaveDomain, UUID>, InsertUp
 
     @Query(
         """
-        SELECT gsak_oppgave_id as first, behandling_id as second FROM oppgave WHERE gsak_oppgave_id IN (:oppgaveIder)
+        SELECT gsak_oppgave_id, o.behandling_id, 
+        t.saksbehandler AS sendt_til_totrinnskontroll_av 
+        FROM oppgave o
+        LEFT JOIN totrinnskontroll t ON t.behandling_id = o.behandling_id AND t.status = 'KAN_FATTE_VEDTAK'
+        WHERE gsak_oppgave_id IN (:oppgaveIder)
         """,
     )
-    fun finnBehandlingIdForGsakOppgaveId(oppgaveIder: Collection<Long>): List<Pair<Long, UUID>>
+    fun finnOppgaveMetadata(oppgaveIder: Collection<Long>): List<OppgaveMetadata>
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/FinnOppgaveResponseDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/FinnOppgaveResponseDto.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgave
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveIdentV2
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgavePrioritet
 import no.nav.tilleggsstonader.kontrakter.oppgave.StatusEnum
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveMetadata
 import java.time.LocalDate
 import java.util.Optional
 import java.util.UUID
@@ -61,11 +62,12 @@ data class OppgaveDto(
      */
     val navn: String?,
     val behandlingId: UUID?,
+    val sendtTilTotrinnskontrollAv: String?,
 ) {
     constructor(
         oppgave: Oppgave,
         navn: String?,
-        behandlingId: UUID?,
+        oppgaveMetadata: OppgaveMetadata?,
     ) : this(
         id = oppgave.id,
         versjon = oppgave.versjon,
@@ -101,6 +103,7 @@ data class OppgaveDto(
         status = oppgave.status,
 
         navn = navn,
-        behandlingId = behandlingId,
+        behandlingId = oppgaveMetadata?.behandlingId,
+        sendtTilTotrinnskontrollAv = oppgaveMetadata?.sendtTilTotrinnskontrollAv,
     )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveRepositoryTest.kt
@@ -163,25 +163,24 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
             testoppsettService.lagreFagsak(fagsak2)
             testoppsettService.lagre(behandling1)
             testoppsettService.lagre(behandling2)
+        }
 
+        @Test
+        fun `skal ikke hente ut informasjon til de oppgaver som ikke har behandlingId`() {
             oppgaveRepository.insert(
                 OppgaveDomain(
-                    behandlingId = behandling1.id,
-                    type = Oppgavetype.BehandleSak,
+                    behandlingId = null,
+                    type = Oppgavetype.Journalføring,
                     gsakOppgaveId = 1,
                 ),
             )
-            oppgaveRepository.insert(
-                OppgaveDomain(
-                    behandlingId = behandling2.id,
-                    type = Oppgavetype.BehandleSak,
-                    gsakOppgaveId = 2,
-                ),
-            )
+
+            assertThat(oppgaveRepository.finnOppgaveMetadata(listOf(1))).isEmpty()
         }
 
         @Test
         fun `skal finne behandlingId til oppgaver`() {
+            opprettOppgaver()
             val metadata = oppgaveRepository.finnOppgaveMetadata(listOf(1, 2, 3))
 
             assertThat(metadata.map { it.gsakOppgaveId to it.behandlingId })
@@ -190,6 +189,7 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
 
         @Test
         fun `skal finne hvem som sendt oppgaven til totrinnskontroll`() {
+            opprettOppgaver()
             totrinnskontrollRepository.insert(
                 totrinnskontroll(
                     status = TotrinnInternStatus.KAN_FATTE_VEDTAK,
@@ -206,6 +206,8 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
 
         @Test
         fun `sendtTilTotrinnskontrollAv er null hvis TotrinnInternStatus ikke er KAN_FATTE_VEDTAK`() {
+            opprettOppgaver()
+
             TotrinnInternStatus.entries
                 .filter { it != TotrinnInternStatus.KAN_FATTE_VEDTAK }
                 .forEach {
@@ -221,6 +223,23 @@ internal class OppgaveRepositoryTest : IntegrationTest() {
 
             assertThat(metadata.map { it.gsakOppgaveId to it.sendtTilTotrinnskontrollAv })
                 .containsExactlyInAnyOrder(Pair(1, null), Pair(2, null))
+        }
+
+        private fun opprettOppgaver() {
+            oppgaveRepository.insert(
+                OppgaveDomain(
+                    behandlingId = behandling1.id,
+                    type = Oppgavetype.BehandleSak,
+                    gsakOppgaveId = 1,
+                ),
+            )
+            oppgaveRepository.insert(
+                OppgaveDomain(
+                    behandlingId = behandling2.id,
+                    type = Oppgavetype.BehandleSak,
+                    gsakOppgaveId = 2,
+                ),
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
@@ -70,7 +70,7 @@ internal class OppgaveServiceTest {
         every { oppgaveClient.finnOppgaveMedId(any()) } returns lagEksternTestOppgave()
         every { oppgaveRepository.insert(capture(opprettOppgaveDomainSlot)) } returns lagTestOppgave()
         every { oppgaveRepository.update(any()) } answers { firstArg() }
-        every { oppgaveRepository.finnBehandlingIdForGsakOppgaveId(any()) } returns emptyList()
+        every { oppgaveRepository.finnOppgaveMetadata(any()) } returns emptyList()
         every { oppgaveClient.finnMapper(any(), any()) } returns FinnMappeResponseDto(
             1,
             listOf(MappeDto(OppgaveClientConfig.MAPPE_ID_PÅ_VENT, "10 På vent", "4462")),
@@ -281,8 +281,10 @@ internal class OppgaveServiceTest {
                 lagEksternTestOppgave().copy(id = 2),
             ),
         )
-        every { oppgaveRepository.finnBehandlingIdForGsakOppgaveId(any()) } answers {
-            firstArg<List<Long>>().filter { it == oppgaveIdMedBehandling }.map { it to behandlingId }
+        every { oppgaveRepository.finnOppgaveMetadata(any()) } answers {
+            firstArg<List<Long>>()
+                .filter { it == oppgaveIdMedBehandling }
+                .map { OppgaveMetadata(it, behandlingId, null) }
         }
 
         val oppgaver = oppgaveService.hentOppgaver(FinnOppgaveRequestDto(ident = null)).oppgaver


### PR DESCRIPTION
…l beslutter.

For at knapp om å plukke Godkjenne Vedtak-oppgaven vises for saksbehandler på egne saker

### Hvorfor er denne endringen nødvendig? ✨
Dette for å unngå at man går inn på behandlinger som man likevel ikke kan beslutte

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/394

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21460
