### PR TITLE
✨ Simuleringssteg

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingSteg.kt
@@ -55,28 +55,33 @@ enum class StegType(
         tillattFor = BehandlerRolle.SAKSBEHANDLER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.UTREDES),
     ),
-    SEND_TIL_BESLUTTER(
+    SIMULERING(
         rekkefølge = 4,
         tillattFor = BehandlerRolle.SAKSBEHANDLER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.UTREDES),
     ),
-    BESLUTTE_VEDTAK(
+    SEND_TIL_BESLUTTER(
         rekkefølge = 5,
+        tillattFor = BehandlerRolle.SAKSBEHANDLER,
+        gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.UTREDES),
+    ),
+    BESLUTTE_VEDTAK(
+        rekkefølge = 6,
         tillattFor = BehandlerRolle.BESLUTTER,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.FATTER_VEDTAK),
     ),
     JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV(
-        rekkefølge = 6,
-        tillattFor = BehandlerRolle.SYSTEM,
-        gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.IVERKSETTER_VEDTAK),
-    ),
-    FERDIGSTILLE_BEHANDLING(
         rekkefølge = 7,
         tillattFor = BehandlerRolle.SYSTEM,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.IVERKSETTER_VEDTAK),
     ),
-    BEHANDLING_FERDIGSTILT(
+    FERDIGSTILLE_BEHANDLING(
         rekkefølge = 8,
+        tillattFor = BehandlerRolle.SYSTEM,
+        gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.IVERKSETTER_VEDTAK),
+    ),
+    BEHANDLING_FERDIGSTILT(
+        rekkefølge = 9,
         tillattFor = BehandlerRolle.SYSTEM,
         gyldigIKombinasjonMedStatus = listOf(BehandlingStatus.FERDIGSTILT),
     ),
