### PR TITLE
Henting av oppgaver skal bruke klarmappe når man ikke henter oppgaver…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppdaterMappePåVåreOppgaverController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppdaterMappePåVåreOppgaverController.kt
@@ -47,8 +47,9 @@ class OppdaterMappePåVåreOppgaverController(
                 oppgaverPåVent = false,
                 limit = 1000,
             ).tilFinnOppgaveRequest(
-                aktørid = null,
-                ventemappe = oppgaveService.finnMappe(OppgaveUtil.ENHET_NR_NAY, OppgaveMappe.PÅ_VENT),
+                null,
+                oppgaveService.finnMappe(OppgaveUtil.ENHET_NR_NAY, OppgaveMappe.KLAR),
+                oppgaveService.finnMappe(OppgaveUtil.ENHET_NR_NAY, OppgaveMappe.PÅ_VENT),
             ),
         )
             .oppgaver

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
@@ -59,7 +59,17 @@ class OppgaveService(
             ?.let { personService.hentAktørId(it) }
 
         val enhet = finnOppgaveRequest.enhet ?: error("Enhet er påkrevd når man søker etter oppgaver")
-        val request = finnOppgaveRequest.tilFinnOppgaveRequest(aktørId, finnMappe(enhet, OppgaveMappe.PÅ_VENT))
+        // TODO fiks tilFinnOppgaveRequest til å ikke håndtere nullable når toggle fjernes
+        val klarmappe = if (unleashService.isEnabled(Toggle.OPPGAVE_BRUK_KLAR_MAPPE)) {
+            finnMappe(enhet, OppgaveMappe.KLAR)
+        } else {
+            null
+        }
+        val request = finnOppgaveRequest.tilFinnOppgaveRequest(
+            aktørId,
+            klarmappe = klarmappe,
+            ventemappe = finnMappe(enhet, OppgaveMappe.PÅ_VENT),
+        )
         return finnOppgaver(request)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/FinnOppgaveRequestDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/dto/FinnOppgaveRequestDto.kt
@@ -24,7 +24,7 @@ data class FinnOppgaveRequestDto(
     val opprettetTom: LocalDate? = null,
     val fristFom: LocalDate? = null,
     val fristTom: LocalDate? = null,
-    val enhetsmappe: Long? = null,
+    val enhetsmappe: Long? = null, // TODO slett?
     val ident: String?,
     val limit: Long = 150, // TODO slett når frontend implementert limit og offset
     val offset: Long = 0, // TODO slett når frontend implementert limit og offset
@@ -33,7 +33,11 @@ data class FinnOppgaveRequestDto(
     val oppgaverPåVent: Boolean = false,
 ) {
 
-    fun tilFinnOppgaveRequest(aktørid: String? = null, ventemappe: MappeDto): FinnOppgaveRequest {
+    fun tilFinnOppgaveRequest(
+        aktørid: String? = null,
+        klarmappe: MappeDto?,
+        ventemappe: MappeDto,
+    ): FinnOppgaveRequest {
         return FinnOppgaveRequest(
             tema = Tema.TSO,
             behandlingstema = if (this.behandlingstema != null) {
@@ -47,7 +51,7 @@ data class FinnOppgaveRequestDto(
                 null
             },
             enhet = this.enhet,
-            erUtenMappe = !this.oppgaverPåVent,
+            erUtenMappe = if (klarmappe != null) false else !this.oppgaverPåVent,
             saksbehandler = this.saksbehandler,
             aktørId = aktørid,
             journalpostId = this.journalpostId,
@@ -59,7 +63,7 @@ data class FinnOppgaveRequestDto(
             fristTomDato = this.fristTom,
             aktivFomDato = null,
             aktivTomDato = null,
-            mappeId = if (this.oppgaverPåVent) ventemappe.id else null,
+            mappeId = if (this.oppgaverPåVent) ventemappe.id else klarmappe?.id,
             limit = this.limit,
             offset = this.offset,
             sorteringsrekkefolge = order,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveServiceTest.kt
@@ -347,12 +347,12 @@ internal class OppgaveServiceTest {
     }
 
     @Test
-    fun `skal ikke sette mappe når oppgaverPåVent er false`() {
+    fun `skal bruke klarmappe når oppgaverPåVent er false`() {
         every { oppgaveClient.hentOppgaver(any()) } returns FinnOppgaveResponseDto(0, emptyList())
 
         oppgaveService.hentOppgaver(FinnOppgaveRequestDto(ident = null, oppgaverPåVent = false, enhet = ENHET_NR_NAY))
 
-        verify { oppgaveClient.hentOppgaver(match { it.erUtenMappe == true }) }
+        verify { oppgaveClient.hentOppgaver(match { it.erUtenMappe == false }) }
     }
 
     private fun mockOpprettOppgave(slot: CapturingSlot<OpprettOppgaveRequest>) {


### PR DESCRIPTION
… som er på vent

### Hvorfor er denne endringen nødvendig? ✨
Vi skal gå over til å kun vise oppgaver fra klar-mappe. 

Featuretoggler funksjonaliteten, så skal fortsatt kunne støtte vanlig oppgavebenk som tidligere, dette gjennom å sende null som "klar-mappe" til `tilFinnOppgaveRequest`

Liker ikke helt at vi nå sender med 2 mapper til `tilFinnOppgaveRequest` men mulig jeg skriver om den når jeg fjerner feature toggle. 

En del av https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21920
