### PR TITLE
Vilkårperioder oppdatere grunnlagsdata

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -33,6 +33,13 @@ class VilkårperiodeController(
         return vilkårperiodeService.hentVilkårperioderResponse(behandlingId)
     }
 
+    @PostMapping("behandling/{behandlingId}/oppdater-grunnlag")
+    fun oppdaterGrunnlag(@PathVariable behandlingId: UUID) {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+
+        vilkårperiodeService.oppdaterGrunnlag(behandlingId)
+    }
+
     @PostMapping
     fun opprettVilkårMedPeriode(
         @RequestBody vilkårperiode: LagreVilkårperiode,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -36,6 +36,7 @@ class VilkårperiodeController(
     @PostMapping("behandling/{behandlingId}/oppdater-grunnlag")
     fun oppdaterGrunnlag(@PathVariable behandlingId: UUID) {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
 
         vilkårperiodeService.oppdaterGrunnlag(behandlingId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -93,6 +93,9 @@ class VilkårperiodeService(
         feilHvis(behandling.steg != StegType.INNGANGSVILKÅR) {
             "Kan ikke oppdatere grunnlag når behandlingen er i annet steg enn vilkår."
         }
+        feilHvisIkke(tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER)) {
+            "Kan ikke oppdatere vilkårperiode hvis man ikke er saksbehandler"
+        }
 
         vilkårperioderGrunnlagRepository.deleteById(behandlingId)
         opprettGrunnlagsdata(behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -96,9 +96,6 @@ class VilkårperiodeService(
         feilHvis(behandling.steg != StegType.INNGANGSVILKÅR) {
             "Kan ikke oppdatere grunnlag når behandlingen er i annet steg enn vilkår."
         }
-        feilHvisIkke(tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER)) {
-            "Kan ikke oppdatere vilkårperiode hvis man ikke er saksbehandler"
-        }
 
         val eksisterendeGrunnlag = vilkårperioderGrunnlagRepository.findByIdOrThrow(behandlingId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -84,6 +84,20 @@ class VilkårperiodeService(
         )
     }
 
+    @Transactional
+    fun oppdaterGrunnlag(behandlingId: UUID) {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke oppdatere grunnlag når behandlingen er låst"
+        }
+        feilHvis(behandling.steg != StegType.INNGANGSVILKÅR) {
+            "Kan ikke oppdatere grunnlag når behandlingen er i annet steg enn vilkår."
+        }
+
+        vilkårperioderGrunnlagRepository.deleteById(behandlingId)
+        opprettGrunnlagsdata(behandlingId)
+    }
+
     private fun hentEllerOpprettGrunnlag(behandlingId: UUID): VilkårperioderGrunnlag? {
         val grunnlag = vilkårperioderGrunnlagRepository.findByBehandlingId(behandlingId)?.grunnlag
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @Service
@@ -104,7 +105,9 @@ class VilkårperiodeService(
 
         val nyGrunnlagsdata = hentGrunnlagsdata(behandlingId, eksisterendeHentetFom, tom)
         vilkårperioderGrunnlagRepository.update(eksisterendeGrunnlag.copy(grunnlag = nyGrunnlagsdata))
-        logger.info("Oppdatert grunnlagsdata for behandling=$behandlingId")
+        val tidSidenForrigeHenting =
+            ChronoUnit.HOURS.between(nyGrunnlagsdata.hentetInformasjon.tidspunktHentet, LocalDateTime.now())
+        logger.info("Oppdatert grunnlagsdata for behandling=$behandlingId timerSidenForrige=$tidSidenForrigeHenting")
     }
 
     private fun hentEllerOpprettGrunnlag(behandlingId: UUID): VilkårperioderGrunnlag? {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeControllerTest.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperioderResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
@@ -76,6 +77,21 @@ class VilkårperiodeControllerTest : IntegrationTest() {
         assertThat(exception.detail.detail).contains("BehandlingId er ikke lik")
     }
 
+    @Nested
+    inner class OppdateringAvGrunnlag {
+
+        @Test
+        fun `må ha saksbehandlerrolle for å kunne oppdatere grunnlag`() {
+            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
+            headers.setBearerAuth(onBehalfOfToken(rolleConfig.veilederRolle))
+            val exception = catchProblemDetailException {
+                oppdaterGrunnlag(behandling.id)
+            }
+            assertThat(exception.detail.detail)
+                .contains("Mangler nødvendig saksbehandlerrolle for å utføre handlingen")
+        }
+    }
+
     private fun hentVilkårperioder(behandling: Behandling) =
         restTemplate.exchange<VilkårperioderResponse>(
             localhost("api/vilkarperiode/behandling/${behandling.id}"),
@@ -98,5 +114,13 @@ class VilkårperiodeControllerTest : IntegrationTest() {
         localhost("api/vilkarperiode/$vilkårperiodeId"),
         HttpMethod.DELETE,
         HttpEntity(slettVikårperiode, headers),
+    ).body!!
+
+    private fun oppdaterGrunnlag(
+        behandlingId: UUID,
+    ) = restTemplate.exchange<LagreVilkårperiodeResponse>(
+        localhost("api/vilkarperiode/behandling/$behandlingId/oppdater-grunnlag"),
+        HttpMethod.POST,
+        HttpEntity(null, headers),
     ).body!!
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -922,18 +922,5 @@ class VilkårperiodeServiceTest : IntegrationTest() {
             val feil = assertThrows<Feil> { vilkårperiodeService.oppdaterGrunnlag(behandling.id) }
             assertThat(feil.frontendFeilmelding).isEqualTo("Kan ikke oppdatere grunnlag når behandlingen er låst")
         }
-
-        @Test
-        fun `skal ikke kunne oppdatere hvis man ikke er saksbehandler`() {
-            val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling(steg = StegType.INNGANGSVILKÅR))
-
-            val feil = assertThrows<Feil> {
-                testWithBrukerContext(groups = listOf(rolleConfig.veilederRolle)) {
-                    vilkårperiodeService.oppdaterGrunnlag(behandling.id)
-                }
-            }
-            assertThat(feil.frontendFeilmelding)
-                .isEqualTo("Kan ikke oppdatere vilkårperiode hvis man ikke er saksbehandler")
-        }
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig å kunne oppdatere vilkårsgrunnlaget for å få opp oppdatert data om aktiviteter og ytelser
Spesielt då en behandling kan ha blitt satt på vent, eller bare blitt liggendes lenge og dataen har blitt utdatert.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21813