@@ -99,7 +104,8 @@ enum class StegType(
             REVURDERING_ÅRSAK -> INNGANGSVILKÅR
             INNGANGSVILKÅR -> VILKÅR
             VILKÅR -> BEREGNE_YTELSE
-            BEREGNE_YTELSE -> SEND_TIL_BESLUTTER
+            BEREGNE_YTELSE -> SIMULERING
+            SIMULERING -> SEND_TIL_BESLUTTER
             SEND_TIL_BESLUTTER -> BESLUTTE_VEDTAK
             BESLUTTE_VEDTAK -> JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV
             JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV -> FERDIGSTILLE_BEHANDLING

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegService.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.StegValidering.validerRollerF
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.RolleConfig
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringSteg
 import no.nav.tilleggsstonader.sak.vilkår.InngangsvilkårSteg
 import no.nav.tilleggsstonader.sak.vilkår.VilkårSteg
 import org.slf4j.LoggerFactory
@@ -71,6 +72,7 @@ class StegService(
         return when (steg) {
             StegType.INNGANGSVILKÅR -> håndterInngangsvilkår(behandlingId)
             StegType.VILKÅR -> håndterVilkår(behandlingId)
+            StegType.SIMULERING -> håndterSimulering(behandlingId)
             else -> error("Steg $steg kan ikke ferdigstilles her")
         }
     }
@@ -86,6 +88,11 @@ class StegService(
     private fun håndterVilkår(behandlingId: UUID): Behandling {
         val vilkårSteg: VilkårSteg = behandlingSteg.filterIsInstance<VilkårSteg>().single()
         return håndterSteg(behandlingId, vilkårSteg)
+    }
+
+    private fun håndterSimulering(behandlingId: UUID): Behandling {
+        val simuleringSteg: SimuleringSteg = behandlingSteg.filterIsInstance<SimuleringSteg>().single()
+        return håndterSteg(behandlingId, simuleringSteg)
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringController.kt
@@ -22,8 +22,8 @@ import java.util.UUID
 class SimuleringController(
     private val tilgangService: TilgangService,
     private val behandlingService: BehandlingService,
-    private val simuleringService: SimuleringService,
     private val unleashService: UnleashService,
+    private val simuleringStegService: SimuleringStegService,
 ) {
 
     @GetMapping("/{behandlingId}")
@@ -35,7 +35,7 @@ class SimuleringController(
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.UPDATE)
 
-        val perioder = simuleringService.simuler(saksbehandling)
+        val perioder = simuleringStegService.hentEllerOpprettSimuleringsresultat(saksbehandling)
 
         return if (perioder.isNullOrEmpty()) {
             null

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.utbetaling.simulering
 
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.IverksettClient
@@ -29,17 +28,6 @@ class SimuleringService(
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
-
-    @Transactional
-    fun simuler(saksbehandling: Saksbehandling): List<OppsummeringForPeriode>? {
-        if (saksbehandling.status.behandlingErLåstForVidereRedigering() ||
-            !tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER)
-        ) {
-            return hentLagretSimuleringsoppsummering(saksbehandling.id)
-        }
-        val simuleringsresultat = hentOgLagreSimuleringsresultat(saksbehandling)
-        return simuleringsresultat.data.oppsummeringer
-    }
 
     fun hentLagretSimuleringsoppsummering(behandlingId: UUID): List<OppsummeringForPeriode>? {
         return hentLagretSimmuleringsresultat(behandlingId)?.oppsummeringer

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringSteg.kt
@@ -1,37 +1,39 @@
 package no.nav.tilleggsstonader.sak.utbetaling.simulering
 
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
 import org.springframework.stereotype.Service
 
 @Service
 class SimuleringSteg(
     val simuleringService: SimuleringService,
+    val vedtaksresultatService: VedtaksresultatService,
 ) : BehandlingSteg<Void?> {
 
     override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
-        if (skalUtFøreSimulering(saksbehandling)) {
+        val resultat = vedtaksresultatService.hentVedtaksresultat(saksbehandling)
+
+        if (skalUtFøreSimulering(saksbehandling, resultat)) {
             simuleringService.hentOgLagreSimuleringsresultat(saksbehandling)
         }
     }
 
-    private fun skalUtFøreSimulering(saksbehandling: Saksbehandling): Boolean =
+    private fun skalUtFøreSimulering(saksbehandling: Saksbehandling, vedtak: TypeVedtak): Boolean =
         when (saksbehandling.type) {
-            BehandlingType.REVURDERING -> resultatSkalSimuleres(saksbehandling.resultat)
+            BehandlingType.REVURDERING -> resultatSkalSimuleres(vedtak)
             BehandlingType.FØRSTEGANGSBEHANDLING -> false
             else -> error("Behandlingstype ${saksbehandling.type} støttes ikke i simulering")
         }
 
-    private fun resultatSkalSimuleres(resultat: BehandlingResultat): Boolean {
-        return when (resultat) {
-            // TODO: Bruke resultat.skalIverksettes ?
-            BehandlingResultat.INNVILGET -> true
-            BehandlingResultat.OPPHØRT -> true
-            BehandlingResultat.AVSLÅTT -> false
-            else -> error("Simulering støtter ikke resultat $resultat")
+    private fun resultatSkalSimuleres(type: TypeVedtak): Boolean {
+        return when (type) {
+            TypeVedtak.INNVILGELSE -> true
+            TypeVedtak.AVSLAG -> false
+            else -> error("Simulering støtter ikke resultat $type")
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringSteg.kt
@@ -1,0 +1,39 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import org.springframework.stereotype.Service
+
+@Service
+class SimuleringSteg(
+    val simuleringService: SimuleringService,
+) : BehandlingSteg<Void?> {
+
+    override fun utførSteg(saksbehandling: Saksbehandling, data: Void?) {
+        if (skalUtFøreSimulering(saksbehandling)) {
+            simuleringService.hentOgLagreSimuleringsresultat(saksbehandling)
+        }
+    }
+
+    private fun skalUtFøreSimulering(saksbehandling: Saksbehandling): Boolean =
+        when (saksbehandling.type) {
+            BehandlingType.REVURDERING -> resultatSkalSimuleres(saksbehandling.resultat)
+            BehandlingType.FØRSTEGANGSBEHANDLING -> false
+            else -> error("Behandlingstype ${saksbehandling.type} støttes ikke i simulering")
+        }
+
+    private fun resultatSkalSimuleres(resultat: BehandlingResultat): Boolean {
+        return when (resultat) {
+            // TODO: Bruke resultat.skalIverksettes ?
+            BehandlingResultat.INNVILGET -> true
+            BehandlingResultat.OPPHØRT -> true
+            BehandlingResultat.AVSLÅTT -> false
+            else -> error("Simulering støtter ikke resultat $resultat")
+        }
+    }
+
+    override fun stegType(): StegType = StegType.SIMULERING
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegService.kt
@@ -1,0 +1,33 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.kontrakt.OppsummeringForPeriode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SimuleringStegService(
+    private val stegService: StegService,
+    private val simuleringService: SimuleringService,
+    private val tilgangService: TilgangService,
+) {
+
+    @Transactional
+    fun hentEllerOpprettSimuleringsresultat(saksbehandling: Saksbehandling): List<OppsummeringForPeriode>? {
+        if (saksbehandling.status.behandlingErLåstForVidereRedigering() ||
+            !tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER)
+        ) {
+            return simuleringService.hentLagretSimuleringsoppsummering(saksbehandling.id)
+        } else {
+            if (saksbehandling.steg == StegType.SIMULERING) {
+                stegService.håndterSteg(saksbehandling.id, StegType.SIMULERING)
+            }
+
+            return simuleringService.hentLagretSimuleringsoppsummering(saksbehandling.id)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
@@ -6,12 +6,15 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgetVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,6 +34,9 @@ internal class SimuleringControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var simuleringsresultatRepository: SimuleringsresultatRepository
 
+    @Autowired
+    private lateinit var tilsynBarnVedtakRepository: TilsynBarnVedtakRepository
+
     @BeforeEach
     fun setUp() {
         headers.setBearerAuth(onBehalfOfToken())
@@ -39,16 +45,10 @@ internal class SimuleringControllerTest : IntegrationTest() {
     @Test
     internal fun `Skal returnere 200 OK for simulering av behandling`() {
         val personIdent = "12345678901"
-        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(personIdent))))
-        val behandling = testoppsettService.lagre(
-            behandling(
-                fagsak,
-                type = BehandlingType.REVURDERING,
-                resultat = BehandlingResultat.INNVILGET,
-                status = BehandlingStatus.UTREDES,
-                steg = StegType.SIMULERING,
-            ),
-        )
+        val fagsak = opprettFagsak(personIdent)
+        val behandling = opprettBehandling(fagsak)
+        opprettVedtak(behandling.id)
+
         tilkjentYtelseRepository.insert(tilkjentYtelse(behandlingId = behandling.id))
 
         val respons: ResponseEntity<SimuleringDto> = simulerForBehandling(behandling.id)
@@ -61,11 +61,30 @@ internal class SimuleringControllerTest : IntegrationTest() {
         assertThat(simuleringsresultat.data.detaljer.perioder).hasSize(16)
     }
 
+    private fun opprettFagsak(personIdent: String) =
+        testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(personIdent))))
+
+    private fun opprettBehandling(fagsak: Fagsak) = testoppsettService.lagre(
+        behandling(
+            fagsak,
+            type = BehandlingType.REVURDERING,
+            resultat = BehandlingResultat.INNVILGET,
+            status = BehandlingStatus.UTREDES,
+            steg = StegType.SIMULERING,
+        ),
+    )
+
     private fun simulerForBehandling(behandlingId: UUID): ResponseEntity<SimuleringDto> {
         return restTemplate.exchange(
             localhost("/api/simulering/$behandlingId"),
             HttpMethod.GET,
             HttpEntity<BehandlingDto>(headers),
+        )
+    }
+
+    private fun opprettVedtak(behandlingId: UUID) {
+        tilsynBarnVedtakRepository.insert(
+            innvilgetVedtak(behandlingId = behandlingId),
         )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
@@ -2,7 +2,10 @@ package no.nav.tilleggsstonader.sak.utbetaling.simulering
 
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
@@ -37,7 +40,15 @@ internal class SimuleringControllerTest : IntegrationTest() {
     internal fun `Skal returnere 200 OK for simulering av behandling`() {
         val personIdent = "12345678901"
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(personIdent))))
-        val behandling = testoppsettService.lagre(behandling(fagsak, resultat = BehandlingResultat.INNVILGET))
+        val behandling = testoppsettService.lagre(
+            behandling(
+                fagsak,
+                type = BehandlingType.REVURDERING,
+                resultat = BehandlingResultat.INNVILGET,
+                status = BehandlingStatus.UTREDES,
+                steg = StegType.SIMULERING,
+            ),
+        )
         tilkjentYtelseRepository.insert(tilkjentYtelse(behandlingId = behandling.id))
 
         val respons: ResponseEntity<SimuleringDto> = simulerForBehandling(behandling.id)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegServiceTest.kt
@@ -1,0 +1,52 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SimuleringStegServiceTest {
+
+    val stegService = mockk<StegService>()
+    val simuleringService = mockk<SimuleringService>()
+    val tilgangService = mockk<TilgangService>()
+
+    val simuleringStegService = SimuleringStegService(
+        stegService = stegService,
+        simuleringService = simuleringService,
+        tilgangService = tilgangService,
+    )
+
+    val fagsak = fagsak()
+
+    @BeforeEach
+    fun setUp() {
+        every { tilgangService.harTilgangTilRolle(any()) } returns true
+    }
+
+    @Test
+    internal fun `skal hente lagret simulering hvis behandlingen ikke er redigerbar`() {
+        val saksbehandling =
+            saksbehandling(
+                fagsak = fagsak,
+                type = BehandlingType.REVURDERING,
+                status = BehandlingStatus.FATTER_VEDTAK,
+            )
+
+        every { simuleringService.hentLagretSimuleringsoppsummering(any()) } returns mockk()
+        val simuleringsresultatDto = simuleringStegService.hentEllerOpprettSimuleringsresultat(saksbehandling)
+
+        verify { stegService wasNot Called }
+
+        assertThat(simuleringsresultatDto).isNotNull
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
@@ -1,0 +1,79 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SimuleringStegTest {
+
+    val simuleringService = mockk<SimuleringService>()
+
+    val simuleringSteg = SimuleringSteg(simuleringService)
+
+    @BeforeEach
+    fun setUp() {
+        every { simuleringService.hentOgLagreSimuleringsresultat(any()) } returns mockk()
+    }
+
+    @Nested
+    inner class Revurdering {
+
+        @Test
+        fun `skal utføre simulering for innvilget revurdering`() {
+            val saksbehandling = saksbehandling(
+                type = BehandlingType.REVURDERING,
+                resultat = BehandlingResultat.INNVILGET,
+            )
+
+            simuleringSteg.utførSteg(saksbehandling, null)
+
+            verify { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
+        }
+
+        @Test
+        fun `skal utføre simulering for opphørt revurdering`() {
+            val saksbehandling = saksbehandling(
+                type = BehandlingType.REVURDERING,
+                resultat = BehandlingResultat.OPPHØRT,
+            )
+
+            simuleringSteg.utførSteg(saksbehandling, null)
+
+            verify { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
+        }
+
+        @Test
+        fun `skal ikke utføre simulering for avslått revurdering`() {
+            val saksbehandling = saksbehandling(
+                type = BehandlingType.REVURDERING,
+                resultat = BehandlingResultat.AVSLÅTT,
+            )
+
+            simuleringSteg.utførSteg(saksbehandling, null)
+
+            verify(exactly = 0) { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
+        }
+    }
+
+    @Nested
+    inner class Førstegangsbehandling {
+
+        @Test
+        fun `skal ikke utføre simulering for førstegangsbehandling`() {
+            val saksbehandling = saksbehandling(
+                type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                resultat = BehandlingResultat.INNVILGET,
+            )
+
+            simuleringSteg.utførSteg(saksbehandling, null)
+
+            verify(exactly = 0) { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
@@ -3,9 +3,10 @@ package no.nav.tilleggsstonader.sak.utbetaling.simulering
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.VedtaksresultatService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -13,13 +14,17 @@ import org.junit.jupiter.api.Test
 class SimuleringStegTest {
 
     val simuleringService = mockk<SimuleringService>()
+    val vedtaksresultatService = mockk<VedtaksresultatService>()
 
-    val simuleringSteg = SimuleringSteg(simuleringService)
+    val simuleringSteg = SimuleringSteg(simuleringService, vedtaksresultatService)
 
     @BeforeEach
     fun setUp() {
         every { simuleringService.hentOgLagreSimuleringsresultat(any()) } returns mockk()
     }
+
+    private fun mockVedtakMedType(type: TypeVedtak) =
+        every { vedtaksresultatService.hentVedtaksresultat(any()) } returns type
 
     @Nested
     inner class Revurdering {
@@ -28,20 +33,8 @@ class SimuleringStegTest {
         fun `skal utføre simulering for innvilget revurdering`() {
             val saksbehandling = saksbehandling(
                 type = BehandlingType.REVURDERING,
-                resultat = BehandlingResultat.INNVILGET,
             )
-
-            simuleringSteg.utførSteg(saksbehandling, null)
-
-            verify { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
-        }
-
-        @Test
-        fun `skal utføre simulering for opphørt revurdering`() {
-            val saksbehandling = saksbehandling(
-                type = BehandlingType.REVURDERING,
-                resultat = BehandlingResultat.OPPHØRT,
-            )
+            mockVedtakMedType(TypeVedtak.INNVILGELSE)
 
             simuleringSteg.utførSteg(saksbehandling, null)
 
@@ -52,8 +45,8 @@ class SimuleringStegTest {
         fun `skal ikke utføre simulering for avslått revurdering`() {
             val saksbehandling = saksbehandling(
                 type = BehandlingType.REVURDERING,
-                resultat = BehandlingResultat.AVSLÅTT,
             )
+            mockVedtakMedType(TypeVedtak.AVSLAG)
 
             simuleringSteg.utførSteg(saksbehandling, null)
 
@@ -68,8 +61,8 @@ class SimuleringStegTest {
         fun `skal ikke utføre simulering for førstegangsbehandling`() {
             val saksbehandling = saksbehandling(
                 type = BehandlingType.FØRSTEGANGSBEHANDLING,
-                resultat = BehandlingResultat.INNVILGET,
             )
+            mockVedtakMedType(TypeVedtak.INNVILGELSE)
 
             simuleringSteg.utførSteg(saksbehandling, null)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -56,8 +56,9 @@ object TilsynBarnTestUtil {
     fun innvilgetVedtak(
         vedtak: VedtaksdataTilsynBarn? = vedtaksdata,
         beregningsresultat: VedtaksdataBeregningsresultat? = vedtakBeregningsresultat,
+        behandlingId: UUID = UUID.randomUUID(),
     ) = VedtakTilsynBarn(
-        behandlingId = UUID.randomUUID(),
+        behandlingId = behandlingId,
         type = TypeVedtak.INNVILGELSE,
         vedtak = vedtak,
         beregningsresultat = beregningsresultat,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi vil at simulering skal være et eget steg i behandlingflyten, sånn at alle behandler som skal simuleres tvinges gjennom steget.

Har nå lagt det opp sånn at dersom man prøver å hente simulering, vil behandlingen gå gjennom det steget og returnere responsen.