### PR TITLE
Skal håndtere simulering uten resultat

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettClient.kt
@@ -50,11 +50,11 @@ class IverksettClient(
         return getForEntity<IverksettStatus>(url, uriVariables = uriVariables)
     }
 
-    fun simuler(simuleringRequest: SimuleringRequestDto): SimuleringResponseDto {
+    fun simuler(simuleringRequest: SimuleringRequestDto): SimuleringResponseDto? {
         val url = UriComponentsBuilder.fromUri(uri)
             .pathSegment("api", "simulering", "v2")
             .toUriString()
 
-        return postForEntity<SimuleringResponseDto>(url, simuleringRequest)
+        return postForEntityNullable<SimuleringResponseDto>(url, simuleringRequest)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringResponse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringResponse.kt
@@ -8,10 +8,12 @@ data class SimuleringResponse(val oppsummeringer: List<OppsummeringForPeriode>, 
 
 object SimuleringResponseMapper {
 
-    fun map(simuleringResponse: SimuleringResponseDto): SimuleringResponse {
-        return SimuleringResponse(
-            oppsummeringer = simuleringResponse.oppsummeringer,
-            detaljer = simuleringResponse.detaljer,
-        )
+    fun map(simuleringResponse: SimuleringResponseDto?): SimuleringResponse? {
+        return simuleringResponse?.let {
+            SimuleringResponse(
+                oppsummeringer = it.oppsummeringer,
+                detaljer = it.detaljer,
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
@@ -60,11 +60,12 @@ class SimuleringService(
             Simuleringsresultat(
                 behandlingId = saksbehandling.id,
                 data = SimuleringResponseMapper.map(resultat),
+                ingenEndringIUtbetaling = resultat == null,
             ),
         )
     }
 
-    private fun simulerMedTilkjentYtelse(saksbehandling: Saksbehandling): SimuleringResponseDto {
+    private fun simulerMedTilkjentYtelse(saksbehandling: Saksbehandling): SimuleringResponseDto? {
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(saksbehandling.id)
         val forrigeIverksettingDto = iverksettService.forrigeIverksetting(saksbehandling, tilkjentYtelse)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/Simuleringsresultat.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/Simuleringsresultat.kt
@@ -6,11 +6,16 @@ import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
 import java.util.UUID
 
+/**
+ * @property ingenEndringIUtbetaling: Hvis man simulerer med identiske utbetalinger som tidligere vil utsjekk svare med 204 NO CONTENT,
+ * fordi det ikke er noen utbetalinger å simulere. Vi setter denne til true for å indikere at det ikke er noen endring i utbetaling.
+ */
 @Table
 data class Simuleringsresultat(
     @Id
     val behandlingId: UUID,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
-    val data: SimuleringResponse,
+    val data: SimuleringResponse?,
+    val ingenEndringIUtbetaling: Boolean = false,
 )

--- a/src/main/resources/db/migration/V46__simulering_ingen_endring.sql
+++ b/src/main/resources/db/migration/V46__simulering_ingen_endring.sql
@@ -1,0 +1,2 @@
+ALTER TABLE simuleringsresultat ADD COLUMN ingen_endring_i_utbetaling BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE simuleringsresultat ALTER COLUMN data DROP NOT NULL;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/IverksettClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/IverksettClientConfig.kt
@@ -38,6 +38,7 @@ class IverksettClientConfig {
             justRun { iverksettClient.iverksett(any()) }
             every { iverksettClient.hentStatus(any(), any(), any()) } returns IverksettStatus.OK
             every { iverksettClient.simuler(any()) } returns simuleringsresultat
+            every { iverksettClient.simuler(match { it.personident == "identIngenEndring" }) } returns null
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
@@ -58,7 +58,26 @@ internal class SimuleringControllerTest : IntegrationTest() {
         val simuleringsresultat = simuleringsresultatRepository.findByIdOrThrow(behandling.id)
 
         // Verifiser at simuleringsresultatet er lagret
-        assertThat(simuleringsresultat.data.detaljer.perioder).hasSize(16)
+        assertThat(simuleringsresultat.data!!.detaljer.perioder).hasSize(16)
+        assertThat(simuleringsresultat.ingenEndringIUtbetaling).isFalse()
+    }
+
+    @Test
+    internal fun `Skal håndtere 204 No Content for behandling uten endring i utbetalinger, og lagre ned dette`() {
+        val personIdent = "identIngenEndring"
+        val fagsak = opprettFagsak(personIdent)
+        val behandling = opprettBehandling(fagsak)
+        opprettVedtak(behandling.id)
+
+        tilkjentYtelseRepository.insert(tilkjentYtelse(behandlingId = behandling.id))
+
+        val respons: ResponseEntity<SimuleringDto> = simulerForBehandling(behandling.id)
+
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
+        val simuleringsresultat = simuleringsresultatRepository.findByIdOrThrow(behandling.id)
+
+        assertThat(simuleringsresultat.data).isNull()
+        assertThat(simuleringsresultat.ingenEndringIUtbetaling).isTrue()
     }
 
     private fun opprettFagsak(personIdent: String) =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -114,6 +114,6 @@ internal class SimuleringServiceTest {
 
         simuleringService.hentOgLagreSimuleringsresultat(saksbehandling(id = behandling.id))
 
-        assertThat(simulerSlot.captured.data.oppsummeringer).hasSize(16)
+        assertThat(simulerSlot.captured.data!!.oppsummeringer).hasSize(16)
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Dersom man simulerer uten noen nye utbetalinger vil man få 204 No Content som svar fra utsjekk, og dette må håndteres. Vi lagrer da ned at det ikke var noe simuleringsresultat

ref https://nav-it.slack.com/archives/C060V3ADLTD/p1724834864179649?thread_ts=1724742254.764759&cid=C060V3ADLTD

