### PR TITLE
1. Vilkårperiodisering - Lagt til fom tom beløp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240522090805_0e9c7a6"
 val tilleggsstønaderLibsVersion = "2024.05.27-10.56.b9a67bfd6080"
-val tilleggsstønaderKontrakterVersion = "2024.08.20-13.25.3735fba235cc"
+val tilleggsstønaderKontrakterVersion = "2024.08.29-17.22.52068bceae9c"
 val tokenSupportVersion = "4.1.7"
 val wiremockVersion = "3.6.0"
 val mockkVersion = "1.13.11"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/TestSaksbehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/TestSaksbehandlingService.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.Vilkårsregel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkårsreglerForStønad
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -29,7 +30,15 @@ class TestSaksbehandlingService(
 
         vilkårsett.forEach { vilkår ->
             val delvilkårsett = lagDelvilkårsett(regler.getValue(vilkår.vilkårType), vilkår)
-            vilkårService.oppdaterVilkår(SvarPåVilkårDto(vilkår.id, behandlingId, delvilkårsett))
+            val svarPåVilkårDto = SvarPåVilkårDto(
+                id = vilkår.id,
+                behandlingId = behandlingId,
+                delvilkårsett = delvilkårsett,
+                fom = LocalDate.now(),
+                tom = LocalDate.now(),
+                beløp = 1,
+            )
+            vilkårService.oppdaterVilkår(svarPåVilkårDto)
         }
         return behandlingId
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -9,6 +9,7 @@ enum class Toggle(override val toggleId: String) : ToggleId {
 
     AUTOMATISK_JOURNALFORING_REVURDERING("sak.automatisk-jfr-revurdering"),
 
+    VILKÅR_PERIODISERING("sak.vilkar-periodisering"),
     SIMULERING("sak.simulering"),
 
     ADMIN_KAN_OPPRETTE_BEHANDLING("sak.admin-kan-opprette-behandling"),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.VilkårPeriodeValidering.validerIkkeOverlappendeVilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.VilkårsresultatUtil
 import org.springframework.stereotype.Service
 
@@ -28,6 +29,7 @@ class VilkårSteg(
         brukerfeilHvisIkke(VilkårsresultatUtil.erAlleVilkårTattStillingTil(vilkårsresultat)) {
             "Alle vilkår må være tatt stilling til"
         }
+        validerIkkeOverlappendeVilkår(vilkår)
     }
 
     override fun stegType(): StegType = StegType.VILKÅR

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
@@ -19,6 +20,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
@@ -51,6 +53,7 @@ class VilkårService(
     private val barnService: BarnService,
     private val behandlingFaktaService: BehandlingFaktaService,
     private val fagsakService: FagsakService,
+    private val unleashService: UnleashService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -99,6 +102,7 @@ class VilkårService(
         val vurderingsresultat = OppdaterVilkår.validerVilkårOgBeregnResultat(
             vilkår = vilkår,
             oppdatering = lagreVilkårDto,
+            toggleVilkårPeriodiseringEnabled = unleashService.isEnabled(Toggle.VILKÅR_PERIODISERING),
         )
         val oppdatertVilkår = OppdaterVilkår.oppdaterVilkår(
             vilkår = vilkår,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -44,6 +44,11 @@ data class Vilkår(
 
     init {
         require(resultat.erIkkeDelvilkårsresultat()) // Verdien AUTOMATISK_OPPFYLT er kun forbeholdt delvilkår
+        if (fom != null || tom != null) {
+            require(fom != null)
+            require(tom != null)
+            require(fom <= tom)
+        }
     }
 
     /**

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -8,6 +8,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -26,6 +27,11 @@ data class Vilkår(
     val behandlingId: UUID,
     val resultat: Vilkårsresultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
     val type: VilkårType,
+    val fom: LocalDate? = null,
+    val tom: LocalDate? = null,
+    @Column("belop")
+    val beløp: Int? = null,
+
     val barnId: UUID? = null,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/LagreVilkårDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/LagreVilkårDto.kt
@@ -1,18 +1,24 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto
 
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import java.time.LocalDate
 import java.util.UUID
 
 sealed interface LagreVilkårDto {
     val behandlingId: UUID
     val delvilkårsett: List<DelvilkårDto>
-    // TODO: fom/tom og utgifter
+    val fom: LocalDate?
+    val tom: LocalDate?
+    val beløp: Int?
 }
 
 data class SvarPåVilkårDto(
     val id: UUID,
     override val behandlingId: UUID,
     override val delvilkårsett: List<DelvilkårDto>,
+    override val fom: LocalDate?,
+    override val tom: LocalDate?,
+    override val beløp: Int?,
 ) : LagreVilkårDto
 
 data class OpprettVilkårDto(
@@ -20,4 +26,7 @@ data class OpprettVilkårDto(
     val barnId: UUID,
     override val behandlingId: UUID,
     override val delvilkårsett: List<DelvilkårDto>,
+    override val fom: LocalDate?,
+    override val tom: LocalDate?,
+    override val beløp: Int?,
 ) : LagreVilkårDto

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/VilkårDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/VilkårDto.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresult
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vurdering
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -15,6 +16,9 @@ data class VilkårDto(
     val behandlingId: UUID,
     val resultat: Vilkårsresultat,
     val vilkårType: VilkårType,
+    val fom: LocalDate?,
+    val tom: LocalDate?,
+    val beløp: Int?,
     val barnId: UUID? = null,
     val endretAv: String,
     val endretTid: LocalDateTime,
@@ -58,6 +62,9 @@ fun Vilkår.tilDto() =
         behandlingId = this.behandlingId,
         resultat = this.resultat,
         vilkårType = this.type,
+        fom = this.fom,
+        tom = this.tom,
+        beløp = this.beløp,
         barnId = this.barnId,
         endretAv = this.sporbar.endret.endretAv,
         endretTid = this.sporbar.endret.endretTid,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -47,14 +47,20 @@ object OppdaterVilkår {
         toggleVilkårPeriodiseringEnabled: Boolean,
     ) {
         if (toggleVilkårPeriodiseringEnabled) {
+            val vilkårType = vilkårsresultat.vilkårType
+            val resultat = vilkårsresultat.vilkår
             feilHvis(oppdatering.fom == null || oppdatering.tom == null) {
                 "Mangler fom/tom på vilkår"
             }
-            feilHvis(vilkårsresultat.vilkårType == VilkårType.PASS_BARN && oppdatering.beløp == null) {
+            feilHvis(
+                vilkårType == VilkårType.PASS_BARN &&
+                    resultat == Vilkårsresultat.OPPFYLT &&
+                    oppdatering.beløp == null,
+            ) {
                 "Mangler beløp på vilkår"
             }
-            feilHvis(vilkårsresultat.vilkårType != VilkårType.PASS_BARN && oppdatering.beløp != null) {
-                "Kan ikke ha beløp på vilkårType=${vilkårsresultat.vilkårType}"
+            feilHvis(vilkårType != VilkårType.PASS_BARN && oppdatering.beløp != null) {
+                "Kan ikke ha beløp på vilkårType=$vilkårType"
             }
         }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.DelvilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.LagreVilkårDto

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -27,6 +27,7 @@ object OppdaterVilkår {
     fun validerVilkårOgBeregnResultat(
         vilkår: Vilkår,
         oppdatering: LagreVilkårDto,
+        toggleVilkårPeriodiseringEnabled: Boolean,
     ): RegelResultat {
         val vilkårsregel = hentVilkårsregel(vilkår.type)
 
@@ -34,7 +35,27 @@ object OppdaterVilkår {
 
         val vilkårsresultat = utledResultat(vilkårsregel, oppdatering.delvilkårsett)
         validerAttResultatErOppfyltEllerIkkeOppfylt(vilkårsresultat)
+        validerPeriodeOgBeløp(oppdatering, vilkårsresultat, toggleVilkårPeriodiseringEnabled)
+
         return vilkårsresultat
+    }
+
+    private fun validerPeriodeOgBeløp(
+        oppdatering: LagreVilkårDto,
+        vilkårsresultat: RegelResultat,
+        toggleVilkårPeriodiseringEnabled: Boolean,
+    ) {
+        if (toggleVilkårPeriodiseringEnabled) {
+            feilHvis(oppdatering.fom == null || oppdatering.tom == null) {
+                "Mangler fom/tom på vilkår"
+            }
+            feilHvis(vilkårsresultat.vilkårType == VilkårType.PASS_BARN && oppdatering.beløp == null) {
+                "Mangler beløp på vilkår"
+            }
+            feilHvis(vilkårsresultat.vilkårType != VilkårType.PASS_BARN && oppdatering.beløp != null) {
+                "Kan ikke ha beløp på vilkårType=${vilkårsresultat.vilkårType}"
+            }
+        }
     }
 
     fun oppdaterVilkår(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -51,6 +51,9 @@ object OppdaterVilkår {
             resultat = vilkårsresultat.vilkår,
             delvilkårwrapper = oppdaterteDelvilkår,
             opphavsvilkår = null,
+            fom = oppdatering.fom,
+            tom = oppdatering.tom,
+            beløp = oppdatering.beløp,
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/VilkårPeriodeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/VilkårPeriodeValidering.kt
@@ -1,0 +1,44 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation
+
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.førsteOverlappendePeriode
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import java.time.LocalDate
+
+object VilkårPeriodeValidering {
+
+    /**
+     * Validerer at vilkår for av samme type/barn ikke overlapper
+     * 2 ulike barn med samme periode kan overlappe
+     * 1 enkelt barn kan ikke ha overlappende perioder
+     * Vilkår av gitt vilkårtype uten tilknytting til barn kan ikke overlappe
+     */
+    fun validerIkkeOverlappendeVilkår(values: List<Vilkår>) {
+        values
+            .groupBy { Pair(it.type, it.barnId) }
+            .mapValues { (_, vilkårliste) -> vilkårTilDatoperiode(vilkårliste) }
+            .forEach { (_, vilkårliste) -> validerIkkeOverlappende(vilkårliste) }
+    }
+
+    private fun validerIkkeOverlappende(vilkårliste: List<Datoperiode>) {
+        val overlappendePeriode = vilkårliste.førsteOverlappendePeriode()
+        if (overlappendePeriode != null) {
+            brukerfeil("Periode=${overlappendePeriode.first} og ${overlappendePeriode.second} overlapper.")
+        }
+    }
+
+    private fun vilkårTilDatoperiode(vilkårliste: List<Vilkår>) =
+        vilkårliste.mapNotNull {
+            if (it.fom == null || it.tom == null) {
+                null
+            } else {
+                Datoperiode(fom = it.fom, tom = it.tom)
+            }
+        }
+
+    private data class Datoperiode(
+        override val fom: LocalDate,
+        override val tom: LocalDate,
+    ) : Periode<LocalDate>
+}

--- a/src/main/resources/db/migration/V46__vilkår_fom_tom_beløp.sql
+++ b/src/main/resources/db/migration/V46__vilkår_fom_tom_beløp.sql
@@ -1,0 +1,4 @@
+ALTER TABLE vilkar
+    ADD COLUMN fom   DATE,
+    ADD COLUMN tom   DATE,
+    ADD COLUMN belop INT;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/UnleashTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/UnleashTestUtil.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.libs.unleash.UnleashService
 fun mockUnleashService(isEnabled: Boolean = true): UnleashService {
     val mockk = mockk<UnleashService>()
     every { mockk.isEnabled(any()) } returns isEnabled
+    every { mockk.isEnabled(Toggle.VILKÅR_PERIODISERING) } returns false
     every { mockk.isEnabled(any(), any<Boolean>()) } returns isEnabled
 
     // Variants må konfigureres en og en då de kan ha ulike navn som er relevant å konfigurere

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -240,6 +240,9 @@ fun vilkår(
     delvilkår: List<Delvilkår> = emptyList(),
     barnId: UUID? = null,
     opphavsvilkår: Opphavsvilkår? = null,
+    fom: LocalDate? = null,
+    tom: LocalDate? = null,
+    beløp: Int? = null,
 ): Vilkår = Vilkår(
     behandlingId = behandlingId,
     resultat = resultat,
@@ -247,6 +250,9 @@ fun vilkår(
     barnId = barnId,
     delvilkårwrapper = DelvilkårWrapper(delvilkår),
     opphavsvilkår = opphavsvilkår,
+    fom = fom,
+    tom = tom,
+    beløp = beløp,
 )
 
 fun fagsakpersoner(vararg identer: String): Set<PersonIdent> = identer.map {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
@@ -247,6 +247,9 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
             barnId = barn.id,
             behandlingId = behandling.id,
             delvilkårsett = oppfylteDelvilkårPassBarnDto(),
+            fom = LocalDate.now(),
+            tom = LocalDate.now().plusDays(1),
+            beløp = 1,
         )
 
         @BeforeEach
@@ -263,6 +266,9 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
             val vilkårFraDb = vilkårRepository.findByBehandlingId(behandling.id).single()
             assertThat(vilkårFraDb.behandlingId).isEqualTo(behandling.id)
             assertThat(vilkårFraDb.type).isEqualTo(VilkårType.PASS_BARN)
+            assertThat(vilkårFraDb.fom).isEqualTo(LocalDate.now())
+            assertThat(vilkårFraDb.tom).isEqualTo(LocalDate.now().plusDays(1))
+            assertThat(vilkårFraDb.beløp).isEqualTo(1)
             assertThat(vilkårFraDb.barnId).isEqualTo(barn.id)
             assertThat(vilkårFraDb.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
             assertThat(vilkårFraDb.opphavsvilkår).isNull()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.behandling.fakta.BehandlingFaktaService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.mapper.SøknadsskjemaBarnetilsynMapper
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
 import no.nav.tilleggsstonader.sak.util.JournalpostUtil.lagJournalpost
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
 import java.time.Year
 import java.util.UUID
 
@@ -66,6 +68,7 @@ internal class VilkårServiceTest {
         behandlingFaktaService = behandlingFaktaService,
         barnService = barnService,
         fagsakService = fagsakService,
+        unleashService = mockUnleashService(),
     )
 
     private val barnUnder9år = FnrGenerator.generer(Year.now().minusYears(1).value, 5, 19)
@@ -296,6 +299,9 @@ internal class VilkårServiceTest {
                             id = vilkårId,
                             behandlingId = behandlingId,
                             delvilkårsett = listOf(),
+                            fom = null,
+                            tom = null,
+                            beløp = null,
                         ),
                     )
                 },
@@ -312,11 +318,17 @@ internal class VilkårServiceTest {
                     id = vilkår.id,
                     behandlingId = behandlingId,
                     delvilkårsett = PassBarnRegelTestUtil.oppfylteDelvilkårPassBarnDto(),
+                    fom = LocalDate.now(),
+                    tom = LocalDate.now(),
+                    beløp = 1,
                 ),
             )
 
             assertThat(lagretVilkår.captured.resultat).isEqualTo(OPPFYLT)
             assertThat(lagretVilkår.captured.type).isEqualTo(vilkår.type)
+            assertThat(lagretVilkår.captured.fom).isEqualTo(LocalDate.now())
+            assertThat(lagretVilkår.captured.tom).isEqualTo(LocalDate.now())
+            assertThat(lagretVilkår.captured.beløp).isEqualTo(1)
             assertThat(lagretVilkår.captured.opphavsvilkår).isNull()
 
             assertThat(lagretVilkår.captured.delvilkårsett).hasSize(3)
@@ -392,6 +404,9 @@ internal class VilkårServiceTest {
                         id = vilkår.id,
                         behandlingId = behandlingId,
                         listOf(),
+                        fom = null,
+                        tom = null,
+                        beløp = null,
                     ),
                 )
             },
@@ -422,6 +437,9 @@ internal class VilkårServiceTest {
                         id = vilkår.id,
                         behandlingId = behandlingId,
                         listOf(),
+                        fom = null,
+                        tom = null,
+                        beløp = null,
                     ),
                 )
             },

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -1,8 +1,63 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation
 
+import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.OppdaterVilkår.validerVilkårOgBeregnResultat
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarn
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarnDto
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
 internal class OppdaterVilkårTest {
 
-    /**
-     * TODO
-     */
+    val behandlingId = UUID.randomUUID()
+    val vilkår = vilkår(
+        behandlingId = behandlingId,
+        type = VilkårType.PASS_BARN,
+        delvilkår = oppfylteDelvilkårPassBarn(),
+    )
+
+    @Nested
+    inner class ValideringAvBeløp {
+        val opprettVilkårDto = OpprettVilkårDto(
+            vilkårType = VilkårType.PASS_BARN,
+            barnId = UUID.randomUUID(),
+            behandlingId = behandlingId,
+            delvilkårsett = oppfylteDelvilkårPassBarnDto(),
+            fom = LocalDate.now(),
+            tom = LocalDate.now().plusDays(1),
+            beløp = 1,
+        )
+
+        @Test
+        fun `skal validere at man har med beløp for vilkår for pass av barn`() {
+            assertThatThrownBy {
+                validerVilkårOgBeregnResultat(vilkår, opprettVilkårDto.copy(fom = null), true)
+            }.hasMessageContaining("Mangler fom/tom på vilkår")
+
+            assertThatThrownBy {
+                validerVilkårOgBeregnResultat(vilkår, opprettVilkårDto.copy(tom = null), true)
+            }.hasMessageContaining("Mangler fom/tom på vilkår")
+        }
+
+        @Test
+        fun `skal validere at pass av barn inneholkder beløp`() {
+            assertThatThrownBy {
+                validerVilkårOgBeregnResultat(vilkår, opprettVilkårDto.copy(beløp = null), true)
+            }.hasMessageContaining("Mangler beløp på vilkår")
+        }
+
+        @Disabled // TODO fiks når annen type enn eksempel er tilgjengelig
+        @Test
+        fun `skal validere at annet vilkår enn pass av barn ikke inneholder beløp`() {
+            assertThatThrownBy {
+                validerVilkårOgBeregnResultat(vilkår, opprettVilkårDto.copy(vilkårType = VilkårType.EKSEMPEL), true)
+            }.hasMessageContaining("Mangler beløp på vilkår")
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.OppdaterVilkår.validerVilkårOgBeregnResultat
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.ikkeOppfylteDelvilkårPassBarnDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarnDto
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -46,10 +47,16 @@ internal class OppdaterVilkårTest {
         }
 
         @Test
-        fun `skal validere at pass av barn inneholkder beløp`() {
+        fun `skal kaste feil hvis innvilget pass av barn ikke inneholder beløp`() {
             assertThatThrownBy {
                 validerVilkårOgBeregnResultat(vilkår, opprettVilkårDto.copy(beløp = null), true)
             }.hasMessageContaining("Mangler beløp på vilkår")
+        }
+
+        @Test
+        fun `skal ikke kaste feil hvis ikke oppfylt pass av barn ikke inneholder beløp`() {
+            val dto = opprettVilkårDto.copy(beløp = null, delvilkårsett = ikkeOppfylteDelvilkårPassBarnDto())
+            validerVilkårOgBeregnResultat(vilkår, dto, true)
         }
 
         @Disabled // TODO fiks når annen type enn eksempel er tilgjengelig

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/VilkårPeriodeValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/VilkårPeriodeValideringTest.kt
@@ -1,0 +1,54 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation
+
+import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.VilkårPeriodeValidering.validerIkkeOverlappendeVilkår
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.LocalDate.now
+import java.util.UUID
+
+class VilkårPeriodeValideringTest {
+
+    val behandlingId = UUID.randomUUID()
+
+    @Test
+    fun `skal ikke kaste feil hvis 2 perioder uten barnId ikke overlapper`() {
+        val vilkår = vilkår(behandlingId = behandlingId, fom = now(), tom = now())
+        val vilkår2 = vilkår.copy(fom = now().plusDays(1), tom = now().plusDays(1))
+
+        validerIkkeOverlappendeVilkår(listOf(vilkår, vilkår2))
+    }
+
+    @Test
+    fun `skal kaste feil hvis 2 perioder uten barnId overlapper`() {
+        val vilkår = vilkår(behandlingId = UUID.randomUUID(), fom = now(), tom = now())
+
+        assertThatThrownBy {
+            validerIkkeOverlappendeVilkår(listOf(vilkår, vilkår))
+        }.hasMessageContaining(" overlapper")
+    }
+
+    @Test
+    fun `skal ikke kaste feil hvis 2 perioder for samme barn ikke overlapper`() {
+        val vilkår = vilkår(behandlingId = UUID.randomUUID(), barnId = UUID.randomUUID(), fom = now(), tom = now())
+        val vilkår2 = vilkår.copy(fom = now().plusDays(1), tom = now().plusDays(1))
+
+        validerIkkeOverlappendeVilkår(listOf(vilkår, vilkår2))
+    }
+
+    @Test
+    fun `skal kaste feil hvis 2 perioder for samme barn overlapper`() {
+        val vilkår = vilkår(behandlingId = UUID.randomUUID(), barnId = UUID.randomUUID(), fom = now(), tom = now())
+        assertThatThrownBy {
+            validerIkkeOverlappendeVilkår(listOf(vilkår, vilkår))
+        }.hasMessageContaining(" overlapper")
+    }
+
+    @Test
+    fun `skal ikke kaste feil hvis 2 perioder for ulike barn ikke overlapper`() {
+        val vilkår = vilkår(behandlingId = UUID.randomUUID(), barnId = UUID.randomUUID(), fom = now(), tom = now())
+        val vilkår2 = vilkår.copy(barnId = UUID.randomUUID())
+
+        validerIkkeOverlappendeVilkår(listOf(vilkår, vilkår2))
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/PassBarnRegelTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/PassBarnRegelTestUtil.kt
@@ -15,7 +15,14 @@ object PassBarnRegelTestUtil {
         delvilkår(Vurdering(RegelId.UTGIFTER_DOKUMENTERT, SvarId.JA)),
     )
 
+    fun ikkeOppfylteDelvilkårPassBarn() = listOf(
+        delvilkår(Vurdering(RegelId.HAR_FULLFØRT_FJERDEKLASSE, SvarId.NEI, "en begrunnelse")),
+        delvilkår(Vurdering(RegelId.ANNEN_FORELDER_MOTTAR_STØTTE, SvarId.JA, "en begrunnelse")),
+        delvilkår(Vurdering(RegelId.UTGIFTER_DOKUMENTERT, SvarId.JA)),
+    )
+
     fun oppfylteDelvilkårPassBarnDto() = oppfylteDelvilkårPassBarn().map { it.tilDto() }
+    fun ikkeOppfylteDelvilkårPassBarnDto() = ikkeOppfylteDelvilkårPassBarn().map { it.tilDto() }
 
     private fun delvilkår(vararg vurderinger: Vurdering) = Delvilkår(
         resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

* Lagrer ned fom, tom og beløp i databasen
* Validerer at man ikke har overlappende vilkår tvers vilkårtype og barnId

Beløp blir plassert på litt rar sted, men vi ble enige om at det var en grei plass i oppstartsmøtet

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22063

Senere:
`utledVilkårsresultat` må nog sjekke `utledResultatForVilkårSomGjelderFlereBarn` for alle type vilkår med en renaming, då alle vilkår kan være flere på en person

Denne er testet uten feature toggle og det såg ut til å virke fint

* https://github.com/navikt/tilleggsstonader-sak/pull/407
* https://github.com/navikt/tilleggsstonader-sak/pull/408
* https://github.com/navikt/tilleggsstonader-sak/pull/411
* https://github.com/navikt/tilleggsstonader-sak/pull/409
* https://github.com/navikt/tilleggsstonader-sak/pull/412

* https://github.com/navikt/tilleggsstonader-htmlify/pull/34