### PR TITLE
Legger informasjon om hovedregel på reglene

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelSteg.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
  *  SVAR_2 som peker til ett nytt spørsmål
  * {
  *  [regelId]: "SPØRSMÅL_1",
+ *  [erHovedregel]: true
  *  [svarMapping]: {
  *      "SVAR_1": SluttSvarRegel.OPPFYLT,
  *      "SVAR_2": {
@@ -24,6 +25,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
  */
 data class RegelSteg(
     val regelId: RegelId,
+    val erHovedregel: Boolean,
     val svarMapping: Map<SvarId, SvarRegel>,
 ) {
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregel.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
@@ -24,7 +25,8 @@ abstract class Vilkårsregel(
     val regler: Map<RegelId, RegelSteg>,
 ) {
 
-    val hovedregler get(): Set<RegelId> = regler.filter { it.value.erHovedregel }.keys.toSet()
+    @get:JsonIgnore
+    val hovedregler: Set<RegelId> = regler.filter { it.value.erHovedregel }.keys.toSet()
 
     open fun initiereDelvilkår(
         metadata: HovedregelMetadata,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregel.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
@@ -23,9 +22,9 @@ data class HovedregelMetadata(
 abstract class Vilkårsregel(
     val vilkårType: VilkårType,
     val regler: Map<RegelId, RegelSteg>,
-    @JsonIgnore
-    val hovedregler: Set<RegelId>,
 ) {
+
+    val hovedregler get(): Set<RegelId> = regler.filter { it.value.erHovedregel }.keys.toSet()
 
     open fun initiereDelvilkår(
         metadata: HovedregelMetadata,
@@ -40,8 +39,8 @@ abstract class Vilkårsregel(
         }
     }
 
-    constructor(vilkårType: VilkårType, regler: Set<RegelSteg>, hovedregler: Set<RegelId>) :
-        this(vilkårType, regler.associateBy { it.regelId }, hovedregler)
+    constructor(vilkårType: VilkårType, regler: Set<RegelSteg>) :
+        this(vilkårType, regler.associateBy { it.regelId })
 
     fun regel(regelId: RegelId): RegelSteg {
         return regler[regelId] ?: throw Feil("Finner ikke regelId=$regelId for vilkårType=$vilkårType")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/EksempelRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/EksempelRegel.kt
@@ -6,12 +6,10 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelSteg
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.OPPFYLT_MED_PÅKREVD_BEGRUNNELSE
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.Vilkårsregel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.jaNeiSvarRegel
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.regelIder
 
 class EksempelRegel : Vilkårsregel(
     vilkårType = VilkårType.EKSEMPEL,
     regler = setOf(HAR_ET_NAVN),
-    hovedregler = regelIder(HAR_ET_NAVN),
 ) {
 
     companion object {
@@ -19,6 +17,7 @@ class EksempelRegel : Vilkårsregel(
         private val HAR_ET_NAVN =
             RegelSteg(
                 regelId = RegelId.HAR_ET_NAVN,
+                erHovedregel = true,
                 svarMapping = jaNeiSvarRegel(hvisJa = OPPFYLT_MED_PÅKREVD_BEGRUNNELSE),
             )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/PassBarnRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/PassBarnRegel.kt
@@ -12,11 +12,11 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.HovedregelMeta
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.NesteRegel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelSteg
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.OPPFYLT_MED_VALGFRI_BEGRUNNELSE
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.Vilkårsregel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.jaNeiSvarRegel
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.regelIder
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelUtil.harFullførtFjerdetrinn
 import java.time.LocalDate
 import java.util.UUID
@@ -28,11 +28,6 @@ class PassBarnRegel : Vilkårsregel(
         ANNEN_FORELDER_MOTTAR_STØTTE,
         HAR_FULLFØRT_FJERDEKLASSE,
         UNNTAK_ALDER,
-    ),
-    hovedregler = regelIder(
-        UTGIFTER_DOKUMENTERT,
-        ANNEN_FORELDER_MOTTAR_STØTTE,
-        HAR_FULLFØRT_FJERDEKLASSE,
     ),
 ) {
 
@@ -56,45 +51,44 @@ class PassBarnRegel : Vilkårsregel(
 
     companion object {
 
-        private val unntakAlderMapping =
-            setOf(
-                SvarId.TRENGER_MER_TILSYN_ENN_JEVNALDRENDE,
-                SvarId.FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID,
-            )
-                .associateWith {
-                    SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE
-                } + mapOf(SvarId.NEI to SluttSvarRegel.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE)
-
         private val UNNTAK_ALDER =
             RegelSteg(
                 regelId = RegelId.UNNTAK_ALDER,
-                svarMapping = unntakAlderMapping,
+                erHovedregel = false,
+                svarMapping = mapOf(
+                    SvarId.TRENGER_MER_TILSYN_ENN_JEVNALDRENDE to OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    SvarId.FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID to OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    SvarId.NEI to IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
+                ),
             )
 
         private val HAR_FULLFØRT_FJERDEKLASSE =
             RegelSteg(
                 regelId = RegelId.HAR_FULLFØRT_FJERDEKLASSE,
+                erHovedregel = true,
                 svarMapping = jaNeiSvarRegel(
                     hvisJa = NesteRegel(UNNTAK_ALDER.regelId),
-                    hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisNei = OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
                 ),
             )
 
         private val UTGIFTER_DOKUMENTERT =
             RegelSteg(
                 regelId = RegelId.UTGIFTER_DOKUMENTERT,
+                erHovedregel = true,
                 jaNeiSvarRegel(
-                    hvisJa = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
-                    hvisNei = SluttSvarRegel.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
+                    hvisJa = OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisNei = IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
                 ),
             )
 
         private val ANNEN_FORELDER_MOTTAR_STØTTE =
             RegelSteg(
                 regelId = RegelId.ANNEN_FORELDER_MOTTAR_STØTTE,
+                erHovedregel = true,
                 jaNeiSvarRegel(
-                    hvisJa = SluttSvarRegel.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
-                    hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    hvisJa = IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
+                    hvisNei = OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
                 ),
             )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/VilkårsregelTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/VilkårsregelTest.kt
@@ -10,6 +10,11 @@ import kotlin.io.path.name
 
 internal class VilkårsregelTest {
 
+    /*
+     * Denne testen feiler hvis regel-treet endrer seg.
+     * Var det meningen? I så fall kan du fikse det ved å sette SKAL_SKRIVE_TIL_FIL = true i FileUtil.kt.
+     * Husk å sette tilbake til false etter du har verifisert at testen kjører grønt.
+     */
     @Test
     internal fun `sjekker at output fortsatt er det samme på json`() {
         val vilkårsregler = Vilkårsregler.ALLE_VILKÅRSREGLER.vilkårsregler.map { it.value }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/TestRegler.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/TestRegler.kt
@@ -14,8 +14,9 @@ class VilkårsregelEnHovedregel :
         VilkårType.EKSEMPEL,
         setOf(
             RegelSteg(
-                RegelId.HAR_ET_NAVN,
-                jaNeiSvarRegel(
+                regelId = RegelId.HAR_ET_NAVN,
+                erHovedregel = true,
+                svarMapping = jaNeiSvarRegel(
                     hvisNei = NesteRegel(
                         RegelId.HAR_ET_NAVN2,
                         BegrunnelseType.PÅKREVD,
@@ -24,10 +25,10 @@ class VilkårsregelEnHovedregel :
             ),
             RegelSteg(
                 regelId = RegelId.HAR_ET_NAVN2,
+                erHovedregel = false,
                 svarMapping = jaNeiSvarRegel(),
             ),
         ),
-        hovedregler = setOf(RegelId.HAR_ET_NAVN),
     )
 
 class VilkårsregelToHovedregler :
@@ -36,15 +37,13 @@ class VilkårsregelToHovedregler :
         setOf(
             RegelSteg(
                 regelId = RegelId.HAR_ET_NAVN,
+                erHovedregel = true,
                 svarMapping = jaNeiSvarRegel(hvisNei = SluttSvarRegel.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE),
             ),
             RegelSteg(
                 regelId = RegelId.HAR_ET_NAVN2,
+                erHovedregel = true,
                 svarMapping = jaNeiSvarRegel(),
             ),
-        ),
-        hovedregler = setOf(
-            RegelId.HAR_ET_NAVN,
-            RegelId.HAR_ET_NAVN2,
         ),
     )

--- a/src/test/resources/vilkår/regler/PASS_BARN.json
+++ b/src/test/resources/vilkår/regler/PASS_BARN.json
@@ -61,6 +61,5 @@
         }
       }
     }
-  },
-  "hovedregler" : [ "UTGIFTER_DOKUMENTERT", "ANNEN_FORELDER_MOTTAR_STØTTE", "HAR_FULLFØRT_FJERDEKLASSE" ]
+  }
 }

--- a/src/test/resources/vilkår/regler/PASS_BARN.json
+++ b/src/test/resources/vilkår/regler/PASS_BARN.json
@@ -3,6 +3,7 @@
   "regler" : {
     "UTGIFTER_DOKUMENTERT" : {
       "regelId" : "UTGIFTER_DOKUMENTERT",
+      "erHovedregel" : true,
       "svarMapping" : {
         "JA" : {
           "begrunnelseType" : "VALGFRI",
@@ -16,6 +17,7 @@
     },
     "ANNEN_FORELDER_MOTTAR_STØTTE" : {
       "regelId" : "ANNEN_FORELDER_MOTTAR_STØTTE",
+      "erHovedregel" : true,
       "svarMapping" : {
         "JA" : {
           "begrunnelseType" : "PÅKREVD",
@@ -29,6 +31,7 @@
     },
     "HAR_FULLFØRT_FJERDEKLASSE" : {
       "regelId" : "HAR_FULLFØRT_FJERDEKLASSE",
+      "erHovedregel" : true,
       "svarMapping" : {
         "JA" : {
           "regelId" : "UNNTAK_ALDER",
@@ -42,6 +45,7 @@
     },
     "UNNTAK_ALDER" : {
       "regelId" : "UNNTAK_ALDER",
+      "erHovedregel" : false,
       "svarMapping" : {
         "TRENGER_MER_TILSYN_ENN_JEVNALDRENDE" : {
           "begrunnelseType" : "VALGFRI",
@@ -57,5 +61,6 @@
         }
       }
     }
-  }
+  },
+  "hovedregler" : [ "UTGIFTER_DOKUMENTERT", "ANNEN_FORELDER_MOTTAR_STØTTE", "HAR_FULLFØRT_FJERDEKLASSE" ]
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når saksbehandlerne klikker på  "Legg til vilkårsperiode" må frontend vite hvordan et "tomt" vilkår ser ut. Da er det praktisk å ha informasjon om hva som er hovedregler og ikke. 

Kunne også bare fjerna `@JsonIgnore`, men da ville vi hatt to ulike sett med regler å forholde oss til i frontend, og en god del duplisert informasjon.