### PR TITLE
Toggler innvilgelse av tidligere iverksatt fagsak for å unngå at man …

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -6,6 +6,7 @@ enum class Toggle(override val toggleId: String) : ToggleId {
     KAN_OPPRETTE_BEHANDLING("sak.kan-opprette-behandling"),
     KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST("sak.kan-opprette-behandling-fra-journalpost"),
     KAN_OPPRETTE_REVURDERING("sak.kan-opprette-revurdering"),
+    REVURDERING_INNVILGE_TIDLIGERE_INNVILGET("sak.revurdering-innvilge-etter-innvilgelse"),
 
     AUTOMATISK_JOURNALFORING_REVURDERING("sak.automatisk-jfr-revurdering"),
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -1,8 +1,11 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
@@ -25,6 +28,7 @@ import java.time.LocalDate
 class TilsynBarnBeregnYtelseSteg(
     private val tilsynBarnBeregningService: TilsynBarnBeregningService,
     private val vilkårService: VilkårService,
+    private val unleashService: UnleashService,
     vedtakRepository: TilsynBarnVedtakRepository,
     tilkjentytelseService: TilkjentYtelseService,
     simuleringService: SimuleringService,
@@ -54,6 +58,13 @@ class TilsynBarnBeregnYtelseSteg(
         saksbehandling: Saksbehandling,
         vedtak: InnvilgelseTilsynBarnDto,
     ) {
+        brukerfeilHvis(
+            saksbehandling.forrigeBehandlingId != null &&
+                !unleashService.isEnabled(Toggle.REVURDERING_INNVILGE_TIDLIGERE_INNVILGET),
+        ) {
+            "Funksjonalitet mangler for å kunne innvilge revurdering når tidligere behandling er innvilget. Sett saken på vent."
+        }
+
         val beregningsresultat =
             tilsynBarnBeregningService.beregn(behandlingId = saksbehandling.id, vedtak.utgifter)
         validerKunBarnMedOppfylteVilkår(saksbehandling, vedtak)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.saksbehandling
@@ -41,6 +42,7 @@ class TilsynBarnBeregnYtelseStegTest {
         tilkjentytelseService = tilkjentYtelseService,
         simuleringService = simuleringService,
         vilkårService = vilkårService,
+        unleashService = mockUnleashService(),
     )
 
     val saksbehandling = saksbehandling()


### PR DESCRIPTION
…ikke får med seg alle utgifter til en behandling.

Vil i slike tilfeller kunne få en tilbakekrevingssak

### Hvorfor er denne endringen nødvendig? ✨
Det er nå mulig å opprette en revurdering.
Vi har dog ikke simulering på plass, og det kan då skje at man får iverksatt en revurdering der man fjerner utbetalingsperioder uten å få med seg det.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21965
