### PR TITLE
Permanent sletting av vilkarperioder som er manuelt opprettet i denne behandlingen

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -80,10 +80,11 @@ class VilkårperiodeController(
     fun slettPeriodePermanent(
         @PathVariable("id") id: UUID,
     ): LagreVilkårperiodeResponse {
-        tilgangService.validerTilgangTilBehandling(id, AuditLoggerEvent.UPDATE)
+        val vilkårperiode = vilkårperiodeService.hentVilkårperiode(id)
+        tilgangService.validerTilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
-        val behandlingId = vilkårperiodeService.slettVilkårperiodePermanent(id)
-        return vilkårperiodeService.validerOgLagResponse(behandlingId = behandlingId)
+        vilkårperiodeService.slettVilkårperiodePermanent(vilkårperiodeId = id, forrigeVilkårperiodeId = vilkårperiode.forrigeVilkårperiodeId)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = vilkårperiode.behandlingId)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -76,7 +76,7 @@ class VilkårperiodeController(
         return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
     }
 
-    @DeleteMapping("{id}/ny-periode")
+    @DeleteMapping("{id}/permanent")
     fun slettPeriodePermanent(
         @PathVariable("id") id: UUID,
     ): LagreVilkårperiodeResponse {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -49,7 +49,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.opprettVilkårperiode(vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.behandlingId, periode = periode)
     }
 
     @PostMapping("{id}")
@@ -61,7 +61,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.oppdaterVilkårperiode(id, vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.behandlingId, periode = periode)
     }
 
     @DeleteMapping("{id}")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -84,7 +84,7 @@ class VilkårperiodeController(
         tilgangService.validerTilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
-        vilkårperiodeService.slettVilkårperiodePermanent(vilkårperiodeId = id, forrigeVilkårperiodeId = vilkårperiode.forrigeVilkårperiodeId)
+        vilkårperiodeService.slettVilkårperiodePermanent(vilkårperiode)
         return vilkårperiodeService.validerOgLagResponse(behandlingId = vilkårperiode.behandlingId)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -49,7 +49,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.opprettVilkårperiode(vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(periode)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
     }
 
     @PostMapping("{id}")
@@ -61,7 +61,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.oppdaterVilkårperiode(id, vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(periode)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
     }
 
     @DeleteMapping("{id}")
@@ -73,16 +73,17 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.slettVilkårperiode(id, slettVikårperiode)
-        return vilkårperiodeService.validerOgLagResponse(periode)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
     }
 
     @DeleteMapping("{id}/ny-periode")
     fun slettPeriodePermanent(
         @PathVariable("id") id: UUID,
-    ) {
+    ): LagreVilkårperiodeResponse {
         tilgangService.validerTilgangTilBehandling(id, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
-        return vilkårperiodeService.slettVilkårperiodePermanent(id)
+        val behandlingId = vilkårperiodeService.slettVilkårperiodePermanent(id)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = behandlingId)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -73,18 +73,7 @@ class VilkårperiodeController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.slettVilkårperiode(id, slettVikårperiode)
-        return vilkårperiodeService.validerOgLagResponse(behandlingId = periode.id, periode = periode)
-    }
 
-    @DeleteMapping("{id}/permanent")
-    fun slettPeriodePermanent(
-        @PathVariable("id") id: UUID,
-    ): LagreVilkårperiodeResponse {
-        val vilkårperiode = vilkårperiodeService.hentVilkårperiode(id)
-        tilgangService.validerTilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
-
-        vilkårperiodeService.slettVilkårperiodePermanent(vilkårperiode)
-        return vilkårperiodeService.validerOgLagResponse(behandlingId = vilkårperiode.behandlingId)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = slettVikårperiode.behandlingId, periode = periode)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -75,4 +75,14 @@ class VilkårperiodeController(
         val periode = vilkårperiodeService.slettVilkårperiode(id, slettVikårperiode)
         return vilkårperiodeService.validerOgLagResponse(periode)
     }
