### PR TITLE
forhåndsvisBeslutterBrev skal vise beslutterbrevet med tom signatur h…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevController.kt
@@ -16,7 +16,11 @@ import java.util.UUID
 @RestController
 @RequestMapping("/api/brev")
 @ProtectedWithClaims(issuer = "azuread")
-class BrevController(private val tilgangService: TilgangService, private val behandlingService: BehandlingService, private val brevService: BrevService) {
+class BrevController(
+    private val tilgangService: TilgangService,
+    private val behandlingService: BehandlingService,
+    private val brevService: BrevService,
+) {
 
     @PostMapping("/{behandlingId}")
     fun genererPdf(@RequestBody request: GenererPdfRequest, @PathVariable behandlingId: UUID): ByteArray {
@@ -30,9 +34,7 @@ class BrevController(private val tilgangService: TilgangService, private val beh
 
     @GetMapping("/{behandlingId}")
     fun hentBrev(@PathVariable behandlingId: UUID): ByteArray {
-        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
-
-        tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.UPDATE)
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
 
         return Base64.getEncoder().encode(brevService.hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId))
     }
@@ -41,7 +43,7 @@ class BrevController(private val tilgangService: TilgangService, private val beh
     fun forhåndsvisBeslutterbrev(@PathVariable behandlingId: UUID): ByteArray {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.ACCESS)
-        tilgangService.validerHarBeslutterrolle()
+
         return Base64.getEncoder().encode(brevService.forhåndsvisBeslutterBrev(saksbehandling))
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/BrevService.kt
@@ -13,16 +13,19 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.util.norskFormat
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
 class BrevService(
     private val vedtaksbrevRepository: VedtaksbrevRepository,
     private val familieDokumentClient: FamilieDokumentClient,
+    private val tilgangService: TilgangService,
 ) {
 
     fun lagSaksbehandlerBrev(saksbehandling: Saksbehandling, html: String): ByteArray {
@@ -70,7 +73,11 @@ class BrevService(
     fun forhåndsvisBeslutterBrev(saksbehandling: Saksbehandling): ByteArray {
         val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(saksbehandling.id)
 
-        val beslutterSignatur = SikkerhetContext.hentSaksbehandlerNavn(strict = true)
+        val beslutterSignatur = if (tilgangService.harTilgangTilRolle(BehandlerRolle.BESLUTTER)) {
+            SikkerhetContext.hentSaksbehandlerNavn(strict = true)
+        } else {
+            ""
+        }
 
         return lagBeslutterPdfMedSignatur(vedtaksbrev.saksbehandlerHtml, beslutterSignatur).bytes
     }


### PR DESCRIPTION
…vis saksbehandler ikke har beslutterrolle

### Hvorfor er denne endringen nødvendig? ✨
Det feiler nå hvis man går til fanen for brev når man har sendt behandlingen til signaturen, hvis man ikke er beslutter.

Jeg har nå lagt til at man fortsatt generer brevet, men med tom besluttersignatur. Tenker det var en grei løsning. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21496