### PR TITLE
Admin opprett førstegangsbehandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/admin/AdminOpprettBehandling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/admin/AdminOpprettBehandling.kt
@@ -1,0 +1,15 @@
+package no.nav.tilleggsstonader.sak.behandling.admin
+
+data class PersoninfoDto(
+    val barn: List<Barn>,
+)
+
+data class Barn(
+    val ident: String,
+    val navn: String,
+)
+
+data class AdminOpprettFørstegangsbehandlingDto(
+    val ident: String,
+    val valgteBarn: Set<String>,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/admin/AdminOpprettBehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/admin/AdminOpprettBehandlingController.kt
@@ -1,36 +1,39 @@
 package no.nav.tilleggsstonader.sak.behandling.admin
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.tilleggsstonader.sak.behandling.admin.AdminOpprettBehandlingService.OpprettBehandlingFraJournalpostStatus
+import no.nav.tilleggsstonader.kontrakter.felles.IdentRequest
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
-@RequestMapping(path = ["/api/behandling/journalpost"])
+@RequestMapping(path = ["/api/behandling/admin"])
 @ProtectedWithClaims(issuer = "azuread")
 class AdminOpprettBehandlingController(
     private val adminOpprettBehandlingService: AdminOpprettBehandlingService,
     private val tilgangService: TilgangService,
 ) {
 
-    @GetMapping("{journalpostId}")
-    fun hentStatus(@PathVariable journalpostId: String): OpprettBehandlingFraJournalpostStatus {
+    @PostMapping("hent-person")
+    fun hentPerson(@RequestBody identRequest: IdentRequest): PersoninfoDto {
         tilgangService.validerHarSaksbehandlerrolle()
-        // Tilgangskontroll gjøres inne i opprettBehandlingFraJournalpost
-        return adminOpprettBehandlingService.hentInformasjon(journalpostId)
+        tilgangService.validerTilgangTilPersonMedBarn(identRequest.ident, AuditLoggerEvent.ACCESS)
+
+        return adminOpprettBehandlingService.hentPerson(ident = identRequest.ident)
     }
 
-    @PostMapping("{journalpostId}")
-    fun opprettBehandlingFraJournalpost(@PathVariable journalpostId: String): UUID {
+    @PostMapping("opprett-foerstegangsbehandling")
+    fun opprettFørstegangsbehandling(@RequestBody request: AdminOpprettFørstegangsbehandlingDto): UUID {
         tilgangService.validerHarSaksbehandlerrolle()
+        tilgangService.validerTilgangTilPersonMedBarn(request.ident, AuditLoggerEvent.CREATE)
 
-        // Tilgangskontroll gjøres inne i opprettBehandlingFraJournalpost
-
-        return adminOpprettBehandlingService.opprettBehandlingFraJournalpost(journalpostId)
+        return adminOpprettBehandlingService.opprettFørstegangsbehandling(
+            ident = request.ident,
+            valgteBarn = request.valgteBarn,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -4,11 +4,12 @@ import no.nav.tilleggsstonader.libs.unleash.ToggleId
 
 enum class Toggle(override val toggleId: String) : ToggleId {
     KAN_OPPRETTE_BEHANDLING("sak.kan-opprette-behandling"),
-    KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST("sak.kan-opprette-behandling-fra-journalpost"),
     KAN_OPPRETTE_REVURDERING("sak.kan-opprette-revurdering"),
     REVURDERING_INNVILGE_TIDLIGERE_INNVILGET("sak.revurdering-innvilge-etter-innvilgelse"),
 
     AUTOMATISK_JOURNALFORING_REVURDERING("sak.automatisk-jfr-revurdering"),
 
     SIMULERING("sak.simulering"),
+
+    ADMIN_KAN_OPPRETTE_BEHANDLING("sak.admin-kan-opprette-behandling"),
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/admin/AdminOpprettBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/admin/AdminOpprettBehandlingServiceTest.kt
@@ -1,29 +1,23 @@
 package no.nav.tilleggsstonader.sak.behandling.admin
 
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
-import no.nav.tilleggsstonader.kontrakter.journalpost.DokumentInfo
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
 import no.nav.tilleggsstonader.sak.opplysninger.dto.SøkerMedBarn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdent
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
-import no.nav.tilleggsstonader.sak.tilgang.TilgangService
-import no.nav.tilleggsstonader.sak.util.FileUtil
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
-import no.nav.tilleggsstonader.sak.util.journalpost
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -35,18 +29,14 @@ class AdminOpprettBehandlingServiceTest {
     val personService = mockk<PersonService>()
     val fagsakService = mockk<FagsakService>()
     val behandlingService = mockk<BehandlingService>()
-    val journalpostService = mockk<JournalpostService>()
     val taskService = mockk<TaskService>(relaxed = true)
-    val tilgangService = mockk<TilgangService>(relaxed = true)
     val barnService = mockk<BarnService>()
 
     val service = AdminOpprettBehandlingService(
         personService = personService,
         fagsakService = fagsakService,
         behandlingService = behandlingService,
-        journalpostService = journalpostService,
         taskService = taskService,
-        tilgangService = tilgangService,
         barnService = barnService,
         unleashService = mockUnleashService(),
     )
@@ -61,16 +51,6 @@ class AdminOpprettBehandlingServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { journalpostService.hentJournalpost("1") } returns
-            journalpost(
-                journalpostId = "1",
-                bruker = Bruker(ident, BrukerIdType.FNR),
-                dokumenter = listOf(DokumentInfo("2", brevkode = "NAV 11-12.15B")),
-            )
-        every { journalpostService.hentIdentFraJournalpost(any()) } returns ident
-        every { journalpostService.hentDokument(any(), "2", any()) } returns
-            FileUtil.readFile("fyllut-sendinn/søknad-1-barn.xml").toByteArray()
-
         every { personService.hentPersonIdenter(ident) } returns PdlIdenter(listOf(PdlIdent(ident, false)))
         every { personService.hentPersonMedBarn(ident) } returns
             SøkerMedBarn(ident, mockk(), barn = mapOf(identBarn to mockk()))
@@ -79,17 +59,22 @@ class AdminOpprettBehandlingServiceTest {
         every { fagsakService.hentEllerOpprettFagsak(personIdent = ident, Stønadstype.BARNETILSYN) } returns fagsak
         every { behandlingService.hentBehandlinger(any<UUID>()) } returns emptyList()
         every { behandlingService.opprettBehandling(fagsak.id, any(), any(), any(), any()) } returns behandling
-        justRun { behandlingService.leggTilBehandlingsjournalpost(any(), any(), any()) }
         every { barnService.opprettBarn(capture(opprettedeBarnSlot)) } answers { firstArg() }
     }
 
     @Test
-    fun `skal opprette behandling med barn fra journalpost`() {
-        service.opprettBehandlingFraJournalpost("1")
+    fun `skal opprette behandling med barn`() {
+        service.opprettFørstegangsbehandling(ident, setOf(identBarn))
 
         with(opprettedeBarnSlot.captured.single()) {
             assertThat(this.ident).isEqualTo(identBarn)
             assertThat(this.behandlingId).isEqualTo(behandling.id)
+        }
+        verify(exactly = 1) {
+            behandlingService.opprettBehandling(
+                fagsakId = fagsak.id,
+                behandlingsårsak = BehandlingÅrsak.MANUELT_OPPRETTET,
+            )
         }
     }
 
@@ -98,7 +83,14 @@ class AdminOpprettBehandlingServiceTest {
         every { behandlingService.hentBehandlinger(any<UUID>()) } returns listOf(behandling())
 
         assertThatThrownBy {
-            service.opprettBehandlingFraJournalpost("1")
+            service.opprettFørstegangsbehandling(ident, setOf(identBarn))
         }.hasMessageContaining("Det finnes allerede en behandling på personen")
+    }
+
+    @Test
+    fun `skal feile hvis barnen ikke finnes på personen`() {
+        assertThatThrownBy {
+            service.opprettFørstegangsbehandling(ident, setOf(identBarn, "annenIdent"))
+        }.hasMessageContaining("Barn finnes ikke på person")
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det var tidligere mulig å opprette førstegangsbehandling fra journalpostId via admin.

Vi har haft noen tilfeller der det finnes papirsøknad eller søknad fra EF der det også er ønskelig å opprette førstegangsbehandling.
For å støtte dette kan man då opprette basert fra ident. Og då velge hvilke barn som skal være med på behandlingen.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21972

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/464
