### PR TITLE
brevmottakere: Lagrer UUID fra frontend i databasen. Bruker BrevMottakerDto fra kontrakter. Utvider BrevMottaker-domeneobjekt

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevTask.kt
@@ -98,7 +98,7 @@ class JournalførVedtaksbrevTask(
         },
         navn = when (brevmottaker.mottakerType) {
             MottakerType.PERSON -> null
-            MottakerType.ORGANISASJON -> brevmottaker.navnHosOrganisasjon
+            MottakerType.ORGANISASJON -> brevmottaker.mottakerNavn
         },
     )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/Brevmottaker.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/Brevmottaker.kt
@@ -13,7 +13,8 @@ data class Brevmottaker(
     val mottakerRolle: MottakerRolle,
     val mottakerType: MottakerType,
     val ident: String,
-    val navnHosOrganisasjon: String? = null,
+    val mottakerNavn: String? = null,
+    val organisasjonsNavn: String? = null,
 
     val journalpostId: String? = null,
     val bestillingId: String? = null,
@@ -22,7 +23,7 @@ data class Brevmottaker(
     val sporbar: Sporbar = Sporbar(),
 ) {
     init {
-        feilHvis(mottakerType == MottakerType.ORGANISASJON && navnHosOrganisasjon.isNullOrBlank()) {
+        feilHvis(mottakerType == MottakerType.ORGANISASJON && mottakerNavn.isNullOrBlank()) {
             "Navn hos organisasjon er påkrevd"
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereDto.kt
@@ -1,34 +1,24 @@
 package no.nav.tilleggsstonader.sak.brev.brevmottaker
 
-import java.util.UUID
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerOrganisasjonDto
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerPersonDto
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.MottakerRolle
 
 data class BrevmottakereDto(
     val personer: List<BrevmottakerPersonDto>,
     val organisasjoner: List<BrevmottakerOrganisasjonDto>,
 )
 
-data class BrevmottakerPersonDto(
-    val id: UUID,
-    val personIdent: String,
-    val mottakerRolle: MottakerRolle,
-)
-
-data class BrevmottakerOrganisasjonDto(
-    val id: UUID,
-    val organisasjonsnummer: String,
-    val navnHosOrganisasjon: String,
-    val mottakerRolle: MottakerRolle,
-)
-
 fun Brevmottaker.tilPersonDto(): BrevmottakerPersonDto =
-    BrevmottakerPersonDto(id = id, personIdent = ident, mottakerRolle = mottakerRolle)
+    BrevmottakerPersonDto(id = id, personIdent = ident, mottakerRolle = MottakerRolle.valueOf(mottakerRolle.name), navn = mottakerNavn)
 
 fun Brevmottaker.tilOrganisasjonDto(): BrevmottakerOrganisasjonDto =
     BrevmottakerOrganisasjonDto(
         id = id,
         organisasjonsnummer = ident,
-        navnHosOrganisasjon = navnHosOrganisasjon ?: error("Navn hos organisasjon er påkrevd"),
-        mottakerRolle = mottakerRolle,
+        navnHosOrganisasjon = mottakerNavn ?: error("Navn hos organisasjon er påkrevd"),
+        organisasjonsnavn = organisasjonsNavn.orEmpty(),
+
     )
 
 fun List<Brevmottaker>.tilBrevmottakereDto(): BrevmottakereDto =

--- a/src/main/resources/db/migration/V48__endre_kolonne_navn_brevmottaker.sql
+++ b/src/main/resources/db/migration/V48__endre_kolonne_navn_brevmottaker.sql
@@ -1,0 +1,2 @@
+ALTER TABLE brevmottaker RENAME COLUMN navn_hos_organisasjon TO mottaker_navn;
+ALTER TABLE brevmottaker ADD COLUMN organisasjons_navn VARCHAR;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereServiceTest.kt
@@ -1,0 +1,205 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerOrganisasjonDto
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerPersonDto
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.MottakerRolle
+import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.util.behandling
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import java.util.*
+
+class BrevmottakereServiceTest {
+
+    private val brevmottakereRepository = mockk<BrevmottakerRepository>()
+    private val behandlingService = mockk<BehandlingService>()
+
+    private val brevmottakereService: BrevmottakereService =
+        BrevmottakereService(brevmottakereRepository, behandlingService)
+
+    val brevmottakerPersonDtoVanligBruker =
+        BrevmottakerPersonDto(UUID.randomUUID(), "12312312323", "Test Testersen", MottakerRolle.BRUKER)
+
+    val brevmottakerOrganisasjonDto =
+        BrevmottakerOrganisasjonDto(UUID.randomUUID(), "45645646456", "Forretninger AS", "Navn navnesen")
+
+    val vanligeBrevmottakereDto =
+        BrevmottakereDto(listOf(brevmottakerPersonDtoVanligBruker), listOf(brevmottakerOrganisasjonDto))
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom behandligsstatus er FATTER_VEDTAK`() {
+        val behandling = behandling(status = BehandlingStatus.FATTER_VEDTAK)
+
+        every { behandlingService.hentBehandling(any()) } returns behandling
+
+        assertThatThrownBy {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), vanligeBrevmottakereDto)
+        }.hasMessageContaining("Kan ikke oppdatere brevmottakere fordi behandling er låst for redigering.")
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom behandligsstatus er IVERKSETTER_VEDTAK`() {
+        val behandling = behandling(status = BehandlingStatus.IVERKSETTER_VEDTAK)
+
+        every { behandlingService.hentBehandling(any()) } returns behandling
+
+        assertThatThrownBy {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), vanligeBrevmottakereDto)
+        }.hasMessageContaining("Kan ikke oppdatere brevmottakere fordi behandling er låst for redigering.")
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom behandligsstatus er FERDIGSTILT`() {
+        val behandling = behandling(status = BehandlingStatus.FERDIGSTILT)
+
+        every { behandlingService.hentBehandling(any()) } returns behandling
+
+        assertThatThrownBy {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), vanligeBrevmottakereDto)
+        }.hasMessageContaining("Kan ikke oppdatere brevmottakere fordi behandling er låst for redigering.")
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom behandligsstatus er SATT_PÅ_VENT`() {
+        val behandling = behandling(status = BehandlingStatus.SATT_PÅ_VENT)
+
+        every { behandlingService.hentBehandling(any()) } returns behandling
+
+        assertThatThrownBy {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), vanligeBrevmottakereDto)
+        }.hasMessageContaining("Kan ikke oppdatere brevmottakere fordi behandling er låst for redigering.")
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom det ikke finnes noen mottakere`() {
+        val brevmottakereDto =
+            BrevmottakereDto(emptyList(), emptyList())
+
+        every { behandlingService.hentBehandling(any()) } returns behandling()
+
+        val feil = catchThrowableOfType<ApiFeil> {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), brevmottakereDto)
+        }
+        assertThat(feil.message).contains("Vedtaksbrevet må ha minst 1 mottaker")
+        assertThat(feil.httpStatus).isEqualTo(BAD_REQUEST)
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom det er fler enn to mottakere`() {
+        val brevmottakerPersonDto2 =
+            BrevmottakerPersonDto(UUID.randomUUID(), "98769876987", "Donald Duck", MottakerRolle.BRUKER)
+
+        val brevmottakereDto =
+            BrevmottakereDto(
+                listOf(brevmottakerPersonDtoVanligBruker, brevmottakerPersonDto2),
+                listOf(brevmottakerOrganisasjonDto),
+            )
+
+        every { behandlingService.hentBehandling(any()) } returns behandling()
+
+        val feil = catchThrowableOfType<ApiFeil> {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), brevmottakereDto)
+        }
+        assertThat(feil.message).contains("Vedtaksbrevet kan ikke ha mer enn 2 mottakere")
+        assertThat(feil.httpStatus).isEqualTo(BAD_REQUEST)
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom man legger inn 2 personer som brevmottakere med samme personIdent`() {
+        val personIdent = "12312312323"
+        val brevmottakerPersonDtoMedSammePersonIdent1 =
+            BrevmottakerPersonDto(UUID.randomUUID(), personIdent, "Test Testersen", MottakerRolle.BRUKER)
+
+        val brevmottakerPersonDtoMedSammePersonIdent2 =
+            BrevmottakerPersonDto(UUID.randomUUID(), personIdent, "Donald Duck", MottakerRolle.BRUKER)
+        val brevmottakereDto =
+            BrevmottakereDto(
+                listOf(
+                    brevmottakerPersonDtoMedSammePersonIdent1,
+                    brevmottakerPersonDtoMedSammePersonIdent2,
+                ),
+                emptyList(),
+            )
+
+        every { behandlingService.hentBehandling(any()) } returns behandling()
+
+        val feil = catchThrowableOfType<ApiFeil> {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), brevmottakereDto)
+        }
+        assertThat(feil.message).contains("En person kan bare legges til en gang som brevmottaker")
+        assertThat(feil.httpStatus).isEqualTo(BAD_REQUEST)
+    }
+
+    @Test
+    fun `lagreBrevmottakere skal kaste feilmelding dersom man legger inn 2 organisasjoner som brevmottakere med samme organisasjonsnummer`() {
+        val organisasjonsnummer = "45645646456"
+
+        val brevmottakerOrganisasjonDtoMedSammeOrgnr1 =
+            BrevmottakerOrganisasjonDto(UUID.randomUUID(), organisasjonsnummer, "Forretninger AS", "Navn navnesen")
+
+        val brevmottakerOrganisasjonDtoMedSammeOrgnr2 =
+            BrevmottakerOrganisasjonDto(UUID.randomUUID(), organisasjonsnummer, "Forretninger AS", "Navn navnesen")
+
+        val brevmottakereDto =
+            BrevmottakereDto(
+                emptyList(),
+                listOf(brevmottakerOrganisasjonDtoMedSammeOrgnr1, brevmottakerOrganisasjonDtoMedSammeOrgnr2),
+            )
+
+        every { behandlingService.hentBehandling(any()) } returns behandling()
+
+        val feil = catchThrowableOfType<ApiFeil> {
+            brevmottakereService.lagreBrevmottakere(UUID.randomUUID(), brevmottakereDto)
+        }
+        assertThat(feil.message).contains("En organisasjon kan bare legges til en gang som brevmottaker")
+        assertThat(feil.httpStatus).isEqualTo(BAD_REQUEST)
+    }
+
+    @Test
+    fun `hentEllerOpprettBrevmottakere skal returnere BrevmottakereDto dersom disse finnes i repository`() {
+        val id = UUID.randomUUID()
+        val behandlingID = UUID.randomUUID()
+        val ident = "123123123"
+        val mottakernavn = "Test Testersen"
+
+        val brevmottakerTestObjekt = Brevmottaker(
+            id = id,
+            behandlingId = behandlingID,
+            mottakerRolle = no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerRolle.BRUKER,
+            mottakerType = MottakerType.PERSON,
+            ident = ident,
+            mottakerNavn = mottakernavn,
+            organisasjonsNavn = null,
+            journalpostId = null,
+            bestillingId = null,
+            sporbar = Sporbar(),
+        )
+
+        val brevmottakereDtoFasit = BrevmottakereDto(
+            personer = listOf(
+                BrevmottakerPersonDto(
+                    id = id,
+                    personIdent = ident,
+                    navn = mottakernavn,
+                    mottakerRolle = MottakerRolle.BRUKER,
+                ),
+            ),
+            organisasjoner = emptyList(),
+        )
+
+        every { brevmottakereRepository.existsByBehandlingId(any()) } returns true
+        every { brevmottakereRepository.findByBehandlingId(any()) } returns listOf(brevmottakerTestObjekt)
+
+        val brevmottakere: BrevmottakereDto = brevmottakereService.hentEllerOpprettBrevmottakere(id)
+
+        assertThat(brevmottakere).isEqualTo(brevmottakereDtoFasit)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Henter BrevmottakerPersonDto og BrevmottakerOrganisasjonDto fra Kontrakter. Disse Dto'ene  skal være felles for SAK og KLAGE.

Utvider Brevmottaker domene-objekt med nytt felt (organisasjonsNavn).

Bytter navn: navnHosOrganisasjon -> mottakerNavn 
Dette for at feltet skal kunne brukes av både personer og organisasjoner

Sees i sammenheng med PR: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/473