### PR TITLE
Skal kunne journalføre klagebehandlinger, uten å opprette ny behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/dto/JournalføringRequest.kt
@@ -60,8 +60,8 @@ data class JournalføringRequest(
 }
 
 fun JournalføringRequest.valider() {
-    feilHvis(gjelderKlage()) {
-        "Journalføring av klage er ikke implementert."
+    feilHvis(gjelderKlage() && skalJournalføreTilNyBehandling()) {
+        "Opprettelse av ny behandling er ikke støttet for klage. Du kan kun journalføre uten ny behandling, for så å opprette ny klagebehandling fra personoversikten."
     }
     dokumentTitler?.let {
         brukerfeilHvis(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi støtter foreløpig ikke å opprette klagebehandlinger fra journalføringen, men det burde likevel være mulig å journalføre klagen i TS-Sak, da klagebehandlingen kan opprettes fra personoversikten