### PR TITLE
Oppretter oppgaver i klar-mappe

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -10,5 +10,7 @@ enum class Toggle(override val toggleId: String) : ToggleId {
 
     AUTOMATISK_JOURNALFORING_REVURDERING("sak.automatisk-jfr-revurdering"),
 
+    OPPGAVE_BRUK_KLAR_MAPPE("sak.oppgave-bruk-klar-mappe"),
+
     SIMULERING("sak.simulering"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveUtil.kt
@@ -43,6 +43,16 @@ object OppgaveUtil {
         else -> error("Håndterer ikke behandlesAvApplikasjon for $oppgavetype")
     }
 
+    fun skalPlasseresIKlarMappe(oppgavetype: Oppgavetype) = when (oppgavetype) {
+        Oppgavetype.Journalføring,
+        Oppgavetype.BehandleSak,
+        Oppgavetype.BehandleUnderkjentVedtak,
+        Oppgavetype.GodkjenneVedtak,
+        -> true
+
+        else -> error("Håndterer ikke klar-mappe-håndtering for $oppgavetype")
+    }
+
     /**
      * Skal ikke opprette oppgave når en behandling har feil status for gitt oppgavetype
      * Eks i en behandling som sendes til beslutter, så opprettes det en task for GodkjenneVedtak

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OpprettOppgave.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OpprettOppgave.kt
@@ -9,7 +9,6 @@ data class OpprettOppgave(
     val beskrivelse: String? = null,
     val tilordnetNavIdent: String? = null,
     val enhetsnummer: String? = null,
-    val mappeId: Long? = null,
     val prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
     val fristFerdigstillelse: LocalDate? = null,
     val journalpostId: String? = null,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientConfig.kt
@@ -71,6 +71,7 @@ class OppgaveClientConfig {
 
         val mapper = listOf(
             MappeDto(MAPPE_ID_PÅ_VENT, OppgaveMappe.PÅ_VENT.navn, "4462"),
+            MappeDto(MAPPE_ID_KLAR, OppgaveMappe.KLAR.navn, "4462"),
         )
         every { oppgaveClient.finnMapper(any(), any()) } returns FinnMappeResponseDto(mapper.size, mapper)
 
@@ -179,5 +180,6 @@ class OppgaveClientConfig {
 
     companion object {
         const val MAPPE_ID_PÅ_VENT = 10
+        const val MAPPE_ID_KLAR = 20
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal opprette behandle-sak oppgaver i klar-mappen for at saksbehandlere ikke skal se oppgaven i gosys i uplassert når de har gosys-vakt

* Featuretogglet

Fortsettelse på
* https://github.com/navikt/tilleggsstonader-sak/pull/377

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21920