### PR TITLE
2. Vilkårperiodisering - Migrering av utgift fra vedtaksperioder til vilkår

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/FlyttBeløpsperioderTilVilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/FlyttBeløpsperioderTilVilkårController.kt
@@ -1,0 +1,123 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.VedtakTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/vilkar/admin")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class FlyttBeløpsperioderTilVilkårController(
+    private val vedtakTilsynBarnVedtakRepository: TilsynBarnVedtakRepository,
+    private val jdbcTemplate: NamedParameterJdbcTemplate,
+    private val behandlingRepository: BehandlingRepository,
+    private val vilkårRepository: VilkårRepository,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private fun utførEndringSomSystem() {
+        SpringTokenValidationContextHolder().setTokenValidationContext(null)
+    }
+
+    @PostMapping
+    @Transactional
+    fun oppdaterVilkår() {
+        utførEndringSomSystem()
+        vedtakTilsynBarnVedtakRepository.findAll()
+            .forEach {
+                håndterVedtak(it)
+            }
+    }
+
+    private fun håndterVedtak(vedtak: VedtakTilsynBarn) {
+        val vedtakData = vedtak.vedtak
+        val behandlingId = vedtak.behandlingId
+        if (vedtakData == null) {
+            logger.info("Ignorerer vedtak=$behandlingId")
+            return
+        }
+        val vilkårForBehandling = vilkårRepository.findByBehandlingId(behandlingId).associateBy { it.barnId }
+        /*
+        Hvordan skal vi populere vilkår med fom/tom der det ikke finnes noe fra vedtaket?
+        Er kanskje greit at disse fortsatt forblir nullable og at man må ta stilling til de vid neste tilfelle man revurderer?
+         */
+        vedtakData.utgifter.forEach { (barnId, utgifter) ->
+            if (utgifter.isNotEmpty()) {
+                val vilkår = vilkårForBehandling[barnId]
+                    ?: error("Finner ikke vilkår for barnId=$barnId behandling=$behandlingId")
+                oppdaterVilkårMedPeriode(vilkår, utgifter)
+                leggTilNyeVilkårForAndreUtgifter(vilkår, utgifter.drop(1))
+            }
+        }
+        /*
+        TODO Trenger vi å oppdatere steget?
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        if (behandling.steg == StegType.BESLUTTE_VEDTAK && vedtak.type == TypeVedtak.INNVILGELSE) {
+            jdbcTemplate.update(
+                "UPDATE behandling SET steg=:steg WHERE id=:behandlingId",
+                mapOf(
+                    "behandlingId" to behandling.id,
+                    "steg" to StegType.
+                )
+            )
+        }
+         */
+    }
+
+    private fun oppdaterVilkårMedPeriode(
+        vilkår: Vilkår,
+        utgifter: List<Utgift>,
+    ) {
+        jdbcTemplate.update(
+            "UPDATE vilkar SET fom=:fom, tom=:tom, utgift=:utgift WHERE id=:id",
+            mapOf(
+                "id" to vilkår.id,
+                "fom" to utgifter.first().fom.atDay(1),
+                "tom" to utgifter.first().tom.atEndOfMonth(),
+                "utgift" to utgifter.first().utgift,
+            ),
+        )
+    }
+
+    private fun leggTilNyeVilkårForAndreUtgifter(
+        vilkår: Vilkår,
+        utgifter: List<Utgift>,
+    ) {
+        utgifter.forEach {
+            jdbcTemplate.update(
+                """
+                    INSERT INTO vilkar (id,behandling_id,opprettet_av,opprettet_tid,endret_av,endret_tid,resultat,
+                    type,begrunnelse,unntak,delvilkar,barn_id,opphavsvilkaar_behandling_id,
+                    opphavsvilkaar_vurderingstidspunkt,fom,tom,utgift) 
+                    SELECT :id,
+                    behandling_id,opprettet_av,opprettet_tid,endret_av,endret_tid,resultat,type,begrunnelse,unntak,
+                    delvilkar,barn_id,opphavsvilkaar_behandling_id,opphavsvilkaar_vurderingstidspunkt,
+                    :fom,:tom,:utgift 
+                    FROM vilkar WHERE id=:kopierFraId
+                """.trimIndent(),
+                mapOf(
+                    "id" to UUID.randomUUID(),
+                    "kopierFraId" to vilkår.id,
+                    "fom" to it.fom.atDay(1),
+                    "tom" to it.tom.atEndOfMonth(),
+                    "utgift" to it.utgift,
+                ),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -31,7 +31,6 @@ data class Vilkår(
     val type: VilkårType,
     val fom: LocalDate? = null,
     val tom: LocalDate? = null,
-    @Column("utgift")
     val utgift: Int? = null,
 
     val barnId: UUID? = null,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/FlyttBeløpsperioderTilVilkårControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/FlyttBeløpsperioderTilVilkårControllerTest.kt
@@ -1,0 +1,141 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnRepository
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.behandlingBarn
+import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgetVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.VedtaksdataTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.YearMonth
+
+class FlyttBeløpsperioderTilVilkårControllerTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var vedtakRepository: TilsynBarnVedtakRepository
+
+    @Autowired
+    lateinit var vilkårRepository: VilkårRepository
+
+    @Autowired
+    lateinit var barnRepository: BarnRepository
+
+    @Autowired
+    lateinit var controller: FlyttBeløpsperioderTilVilkårController
+
+    val behandling = behandling(steg = StegType.BESLUTTE_VEDTAK)
+    val barn = behandlingBarn(behandlingId = behandling.id)
+
+    @BeforeEach
+    fun setUp() {
+        testoppsettService.opprettBehandlingMedFagsak(behandling)
+        barnRepository.insert(barn)
+    }
+
+    @Test
+    fun `skal oppdatere vilkår med utgift fra vedtak`() {
+        val fom = YearMonth.of(2023, 1)
+        val tom = YearMonth.of(2023, 2)
+        val utgift = 100
+        val vedtaksdata = VedtaksdataTilsynBarn(
+            utgifter = mapOf(
+                barn(
+                    barnId = barn.id,
+                    Utgift(fom, tom, utgift),
+                ),
+            ),
+        )
+        vedtakRepository.insert(innvilgetVedtak(behandlingId = behandling.id, vedtak = vedtaksdata))
+        val opprinneligVilkår = vilkårRepository.insert(
+            vilkår(behandlingId = behandling.id, barnId = barn.id, type = VilkårType.PASS_BARN),
+        )
+
+        testWithBrukerContext {
+            controller.oppdaterVilkår()
+        }
+
+        val oppdatertVilkår = vilkårRepository.findByBehandlingId(behandling.id).single()
+        assertThat(oppdatertVilkår)
+            .usingRecursiveComparison()
+            .ignoringFields("fom", "tom", "utgift")
+            .isEqualTo(opprinneligVilkår)
+
+        assertThat(oppdatertVilkår.fom).isEqualTo(fom.atDay(1))
+        assertThat(oppdatertVilkår.tom).isEqualTo(tom.atEndOfMonth())
+        assertThat(oppdatertVilkår.utgift).isEqualTo(utgift)
+    }
+
+    @Test
+    fun `skal opprette nye vilkår dersom det finnes fler enn 1 utgift`() {
+        val fom = YearMonth.of(2023, 1)
+        val tom = YearMonth.of(2023, 2)
+        val utgift = 100
+        val vedtaksdata = VedtaksdataTilsynBarn(
+            utgifter = mapOf(
+                barn(
+                    barnId = barn.id,
+                    Utgift(fom, tom, utgift),
+                    Utgift(fom.plusYears(1), tom.plusYears(2), utgift + 1),
+                ),
+            ),
+        )
+        vedtakRepository.insert(innvilgetVedtak(behandlingId = behandling.id, vedtak = vedtaksdata))
+        val opprinneligVilkår = vilkårRepository.insert(
+            vilkår(behandlingId = behandling.id, barnId = barn.id, type = VilkårType.PASS_BARN),
+        )
+
+        testWithBrukerContext {
+            controller.oppdaterVilkår()
+        }
+
+        val oppdaterteVilkår = vilkårRepository.findByBehandlingId(behandling.id)
+        val oppdatertVilkår = oppdaterteVilkår.single { it.id == opprinneligVilkår.id }
+        val opprettetVilkår = oppdaterteVilkår.single { it.id != opprinneligVilkår.id }
+        with(oppdatertVilkår) {
+            assertThat(this)
+                .usingRecursiveComparison()
+                .ignoringFields("fom", "tom", "utgift")
+                .isEqualTo(opprinneligVilkår)
+
+            assertThat(this.fom).isEqualTo(fom.atDay(1))
+            assertThat(this.tom).isEqualTo(tom.atEndOfMonth())
+            assertThat(this.utgift).isEqualTo(utgift)
+        }
+        assertThat(opprettetVilkår)
+            .usingRecursiveComparison()
+            .ignoringFields("id", "fom", "tom", "utgift")
+            .isEqualTo(oppdatertVilkår)
+
+        assertThat(opprettetVilkår.fom).isEqualTo(fom.atDay(1).plusYears(1))
+        assertThat(opprettetVilkår.tom).isEqualTo(tom.atEndOfMonth().plusYears(2))
+        assertThat(opprettetVilkår.utgift).isEqualTo(101)
+    }
+
+    @Test
+    fun `skal oppdatere en behandling som er i steg vedtak som mangler vedtak til steg inngangsvilkår for å kunne legge in perioder og utgift på vilkår`() {
+        testWithBrukerContext {
+            controller.oppdaterVilkår()
+        }
+
+        assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.INNGANGSVILKÅR)
+    }
+
+    @Test
+    fun `skal ikke oppdatere behandling dersom behandling er henlagt, dermed avsluttet`() {
+        testoppsettService.oppdater(behandling.copy(status = BehandlingStatus.FERDIGSTILT))
+        testWithBrukerContext {
+            controller.oppdaterVilkår()
+        }
+
+        assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.BESLUTTE_VEDTAK)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/FlyttBeløpsperioderTilVilkårControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/FlyttBeløpsperioderTilVilkårControllerTest.kt
@@ -2,6 +2,8 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår
 
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.behandlingBarn
@@ -12,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.VedtaksdataTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.Utgift
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -137,5 +140,14 @@ class FlyttBeløpsperioderTilVilkårControllerTest : IntegrationTest() {
         }
 
         assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.BESLUTTE_VEDTAK)
+    }
+
+    @Test
+    fun `skal oppdatere en behandling som er i steg vedtak som mangler vedtak til steg inngangsvilkår for å kunne legge in perioder og beløp på vilkår`() {
+        testWithBrukerContext {
+            controller.oppdaterVilkår()
+        }
+
+        assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.INNGANGSVILKÅR)
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Skal flytte fom/tom fra utgifter i vedtak til vilkår.
Det fantes 1 tilfelle i prod med fler enn 1 utgift på et barn, for dette vil vilkåret bli kopiert og lagt inn med riktig periode med nytt ID.
Beholder dermed sportbar-attributer.

Fortsettelse på
* https://github.com/navikt/tilleggsstonader-sak/pull/407

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22063

* https://github.com/navikt/tilleggsstonader-sak/pull/407
* https://github.com/navikt/tilleggsstonader-sak/pull/408
* https://github.com/navikt/tilleggsstonader-sak/pull/411
* https://github.com/navikt/tilleggsstonader-sak/pull/409
* https://github.com/navikt/tilleggsstonader-sak/pull/412

* https://github.com/navikt/tilleggsstonader-htmlify/pull/34