### PR TITLE
Skal legge kommentar for sett på vent i historikken

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
@@ -52,7 +52,7 @@ class SettPåVentService(
         feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
             "Kan ikke sette behandling på vent når status=${behandling.status}"
         }
-        opprettHistorikkInnslag(behandling, StegUtfall.SATT_PÅ_VENT, mapOf("årsaker" to dto.årsaker))
+        opprettHistorikkInnslag(behandling, StegUtfall.SATT_PÅ_VENT, årsaker = dto.årsaker, kommentar = dto.kommentar)
         behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.SATT_PÅ_VENT)
 
         val oppdatertOppgave = settOppgavePåVent(behandlingId, dto)
@@ -90,7 +90,12 @@ class SettPåVentService(
         val settPåVent = finnAktivSattPåVent(behandlingId)
 
         if (harEndretÅrsaker(settPåVent, dto)) {
-            opprettHistorikkInnslag(behandling, StegUtfall.SATT_PÅ_VENT, mapOf("årsaker" to dto.årsaker))
+            opprettHistorikkInnslag(
+                behandling,
+                StegUtfall.SATT_PÅ_VENT,
+                årsaker = dto.årsaker,
+                kommentar = dto.kommentar,
+            )
         }
         val oppdatertSettPåVent =
             settPåVentRepository.update(settPåVent.copy(årsaker = dto.årsaker, kommentar = dto.kommentar))
@@ -205,8 +210,14 @@ class SettPåVentService(
     private fun opprettHistorikkInnslag(
         behandling: Behandling,
         utfall: StegUtfall,
-        metadata: Map<String, List<ÅrsakSettPåVent>>?,
+        kommentar: String?,
+        årsaker: List<ÅrsakSettPåVent>,
     ) {
+        val metadata: MutableMap<String, Any> = mutableMapOf(
+            "årsaker" to årsaker,
+        )
+        kommentar?.let { metadata["kommentarSettPåVent"] = it }
+
         behandlingshistorikkService.opprettHistorikkInnslag(
             behandlingId = behandling.id,
             stegtype = behandling.steg,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentServiceTest.kt
@@ -89,6 +89,11 @@ class SettPåVentServiceTest : IntegrationTest() {
                     assertThat(tilordnetRessurs).isNull()
                     assertThat(mappeId?.getOrNull()).isEqualTo(MAPPE_ID_PÅ_VENT.toLong())
                 }
+
+                with(behandlingshistorikkService.finnSisteBehandlingshistorikk(behandling.id)) {
+                    assertThat(utfall).isEqualTo(StegUtfall.SATT_PÅ_VENT)
+                    assertThat(metadata).isNotNull()
+                }
             }
         }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønskelig å se kommentaren for satt på vent i historikken slik at man har den tilgjengelig når man tar behandlingen av vent. 
Fra diskusjon på [slack](https://nav-it.slack.com/archives/C05TU86SU8Y/p1721635186981229)