### PR TITLE
Endre forsinkelse i prosessering fra 15sek til 2sek

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,7 @@ management:
 
 prosessering:
   continuousRunning.enabled: true
-  fixedDelayString.in.milliseconds: 15000
+  fixedDelayString.in.milliseconds: 2000
   delete.after.weeks: 16
 
 rolle:


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Hindre at oppgaver blir liggende igjen med feil status når saksbehandler kommer tilbake til oppgavebenken etter å ha fullført oppgaven