### PR TITLE
Håndterer andre enheter enn 4462

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -23,7 +23,6 @@ class ArbeidsfordelingService(
 
     companion object {
         const val MASKINELL_JOURNALFOERENDE_ENHET = "9999"
-        val ENHET_NASJONAL_NAY = Arbeidsfordelingsenhet("4462", "Tilleggsstønad INN")
     }
 
     fun hentNavEnhetId(ident: String, oppgavetype: Oppgavetype, tema: Tema = Tema.TSO) = when (oppgavetype) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.config.getNullable
 import no.nav.tilleggsstonader.sak.opplysninger.egenansatt.EgenAnsattService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.tilDiskresjonskode
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Component
@@ -21,6 +22,8 @@ class ArbeidsfordelingService(
     private val egenAnsattService: EgenAnsattService,
 ) {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     companion object {
         const val MASKINELL_JOURNALFOERENDE_ENHET = "9999"
     }
@@ -32,7 +35,12 @@ class ArbeidsfordelingService(
 
     fun hentNavEnhet(ident: String, tema: Tema = Tema.TSO): Arbeidsfordelingsenhet? {
         return cacheManager.getNullable("navEnhet", ident) {
-            arbeidsfordelingClient.finnArbeidsfordelingsenhet(lagArbeidsfordelingKritierieForPerson(ident, tema)).firstOrNull()
+            val kriterie = lagArbeidsfordelingKritierieForPerson(ident, tema)
+            val enheter = arbeidsfordelingClient.finnArbeidsfordelingsenhet(kriterie)
+            if (enheter.size != 1) {
+                logger.warn("Fant enheter=$enheter for $kriterie")
+            }
+            enheter.firstOrNull()
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentService.kt
@@ -11,6 +11,7 @@ import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkServ
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveMappe
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.statistikk.task.BehandlingsstatistikkTask
 import org.springframework.stereotype.Service
@@ -161,7 +162,8 @@ class SettPåVentService(
     ): OppdatertOppgaveResponse {
         val oppgave = hentOppgave(behandlingId)
 
-        val mappeId = oppgaveService.finnVentemappe().id
+        val enhet = oppgave.tildeltEnhetsnr ?: error("Oppgave=${oppgave.id} mangler enhetsnummer")
+        val mappeId = oppgaveService.finnMappe(enhet, OppgaveMappe.PÅ_VENT)
         val oppdatertOppgave = Oppgave(
             id = oppgave.id,
             versjon = oppgave.versjon,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveController.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveUtil.ENHET_NR_EGEN_ANSATT
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveUtil.ENHET_NR_NAY
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveUtil.ENHET_NR_STRENGT_FORTROLIG
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.dto.FinnOppgaveRequestDto
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.dto.FinnOppgaveResponseDto
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.dto.OppgaveDto
@@ -60,6 +61,9 @@ class OppgaveController(
         val enheter = mutableListOf(ENHET_NR_NAY)
         if (tilgangService.harEgenAnsattRolle()) {
             enheter += ENHET_NR_EGEN_ANSATT
+        }
+        if (tilgangService.harStrengtFortroligRolle()) {
+            enheter += ENHET_NR_STRENGT_FORTROLIG
         }
         return oppgaveService.finnMapper(enheter = enheter)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveUtil.kt
@@ -13,8 +13,9 @@ object OppgaveUtil {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    val ENHET_NR_NAY = "4462"
-    val ENHET_NR_EGEN_ANSATT = "4483"
+    val ENHET_NR_NAY = "4462" // Tilleggsstønad INN
+    val ENHET_NR_EGEN_ANSATT = "4483" // NAV Arbeid og ytelser Egne ansatte
+    val ENHET_NR_STRENGT_FORTROLIG = "2103" // NAV Vikafossen
 
     fun sekunderSidenEndret(oppgave: Oppgave): Long? {
         val endretTidspunkt = oppgave.endretTidspunkt

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
@@ -169,6 +169,9 @@ class TilgangService(
     fun harEgenAnsattRolle(): Boolean =
         hentGrupperFraToken().contains(rolleConfig.egenAnsatt)
 
+    fun harStrengtFortroligRolle(): Boolean =
+        hentGrupperFraToken().contains(rolleConfig.kode6)
+
     /**
      * Filtrerer data basert på om man har tilgang til den eller ikke
      * Filtrer ikke på egen ansatt

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingTestUtil.kt
@@ -1,0 +1,5 @@
+package no.nav.tilleggsstonader.sak.arbeidsfordeling
+
+object ArbeidsfordelingTestUtil {
+    val ENHET_NASJONAL_NAY = Arbeidsfordelingsenhet("4462", "Tilleggsstønad INN")
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevTaskTest.kt
@@ -6,6 +6,7 @@ import io.mockk.slot
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingTestUtil
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.Brevmottaker
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerRepository
@@ -48,7 +49,7 @@ class JournalførVedtaksbrevTaskTest {
     @BeforeEach
     fun setUp() {
         every { brevService.hentBesluttetBrev(saksbehandling.id) } returns vedtaksbrev(behandlingId = saksbehandling.id)
-        every { arbeidsfordelingService.hentNavEnhet(any()) } returns ArbeidsfordelingService.ENHET_NASJONAL_NAY
+        every { arbeidsfordelingService.hentNavEnhet(any()) } returns ArbeidsfordelingTestUtil.ENHET_NASJONAL_NAY
         every { brevmottakerRepository.insert(any()) } returns mockk()
         every { brevmottakerRepository.findByBehandlingId(saksbehandling.id) } returns listOf(
             Brevmottaker(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/AutomatiskJournalføringServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.sak.journalføring.HåndterSøknadRequest
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingTestUtil
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
@@ -69,7 +70,7 @@ internal class AutomatiskJournalføringServiceTest {
         arbeidsfordelingService = arbeidsfordelingService,
     )
 
-    val enhet = ArbeidsfordelingService.ENHET_NASJONAL_NAY.enhetNr
+    val enhet = ArbeidsfordelingTestUtil.ENHET_NASJONAL_NAY.enhetNr
     val personIdent = "123456789"
     val aktørId = "9876543210127"
     val tidligerePersonIdent = "9123456789"

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
@@ -18,7 +18,7 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
-import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingTestUtil
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
@@ -63,7 +63,7 @@ class JournalføringServiceTest {
         unleashService,
     )
 
-    val enhet = ArbeidsfordelingService.ENHET_NASJONAL_NAY.enhetNr
+    val enhet = ArbeidsfordelingTestUtil.ENHET_NASJONAL_NAY.enhetNr
     val personIdent = "123456789"
     val aktørId = "9876543210127"
     val tidligerePersonIdent = "9123456789"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Mapper er koblet til enheten man representerer/som oppgaven skal plasseres i. Slik at 4462 og 4483 har 2 ulike mapper for "på vent".

* Ved flytting til ventemappe brukes enheten til den opprinnelige oppgaven. Slik at hvis den er plassert til "egne ansatt"-enheten, så skal vi bruke "egne ansatt"-enheten sin vente-mappe og. 
* Henter mapper for strengt fortrolig for å kunne vise mappenavnen i frontend.
* Vi har kode som på en måte forventer at det kun finnes 1 match, ønsker å logge i tilfelle den finner flere. https://github.com/navikt/tilleggsstonader-sak/commit/7688e80b9205a5ce7937be9177b2aae64509c7b0

❗ Se commit for commit
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21985

Denne håndterer ikke enheten som brukes for journalføring. Det finnes en egen oppgave for det.