### PR TITLE
✨ Gjenbruk inngangsvilkår i en revurdering

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -23,6 +24,7 @@ class OpprettRevurderingBehandlingService(
     val taskService: TaskService,
     val behandlingService: BehandlingService,
     val barnService: BarnService,
+    val vilkårperiodeService: VilkårperiodeService,
     val unleashService: UnleashService,
 ) {
 
@@ -59,7 +61,10 @@ class OpprettRevurderingBehandlingService(
         val barnIder: Map<TidligereBarnId, NyttBarnId> =
             barnService.gjenbrukBarn(forrigeBehandlingId = forrigeBehandlingId, nyBehandlingId = behandling.id)
 
-        // TODO kopier vilkårperioder
+        vilkårperiodeService.gjenbrukVilkårperioder(
+            forrigeBehandlingId = forrigeBehandlingId,
+            nyBehandlingId = behandling.id
+        )
         // TODO kopier stønadsperioder
         // TODO kopier vilkår
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -25,6 +26,7 @@ class OpprettRevurderingBehandlingService(
     val behandlingService: BehandlingService,
     val barnService: BarnService,
     val vilkårperiodeService: VilkårperiodeService,
+    val stønadsperiodeService: StønadsperiodeService,
     val unleashService: UnleashService,
 ) {
 
@@ -65,7 +67,12 @@ class OpprettRevurderingBehandlingService(
             forrigeBehandlingId = forrigeBehandlingId,
             nyBehandlingId = behandling.id
         )
-        // TODO kopier stønadsperioder
+
+        stønadsperiodeService.gjenbrukStønadsperioder(
+            forrigeBehandlingId = forrigeBehandlingId,
+            nyBehandlingId = behandling.id
+        )
+
         // TODO kopier vilkår
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
@@ -65,12 +65,12 @@ class OpprettRevurderingBehandlingService(
 
         vilkårperiodeService.gjenbrukVilkårperioder(
             forrigeBehandlingId = forrigeBehandlingId,
-            nyBehandlingId = behandling.id
+            nyBehandlingId = behandling.id,
         )
 
         stønadsperiodeService.gjenbrukStønadsperioder(
             forrigeBehandlingId = forrigeBehandlingId,
-            nyBehandlingId = behandling.id
+            nyBehandlingId = behandling.id,
         )
 
         // TODO kopier vilkår

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsperiode
 
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
@@ -117,6 +118,7 @@ class StønadsperiodeService(
             it.copy(
                 id = UUID.randomUUID(),
                 behandlingId = nyBehandlingId,
+                sporbar = Sporbar()
             )
         }
         stønadsperiodeRepository.insertAll(nyeStønadsperioder)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -110,4 +110,15 @@ class StønadsperiodeService(
 
         StønadsperiodeValideringUtil.validerStønadsperioder(stønadsperioder, vilkårperioder, fødselsdato)
     }
+
+    fun gjenbrukStønadsperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {
+        val eksisterendeStønadsperioder = stønadsperiodeRepository.findAllByBehandlingId(forrigeBehandlingId)
+        val nyeStønadsperioder = eksisterendeStønadsperioder.map {
+            it.copy(
+                id = UUID.randomUUID(),
+                behandlingId = nyBehandlingId,
+            )
+        }
+        stønadsperiodeRepository.insertAll(nyeStønadsperioder)
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -118,7 +118,7 @@ class StønadsperiodeService(
             it.copy(
                 id = UUID.randomUUID(),
                 behandlingId = nyBehandlingId,
-                sporbar = Sporbar()
+                sporbar = Sporbar(),
             )
         }
         stønadsperiodeRepository.insertAll(nyeStønadsperioder)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -288,6 +288,23 @@ class VilkårperiodeService(
         )
     }
 
+    @Transactional
+    fun gjenbrukVilkårperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {
+        val eksisterendeVilkårperioder = vilkårperiodeRepository.findByBehandlingId(forrigeBehandlingId)
+
+        val kopiertePerioderMedReferanse = eksisterendeVilkårperioder
+            .filter { it.resultat !== ResultatVilkårperiode.SLETTET }
+            .map {
+                it.copy(
+                    id = UUID.randomUUID(),
+                    behandlingId = nyBehandlingId,
+                    forrigeVilkårperiodeId = it.id,
+
+                    )
+            }
+        vilkårperiodeRepository.insertAll(kopiertePerioderMedReferanse)
+    }
+
     private fun behandlingErLåstForVidereRedigering(behandlingId: UUID) =
         behandlingService.hentBehandling(behandlingId).status.behandlingErLåstForVidereRedigering()
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -291,10 +291,9 @@ class VilkårperiodeService(
 
     @Transactional
     fun gjenbrukVilkårperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {
-        val eksisterendeVilkårperioder = vilkårperiodeRepository.findByBehandlingId(forrigeBehandlingId)
+        val eksisterendeVilkårperioder = vilkårperiodeRepository.findByBehandlingIdAndResultatNot(forrigeBehandlingId, ResultatVilkårperiode.SLETTET)
 
         val kopiertePerioderMedReferanse = eksisterendeVilkårperioder
-            .filter { it.resultat !== ResultatVilkårperiode.SLETTET }
             .map {
                 it.copy(
                     id = UUID.randomUUID(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -300,7 +300,7 @@ class VilkårperiodeService(
                     id = UUID.randomUUID(),
                     behandlingId = nyBehandlingId,
                     forrigeVilkårperiodeId = it.id,
-                    sporbar = Sporbar()
+                    sporbar = Sporbar(),
                 )
             }
         vilkårperiodeRepository.insertAll(kopiertePerioderMedReferanse)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -289,7 +289,6 @@ class VilkårperiodeService(
         )
     }
 
-    @Transactional
     fun gjenbrukVilkårperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {
         val eksisterendeVilkårperioder = vilkårperiodeRepository.findByBehandlingIdAndResultatNot(forrigeBehandlingId, ResultatVilkårperiode.SLETTET)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -300,7 +300,7 @@ class VilkårperiodeService(
                     behandlingId = nyBehandlingId,
                     forrigeVilkårperiodeId = it.id,
 
-                    )
+                )
             }
         vilkårperiodeRepository.insertAll(kopiertePerioderMedReferanse)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.validerBehandlingIdErLik
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
@@ -299,7 +300,7 @@ class VilkårperiodeService(
                     id = UUID.randomUUID(),
                     behandlingId = nyBehandlingId,
                     forrigeVilkårperiodeId = it.id,
-
+                    sporbar = Sporbar()
                 )
             }
         vilkårperiodeRepository.insertAll(kopiertePerioderMedReferanse)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -20,6 +20,8 @@ data class Vilkårperiode(
     val id: UUID = UUID.randomUUID(),
     val behandlingId: UUID,
     val kilde: KildeVilkårsperiode,
+    @Column("forrige_vilkarperiode_id")
+    val forrigeVilkårperiodeId: UUID? = null,
 
     val fom: LocalDate,
     val tom: LocalDate,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/VilkårperiodeRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/VilkårperiodeRepository.kt
@@ -11,4 +11,6 @@ interface VilkårperiodeRepository : RepositoryInterface<Vilkårperiode, UUID>, 
     fun findByBehandlingId(behandlingId: UUID): List<Vilkårperiode>
 
     fun findByBehandlingIdAndResultat(behandlingId: UUID, resultat: ResultatVilkårperiode): List<Vilkårperiode>
+
+    fun findByBehandlingIdAndResultatNot(behandlingId: UUID, resultat: ResultatVilkårperiode): List<Vilkårperiode>
 }

--- a/src/main/resources/db/migration/V43__vilkårperioder_forrige_id.sql
+++ b/src/main/resources/db/migration/V43__vilkårperioder_forrige_id.sql
@@ -1,2 +1,2 @@
 ALTER TABLE vilkar_periode
-    ADD COLUMN forrige_vilkarperiode_id UUID;
+    ADD COLUMN forrige_vilkarperiode_id UUID REFERENCES vilkar_periode (id);

--- a/src/main/resources/db/migration/V43__vilkårperioder_forrige_id.sql
+++ b/src/main/resources/db/migration/V43__vilkårperioder_forrige_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vilkar_periode
+    ADD COLUMN forrige_vilkarperiode_id UUID;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
@@ -3,6 +3,8 @@ package no.nav.tilleggsstonader.sak.util
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingId
 import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingIdRepository
 import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
@@ -91,6 +93,13 @@ class TestoppsettService(
         )
         val eksternFagsakId = eksternFagsakIdRepository.insert(EksternFagsakId(fagsakId = fagsak.id))
         return fagsak.tilFagsakMedPerson(person.identer, eksternFagsakId)
+    }
+
+    fun lagBehandlingOgRevurdering(): Behandling {
+        val fagsak = fagsak()
+        lagreFagsak(fagsak)
+        val førsteBehandling = lagre(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET))
+        return lagre(behandling(fagsak = fagsak, forrigeBehandlingId = førsteBehandling.id))
     }
 
     private fun hentEllerOpprettPerson(fagsak: Fagsak): FagsakPerson {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -230,41 +230,20 @@ class StønadsperiodeServiceTest : IntegrationTest() {
 
     @Nested
     inner class GjenbrukStønadsperioder() {
-        val forrigeBehandlingId = UUID.randomUUID()
-        val nyBehandlingId = UUID.randomUUID()
-
-        @BeforeEach
-        fun setup() {
-            val fagsak = testoppsettService.lagreFagsak(fagsak())
-            testoppsettService.lagre(
-                behandling(
-                    fagsak = fagsak,
-                    id = forrigeBehandlingId,
-                    status = BehandlingStatus.FERDIGSTILT,
-                ),
-            )
-            testoppsettService.lagre(
-                behandling(
-                    fagsak = fagsak,
-                    id = nyBehandlingId,
-                    status = BehandlingStatus.UTREDES,
-                    forrigeBehandlingId = forrigeBehandlingId,
-                ),
-            )
-        }
-
         @Test
         fun `skal gjenbruke stønadsperioder fra forrige behandlingen`() {
+            val revurdering = testoppsettService.lagBehandlingOgRevurdering()
+
             val eksisterendeStønadsperidoder = listOf(
                 stønadsperiode(
-                    behandlingId = forrigeBehandlingId,
+                behandlingId = revurdering.forrigeBehandlingId!!,
                     fom = LocalDate.of(2024, 1, 1),
                     tom = LocalDate.of(2024, 1, 31),
                     målgruppe = MålgruppeType.AAP,
                     aktivitet = AktivitetType.TILTAK,
                 ),
                 stønadsperiode(
-                    behandlingId = forrigeBehandlingId,
+                    behandlingId = revurdering.forrigeBehandlingId!!,
                     fom = LocalDate.of(2024, 2, 1),
                     tom = LocalDate.of(2024, 1, 10),
                     målgruppe = MålgruppeType.OVERGANGSSTØNAD,
@@ -274,11 +253,11 @@ class StønadsperiodeServiceTest : IntegrationTest() {
             stønadsperiodeRepository.insertAll(eksisterendeStønadsperidoder)
 
             stønadsperiodeService.gjenbrukStønadsperioder(
-                forrigeBehandlingId = forrigeBehandlingId,
-                nyBehandlingId = nyBehandlingId,
+                forrigeBehandlingId = revurdering.forrigeBehandlingId!!,
+                nyBehandlingId = revurdering.id,
             )
 
-            val stønadsperioder = stønadsperiodeRepository.findAllByBehandlingId(nyBehandlingId)
+            val stønadsperioder = stønadsperiodeRepository.findAllByBehandlingId(revurdering.id)
 
             assertThat(stønadsperioder).hasSize(2)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -236,7 +236,7 @@ class StønadsperiodeServiceTest : IntegrationTest() {
 
             val eksisterendeStønadsperidoder = listOf(
                 stønadsperiode(
-                behandlingId = revurdering.forrigeBehandlingId!!,
+                    behandlingId = revurdering.forrigeBehandlingId!!,
                     fom = LocalDate.of(2024, 1, 1),
                     tom = LocalDate.of(2024, 1, 31),
                     målgruppe = MålgruppeType.AAP,
@@ -261,10 +261,13 @@ class StønadsperiodeServiceTest : IntegrationTest() {
 
             assertThat(stønadsperioder).hasSize(2)
 
-            stønadsperioder.forEachIndexed { index, stønadsperiode ->
-                assertThat(stønadsperiode).usingRecursiveComparison().ignoringFields("id", "sporbar", "behandlingId")
-                    .isEqualTo(eksisterendeStønadsperidoder[index])
-            }
+            assertThat(stønadsperioder)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                    "id",
+                    "sporbar",
+                    "behandlingId"
+                )
+                .containsExactlyInAnyOrderElementsOf(eksisterendeStønadsperidoder)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -4,7 +4,6 @@ import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
-import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
@@ -20,7 +19,6 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiod
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VurderingDto
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -265,7 +263,7 @@ class StønadsperiodeServiceTest : IntegrationTest() {
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
                     "id",
                     "sporbar",
-                    "behandlingId"
+                    "behandlingId",
                 )
                 .containsExactlyInAnyOrderElementsOf(eksisterendeStønadsperidoder)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -240,16 +240,16 @@ class StønadsperiodeServiceTest : IntegrationTest() {
                 behandling(
                     fagsak = fagsak,
                     id = forrigeBehandlingId,
-                    status = BehandlingStatus.FERDIGSTILT
-                )
+                    status = BehandlingStatus.FERDIGSTILT,
+                ),
             )
             testoppsettService.lagre(
                 behandling(
                     fagsak = fagsak,
                     id = nyBehandlingId,
                     status = BehandlingStatus.UTREDES,
-                    forrigeBehandlingId = forrigeBehandlingId
-                )
+                    forrigeBehandlingId = forrigeBehandlingId,
+                ),
             )
         }
 
@@ -261,21 +261,21 @@ class StønadsperiodeServiceTest : IntegrationTest() {
                     fom = LocalDate.of(2024, 1, 1),
                     tom = LocalDate.of(2024, 1, 31),
                     målgruppe = MålgruppeType.AAP,
-                    aktivitet = AktivitetType.TILTAK
+                    aktivitet = AktivitetType.TILTAK,
                 ),
                 stønadsperiode(
                     behandlingId = forrigeBehandlingId,
                     fom = LocalDate.of(2024, 2, 1),
                     tom = LocalDate.of(2024, 1, 10),
                     målgruppe = MålgruppeType.OVERGANGSSTØNAD,
-                    aktivitet = AktivitetType.UTDANNING
+                    aktivitet = AktivitetType.UTDANNING,
                 ),
             )
             stønadsperiodeRepository.insertAll(eksisterendeStønadsperidoder)
 
             stønadsperiodeService.gjenbrukStønadsperioder(
                 forrigeBehandlingId = forrigeBehandlingId,
-                nyBehandlingId = nyBehandlingId
+                nyBehandlingId = nyBehandlingId,
             )
 
             val stønadsperioder = stønadsperiodeRepository.findAllByBehandlingId(nyBehandlingId)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -184,7 +184,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                         behandlingId = behandling.id,
                     ),
 
-                )
+                    )
             }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid")
         }
 
@@ -713,29 +713,6 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
     @Nested
     inner class GjenbrukVilkårperioder {
-//        val forrigeBehandlingId = UUID.randomUUID()
-//        val nyBehandlingId = UUID.randomUUID()
-//
-//        @BeforeEach
-//        fun setUp() {
-//            val fagsak = testoppsettService.lagreFagsak(fagsak())
-//            testoppsettService.lagre(
-//                behandling(
-//                    fagsak = fagsak,
-//                    id = forrigeBehandlingId,
-//                    status = BehandlingStatus.FERDIGSTILT,
-//                ),
-//            )
-//            testoppsettService.lagre(
-//                behandling(
-//                    fagsak = fagsak,
-//                    id = nyBehandlingId,
-//                    status = BehandlingStatus.UTREDES,
-//                    forrigeBehandlingId = forrigeBehandlingId,
-//                ),
-//            )
-//        }
-
         @Test
         fun `skal gjenbruke vilkår fra forrige behandling`() {
             val revurdering = testoppsettService.lagBehandlingOgRevurdering()
@@ -752,14 +729,14 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             val res = vilkårperiodeRepository.findByBehandlingId(revurdering.id)
             assertThat(res).hasSize(2)
 
-            res.forEachIndexed { index, vilkårperiode ->
-                assertThat(vilkårperiode)
-                    .usingRecursiveComparison()
-                    .ignoringFields("id", "forrigeVilkårperiodeId", "behandlingId", "sporbar")
-                    .isEqualTo(eksisterendeVilkårperioder[index])
-
-                assertThat(vilkårperiode.forrigeVilkårperiodeId).isEqualTo(eksisterendeVilkårperioder[index].id)
-            }
+            assertThat(res)
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                    "id",
+                    "sporbar",
+                    "behandlingId",
+                    "forrigeVilkårperiodeId"
+                )
+                .containsExactlyInAnyOrderElementsOf(eksisterendeVilkårperioder)
         }
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -16,7 +16,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.akti
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
-import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.dekketAvAnnetRegelverk
@@ -47,12 +46,10 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.tilDto
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
-import java.util.UUID
 
 class VilkårperiodeServiceTest : IntegrationTest() {
 
@@ -184,7 +181,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                         behandlingId = behandling.id,
                     ),
 
-                    )
+                )
             }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid")
         }
 
