### PR TITLE
Oppdater kontrakter og håndter ny stønadstype

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240522090805_0e9c7a6"
 val tilleggsstønaderLibsVersion = "2024.05.27-10.56.b9a67bfd6080"
-val tilleggsstønaderKontrakterVersion = "2024.08.29-17.22.52068bceae9c"
+val tilleggsstønaderKontrakterVersion = "2024.09.02-14.13.c53d34104b87"
 val tokenSupportVersion = "4.1.7"
 val wiremockVersion = "3.6.0"
 val mockkVersion = "1.13.11"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettTestBehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettTestBehandlingController.kt
@@ -81,6 +81,7 @@ class OpprettTestBehandlingController(
     private fun opprettSøknad(fagsak: Fagsak, behandling: Behandling) {
         when (fagsak.stønadstype) {
             Stønadstype.BARNETILSYN -> opprettSøknadBarnetilsyn(fagsak, behandling)
+            else -> error("Kan ikke opprette søknad for stønadstype ${fagsak.stønadstype}.")
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/FrittståendeBrevService.kt
@@ -88,5 +88,6 @@ class FrittståendeBrevService(
     private fun utledDokumenttype(stønadstype: Stønadstype) =
         when (stønadstype) {
             Stønadstype.BARNETILSYN -> Dokumenttype.BARNETILSYN_FRITTSTÅENDE_BREV
+            else -> error("Frittstående brev er ikke støttet for stønadstype $stønadstype")
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevTask.kt
@@ -114,11 +114,13 @@ class JournalførVedtaksbrevTask(
 
     private fun utledBrevtittel(saksbehandling: Saksbehandling) = when (saksbehandling.stønadstype) {
         Stønadstype.BARNETILSYN -> "Vedtak om stønad til tilsyn barn" // TODO
+        else -> error("Utledning av brevtype er ikke implementert for ${saksbehandling.stønadstype}")
     }
 
     private fun utledDokumenttype(saksbehandling: Saksbehandling) =
         when (saksbehandling.stønadstype) {
             Stønadstype.BARNETILSYN -> Dokumenttype.BARNETILSYN_VEDTAKSBREV
+            else -> error("Utledning av dokumenttype er ikke implementert for ${saksbehandling.stønadstype}")
         }
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakService.kt
@@ -90,6 +90,7 @@ class InterntVedtakService(
     ): Søknadsinformasjon? {
         val søknad = when (behandling.stønadstype) {
             Stønadstype.BARNETILSYN -> søknadService.hentSøknadBarnetilsyn(behandling.id)
+            else -> error("Kan ikke hente søknad for stønadstype ${behandling.stønadstype}")
         }
         if (søknad == null) {
             return null

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveService.kt
@@ -277,6 +277,7 @@ class OppgaveService(
     private fun finnBehandlingstema(stønadstype: Stønadstype): Behandlingstema {
         return when (stønadstype) {
             Stønadstype.BARNETILSYN -> Behandlingstema.TilsynBarn
+            else -> error("Behandlingstema er ikke implementert for stønadstype $stønadstype")
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
@@ -77,5 +77,6 @@ class YtelseService(
                     TypeYtelsePeriode.ENSLIG_FORSØRGER,
                     TypeYtelsePeriode.OMSTILLINGSSTØNAD,
                 )
+            else -> error("Finner ikke relevante ytelser for stønadstype $type")
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksresultatService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksresultatService.kt
@@ -14,6 +14,7 @@ class VedtaksresultatService(
     fun hentVedtaksresultat(saksbehandling: Saksbehandling): TypeVedtak {
         return when (saksbehandling.stønadstype) {
             Stønadstype.BARNETILSYN -> tilsynBarnRepository.findByIdOrNull(saksbehandling.id)?.type
+            else -> error("Kan ikke hente vedtaksresultat for stønadstype ${saksbehandling.stønadstype}.")
         } ?: error("Finner ikke vedtaksresultat for behandling=$saksbehandling")
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregler.kt
@@ -23,6 +23,7 @@ fun vilkårsreglerForStønad(stønadstype: Stønadstype): List<Vilkårsregel> =
         Stønadstype.BARNETILSYN -> listOf(
             PassBarnRegel(),
         )
+        Stønadstype.LÆREMIDLER -> emptyList()
     }
 
 private val vilkårstyperPerStønad: Map<Stønadstype, Set<VilkårType>> =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/MålgruppeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/MålgruppeValidering.kt
@@ -18,6 +18,7 @@ object MålgruppeValidering {
                 MålgruppeType.SYKEPENGER_100_PROSENT -> true
                 MålgruppeType.INGEN_MÅLGRUPPE -> true
             }
+            else -> error("Målgruppevalidering for stønadstype=$stønadstype er ikke implementert")
         }
         feilHvisIkke(gyldig) {
             "målgruppe=$målgruppeType er ikke gyldig for $stønadstype"

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OpprettOppgaveConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OpprettOppgaveConfig.kt
@@ -94,9 +94,11 @@ class OpprettOppgaveConfig(
 
     private fun mapTema(stønadstype: Stønadstype): Tema = when (stønadstype) {
         Stønadstype.BARNETILSYN -> Tema.TSO
+        Stønadstype.LÆREMIDLER -> Tema.TSO
     }
 
     private fun mapBehandlingstema(stønadstype: Stønadstype): Behandlingstema = when (stønadstype) {
         Stønadstype.BARNETILSYN -> Behandlingstema.TilsynBarn
+        else -> error("Finner ikke behandlingstema for stønadstype $stønadstype")
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
La til [LÆREMIDLER som stønadstype](https://github.com/navikt/tilleggsstonader-kontrakter/pull/86) i kontrakter, så dette må håndteres i sak alle steder hvor man har en `when` som ikke lenger er exhausting. 

Har fikset det ved bruk av `else` og feilmelding om at det ikke er implementert. Bortsett fra en hvor det måtte returneres `emptyList()` for å kjøre