### PR TITLE
Revurdering velge barn

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
@@ -4,6 +4,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.IdentStønadstype
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandling.dto.BarnTilRevurderingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
 import no.nav.tilleggsstonader.sak.behandling.dto.OpprettBehandlingDto
@@ -50,7 +51,14 @@ class BehandlingController(
         return saksbehandling.tilDto()
     }
 
-    @PostMapping()
+    @GetMapping("barn-til-revurdering/{fagsakId}")
+    fun hentBarnTilRevurdering(@PathVariable fagsakId: UUID): BarnTilRevurderingDto {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarSaksbehandlerrolle()
+        return opprettRevurderingBehandlingService.hentBarnTilRevurdering(fagsakId)
+    }
+
+    @PostMapping
     fun opprettBehandling(@RequestBody request: OpprettBehandlingDto): UUID {
         tilgangService.validerTilgangTilFagsak(request.fagsakId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolle()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
@@ -1,15 +1,18 @@
 package no.nav.tilleggsstonader.sak.behandling
 
 import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sisteFerdigstilteBehandling
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandling.dto.BarnTilRevurderingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.OpprettBehandlingDto
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
@@ -53,7 +56,10 @@ class OpprettRevurderingBehandlingService(
 
         val forrigeBehandlingId = behandling.forrigeBehandlingId ?: sisteAvsluttetBehandlingId(fagsakId)
 
+        validerValgteBarn(request, forrigeBehandlingId)
+
         gjenbrukDataRevurderingService.gjenbrukData(behandling, forrigeBehandlingId)
+        barnService.opprettBarn(request.valgteBarn.map { BehandlingBarn(behandlingId = behandling.id, ident = it) })
 
         taskService.save(
             OpprettOppgaveForOpprettetBehandlingTask.opprettTask(
@@ -68,11 +74,36 @@ class OpprettRevurderingBehandlingService(
         return behandling.id
     }
 
+    private fun validerValgteBarn(request: OpprettBehandlingDto, forrigeBehandlingId: UUID) {
+        val stønadstype: Stønadstype by lazy { fagsakService.hentFagsak(request.fagsakId).stønadstype }
+        feilHvis(request.valgteBarn.isNotEmpty() && stønadstype != Stønadstype.BARNETILSYN) {
+            "Kan ikke sende inn barn til $stønadstype"
+        }
+
+        feilHvis(request.årsak != BehandlingÅrsak.SØKNAD && request.valgteBarn.isNotEmpty()) {
+            "Kan ikke sende med barn på annet enn årsak Søknad"
+        }
+
+        val barnTilRevurdering = hentBarnTilRevurdering(request.fagsakId, forrigeBehandlingId).barn
+
+        val valgbareIdenter = barnTilRevurdering.filterNot { it.finnesPåForrigeBehandling }.map { it.ident }
+        feilHvis(!valgbareIdenter.containsAll(request.valgteBarn)) {
+            "Kan ikke velge barn som ikke er valgbare."
+        }
+    }
+
     fun hentBarnTilRevurdering(fagsakId: UUID): BarnTilRevurderingDto {
-        val ident = fagsakService.hentAktivIdent(fagsakId)
         val forrigeBehandlingId = behandlingService.finnSisteIverksatteBehandling(fagsakId)?.id
             ?: sisteAvsluttetBehandlingId(fagsakId)
 
+        return hentBarnTilRevurdering(fagsakId, forrigeBehandlingId)
+    }
+
+    private fun hentBarnTilRevurdering(
+        fagsakId: UUID,
+        forrigeBehandlingId: UUID,
+    ): BarnTilRevurderingDto {
+        val ident = fagsakService.hentAktivIdent(fagsakId)
         val barnPåSøker = personService.hentPersonMedBarn(ident).barn
         val eksisterendeBarn = barnService.finnBarnPåBehandling(forrigeBehandlingId).associateBy { it.ident }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/OpprettBehandlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/OpprettBehandlingDto.kt
@@ -7,3 +7,13 @@ data class OpprettBehandlingDto(
     val fagsakId: UUID,
     val årsak: BehandlingÅrsak,
 )
+
+data class BarnTilRevurderingDto(
+    val barn: List<Barn>,
+) {
+    data class Barn(
+        val ident: String,
+        val navn: String,
+        val finnesPåForrigeBehandling: Boolean,
+    )
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/OpprettBehandlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/OpprettBehandlingDto.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 data class OpprettBehandlingDto(
     val fagsakId: UUID,
     val årsak: BehandlingÅrsak,
+    val valgteBarn: Set<String> = emptySet(),
 )
 
 data class BarnTilRevurderingDto(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingServiceTest.kt
@@ -131,7 +131,7 @@ class OpprettRevurderingBehandlingServiceTest : IntegrationTest() {
     @Nested
     inner class GjenbrukDataFraForrigeBehandling {
         var tidligereBehandling: Behandling? = null
-        val barnIdent = "barn1"
+        val barnIdent = PdlClientConfig.barnFnr
         val fom = LocalDate.of(2024, 1, 1)
         val tom = LocalDate.of(2024, 1, 31)
 
@@ -215,12 +215,24 @@ class OpprettRevurderingBehandlingServiceTest : IntegrationTest() {
             resultat = BehandlingResultat.INNVILGET,
         )
 
+        val eksisterendeBarn = behandlingBarn(behandlingId = behandling.id, personIdent = PdlClientConfig.barnFnr)
+
+        @BeforeEach
+        fun setUp() {
+            testoppsettService.opprettBehandlingMedFagsak(behandling, opprettGrunnlagsdata = false)
+            val barn = barnService.opprettBarn(listOf(eksisterendeBarn))
+            val vilkår = barn.map {
+                vilkår(
+                    behandlingId = behandling.id,
+                    barnId = it.id,
+                    type = VilkårType.PASS_BARN,
+                )
+            }
+            vilkårRepository.insertAll(vilkår)
+        }
+
         @Test
         fun `hentBarnTilRevurdering - skal markere barn som finnes med på forrige behandling`() {
-            testoppsettService.opprettBehandlingMedFagsak(behandling, opprettGrunnlagsdata = false)
-            val eksisterendeBarn = behandlingBarn(behandlingId = behandling.id, personIdent = PdlClientConfig.barnFnr)
-            barnService.opprettBarn(listOf(eksisterendeBarn))
-
             val barnTilRevurdering = service.hentBarnTilRevurdering(behandling.fagsakId)
 
             assertThat(barnTilRevurdering.barn).hasSize(2)
@@ -230,13 +242,85 @@ class OpprettRevurderingBehandlingServiceTest : IntegrationTest() {
             assertThat(barnTilRevurdering.barn.single { it.ident == PdlClientConfig.barn2Fnr }.finnesPåForrigeBehandling)
                 .isFalse()
         }
+
+        @Test
+        fun `skal opprette behandling med nytt barn`() {
+            val request = opprettBehandlingDto(
+                fagsakId = behandling.fagsakId,
+                årsak = BehandlingÅrsak.SØKNAD,
+                valgteBarn = setOf(PdlClientConfig.barn2Fnr),
+            )
+            val behandlingIdRevurdering = service.opprettBehandling(request)
+
+            with(barnService.finnBarnPåBehandling(behandlingIdRevurdering)) {
+                assertThat(this).hasSize(2)
+                assertThat(this.map { it.ident })
+                    .containsExactlyInAnyOrder(PdlClientConfig.barnFnr, PdlClientConfig.barn2Fnr)
+            }
+        }
+
+        @Test
+        fun `hvis man ikke sender inn noen barn skal man kun beholde barn fra forrige behandling`() {
+            val request = opprettBehandlingDto(
+                fagsakId = behandling.fagsakId,
+                årsak = BehandlingÅrsak.SØKNAD,
+                valgteBarn = setOf(),
+            )
+            val behandlingIdRevurdering = service.opprettBehandling(request)
+
+            with(barnService.finnBarnPåBehandling(behandlingIdRevurdering)) {
+                assertThat(this).hasSize(1)
+                assertThat(this.map { it.ident }).containsExactlyInAnyOrder(PdlClientConfig.barnFnr)
+            }
+        }
+
+        @Test
+        fun `skal feile hvis man sender inn barn på årsak nye opplysninger`() {
+            val request = opprettBehandlingDto(
+                fagsakId = behandling.fagsakId,
+                årsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+                valgteBarn = setOf(PdlClientConfig.barn2Fnr),
+            )
+
+            assertThatThrownBy {
+                service.opprettBehandling(request)
+            }.hasMessage("Kan ikke sende med barn på annet enn årsak Søknad")
+        }
+
+        @Test
+        fun `skal feile hvis man prøver å sende inn barn som ikke finnes på personen`() {
+            val request = opprettBehandlingDto(
+                fagsakId = behandling.fagsakId,
+                årsak = BehandlingÅrsak.SØKNAD,
+                valgteBarn = setOf("ukjent ident"),
+            )
+
+            assertThatThrownBy {
+                service.opprettBehandling(request)
+            }.hasMessage("Kan ikke velge barn som ikke er valgbare.")
+        }
+
+        @Test
+        fun `skal feile hvis man prøver å sende inn barn som allerede finnes på behandlingen`() {
+            val request = opprettBehandlingDto(
+                fagsakId = behandling.fagsakId,
+                årsak = BehandlingÅrsak.SØKNAD,
+                valgteBarn = setOf(PdlClientConfig.barnFnr),
+            )
+
+            assertThatThrownBy {
+                service.opprettBehandling(request)
+            }.hasMessage("Kan ikke velge barn som ikke er valgbare.")
+        }
     }
 
     private fun opprettBehandlingDto(
         fagsakId: UUID,
         årsak: BehandlingÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
+        valgteBarn: Set<String> = emptySet(),
     ) = OpprettBehandlingDto(
         fagsakId = fagsakId,
         årsak = årsak,
+        valgteBarn = valgteBarn,
     )
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig å kunne velge barn når man oppretter en revurdering.
Vi gjenbruker data fra forrige behandling. I tilfelle det i en første behandling er behandlet 1 barn, og i en ny søknad kommer et nytt barn, så må man kunne legge til denne til den nye behandlingen

Vi har noen ulike situasjoner:
* Mottatt papirsøknad
* En digital søknad for revurdering har blitt journalført men ikke fått opprettet behandling
* Søknad til barnetilsyn fra enslig forsørger

I tillegg så har vi mulighet for å kunne opprette førstegangsbehandling med barn fra admin-funksjonalitet. Det er mulig det blir flyttet hit en gang. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21972

Har ikke opprettet PR for frontend ennå, trenger noen tekstelige avklaringer
https://github.com/navikt/tilleggsstonader-sak-frontend/compare/main...revurdering-velge-barn

Hvis man ønsker å teste de nå lokalt så kan man sjekke ut branchen `revurdering-velge-barn-test`
* https://github.com/navikt/tilleggsstonader-sak/compare/revurdering-velge-barn...revurdering-velge-barn-test