### PR TITLE
Fjerner v2-path då frontend nå bruker uten v2

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -26,8 +26,7 @@ class VilkårperiodeController(
     private val vilkårperiodeService: VilkårperiodeService,
 ) {
 
-    // TODO fjern v2 når uten v2 er tatt i bruk av frontend
-    @GetMapping("behandling/{behandlingId}/v2", "behandling/{behandlingId}")
+    @GetMapping("behandling/{behandlingId}")
     fun hentVilkårperioder(@PathVariable behandlingId: UUID): VilkårperioderResponse {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Har fjerner den tidligere "behandling/{behandlingId}" og erstatt "v2" med "behandling/{behandlingId}"
Frontend har allerede tatt i bruk uten v2.

Denne kan merges når frontend-endringene vært i prod noen timer