### PR TITLE
Feil som kastes av feilHvis logger meldingen i vanlig logg. For å ikk…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/manuell/OpprettBehandlingFraJournalpostService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/manuell/OpprettBehandlingFraJournalpostService.kt
@@ -144,9 +144,12 @@ class OpprettBehandlingFraJournalpostService(
             "Søknaden mangler identer på barn - kan ikke opprette behandling manuelt uten barn"
         }
         val søker = personService.hentPersonMedBarn(gjeldendeIdent)
-        barnIdenterFraSøknad.forEach { it ->
-            feilHvisIkke(søker.barn.containsKey(it)) {
-                "Søknaden inneholder barn $it som ikke finnes på personen=$gjeldendeIdent"
+        barnIdenterFraSøknad.forEach {
+            feilHvisIkke(
+                søker.barn.containsKey(it),
+                sensitivFeilmelding = { "Søknaden inneholder barn $it som ikke finnes på personen=$gjeldendeIdent" },
+            ) {
+                "Søknaden inneholder barn som ikke finnes på personen"
             }
         }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPersonService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPersonService.kt
@@ -23,7 +23,9 @@ class FagsakPersonService(
 
     fun hentIdenter(personId: UUID): Set<PersonIdent> {
         val personIdenter = fagsakPersonRepository.findPersonIdenter(personId)
-        feilHvis(personIdenter.isEmpty()) { "Finner ikke personidenter til person=$personId" }
+        feilHvis(personIdenter.isEmpty(), sensitivFeilmelding = { "Finner ikke personidenter til person=$personId" }) {
+            "Finner ikke personidenter til person"
+        }
         return personIdenter
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/ApiExceptionHandler.kt
@@ -55,12 +55,12 @@ class ApiExceptionHandler {
     @ExceptionHandler(ApiFeil::class)
     fun handleThrowable(feil: ApiFeil): ProblemDetail {
         val metodeSomFeiler = finnMetodeSomFeiler(feil)
-        secureLogger.info("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.feil}", feil)
+        secureLogger.info("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.frontendFeilmelding}", feil)
         logger.info(
             "En håndtert feil har oppstått(${feil.httpStatus}) " +
                 "metode=$metodeSomFeiler exception=${rootCause(feil)}: ${feil.message} ",
         )
-        return ProblemDetail.forStatusAndDetail(feil.httpStatus, feil.feil)
+        return ProblemDetail.forStatusAndDetail(feil.httpStatus, feil.frontendFeilmelding)
     }
 
     @ExceptionHandler(Feil::class)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
@@ -7,7 +7,14 @@ import kotlin.contracts.contract
 /**
  * Brukes primært som feil som er årsaket av en saksbehandler, som logges som info, og feil blir logge i vanlig logg
  */
-open class ApiFeil(val feil: String, val httpStatus: HttpStatus) : RuntimeException(feil)
+open class ApiFeil(
+    val feil: String,
+    val frontendFeilmelding: String = feil,
+    val httpStatus: HttpStatus,
+) : RuntimeException(feil) {
+    constructor(feil: String, httpStatus: HttpStatus) :
+        this(feil = feil, frontendFeilmelding = feil, httpStatus = httpStatus)
+}
 
 /**
  * Generelle feil. Logger som Error.
@@ -24,13 +31,18 @@ class Feil(
 inline fun feilHvis(
     boolean: Boolean,
     httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+    noinline sensitivFeilmelding: (() -> String)? = null,
     lazyMessage: () -> String,
 ) {
     contract {
         returns() implies !boolean
     }
     if (boolean) {
-        throw Feil(message = lazyMessage(), frontendFeilmelding = lazyMessage(), httpStatus)
+        throw Feil(
+            message = lazyMessage(),
+            frontendFeilmelding = sensitivFeilmelding?.invoke() ?: lazyMessage(),
+            httpStatus = httpStatus,
+        )
     }
 }
 
@@ -43,30 +55,37 @@ inline fun brukerfeil(
 inline fun brukerfeilHvis(
     boolean: Boolean,
     httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    noinline sensitivFeilmelding: (() -> String)? = null,
     lazyMessage: () -> String,
 ) {
     contract {
         returns() implies !boolean
     }
     if (boolean) {
-        throw ApiFeil(feil = lazyMessage(), httpStatus = httpStatus)
+        throw ApiFeil(
+            feil = lazyMessage(),
+            frontendFeilmelding = sensitivFeilmelding?.invoke() ?: lazyMessage(),
+            httpStatus = httpStatus,
+        )
     }
 }
 
 inline fun feilHvisIkke(
     boolean: Boolean,
     httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+    noinline sensitivFeilmelding: (() -> String)? = null,
     lazyMessage: () -> String,
 ) {
-    feilHvis(!boolean, httpStatus) { lazyMessage() }
+    feilHvis(!boolean, httpStatus, sensitivFeilmelding) { lazyMessage() }
 }
 
 inline fun brukerfeilHvisIkke(
     boolean: Boolean,
     httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    noinline sensitivFeilmelding: (() -> String)? = null,
     lazyMessage: () -> String,
 ) {
-    brukerfeilHvis(!boolean, httpStatus) { lazyMessage() }
+    brukerfeilHvis(!boolean, httpStatus, sensitivFeilmelding) { lazyMessage() }
 }
 
 class ManglerTilgang(val melding: String, val frontendFeilmelding: String) : RuntimeException(melding)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/GrunnlagsdataService.kt
@@ -79,8 +79,11 @@ class GrunnlagsdataService(
         val barnIdenter = barnService.finnBarnPåBehandling(behandling.id).map { it.ident }.toSet()
         val barn = person.barn.filter { (ident, _) -> barnIdenter.contains(ident) }
 
-        feilHvis(!barn.keys.containsAll(barnIdenter)) {
-            "Finner ikke grunnlag for barn. behandlingBarn=$barnIdenter pdlBarn=${barn.keys}"
+        feilHvis(
+            !barn.keys.containsAll(barnIdenter),
+            sensitivFeilmelding = { "Finner ikke grunnlag for barn. behandlingBarn=$barnIdenter pdlBarn=${barn.keys}" },
+        ) {
+            "Finner ikke grunnlag for barn. Se securelogs for detaljer."
         }
 
         return barn.tilGrunnlagsdataBarn()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/PassBarnRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/PassBarnRegel.kt
@@ -122,7 +122,9 @@ class PassBarnRegel : Vilkårsregel(
         datoForBeregning: LocalDate = osloDateNow(),
     ): Boolean {
         val ident = metadata.barn.firstOrNull { it.id == barnId }?.ident
-        feilHvis(ident == null) { "Fant ikke barn med id=$barnId i metadata" }
+        feilHvis(ident == null, sensitivFeilmelding = { "Fant ikke barn med id=$barnId i metadata" }) {
+            "Fant ikke barn i metadata"
+        }
 
         return harFullførtFjerdetrinn(Fødselsnummer(ident).fødselsdato, datoForBeregning)
     }


### PR DESCRIPTION
…e logge sensitiv informasjon i vanlig logg så skal dette logges separat.

Ulempen nå er at den sensitive feilmeldingen er densom blir sendt til brukeren, som kanskje ikke alltid er ønskelig. Har noen ganger behov for logg, secure logg, og feil til bruker.

### Hvorfor er denne endringen nødvendig? ✨
Tanken med `feilHvis` fra utgangspunktet var at den skulle gi en kontrollert feilmelding men som ikke inneholdt noen sensitiv informasjon. 
Denne informasjonen var også den som brukeren fikk til seg. Så behovet for å få eks med et fnr er nyttig for brukeren i noen tilfeller. Denne sensitive informasjonen er nå flyttet til en egen function, og kan brukes for sensitive feilmeldinger.

Føler ikke dette er en optimal løsning, men fjerner i hvert fall logging av fnr fra vanlig logg i det første. 