### PR TITLE
Tar i bruk value class for id til FagsakPerson for bedre typsikring, …

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -27,6 +27,7 @@ import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkServ
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.Behandlingshistorikk
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findAllByIdOrThrow
@@ -81,7 +82,7 @@ class BehandlingService(
         return behandlingsjournalpostRepository.findAllByBehandlingId(behandlingId)
     }
 
-    fun hentBehandlingerForGjenbrukAvVilkår(fagsakPersonId: UUID): List<Behandling> {
+    fun hentBehandlingerForGjenbrukAvVilkår(fagsakPersonId: FagsakPersonId): List<Behandling> {
         return behandlingRepository.finnBehandlingerForGjenbrukAvVilkår(fagsakPersonId)
             .sortertEtterVedtakstidspunktEllerEndretTid()
             .reversed()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.behandling.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
 import org.springframework.data.jdbc.repository.query.Query
@@ -140,7 +141,7 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
          AND b.arsak != 'MIGRERING'
     """,
     )
-    fun finnBehandlingerForGjenbrukAvVilkår(fagsakPersonId: UUID): List<Behandling>
+    fun finnBehandlingerForGjenbrukAvVilkår(fagsakPersonId: FagsakPersonId): List<Behandling>
 
     fun existsByFagsakIdAndStatusIsNot(fagsakId: UUID, behandlingStatus: BehandlingStatus): Boolean
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/Saksbehandling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/Saksbehandling.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.behandling.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -27,7 +28,7 @@ data class Saksbehandling(
     val henlagtÅrsak: HenlagtÅrsak? = null,
     val ident: String,
     val fagsakId: UUID,
-    val fagsakPersonId: UUID,
+    val fagsakPersonId: FagsakPersonId,
     val eksternFagsakId: Long,
     @Column("stonadstype")
     val stønadstype: Stønadstype,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/BehandlingDto.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandling.domain.HenlagtÅrsak
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -17,7 +18,7 @@ data class BehandlingDto(
     val id: UUID,
     val forrigeBehandlingId: UUID?,
     val fagsakId: UUID,
-    val fagsakPersonId: UUID,
+    val fagsakPersonId: FagsakPersonId,
     val steg: StegType,
     val kategori: BehandlingKategori,
     val type: BehandlingType,
@@ -32,7 +33,7 @@ data class BehandlingDto(
     val henlagtÅrsak: HenlagtÅrsak? = null,
 )
 
-fun Behandling.tilDto(stønadstype: Stønadstype, fagsakPersonId: UUID): BehandlingDto =
+fun Behandling.tilDto(stønadstype: Stønadstype, fagsakPersonId: FagsakPersonId): BehandlingDto =
     BehandlingDto(
         id = this.id,
         forrigeBehandlingId = this.forrigeBehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakPersonController.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.IdentRequest
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
 import no.nav.tilleggsstonader.sak.fagsak.dto.FagsakPersonDto
 import no.nav.tilleggsstonader.sak.fagsak.dto.FagsakPersonUtvidetDto
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.validation.annotation.Validated
@@ -14,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/fagsak-person"])
@@ -27,7 +27,7 @@ class FagsakPersonController(
 ) {
 
     @PostMapping
-    fun hentEllerOpprettFagsakPerson(@RequestBody identRequest: IdentRequest): UUID {
+    fun hentEllerOpprettFagsakPerson(@RequestBody identRequest: IdentRequest): FagsakPersonId {
         tilgangService.validerTilgangTilPersonMedBarn(identRequest.ident, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -35,7 +35,7 @@ class FagsakPersonController(
     }
 
     @GetMapping("{fagsakPersonId}")
-    fun hentFagsakPerson(@PathVariable fagsakPersonId: UUID): FagsakPersonDto {
+    fun hentFagsakPerson(@PathVariable fagsakPersonId: FagsakPersonId): FagsakPersonDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val person = fagsakPersonService.hentPerson(fagsakPersonId)
         val fagsaker = fagsakService.finnFagsakerForFagsakPersonId(person.id)
@@ -46,7 +46,7 @@ class FagsakPersonController(
     }
 
     @GetMapping("{fagsakPersonId}/utvidet")
-    fun hentFagsakPersonUtvidet(@PathVariable fagsakPersonId: UUID): FagsakPersonUtvidetDto {
+    fun hentFagsakPersonUtvidet(@PathVariable fagsakPersonId: FagsakPersonId): FagsakPersonUtvidetDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val person = fagsakPersonService.hentPerson(fagsakPersonId)
         val fagsaker = fagsakService.finnFagsakerForFagsakPersonId(person.id)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakService.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.fagsak.domain.tilFagsakMedPerson
 import no.nav.tilleggsstonader.sak.fagsak.dto.FagsakDto
 import no.nav.tilleggsstonader.sak.fagsak.dto.tilDto
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
@@ -81,7 +82,7 @@ class FagsakService(
         )
     }
 
-    fun finnFagsakerForFagsakPersonId(fagsakPersonId: UUID): Fagsaker {
+    fun finnFagsakerForFagsakPersonId(fagsakPersonId: FagsakPersonId): Fagsaker {
         val fagsaker = fagsakRepository.findByFagsakPersonId(fagsakPersonId)
             .map { it.tilFagsakMedPerson() }
             .associateBy { it.stønadstype }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.fagsak.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
@@ -14,7 +15,7 @@ data class Fagsaker(
 
 data class Fagsak(
     val id: UUID,
-    val fagsakPersonId: UUID,
+    val fagsakPersonId: FagsakPersonId,
     val personIdenter: Set<PersonIdent>,
     val eksternId: EksternFagsakId,
     val stønadstype: Stønadstype,
@@ -33,7 +34,7 @@ data class Fagsak(
 data class FagsakDomain(
     @Id
     val id: UUID = UUID.randomUUID(),
-    val fagsakPersonId: UUID,
+    val fagsakPersonId: FagsakPersonId,
     @Column("stonadstype")
     val stønadstype: Stønadstype,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPerson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPerson.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.fagsak.domain
 
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Endret
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
@@ -8,11 +9,10 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.MappedCollection
 import java.time.LocalDateTime
-import java.util.UUID
 
 data class FagsakPerson(
     @Id
-    val id: UUID = UUID.randomUUID(),
+    val id: FagsakPersonId = FagsakPersonId.random(),
     @MappedCollection(idColumn = "fagsak_person_id")
     val identer: Set<PersonIdent>,
     val opprettetAv: String = SikkerhetContext.hentSaksbehandlerEllerSystembruker(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPersonRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPersonRepository.kt
@@ -1,13 +1,13 @@
 package no.nav.tilleggsstonader.sak.fagsak.domain
 
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
 import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
-import java.util.UUID
 
 @Repository
-interface FagsakPersonRepository : RepositoryInterface<FagsakPerson, UUID>, InsertUpdateRepository<FagsakPerson> {
+interface FagsakPersonRepository : RepositoryInterface<FagsakPerson, FagsakPersonId>, InsertUpdateRepository<FagsakPerson> {
 
     @Query(
         """SELECT p.* FROM fagsak_person p WHERE 
@@ -16,8 +16,8 @@ interface FagsakPersonRepository : RepositoryInterface<FagsakPerson, UUID>, Inse
     fun findByIdent(identer: Collection<String>): FagsakPerson?
 
     @Query("SELECT * FROM person_ident WHERE fagsak_person_id = :personId")
-    fun findPersonIdenter(personId: UUID): Set<PersonIdent>
+    fun findPersonIdenter(personId: FagsakPersonId): Set<PersonIdent>
 
     @Query("SELECT ident FROM person_ident WHERE fagsak_person_id = :personId ORDER BY endret_tid DESC LIMIT 1")
-    fun hentAktivIdent(personId: UUID): String
+    fun hentAktivIdent(personId: FagsakPersonId): String
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPersonService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakPersonService.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.fagsak.domain
 
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
@@ -7,7 +8,6 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
 
 @Service
 class FagsakPersonService(
@@ -15,13 +15,13 @@ class FagsakPersonService(
     private val fagsakPersonRepository: FagsakPersonRepository,
 ) {
 
-    fun hentPerson(personId: UUID): FagsakPerson = fagsakPersonRepository.findByIdOrThrow(personId)
+    fun hentPerson(personId: FagsakPersonId): FagsakPerson = fagsakPersonRepository.findByIdOrThrow(personId)
 
-    fun hentPersoner(personId: List<UUID>): Iterable<FagsakPerson> = fagsakPersonRepository.findAllById(personId)
+    fun hentPersoner(personId: List<FagsakPersonId>): Iterable<FagsakPerson> = fagsakPersonRepository.findAllById(personId)
 
     fun finnPerson(personIdenter: Set<String>): FagsakPerson? = fagsakPersonRepository.findByIdent(personIdenter)
 
-    fun hentIdenter(personId: UUID): Set<PersonIdent> {
+    fun hentIdenter(personId: FagsakPersonId): Set<PersonIdent> {
         val personIdenter = fagsakPersonRepository.findPersonIdenter(personId)
         feilHvis(personIdenter.isEmpty(), sensitivFeilmelding = { "Finner ikke personidenter til person=$personId" }) {
             "Finner ikke personidenter til person"
@@ -29,7 +29,7 @@ class FagsakPersonService(
         return personIdenter
     }
 
-    fun hentAktivIdent(personId: UUID): String = fagsakPersonRepository.hentAktivIdent(personId)
+    fun hentAktivIdent(personId: FagsakPersonId): String = fagsakPersonRepository.hentAktivIdent(personId)
 
     @Transactional
     fun hentEllerOpprettPerson(ident: String): FagsakPerson {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.fagsak.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
 import org.springframework.data.jdbc.repository.query.Query
@@ -21,7 +22,7 @@ interface FagsakRepository : RepositoryInterface<FagsakDomain, UUID>, InsertUpda
     )
     fun findBySøkerIdent(personIdenter: Set<String>, stønadstype: Stønadstype): FagsakDomain?
 
-    fun findByFagsakPersonIdAndStønadstype(fagsakPersonId: UUID, stønadstype: Stønadstype): FagsakDomain?
+    fun findByFagsakPersonIdAndStønadstype(fagsakPersonId: FagsakPersonId, stønadstype: Stønadstype): FagsakDomain?
 
     // language=PostgreSQL
     @Query(
@@ -43,7 +44,7 @@ interface FagsakRepository : RepositoryInterface<FagsakDomain, UUID>, InsertUpda
     )
     fun findBySøkerIdent(personIdenter: Set<String>): List<FagsakDomain>
 
-    fun findByFagsakPersonId(fagsakPersonId: UUID): List<FagsakDomain>
+    fun findByFagsakPersonId(fagsakPersonId: FagsakPersonId): List<FagsakDomain>
 
     // language=PostgreSQL
     @Query(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/dto/FagsakDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/dto/FagsakDto.kt
@@ -3,11 +3,12 @@ package no.nav.tilleggsstonader.sak.fagsak.dto
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import java.util.UUID
 
 data class FagsakDto(
     val id: UUID,
-    val fagsakPersonId: UUID,
+    val fagsakPersonId: FagsakPersonId,
     val personIdent: String,
     val stønadstype: Stønadstype,
     val erLøpende: Boolean,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/dto/FagsakPersonDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/dto/FagsakPersonDto.kt
@@ -1,13 +1,14 @@
 package no.nav.tilleggsstonader.sak.fagsak.dto
 
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import java.util.UUID
 
 class FagsakPersonDto(
-    val id: UUID,
+    val id: FagsakPersonId,
     val tilsynBarn: UUID?,
 )
 
 class FagsakPersonUtvidetDto(
-    val id: UUID,
+    val id: FagsakPersonId,
     val tilsynBarn: FagsakDto?,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/Søkeresultat.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/Søkeresultat.kt
@@ -1,11 +1,11 @@
 package no.nav.tilleggsstonader.sak.fagsak.søk
 
-import java.util.UUID
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 
 data class Søkeresultat(
     val personIdent: String,
     val visningsnavn: String,
-    val fagsakPersonId: UUID?,
+    val fagsakPersonId: FagsakPersonId?,
 )
 
 data class SøkeresultatUtenFagsak(val personIdent: String, val navn: String)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/felles/domain/FagsakPersonId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/felles/domain/FagsakPersonId.kt
@@ -1,0 +1,18 @@
+package no.nav.tilleggsstonader.sak.felles.domain
+
+import java.util.UUID
+
+@JvmInline
+value class FagsakPersonId(
+    val id: UUID,
+) {
+
+    override fun toString(): String {
+        return id.toString()
+    }
+
+    companion object {
+        fun random() = FagsakPersonId(UUID.randomUUID())
+        fun fromString(id: String) = FagsakPersonId(UUID.fromString(id))
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/DatabaseConfiguration.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.prosessering.PropertiesWrapperTilStringConverter
 import no.nav.familie.prosessering.StringTilPropertiesWrapperConverter
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.sak.infrastruktur.database.IdConverters.alleValueClassConverters
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlag
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.BarnMedBarnepass
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SkjemaBarnetilsyn
@@ -122,7 +123,8 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                 VilkårperioderGrunnlagReader(),
                 VilkårperioderGrunnlagWriter(),
 
-            ) + alleVedtaksstatistikkJsonConverters,
+            ) + alleVedtaksstatistikkJsonConverters +
+                alleValueClassConverters,
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/IdConverters.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/IdConverters.kt
@@ -1,0 +1,32 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.database
+
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
+import org.springframework.core.convert.converter.Converter
+import org.springframework.data.convert.ReadingConverter
+import org.springframework.data.convert.WritingConverter
+import java.util.UUID
+
+/**
+ * Spring data jdbc støtter ikke value classes for primary keys, dvs @Id-markerte felter
+ */
+object IdConverters {
+
+    @WritingConverter
+    abstract class ValueClassWriter<T>(val convert: (T) -> UUID) : Converter<T, UUID> {
+        override fun convert(valueClass: T & Any): UUID = this.convert.invoke(valueClass)
+    }
+
+    @ReadingConverter
+    abstract class ValueClassReader<T : Any>(val convert: (UUID) -> T) : Converter<UUID, T> {
+        override fun convert(id: UUID): T = this.convert.invoke(id)
+    }
+
+    class FagsakPersonIdWritingConverter : ValueClassWriter<FagsakPersonId>({ it.id })
+
+    class FagsakPersonIdReaderConverter : ValueClassReader<FagsakPersonId>({ FagsakPersonId(it) })
+
+    val alleValueClassConverters = listOf(
+        FagsakPersonIdWritingConverter(),
+        FagsakPersonIdReaderConverter(),
+    )
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageController.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.klage
 import no.nav.familie.prosessering.rest.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.klage.FagsystemVedtak
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.klage.dto.KlagebehandlingerDto
 import no.nav.tilleggsstonader.sak.klage.dto.OpprettKlageDto
@@ -34,7 +35,7 @@ class KlageController(
     }
 
     @GetMapping("/fagsak-person/{fagsakPersonId}")
-    fun hentKlagebehandlinger(@PathVariable fagsakPersonId: UUID): KlagebehandlingerDto {
+    fun hentKlagebehandlinger(@PathVariable fagsakPersonId: FagsakPersonId): KlagebehandlingerDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return klageService.hentBehandlinger(fagsakPersonId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/klage/KlageService.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.kontrakter.klage.OpprettKlagebehandlingRequest
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.klage.dto.KlagebehandlingerDto
 import no.nav.tilleggsstonader.sak.klage.dto.OpprettKlageDto
@@ -22,7 +23,7 @@ class KlageService(
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val klageClient: KlageClient,
 ) {
-    fun hentBehandlinger(fagsakPersonId: UUID): KlagebehandlingerDto {
+    fun hentBehandlinger(fagsakPersonId: FagsakPersonId): KlagebehandlingerDto {
         val fagsaker = fagsakService.finnFagsakerForFagsakPersonId(fagsakPersonId)
         val eksterneFagsakIder = listOfNotNull(fagsaker.barnetilsyn?.eksternId?.id)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
@@ -5,12 +5,12 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.migrering.routing.SøknadRoutingService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 /**
  * Arena kaller på oss for å sjekke om personen finnes i ny løsning.
@@ -56,7 +56,7 @@ class ArenaStatusService(
     private fun skalKunneOppretteSakIArenaForPerson(identer: Set<String>): Boolean {
         val fagsakPersonId = fagsakPersonService.finnPerson(identer)?.id
         return fagsakPersonId in setOf(
-            UUID.fromString("5b04e044-8701-4de5-a5d9-6a30443df150"),
+            FagsakPersonId.fromString("5b04e044-8701-4de5-a5d9-6a30443df150"),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningController.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.opplysninger
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.opplysninger.dto.PersonopplysningerDto
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -25,7 +26,7 @@ class PersonopplysningController(
     }
 
     @GetMapping("fagsak-person/{fagsakPersonId}")
-    fun hentPersonopplysningerForPerson(@PathVariable fagsakPersonId: UUID): PersonopplysningerDto {
+    fun hentPersonopplysningerForPerson(@PathVariable fagsakPersonId: FagsakPersonId): PersonopplysningerDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return personopplysningerService.hentPersonopplysningerForFagsakPerson(fagsakPersonId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.opplysninger
 
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.opplysninger.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.dto.NavnDto
 import no.nav.tilleggsstonader.sak.opplysninger.dto.PersonopplysningerDto
@@ -23,7 +24,7 @@ class PersonopplysningerService(
         return hentPersonopplysninger(behandlingService.hentAktivIdent(behandlingId))
     }
 
-    fun hentPersonopplysningerForFagsakPerson(fagsakPersonId: UUID): PersonopplysningerDto {
+    fun hentPersonopplysningerForFagsakPerson(fagsakPersonId: FagsakPersonId): PersonopplysningerDto {
         return hentPersonopplysninger(fagsakPersonService.hentAktivIdent(fagsakPersonId))
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetController.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.opplysninger.aktivitet
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,7 +23,7 @@ class AktivitetController(
 
     @GetMapping("{fagsakPersonId}")
     fun hentAktiviteter(
-        @PathVariable fagsakPersonId: UUID,
+        @PathVariable fagsakPersonId: FagsakPersonId,
     ): List<AktivitetArenaDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return aktivitetService.hentAktiviteter(fagsakPersonId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetService.kt
@@ -6,10 +6,10 @@ import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.util.UUID
 
 @Service
 class AktivitetService(
@@ -18,7 +18,7 @@ class AktivitetService(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun hentAktiviteter(fagsakPersonId: UUID): List<AktivitetArenaDto> {
+    fun hentAktiviteter(fagsakPersonId: FagsakPersonId): List<AktivitetArenaDto> {
         val ident = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         return aktivitetClient.hentAktiviteter(
             ident = ident,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaOppgaveController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaOppgaveController.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.opplysninger.arena
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.arena.oppgave.ArenaOppgaveDto
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.validation.annotation.Validated
@@ -9,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping("/api/oppgave/arena")
@@ -21,7 +21,7 @@ class ArenaOppgaveController(
 ) {
 
     @GetMapping("{fagsakPersonId}")
-    fun hentOppgaver(@PathVariable fagsakPersonId: UUID): List<ArenaOppgaveDto> {
+    fun hentOppgaver(@PathVariable fagsakPersonId: FagsakPersonId): List<ArenaOppgaveDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return arenaService.hentOppgaver(fagsakPersonId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/arena/ArenaService.kt
@@ -6,11 +6,11 @@ import no.nav.tilleggsstonader.kontrakter.felles.IdenterRequest
 import no.nav.tilleggsstonader.kontrakter.felles.IdenterStønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class ArenaService(
@@ -31,7 +31,7 @@ class ArenaService(
     }
 
     @Cacheable("arena-oppgaver", cacheManager = "5secCache")
-    fun hentOppgaver(fagsakPersonId: UUID): List<ArenaOppgaveDto> {
+    fun hentOppgaver(fagsakPersonId: FagsakPersonId): List<ArenaOppgaveDto> {
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         val identer = personService.hentPersonIdenter(aktivIdent).identer()
         return arenaClient.hentOppgaver(IdenterRequest(identer))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveController.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.opplysninger.oppgave
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.oppgave.MappeDto
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveUtil.ENHET_NR_EGEN_ANSATT
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveUtil.ENHET_NR_NAY
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping("/api/oppgave")
@@ -38,7 +38,7 @@ class OppgaveController(
     }
 
     @GetMapping("/soek/person/{fagsakPersonId}")
-    fun hentOppgaverForPerson(@PathVariable fagsakPersonId: UUID): FinnOppgaveResponseDto {
+    fun hentOppgaverForPerson(@PathVariable fagsakPersonId: FagsakPersonId): FinnOppgaveResponseDto {
         val personIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         tilgangService.validerTilgangTilPerson(personIdent, AuditLoggerEvent.ACCESS)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseController.kt
@@ -1,13 +1,13 @@
 package no.nav.tilleggsstonader.sak.opplysninger.ytelse
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/ytelse"])
@@ -19,7 +19,7 @@ class YtelseController(
 
     @GetMapping("{fagsakPersonId}")
     fun hentYtelser(
-        @PathVariable fagsakPersonId: UUID,
+        @PathVariable fagsakPersonId: FagsakPersonId,
     ): YtelserRegisterDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return aktivitetService.hentYtelser(fagsakPersonId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderRequest
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelserRegisterDtoMapper.tilDto
 import org.springframework.stereotype.Service
@@ -21,7 +22,7 @@ class YtelseService(
     private val ytelseClient: YtelseClient,
     private val behandlingService: BehandlingService,
 ) {
-    fun hentYtelser(fagsakPersonId: UUID): YtelserRegisterDto {
+    fun hentYtelser(fagsakPersonId: FagsakPersonId): YtelserRegisterDto {
         val ident = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         val typer = listOf(
             TypeYtelsePeriode.AAP,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.config.getValue
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ManglerTilgang
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
@@ -121,13 +122,13 @@ class TilgangService(
         validerTilgangTilFagsak(fagsakId, event)
     }
 
-    fun validerTilgangTilFagsakPerson(fagsakPersonId: UUID, event: AuditLoggerEvent) {
+    fun validerTilgangTilFagsakPerson(fagsakPersonId: FagsakPersonId, event: AuditLoggerEvent) {
         val personIdent = cacheManager.getValue("fagsakPersonIdent", fagsakPersonId) {
             fagsakPersonService.hentAktivIdent(fagsakPersonId)
         }
         val tilgang = harTilgangTilPersonMedRelasjoner(personIdent)
         auditLogger.log(
-            Sporingsdata(event, personIdent, tilgang, custom1 = CustomKeyValue("fagsakPersonId", fagsakPersonId)),
+            Sporingsdata(event, personIdent, tilgang, custom1 = CustomKeyValue("fagsakPersonId", fagsakPersonId.id)),
         )
         if (!tilgang.harTilgang) {
             throw ManglerTilgang(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedlegg/VedleggController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedlegg/VedleggController.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedlegg
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.web.bind.annotation.PathVariable
@@ -8,7 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping("/api/vedlegg")
@@ -16,7 +16,7 @@ import java.util.UUID
 class VedleggController(private val tilgangService: TilgangService, private val vedleggService: VedleggService) {
     @PostMapping("/fagsak-person/{fagsakPersonId}")
     fun finnVedleggForBruker(
-        @PathVariable fagsakPersonId: UUID,
+        @PathVariable fagsakPersonId: FagsakPersonId,
         @RequestBody vedleggRequest: VedleggRequest,
     ): List<DokumentInfoDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedlegg/VedleggService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedlegg/VedleggService.kt
@@ -1,16 +1,16 @@
 package no.nav.tilleggsstonader.sak.vedlegg
 
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class VedleggService(
     private val journalpostService: JournalpostService,
     private val fagsakPersonService: FagsakPersonService,
 ) {
-    fun finnVedleggForBruker(fagsakPersonId: UUID, vedleggRequest: VedleggRequest): List<DokumentInfoDto> {
+    fun finnVedleggForBruker(fagsakPersonId: FagsakPersonId, vedleggRequest: VedleggRequest): List<DokumentInfoDto> {
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         val journalposter = journalpostService.finnJournalposterForBruker(aktivIdent, vedleggRequest)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepositoryTest.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus.UTREDES
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonRepository
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Endret
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
@@ -502,7 +503,7 @@ class BehandlingRepositoryTest : IntegrationTest() {
     private fun lagreFagsak(
         fagsakId: UUID,
         stønadstype: Stønadstype,
-        fagsakPersonId: UUID,
+        fagsakPersonId: FagsakPersonId,
     ): Fagsak {
         return testoppsettService.lagreFagsak(
             fagsak(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakServiceTest.kt
@@ -4,13 +4,13 @@ import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.util.UUID
 
 internal class FagsakServiceTest : IntegrationTest() {
 
@@ -40,7 +40,7 @@ internal class FagsakServiceTest : IntegrationTest() {
 
         @Test
         fun `skal ikke returnere noe om ingen fagsaker er knyttet til personid`() {
-            val res = fagsakService.finnFagsakerForFagsakPersonId(UUID.randomUUID())
+            val res = fagsakService.finnFagsakerForFagsakPersonId(FagsakPersonId.random())
             assertThat(res.barnetilsyn).isNull()
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/felles/domain/FagsakPersonIdTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/felles/domain/FagsakPersonIdTest.kt
@@ -1,0 +1,29 @@
+package no.nav.tilleggsstonader.sak.felles.domain
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class FagsakPersonIdTest {
+
+    val id = "96673a99-1d90-4f22-abdf-faee57062432"
+
+    @Test
+    fun `toString skal returnere verdiet på UUID`() {
+        assertThat(FagsakPersonId.fromString(id).toString()).isEqualTo(id)
+    }
+
+    @Test
+    fun `skal håndteres riktig i fra og til json`() {
+        val foo = Foo(FagsakPersonId.fromString(id))
+        val json = objectMapper.writeValueAsString(foo)
+
+        assertThat(json).isEqualTo("""{"id":"96673a99-1d90-4f22-abdf-faee57062432"}""")
+        assertThat(objectMapper.readValue<Foo>(json)).isEqualTo(foo)
+    }
+
+    private data class Foo(
+        val id: FagsakPersonId,
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/InsertUpdateRepositoryImplTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/InsertUpdateRepositoryImplTest.kt
@@ -7,12 +7,12 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonRepository
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakRepository
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.relational.core.conversion.DbActionExecutionException
-import java.util.UUID
 
 class InsertUpdateRepositoryImplTest : IntegrationTest() {
 
@@ -127,7 +127,7 @@ class InsertUpdateRepositoryImplTest : IntegrationTest() {
     private fun fagsakPerson(ident: String = "1") = FagsakPerson(identer = setOf(PersonIdent(ident)))
 
     private fun fagsakDomain(
-        fagsakPersonId: UUID,
+        fagsakPersonId: FagsakPersonId,
         stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
     ) =
         FagsakDomain(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.tilleggsstonader.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.klage.dto.OpprettKlageDto
 import no.nav.tilleggsstonader.sak.util.fagsak
@@ -46,7 +47,7 @@ internal class KlageServiceTest {
         )
 
     private val fagsakId = UUID.randomUUID()
-    private val fagsakPersonId = UUID.randomUUID()
+    private val fagsakPersonId = FagsakPersonId.random()
     private val eksternFagsakId = EksternFagsakId(1L, fagsakId)
     private val personIdent = "12345678910"
     private val arbeidsfordelingEnhetNr = "1"
@@ -174,7 +175,7 @@ internal class KlageServiceTest {
                 ),
             )
 
-            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+            val klager = klageService.hentBehandlinger(FagsakPersonId.random())
 
             assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidsPunktAvsluttetIKabal)
         }
@@ -195,7 +196,7 @@ internal class KlageServiceTest {
             every { klageClient.hentKlagebehandlinger(any()) } returns
                 mapOf(eksternFagsakId.id to listOf(klagebehandlingIkkeAvsluttetKabal))
 
-            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+            val klager = klageService.hentBehandlinger(FagsakPersonId.random())
 
             assertThat(klager.barnetilsyn.first().vedtaksdato).isNull()
         }
@@ -218,7 +219,7 @@ internal class KlageServiceTest {
                         ),
                 )
 
-            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+            val klager = klageService.hentBehandlinger(FagsakPersonId.random())
 
             assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidspunktAvsluttetFamilieKlage)
         }
@@ -251,7 +252,7 @@ internal class KlageServiceTest {
             every { klageClient.hentKlagebehandlinger(any()) } returns
                 mapOf(eksternFagsakId.id to listOf(klagebehandlingAvsluttetKabal))
 
-            val klager = klageService.hentBehandlinger(UUID.randomUUID())
+            val klager = klageService.hentBehandlinger(FagsakPersonId.random())
 
             assertThat(klager.barnetilsyn.first().vedtaksdato).isEqualTo(tidsPunktAvsluttetIKabal)
             assertThat(klager.barnetilsyn.first().klageinstansResultat.first().årsakFeilregistrert).isEqualTo(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.opplysninger.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
@@ -14,7 +15,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.UUID
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Adressebeskyttelse as AdressebeskyttelsePdl
 
 class PersonopplysningerServiceTest {
@@ -42,7 +42,7 @@ class PersonopplysningerServiceTest {
         fun `har ikke verge hvis man ikke har noen vergemål`() {
             every { personService.hentSøker(any()) } returns pdlSøker()
 
-            assertThat(service.hentPersonopplysningerForFagsakPerson(UUID.randomUUID()).harVergemål).isFalse
+            assertThat(service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random()).harVergemål).isFalse
         }
 
         @Test
@@ -51,7 +51,7 @@ class PersonopplysningerServiceTest {
             val pdlSøker = pdlSøker(vergemaalEllerFremtidsfullmakt = listOf(vergemaalEllerFremtidsfullmakt))
             every { personService.hentSøker(any()) } returns pdlSøker
 
-            assertThat(service.hentPersonopplysningerForFagsakPerson(UUID.randomUUID()).harVergemål).isFalse
+            assertThat(service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random()).harVergemål).isFalse
         }
 
         @Test
@@ -59,7 +59,7 @@ class PersonopplysningerServiceTest {
             val pdlSøker = pdlSøker(vergemaalEllerFremtidsfullmakt = listOf(vergemaalEllerFremtidsfullmakt()))
             every { personService.hentSøker(any()) } returns pdlSøker
 
-            assertThat(service.hentPersonopplysningerForFagsakPerson(UUID.randomUUID()).harVergemål).isTrue
+            assertThat(service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random()).harVergemål).isTrue
         }
     }
 
@@ -72,7 +72,7 @@ class PersonopplysningerServiceTest {
             val pdlSøker = pdlSøker(adressebeskyttelse = listOf(AdressebeskyttelsePdl(gradering, metadataGjeldende)))
             every { personService.hentSøker(any()) } returns pdlSøker
 
-            assertThat(service.hentPersonopplysningerForFagsakPerson(UUID.randomUUID()).adressebeskyttelse)
+            assertThat(service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random()).adressebeskyttelse)
                 .isEqualTo(Adressebeskyttelse.FORTROLIG)
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/AktivitetServiceTest.kt
@@ -4,12 +4,12 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 class AktivitetServiceTest {
 
@@ -18,7 +18,7 @@ class AktivitetServiceTest {
 
     val service = AktivitetService(fagsakPersonService, aktivitetClient)
 
-    val personId = UUID.randomUUID()
+    val personId = FagsakPersonId.random()
 
     @BeforeEach
     fun setUp() {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -29,6 +29,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakDomain
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
@@ -180,7 +181,7 @@ fun fagsak(
     id: UUID = UUID.randomUUID(),
     eksternId: EksternFagsakId = EksternFagsakId(fagsakId = id),
     sporbar: Sporbar = Sporbar(),
-    fagsakPersonId: UUID = UUID.randomUUID(),
+    fagsakPersonId: FagsakPersonId = FagsakPersonId.random(),
 ): Fagsak {
     return fagsak(stønadstype, id, FagsakPerson(id = fagsakPersonId, identer = identer), eksternId, sporbar)
 }
@@ -205,7 +206,7 @@ fun fagsak(
 fun fagsakDomain(
     id: UUID = UUID.randomUUID(),
     stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
-    personId: UUID = UUID.randomUUID(),
+    personId: FagsakPersonId = FagsakPersonId.random(),
 ): FagsakDomain = FagsakDomain(
     id = id,
     fagsakPersonId = personId,


### PR DESCRIPTION
…og unngår sende rundt UUID

### Hvorfor er denne endringen nødvendig? ✨
UUID er en type som sier veldig lite om hva det egentlige er.
Gjennom å bruke value class så kan vi wrappe enkelte typer. Eks FagsakPersonId, FagsakId, BehandlingId, etc 
https://kotlinlang.org/docs/inline-classes.html

Då får vi ryddigere interfaces, eks
```kotlin
fun hentPersoner(fagsakPersonId: FagsakPersonId): List<Person>
// eller
fun hentPersoner(id: FagsakPersonId): List<Person>
//vs
fun hentPersoner(fagsakPersonId: UUID): List<Person>
fun hentPersoner(id: UUID): List<Person>
```

### Json
Då det er en inline class, så wrappes det ikke i konvertering til json. 
```kotlin
data class Foo(
    val id: FagsakPersonId
)
fun main() {
    val foo = Foo(FagsakPersonId.randomUUID())
    println(objectMapper.writeValueAsString(foo))
}
```
Output
```json
{"id":"9e6162b4-e7b2-475f-855e-9fcb0bef1f3a"}
```

### Diskusjon
Burde `randomUUID` ha navnet `randomId`?