### PR TITLE
🐛 Validering av overlapp med perioder uten rett skal ikke tas med i val…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringUtil.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.util.norskFormat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.Datoperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
@@ -84,7 +85,7 @@ object StønadsperiodeValideringUtil {
         stønadsperioder: List<StønadsperiodeDto>,
     ) {
         val perioderSomIkkeGirRett = (vilkårperioder.målgrupper + vilkårperioder.aktiviteter)
-            .filter { it.type.girIkkeRettPåStønadsperiode() }
+            .filter { it.type.girIkkeRettPåStønadsperiode() && it.resultat != ResultatVilkårperiode.SLETTET }
         stønadsperioder.forEach { validerIkkeOverlapperMedPeriodeSomIkkeGirRettPåStønad(perioderSomIkkeGirRett, it) }
     }
 


### PR DESCRIPTION
…idering

### Hvorfor er denne endringen nødvendig? ✨
Når man validerer stønadsperioder og overlapp med vilkårperioder som ikke gir rett skal man _ikke_ ta hensyn til de som er slettet. 

Feil rapportert inn [her](https://nav-it.slack.com/archives/C05TU86SU8Y/p1719296462885759)