### PR TITLE
Fellesmetode for å finne behandlingId for gjenbruk

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/GjennbrukDataRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/GjennbrukDataRevurderingService.kt
@@ -1,12 +1,12 @@
 package no.nav.tilleggsstonader.sak.behandling
 
-import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.NyttBarnId
 import no.nav.tilleggsstonader.sak.behandling.barn.TidligereBarnId
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
@@ -16,36 +16,50 @@ import java.util.UUID
 
 @Service
 class GjennbrukDataRevurderingService(
-    val taskService: TaskService,
-    val barnService: BarnService,
-    val vilkårperiodeService: VilkårperiodeService,
-    val stønadsperiodeService: StønadsperiodeService,
-    val vilkårService: VilkårService,
-    val unleashService: UnleashService,
+    private val behandlingService: BehandlingService,
+    private val barnService: BarnService,
+    private val vilkårperiodeService: VilkårperiodeService,
+    private val stønadsperiodeService: StønadsperiodeService,
+    private val vilkårService: VilkårService,
 ) {
 
     @Transactional
-    fun gjenbrukData(behandling: Behandling, gjennbrukDataFraBehandlingId: UUID) {
-        // TODO skal vi kopiere fra forrige henlagte/avslåtte? Hva hvis behandlingen før er innvilget.
-
+    fun gjenbrukData(behandling: Behandling, behandlingIdForGjenbruk: UUID) {
         val barnIder: Map<TidligereBarnId, NyttBarnId> =
-            barnService.gjenbrukBarn(forrigeBehandlingId = gjennbrukDataFraBehandlingId, nyBehandlingId = behandling.id)
+            barnService.gjenbrukBarn(forrigeBehandlingId = behandlingIdForGjenbruk, nyBehandlingId = behandling.id)
 
         vilkårperiodeService.gjenbrukVilkårperioder(
-            forrigeBehandlingId = gjennbrukDataFraBehandlingId,
+            forrigeBehandlingId = behandlingIdForGjenbruk,
             nyBehandlingId = behandling.id,
         )
 
         stønadsperiodeService.gjenbrukStønadsperioder(
-            forrigeBehandlingId = gjennbrukDataFraBehandlingId,
+            forrigeBehandlingId = behandlingIdForGjenbruk,
             nyBehandlingId = behandling.id,
         )
 
         vilkårService.kopierVilkårsettTilNyBehandling(
-            forrigeBehandlingId = gjennbrukDataFraBehandlingId,
+            forrigeBehandlingId = behandlingIdForGjenbruk,
             nyBehandling = behandling,
             barnIdMap = barnIder,
             stønadstype = Stønadstype.BARNETILSYN, // TODO: Hent stønadstype fra behandling
         )
+    }
+
+    fun finnBehandlingIdForGjenbruk(behandling: Behandling): UUID? {
+        return behandling.forrigeBehandlingId
+            ?: finnSisteFerdigstilteBehandlingSomIkkeErHenlagt(behandling.fagsakId)
+    }
+
+    fun finnBehandlingIdForGjenbruk(fagsakId: UUID): UUID? {
+        return behandlingService.finnSisteIverksatteBehandling(fagsakId)?.id
+            ?: finnSisteFerdigstilteBehandlingSomIkkeErHenlagt(fagsakId)
+    }
+
+    private fun finnSisteFerdigstilteBehandlingSomIkkeErHenlagt(fagsakId: UUID): UUID? {
+        return behandlingService.hentBehandlinger(fagsakId).lastOrNull {
+            it.status == BehandlingStatus.FERDIGSTILT &&
+                it.resultat != BehandlingResultat.HENLAGT
+        }?.id
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettRevurderingBehandlingService.kt
@@ -3,14 +3,12 @@ package no.nav.tilleggsstonader.sak.behandling
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
-import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sisteFerdigstilteBehandling
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.dto.BarnTilRevurderingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.OpprettBehandlingDto
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
@@ -53,11 +51,11 @@ class OpprettRevurderingBehandlingService(
             kravMottatt = null, // TODO flytt til request
         )
 
-        val forrigeBehandlingId = behandling.forrigeBehandlingId ?: sisteAvsluttetBehandlingId(fagsakId)
+        val behandlingIdForGjenbruk = gjenbrukDataRevurderingService.finnBehandlingIdForGjenbruk(behandling)
 
-        validerValgteBarn(request, forrigeBehandlingId)
+        validerValgteBarn(request, behandlingIdForGjenbruk)
 
-        gjenbrukDataRevurderingService.gjenbrukData(behandling, forrigeBehandlingId)
+        behandlingIdForGjenbruk?.let { gjenbrukDataRevurderingService.gjenbrukData(behandling, it) }
         barnService.opprettBarn(request.valgteBarn.map { BehandlingBarn(behandlingId = behandling.id, ident = it) })
 
         taskService.save(
@@ -73,38 +71,45 @@ class OpprettRevurderingBehandlingService(
         return behandling.id
     }
 
-    private fun validerValgteBarn(request: OpprettBehandlingDto, forrigeBehandlingId: UUID) {
+    private fun validerValgteBarn(request: OpprettBehandlingDto, behandlingIdForGjenbruk: UUID?) {
         val stønadstype: Stønadstype by lazy { fagsakService.hentFagsak(request.fagsakId).stønadstype }
         feilHvis(request.valgteBarn.isNotEmpty() && stønadstype != Stønadstype.BARNETILSYN) {
             "Kan ikke sende inn barn til $stønadstype"
+        }
+        if (stønadstype != Stønadstype.BARNETILSYN) {
+            return
         }
 
         feilHvis(!request.årsak.erSøknadEllerPapirsøknad() && request.valgteBarn.isNotEmpty()) {
             "Kan ikke sende med barn på annet enn årsak Søknad"
         }
 
-        val barnTilRevurdering = hentBarnTilRevurdering(request.fagsakId, forrigeBehandlingId).barn
+        val barnTilRevurdering = hentBarnTilRevurdering(request.fagsakId, behandlingIdForGjenbruk).barn
 
         val valgbareIdenter = barnTilRevurdering.filterNot { it.finnesPåForrigeBehandling }.map { it.ident }
         feilHvis(!valgbareIdenter.containsAll(request.valgteBarn)) {
             "Kan ikke velge barn som ikke er valgbare."
         }
+
+        feilHvis(behandlingIdForGjenbruk == null && request.valgteBarn.isEmpty()) {
+            "Behandling må opprettes med minimum 1 barn"
+        }
     }
 
     fun hentBarnTilRevurdering(fagsakId: UUID): BarnTilRevurderingDto {
-        val forrigeBehandlingId = behandlingService.finnSisteIverksatteBehandling(fagsakId)?.id
-            ?: sisteAvsluttetBehandlingId(fagsakId)
-
+        val forrigeBehandlingId = gjenbrukDataRevurderingService.finnBehandlingIdForGjenbruk(fagsakId)
         return hentBarnTilRevurdering(fagsakId, forrigeBehandlingId)
     }
 
     private fun hentBarnTilRevurdering(
         fagsakId: UUID,
-        forrigeBehandlingId: UUID,
+        forrigeBehandlingId: UUID?,
     ): BarnTilRevurderingDto {
         val ident = fagsakService.hentAktivIdent(fagsakId)
         val barnPåSøker = personService.hentPersonMedBarn(ident).barn
-        val eksisterendeBarn = barnService.finnBarnPåBehandling(forrigeBehandlingId).associateBy { it.ident }
+        val eksisterendeBarn = forrigeBehandlingId
+            ?.let { barnService.finnBarnPåBehandling(forrigeBehandlingId).associateBy { it.ident } }
+            ?: emptyMap()
 
         return BarnTilRevurderingDto(
             barn = mapEksisterendeBarn(eksisterendeBarn, barnPåSøker) + mapValgbareBarn(barnPåSøker, eksisterendeBarn),
@@ -135,11 +140,4 @@ class OpprettRevurderingBehandlingService(
                 finnesPåForrigeBehandling = false,
             )
         }
-
-    private fun sisteAvsluttetBehandlingId(fagsakId: UUID): UUID {
-        return behandlingService.hentBehandlinger(fagsakId)
-            .sisteFerdigstilteBehandling()
-            ?.id
-            ?: throw Feil("Finner ikke forrige behandling for fagsak=$fagsakId")
-    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
@@ -9,7 +9,6 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
 import no.nav.tilleggsstonader.kontrakter.journalpost.LogiskVedlegg
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sisteFerdigstilteBehandling
 import no.nav.tilleggsstonader.sak.behandling.GjennbrukDataRevurderingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
@@ -113,10 +112,10 @@ class JournalføringService(
             behandlingÅrsak = behandlingÅrsak,
         )
 
-        val forrigeBehandling = behandlingService.hentBehandlinger(behandling.fagsakId).sisteFerdigstilteBehandling()
+        val behandlingIdForGjenbruk = gjennbrukDataRevurderingService.finnBehandlingIdForGjenbruk(behandling)
 
-        if (forrigeBehandling != null) {
-            gjennbrukDataRevurderingService.gjenbrukData(behandling, forrigeBehandling.id)
+        if (behandlingIdForGjenbruk != null) {
+            gjennbrukDataRevurderingService.gjenbrukData(behandling, behandlingIdForGjenbruk)
         }
 
         if (journalpost.harStrukturertSøknad()) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/GjennbrukDataRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/GjennbrukDataRevurderingServiceTest.kt
@@ -1,0 +1,118 @@
+package no.nav.tilleggsstonader.sak.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class GjennbrukDataRevurderingServiceTest {
+
+    val behandlingService = mockk<BehandlingService>()
+    val barnService = mockk<BarnService>()
+    val vilkårperiodeService = mockk<VilkårperiodeService>()
+    val stønadsperiodeService = mockk<StønadsperiodeService>()
+    val vilkårService = mockk<VilkårService>()
+
+    val service = GjennbrukDataRevurderingService(
+        behandlingService = behandlingService,
+        barnService = barnService,
+        vilkårperiodeService = vilkårperiodeService,
+        stønadsperiodeService = stønadsperiodeService,
+        vilkårService = vilkårService,
+    )
+
+    val fagsakId = UUID.randomUUID()
+    val iverksattFerdigstiltBehandling = behandling()
+    val henlagtBehandling = behandling(
+        status = BehandlingStatus.FERDIGSTILT,
+        resultat = BehandlingResultat.HENLAGT,
+    )
+    val avslåttBehandling = behandling(
+        status = BehandlingStatus.FERDIGSTILT,
+        resultat = BehandlingResultat.AVSLÅTT,
+    )
+    val opphørtBehandling = behandling(
+        status = BehandlingStatus.FERDIGSTILT,
+        resultat = BehandlingResultat.OPPHØRT,
+    )
+
+    @BeforeEach
+    fun setUp() {
+        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns null
+        every { behandlingService.hentBehandlinger(any<UUID>()) } returns emptyList()
+    }
+
+    @Nested
+    inner class FinnBehandlingIdForGjenbrukFraBehandling {
+
+        @Test
+        fun `skal bruke forrige behandlingId hvis den finnes på behandling som man sender inn`() {
+            val behandling = behandling(forrigeBehandlingId = UUID.randomUUID())
+
+            assertThat(service.finnBehandlingIdForGjenbruk(behandling)).isEqualTo(behandling.forrigeBehandlingId)
+
+            verify(exactly = 0) { behandlingService.hentBehandlinger(any<UUID>()) }
+        }
+
+        @Test
+        fun `skal bruke siste avslåtte behandling hvis forrigeBehandlingId på behandling er null`() {
+            val behandling = behandling()
+            every { behandlingService.hentBehandlinger(any<UUID>()) } returns listOf(avslåttBehandling)
+
+            assertThat(service.finnBehandlingIdForGjenbruk(behandling)).isEqualTo(avslåttBehandling.id)
+
+            verify(exactly = 1) { behandlingService.hentBehandlinger(any<UUID>()) }
+        }
+    }
+
+    @Nested
+    inner class FinnBehandlingIdForGjenbrukFraFagsakId {
+
+        @Test
+        fun `skal finne siste iverksatte behandling hvis den finnes`() {
+            every { behandlingService.finnSisteIverksatteBehandling(any()) } returns iverksattFerdigstiltBehandling
+
+            assertThat(service.finnBehandlingIdForGjenbruk(fagsakId)).isEqualTo(iverksattFerdigstiltBehandling.id)
+        }
+
+        @Test
+        fun `skal bruke siste behandling som er avslått hvis det finnes henlagte behandlinger før den avslåtte`() {
+            every { behandlingService.hentBehandlinger(any<UUID>()) } returns listOf(
+                henlagtBehandling,
+                avslåttBehandling,
+                henlagtBehandling,
+            )
+
+            assertThat(service.finnBehandlingIdForGjenbruk(fagsakId)).isEqualTo(avslåttBehandling.id)
+        }
+
+        @Test
+        fun `skal bruke siste behandling som er opphørt hvis det finnes henlagte behandlinger før den opphørte`() {
+            every { behandlingService.hentBehandlinger(any<UUID>()) } returns listOf(
+                henlagtBehandling,
+                opphørtBehandling,
+                henlagtBehandling,
+            )
+
+            assertThat(service.finnBehandlingIdForGjenbruk(fagsakId)).isEqualTo(opphørtBehandling.id)
+        }
+
+        @Test
+        fun `skal returnere null hvis det kun finnes henlagte behandlinger`() {
+            every { behandlingService.hentBehandlinger(any<UUID>()) } returns listOf(henlagtBehandling)
+
+            assertThat(service.finnBehandlingIdForGjenbruk(fagsakId)).isNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.GjennbrukDataRevurderingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
@@ -114,6 +115,8 @@ class JournalføringServiceTest {
         every { journalpostService.hentIdentFraJournalpost(any()) } returns personIdent
         justRun { journalpostService.oppdaterOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), captureNullable(nyAvsenderSlot)) }
         every { søknadService.lagreSøknad(any(), any(), any()) } returns mockk()
+
+        every { gjennbrukDataRevurderingService.finnBehandlingIdForGjenbruk(any<Behandling>()) } returns null
     }
 
     @AfterEach
@@ -284,7 +287,7 @@ class JournalføringServiceTest {
                 resultat = BehandlingResultat.INNVILGET,
                 status = BehandlingStatus.FERDIGSTILT,
             )
-        val nyBehandling = behandling(fagsak = fagsak)
+        val nyBehandling = behandling(fagsak = fagsak, forrigeBehandlingId = forrigeBehandling.id)
         val barn1 = SøknadBarn(ident = "123456789", data = mockk())
         val barn2 = SøknadBarn(ident = "987654321", data = mockk())
         val eksisterendeBarn = listOf(barn1, barn2)
@@ -319,6 +322,9 @@ class JournalføringServiceTest {
 
         @Test
         fun `skal gjennbruke data fra tidligere behandling`() {
+            every { gjennbrukDataRevurderingService.finnBehandlingIdForGjenbruk(any<Behandling>()) } returns
+                forrigeBehandling.id
+
             journalføringService.journalførTilNyBehandling(
                 journalpost.journalpostId,
                 personIdent,


### PR DESCRIPTION
- skal bruke forrigeBehandlingId hvis det eksisterer
- hvis ikke skal siste avslåtte eller opphørte behandling brukes
- skal ikke bruke henlagte behandlinger for gjenbruk

Ble litt mange endringer.. 

### Hvorfor er denne endringen nødvendig? ✨

Idag kopierer vi data fra forrige henlagte behandling hvis den finnes.
I stedet for det så skal vi kun gjenbruke data fra forrige iverksatte - innvilget eller opphørt. Hvis ikke de finnes så skal man bruke siste behandling som ikke er henlagt, som naturlig vil være avslått.
En henlagt behandling kan være pga saksbehandlerfeil, og kopiere fra den er på en måte feil.

Det som kan skje her er at vi har en innvilget behandling, men allikevel har en nyere avslått behandling, vi vil då fortsatt bruke den sist innvilgede behandlingen. Muligens ikke helt riktig i alle tilfeller - men i de fleste håper jeg. 

EF gjør det sånn https://nav-it.slack.com/archives/C05EKNFUXJ7/p1724359274495539

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22183