+
+    @DeleteMapping("{id}/ny-periode")
+    fun slettPeriodePermanent(
+        @PathVariable("id") id: UUID,
+    ) {
+        tilgangService.validerTilgangTilBehandling(id, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return vilkårperiodeService.slettVilkårperiodePermanent(id)
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -293,10 +293,11 @@ class VilkårperiodeService(
         )
     }
 
-    fun slettVilkårperiodePermanent(vilkårperiodeId: UUID, forrigeVilkårperiodeId: UUID?) {
-        feilHvis(forrigeVilkårperiodeId != null) { "Skal ikke permanent slette vilkårsperiode fra tidligere behandling. Teknisk feil. Ta kontakt med utviklerteamet." }
+    fun slettVilkårperiodePermanent(vilkårperiode: Vilkårperiode) {
+        feilHvis(vilkårperiode.forrigeVilkårperiodeId != null) { "Skal ikke permanent slette vilkårsperiode fra tidligere behandling. Teknisk feil. Ta kontakt med utviklerteamet." }
+        feilHvis(vilkårperiode.kilde == KildeVilkårsperiode.SYSTEM) {"Kan ikke slette vilkårperioder som er opprettet av system"}
 
-        return vilkårperiodeRepository.deleteById(vilkårperiodeId)
+        return vilkårperiodeRepository.deleteById(vilkårperiode.id)
     }
 
     fun gjenbrukVilkårperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -289,6 +289,14 @@ class VilkårperiodeService(
         )
     }
 
+    fun slettVilkårperiodePermanent(id: UUID) {
+        val vilkårperiode = vilkårperiodeRepository.findByIdOrThrow(id)
+
+        feilHvis(vilkårperiode.forrigeVilkårperiodeId != null) { "Skal ikke permanent slette vilkårsperiode fra tidligere behandling. Teknisk feil. Ta kontakt med utviklerteamet." }
+
+        return vilkårperiodeRepository.deleteById(id)
+    }
+
     fun gjenbrukVilkårperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {
         val eksisterendeVilkårperioder = vilkårperiodeRepository.findByBehandlingIdAndResultatNot(forrigeBehandlingId, ResultatVilkårperiode.SLETTET)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -71,6 +71,10 @@ class VilkårperiodeService(
         )
     }
 
+    fun hentVilkårperiode(id: UUID): Vilkårperiode {
+        return vilkårperiodeRepository.findByIdOrThrow(id)
+    }
+
     fun hentVilkårperioderResponse(behandlingId: UUID): VilkårperioderResponse {
         val grunnlagsdataVilkårsperioder = hentEllerOpprettGrunnlag(behandlingId)
 
@@ -289,14 +293,10 @@ class VilkårperiodeService(
         )
     }
 
-    fun slettVilkårperiodePermanent(id: UUID): UUID {
-        val vilkårperiode = vilkårperiodeRepository.findByIdOrThrow(id)
+    fun slettVilkårperiodePermanent(vilkårperiodeId: UUID, forrigeVilkårperiodeId: UUID?) {
+        feilHvis(forrigeVilkårperiodeId != null) { "Skal ikke permanent slette vilkårsperiode fra tidligere behandling. Teknisk feil. Ta kontakt med utviklerteamet." }
 
-        feilHvis(vilkårperiode.forrigeVilkårperiodeId != null) { "Skal ikke permanent slette vilkårsperiode fra tidligere behandling. Teknisk feil. Ta kontakt med utviklerteamet." }
-
-        vilkårperiodeRepository.deleteById(id)
-
-        return vilkårperiode.behandlingId
+        return vilkårperiodeRepository.deleteById(vilkårperiodeId)
     }
 
     fun gjenbrukVilkårperioder(forrigeBehandlingId: UUID, nyBehandlingId: UUID) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -295,7 +295,7 @@ class VilkårperiodeService(
 
     fun slettVilkårperiodePermanent(vilkårperiode: Vilkårperiode) {
         feilHvis(vilkårperiode.forrigeVilkårperiodeId != null) { "Skal ikke permanent slette vilkårsperiode fra tidligere behandling. Teknisk feil. Ta kontakt med utviklerteamet." }
-        feilHvis(vilkårperiode.kilde == KildeVilkårsperiode.SYSTEM) {"Kan ikke slette vilkårperioder som er opprettet av system"}
+        feilHvis(vilkårperiode.kilde == KildeVilkårsperiode.SYSTEM) { "Kan ikke slette vilkårperioder som er opprettet av system" }
 
         return vilkårperiodeRepository.deleteById(vilkårperiode.id)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -104,7 +104,7 @@ data class Vilkårperiode(
             feilHvis(kilde != KildeVilkårsperiode.MANUELL) {
                 "Kan ikke slette når kilde=$kilde"
             }
-            feilHvis(slettetKommentar.isNullOrBlank()) {
+            feilHvis(slettetKommentar.isNullOrBlank() && forrigeVilkårperiodeId != null) {
                 "Mangler kommentar for resultat=$resultat"
             }
         } else {
@@ -113,6 +113,8 @@ data class Vilkårperiode(
             }
         }
     }
+    fun kanSlettesPermanent() =
+        this.forrigeVilkårperiodeId == null && this.kilde != KildeVilkårsperiode.SYSTEM
 }
 
 enum class KildeVilkårsperiode {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiodeResponse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiodeResponse.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto
 
 data class LagreVilkårperiodeResponse(
-    val periode: VilkårperiodeDto,
+    val periode: VilkårperiodeDto? = null,
     val stønadsperiodeStatus: Stønadsperiodestatus,
     val stønadsperiodeFeil: String? = null,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -39,6 +39,7 @@ data class VilkårperiodeDto(
     val slettetKommentar: String?,
     val sistEndret: LocalDateTime,
     val aktivitetsdager: Int? = null,
+    val forrigeVilkårperiodeId: UUID?,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
@@ -58,6 +59,7 @@ fun Vilkårperiode.tilDto() =
         aktivitetsdager = this.aktivitetsdager,
         slettetKommentar = this.slettetKommentar,
         sistEndret = this.sporbar.endret.endretTid,
+        forrigeVilkårperiodeId = this.forrigeVilkårperiodeId,
     )
 
 fun DelvilkårVilkårperiode.tilDto() = when (this) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -137,7 +137,7 @@ data class VurderingDto(
 
 data class SlettVikårperiode(
     val behandlingId: UUID,
-    val kommentar: String,
+    val kommentar: String? = null,
 )
 
 data class VilkårperioderDto(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeServiceTest.kt
@@ -316,6 +316,6 @@ class StønadsperiodeServiceTest : IntegrationTest() {
 
     private fun opprettVilkårperiode(periode: LagreVilkårperiode): LagreVilkårperiodeResponse {
         val oppdatertPeriode = vilkårperiodeService.opprettVilkårperiode(periode)
-        return vilkårperiodeService.validerOgLagResponse(oppdatertPeriode)
+        return vilkårperiodeService.validerOgLagResponse(behandlingId = oppdatertPeriode.id, periode = oppdatertPeriode)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeControllerTest.kt
@@ -69,7 +69,7 @@ class VilkårperiodeControllerTest : IntegrationTest() {
         )
         val exception = catchProblemDetailException {
             slettVilkårperiode(
-                vilkårperiodeId = response.periode.id,
+                vilkårperiodeId = response.periode!!.id,
                 SlettVikårperiode(behandlingForAnnenFagsak.id, "test"),
             )
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -13,7 +13,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.mocks.AktivitetClientConfig.Com
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetClient
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
-import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
@@ -279,13 +278,12 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         fun `skal oppdatere alle felter hvis periode er lagt til manuelt`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
 
-            val vilkårperiode =
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeMålgruppe(
-                        medlemskap = null,
-                        behandlingId = behandling.id,
-                    ),
-                )
+            val vilkårperiode = vilkårperiodeService.opprettVilkårperiode(
+                opprettVilkårperiodeMålgruppe(
+                    medlemskap = null,
+                    behandlingId = behandling.id,
+                ),
+            )
 
             val nyttDato = LocalDate.of(2020, 1, 1)
             val oppdatering = vilkårperiode.tilOppdatering().copy(
@@ -313,16 +311,15 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         fun `skal oppdatere felter for periode som er lagt til av system`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
 
-            val vilkårperiode =
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeMålgruppe(
-                        begrunnelse = "Begrunnelse",
-                        medlemskap = VurderingDto(
-                            SvarJaNei.JA,
-                        ),
-                        behandlingId = behandling.id,
+            val vilkårperiode = vilkårperiodeService.opprettVilkårperiode(
+                opprettVilkårperiodeMålgruppe(
+                    begrunnelse = "Begrunnelse",
+                    medlemskap = VurderingDto(
+                        SvarJaNei.JA,
                     ),
-                )
+                    behandlingId = behandling.id,
+                ),
+            )
 
             val oppdatering = vilkårperiode.tilOppdatering().copy(
                 begrunnelse = "Oppdatert begrunnelse",
@@ -340,24 +337,24 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             assertThat(oppdatertPeriode.tom).isEqualTo(vilkårperiode.tom)
             assertThat(oppdatertPeriode.begrunnelse).isEqualTo("Oppdatert begrunnelse")
             assertThat((oppdatertPeriode.delvilkår as DelvilkårMålgruppe).medlemskap.svar).isEqualTo(SvarJaNei.NEI)
-            assertThat((oppdatertPeriode.delvilkår as DelvilkårMålgruppe).medlemskap.resultat)
-                .isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
+            assertThat((oppdatertPeriode.delvilkår as DelvilkårMålgruppe).medlemskap.resultat).isEqualTo(
+                ResultatDelvilkårperiode.IKKE_OPPFYLT,
+            )
         }
 
         @Test
         fun `skal feile dersom manglende begrunnelse når dekket av annet regelverk endres til ja`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
 
-            val vilkårperiode =
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeMålgruppe(
-                        type = MålgruppeType.UFØRETRYGD,
-                        dekkesAvAnnetRegelverk = VurderingDto(
-                            SvarJaNei.NEI,
-                        ),
-                        behandlingId = behandling.id,
+            val vilkårperiode = vilkårperiodeService.opprettVilkårperiode(
+                opprettVilkårperiodeMålgruppe(
+                    type = MålgruppeType.UFØRETRYGD,
+                    dekkesAvAnnetRegelverk = VurderingDto(
+                        SvarJaNei.NEI,
                     ),
-                )
+                    behandlingId = behandling.id,
+                ),
+            )
 
             val oppdatering = vilkårperiode.tilOppdatering().copy(
                 begrunnelse = "",
@@ -375,15 +372,14 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         fun `skal feile dersom manglende begrunnelse når lønnet endres til ja`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
 
-            val vilkårperiode =
-                vilkårperiodeService.opprettVilkårperiode(
-                    opprettVilkårperiodeAktivitet(
-                        lønnet = VurderingDto(
-                            SvarJaNei.NEI,
-                        ),
-                        behandlingId = behandling.id,
+            val vilkårperiode = vilkårperiodeService.opprettVilkårperiode(
+                opprettVilkårperiodeAktivitet(
+                    lønnet = VurderingDto(
+                        SvarJaNei.NEI,
                     ),
-                )
+                    behandlingId = behandling.id,
+                ),
+            )
 
             val oppdatering = vilkårperiode.tilOppdatering().copy(
                 begrunnelse = "",
@@ -487,8 +483,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
         @Test
         fun `skal ikke kunne slette kommentar hvis man mangler kommentar`() {
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val målgruppe = målgruppe(
                 behandlingId = behandling.id,
                 kilde = KildeVilkårsperiode.MANUELL,
@@ -502,8 +497,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
         @Test
         fun `skal ikke kunne slette kommentar hvis kilden er system`() {
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val målgruppe = målgruppe(
                 behandlingId = behandling.id,
                 kilde = KildeVilkårsperiode.SYSTEM,
@@ -518,8 +512,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal kunne slette kommentar som er manuellt opprettet`() {
             val saksbehandler = "saksbehandlerX"
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val målgruppe = målgruppe(
                 behandlingId = behandling.id,
                 kilde = KildeVilkårsperiode.MANUELL,
@@ -528,7 +521,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
             assertThat(periode.sporbar.endret.endretAv).isEqualTo(SikkerhetContext.SYSTEM_FORKORTELSE)
 
-            BrukerContextUtil.testWithBrukerContext(saksbehandler) {
+            testWithBrukerContext(saksbehandler) {
                 vilkårperiodeService.slettVilkårperiode(
                     periode.id,
                     SlettVikårperiode(behandling.id, "kommentar"),
@@ -542,18 +535,18 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
         @Test
         fun `skal permanent slette vilkårperioder uten referanse til forrige vilkårperiode`() {
-            val behandling =
-                testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val målgruppe = målgruppe(
                 behandlingId = behandling.id,
                 kilde = KildeVilkårsperiode.MANUELL,
             )
             val periode = vilkårperiodeRepository.insert(målgruppe)
 
-            vilkårperiodeService.slettVilkårperiodePermanent(periode.id)
+            val res = vilkårperiodeService.slettVilkårperiodePermanent(periode.id)
 
             assertThatThrownBy { vilkårperiodeRepository.findByIdOrThrow(periode.id) }.hasMessageContaining("Finner ikke Vilkårperiode med id=")
             assertThat(vilkårperiodeRepository.findByBehandlingId(behandling.id).size).isEqualTo(0)
+            assertThat(res).isEqualTo(behandling.id)
         }
 
         @Test
@@ -595,7 +588,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 ),
             )
 
-            val response = vilkårperiodeService.validerOgLagResponse(periode)
+            val response = vilkårperiodeService.validerOgLagResponse(behandlingId = behandling.id, periode = periode)
 
             assertThat(response.stønadsperiodeStatus).isEqualTo(Stønadsperiodestatus.OK)
             assertThat(response.stønadsperiodeFeil).isNull()
@@ -621,7 +614,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                 ),
             )
 
-            assertThat(vilkårperiodeService.validerOgLagResponse(opprettetMålgruppe).stønadsperiodeStatus).isEqualTo(
+            assertThat(vilkårperiodeService.validerOgLagResponse(behandlingId = behandling.id, periode = opprettetMålgruppe).stønadsperiodeStatus).isEqualTo(
                 Stønadsperiodestatus.OK,
             )
 
@@ -635,7 +628,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     aktivitetsdager = 5,
                 ),
             )
-            assertThat(vilkårperiodeService.validerOgLagResponse(opprettetTiltakPeriode).stønadsperiodeStatus).isEqualTo(
+            assertThat(vilkårperiodeService.validerOgLagResponse(behandlingId = behandling.id, periode = opprettetTiltakPeriode).stønadsperiodeStatus).isEqualTo(
                 Stønadsperiodestatus.OK,
             )
             stønadsperiodeService.lagreStønadsperioder(behandling.id, listOf(nyStønadsperiode(fom1, tom1)))
@@ -651,9 +644,9 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     aktivitetsdager = 5,
                 ),
             )
-            vilkårperiodeService.validerOgLagResponse(oppdatertPeriode)
+            vilkårperiodeService.validerOgLagResponse(behandlingId = behandling.id, periode = opprettetMålgruppe)
 
-            assertThat(vilkårperiodeService.validerOgLagResponse(oppdatertPeriode).stønadsperiodeStatus).isEqualTo(
+            assertThat(vilkårperiodeService.validerOgLagResponse(behandlingId = behandling.id, periode = opprettetMålgruppe).stønadsperiodeStatus).isEqualTo(
                 Stønadsperiodestatus.FEIL,
             )
         }
@@ -679,8 +672,9 @@ class VilkårperiodeServiceTest : IntegrationTest() {
 
             val response = vilkårperiodeService.hentVilkårperioderResponse(behandling.id)
 
-            assertThat(vilkårperioderGrunnlagRepository.findByBehandlingId(behandling.id)!!.grunnlag.tilDto())
-                .isEqualTo(response.grunnlag)
+            assertThat(vilkårperioderGrunnlagRepository.findByBehandlingId(behandling.id)!!.grunnlag.tilDto()).isEqualTo(
+                response.grunnlag,
+            )
             assertThat(response.grunnlag!!.aktivitet.aktiviteter).isNotEmpty
             assertThat(response.grunnlag!!.ytelse?.perioder).isNotEmpty
         }
@@ -709,9 +703,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             vilkårperiodeService.hentVilkårperioderResponse(behandling.id)
 
             val grunnlag = vilkårperioderGrunnlagRepository.findByBehandlingId(behandling.id)
-            assertThat(grunnlag!!.grunnlag.aktivitet.aktiviteter.map { it.id })
-                .hasSize(1)
-                .contains(idStønadsberettiget)
+            assertThat(grunnlag!!.grunnlag.aktivitet.aktiviteter.map { it.id }).hasSize(1).contains(idStønadsberettiget)
         }
 
         @Test
@@ -767,14 +759,12 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             val res = vilkårperiodeRepository.findByBehandlingId(revurdering.id)
             assertThat(res).hasSize(2)
 
-            assertThat(res)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields(
-                    "id",
-                    "sporbar",
-                    "behandlingId",
-                    "forrigeVilkårperiodeId",
-                )
-                .containsExactlyInAnyOrderElementsOf(eksisterendeVilkårperioder)
+            assertThat(res).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                "id",
+                "sporbar",
+                "behandlingId",
+                "forrigeVilkårperiodeId",
+            ).containsExactlyInAnyOrderElementsOf(eksisterendeVilkårperioder)
         }
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -542,11 +542,10 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             )
             val periode = vilkårperiodeRepository.insert(målgruppe)
 
-            val res = vilkårperiodeService.slettVilkårperiodePermanent(periode.id)
+            vilkårperiodeService.slettVilkårperiodePermanent(periode.id, forrigeVilkårperiodeId = null)
 
             assertThatThrownBy { vilkårperiodeRepository.findByIdOrThrow(periode.id) }.hasMessageContaining("Finner ikke Vilkårperiode med id=")
             assertThat(vilkårperiodeRepository.findByBehandlingId(behandling.id).size).isEqualTo(0)
-            assertThat(res).isEqualTo(behandling.id)
         }
 
         @Test
@@ -567,7 +566,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             vilkårperiodeRepository.insert(originalMålgruppe)
             val periode = vilkårperiodeRepository.insert(revurderingMålgruppe)
 
-            assertThatThrownBy { vilkårperiodeService.slettVilkårperiodePermanent(periode.id) }.hasMessageContaining("Skal ikke permanent slette vilkårsperiode fra tidligere behandling")
+            assertThatThrownBy { vilkårperiodeService.slettVilkårperiodePermanent(periode.id, forrigeVilkårperiodeId = revurderingMålgruppe.forrigeVilkårperiodeId) }.hasMessageContaining("Skal ikke permanent slette vilkårsperiode fra tidligere behandling")
             assertThat(vilkårperiodeRepository.findByBehandlingId(revurdering.id).size).isEqualTo(1)
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -30,6 +30,7 @@ object VilkårperiodeTestUtil {
         kilde: KildeVilkårsperiode = KildeVilkårsperiode.SYSTEM,
         resultat: ResultatVilkårperiode = ResultatVilkårperiode.OPPFYLT,
         slettetKommentar: String? = null,
+        forrigeVilkårperiodeId: UUID? = null,
     ) = Vilkårperiode(
         behandlingId = behandlingId,
         fom = fom,
@@ -41,6 +42,7 @@ object VilkårperiodeTestUtil {
         resultat = resultat,
         aktivitetsdager = null,
         slettetKommentar = slettetKommentar,
+        forrigeVilkårperiodeId = forrigeVilkårperiodeId,
     )
 
     fun delvilkårMålgruppe(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/VilkårperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/VilkårperiodeTest.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class VilkårperiodeTest {
 
@@ -55,9 +56,9 @@ class VilkårperiodeTest {
         }
 
         @Test
-        fun `feiler hvis man mangler kommentar når resultat er slettet`() {
+        fun `feiler hvis man mangler kommentar når resultat er slettet og perioden er gjenbrukt`() {
             assertThatThrownBy {
-                målgruppe(kilde = KildeVilkårsperiode.MANUELL)
+                målgruppe(kilde = KildeVilkårsperiode.MANUELL, forrigeVilkårperiodeId = UUID.randomUUID())
                     .copy(resultat = ResultatVilkårperiode.SLETTET)
             }.hasMessageContaining("Mangler kommentar for resultat=")
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis en vilkårperiode er manuelt opprettet i denne behandlingen skal den slettes permanent. 

Vi hadde en diskusjon om det burde slettes permanent eller disse skulle filtreres vekk enten i frontend eller ved henting. Vi landet på å slette de permanent fordi det ikke er noe grunn til å ha disse videre.

Tas i bruk i [pr 416 i frontend](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/416)