### PR TITLE
AAP-perioder info om aktivitetsfase ferdig avklart 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240522090805_0e9c7a6"
 val tilleggsstønaderLibsVersion = "2024.05.27-10.56.b9a67bfd6080"
-val tilleggsstønaderKontrakterVersion = "2024.08.12-08.20.e194558f350e"
+val tilleggsstønaderKontrakterVersion = "2024.08.14-17.17.7812164fb0d8"
 val tokenSupportVersion = "4.1.7"
 val wiremockVersion = "3.6.0"
 val mockkVersion = "1.13.11"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDto.kt
@@ -15,7 +15,7 @@ data class YtelsePeriodeRegisterDto(
     val type: TypeYtelsePeriode,
     val fom: LocalDate,
     val tom: LocalDate?,
-    val aapAktivitetsfase: String? = null,
+    val aapErFerdigAvklart: Boolean? = null,
 )
 
 data class HentetInformasjonDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDto.kt
@@ -15,6 +15,7 @@ data class YtelsePeriodeRegisterDto(
     val type: TypeYtelsePeriode,
     val fom: LocalDate,
     val tom: LocalDate?,
+    val aapAktivitetsfase: String? = null,
 )
 
 data class HentetInformasjonDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDtoMapper.kt
@@ -17,7 +17,7 @@ object YtelserRegisterDtoMapper {
                     type = it.type,
                     fom = it.fom,
                     tom = it.tom,
-                    aapAktivitetsfase = it.aapAktivitetsfase,
+                    aapErFerdigAvklart = it.aapErFerdigAvklart,
                 )
             }.sortedWith(sorteringTomDesc),
             hentetInformasjon = hentetInformasjon.map { HentetInformasjonDto(type = it.type, status = it.status) },

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserRegisterDtoMapper.kt
@@ -12,8 +12,14 @@ object YtelserRegisterDtoMapper {
 
     fun YtelsePerioderDto.tilDto(): YtelserRegisterDto {
         return YtelserRegisterDto(
-            perioder = this.perioder.map { YtelsePeriodeRegisterDto(type = it.type, fom = it.fom, tom = it.tom) }
-                .sortedWith(sorteringTomDesc),
+            perioder = this.perioder.map {
+                YtelsePeriodeRegisterDto(
+                    type = it.type,
+                    fom = it.fom,
+                    tom = it.tom,
+                    aapAktivitetsfase = it.aapAktivitetsfase,
+                )
+            }.sortedWith(sorteringTomDesc),
             hentetInformasjon = hentetInformasjon.map { HentetInformasjonDto(type = it.type, status = it.status) },
             tidspunktHentet = LocalDateTime.now(),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -146,7 +146,7 @@ class VilkårperiodeService(
 
         return GrunnlagYtelse(
             perioder = ytelserFraRegister.perioder
-                .filter { it.aapAktivitetsfase != "Ferdig avklart" }
+                .filter { it.aapErFerdigAvklart != true }
                 .map {
                     PeriodeGrunnlagYtelse(
                         type = it.type,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -145,13 +145,15 @@ class VilkårperiodeService(
         val ytelserFraRegister = ytelseService.hentYtelseForGrunnlag(behandlingId = behandlingId, fom = fom, tom = tom)
 
         return GrunnlagYtelse(
-            perioder = ytelserFraRegister.perioder.map {
-                PeriodeGrunnlagYtelse(
-                    type = it.type,
-                    fom = it.fom,
-                    tom = it.tom,
-                )
-            },
+            perioder = ytelserFraRegister.perioder
+                .filter { it.aapAktivitetsfase != "Ferdig avklart" }
+                .map {
+                    PeriodeGrunnlagYtelse(
+                        type = it.type,
+                        fom = it.fom,
+                        tom = it.tom,
+                    )
+                },
         )
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/YtelseClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/YtelseClientConfig.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.kontrakter.ytelse.HentetInformasjon
 import no.nav.tilleggsstonader.kontrakter.ytelse.StatusHentetInformasjon
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePeriode
 import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderDto
 import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderRequest
@@ -28,7 +29,7 @@ class YtelseClientConfig {
 
             val perioder = request.typer.map {
                 YtelsePeriode(type = it, fom = LocalDate.now(), tom = LocalDate.now())
-            }
+            } + YtelsePeriode(type = TypeYtelsePeriode.AAP, fom = LocalDate.now(), tom = LocalDate.now(), aapAktivitetsfase = "Ferdig avklart")
             val hentetInformasjon = request.typer.map {
                 HentetInformasjon(type = it, status = StatusHentetInformasjon.OK)
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/YtelseClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/YtelseClientConfig.kt
@@ -29,7 +29,15 @@ class YtelseClientConfig {
 
             val perioder = request.typer.map {
                 YtelsePeriode(type = it, fom = LocalDate.now(), tom = LocalDate.now())
-            } + YtelsePeriode(type = TypeYtelsePeriode.AAP, fom = LocalDate.now(), tom = LocalDate.now(), aapAktivitetsfase = "Ferdig avklart")
+            }.toMutableList()
+            if (request.typer.contains(TypeYtelsePeriode.AAP)) {
+                perioder += YtelsePeriode(
+                    type = TypeYtelsePeriode.AAP,
+                    fom = LocalDate.now().plusDays(1),
+                    tom = LocalDate.now().plusDays(1),
+                    aapErFerdigAvklart = true,
+                )
+            }
             val hentetInformasjon = request.typer.map {
                 HentetInformasjon(type = it, status = StatusHentetInformasjon.OK)
             }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi henter perioder fra AAP som gir rett på våre stønader
Dersom en periode har aktivitetsfase "ferdig avklart" gir den ikke rett på tilsyn barn.

Dersom man henter periodene til personoversikten er det fortsatt ønskelig å vise informasjonen.
Dersom man henter de som grunnlag til behandlingen så er det ikke ønskelig å vise de.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21588

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/454
* https://github.com/navikt/tilleggsstonader-integrasjoner/pull/109