@@ -734,7 +731,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     "id",
                     "sporbar",
                     "behandlingId",
-                    "forrigeVilkårperiodeId"
+                    "forrigeVilkårperiodeId",
                 )
                 .containsExactlyInAnyOrderElementsOf(eksisterendeVilkårperioder)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -184,7 +184,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                         behandlingId = behandling.id,
                     ),
 
-                    )
+                )
             }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid")
         }
 
@@ -723,16 +723,16 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 behandling(
                     fagsak = fagsak,
                     id = forrigeBehandlingId,
-                    status = BehandlingStatus.FERDIGSTILT
-                )
+                    status = BehandlingStatus.FERDIGSTILT,
+                ),
             )
             testoppsettService.lagre(
                 behandling(
                     fagsak = fagsak,
                     id = nyBehandlingId,
                     status = BehandlingStatus.UTREDES,
-                    forrigeBehandlingId = forrigeBehandlingId
-                )
+                    forrigeBehandlingId = forrigeBehandlingId,
+                ),
             )
         }
 
@@ -768,14 +768,14 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     behandlingId = forrigeBehandlingId,
                     resultat = ResultatVilkårperiode.SLETTET,
                     kilde = KildeVilkårsperiode.MANUELL,
-                    slettetKommentar = "slettet"
+                    slettetKommentar = "slettet",
                 ),
                 aktivitet(behandlingId = forrigeBehandlingId),
                 aktivitet(
                     behandlingId = forrigeBehandlingId,
                     resultat = ResultatVilkårperiode.SLETTET,
                     kilde = KildeVilkårsperiode.MANUELL,
-                    slettetKommentar = "slettet"
+                    slettetKommentar = "slettet",
                 ),
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -29,6 +29,7 @@ object VilkårperiodeTestUtil {
         begrunnelse: String? = null,
         kilde: KildeVilkårsperiode = KildeVilkårsperiode.SYSTEM,
         resultat: ResultatVilkårperiode = ResultatVilkårperiode.OPPFYLT,
+        slettetKommentar: String? = null,
     ) = Vilkårperiode(
         behandlingId = behandlingId,
         fom = fom,
@@ -39,6 +40,7 @@ object VilkårperiodeTestUtil {
         kilde = kilde,
         resultat = resultat,
         aktivitetsdager = null,
+        slettetKommentar = slettetKommentar,
     )
 
     fun delvilkårMålgruppe(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å gjøre revurdering lettere og hindre feil skal både vilkårperioder og stønadsperioder kopieres med videre. 

Kopierer kun med vilkårperioder som ikke er slettet!

### Implementasjon
- Vilkårperioder har en referanse til perioden den ble kopiert fra
- Stønadsperioder har ingen referanser og alle kopieres over

Skrevet tester og sjekket at det funker ved oppretting av revurdering fra sak-frontend lokalt. 

### Spørsmål
- Burde vi ha 
- Har lagt testene i servicene og ikke i `OpprettRevurderingBehandlingService` slik at funksjonene testes direkte. Burde kanskje ha en test i den filen også som bare passer på at alle tingene faktisk skjer samlet? 