### PR TITLE
Endring av revurder fra med nullstilling av en behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
 
 @RestController
 @RequestMapping(path = ["/api/behandling"])
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController
 class BehandlingController(
     private val behandlingService: BehandlingService,
     private val opprettRevurderingBehandlingService: OpprettRevurderingBehandlingService,
+    private val revurderFraService: RevurderFraService,
     private val grunnlagsdataService: GrunnlagsdataService,
     // private val behandlingPåVentService: BehandlingPåVentService,
     private val fagsakService: FagsakService,
@@ -119,6 +121,12 @@ class BehandlingController(
         val saksbehandling = behandlingService.hentSaksbehandling(eksternBehandlingId)
         tilgangService.validerTilgangTilPersonMedBarn(saksbehandling.ident, AuditLoggerEvent.ACCESS)
         return saksbehandling.tilDto()
+    }
+
+    @PostMapping("{behandlingId}/revurder-fra/{revurderFra}")
+    fun oppdaterRevurderFra(@PathVariable behandlingId: BehandlingId, @PathVariable revurderFra: LocalDate): BehandlingDto {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        return revurderFraService.oppdaterRevurderFra(behandlingId, revurderFra).tilDto()
     }
 
     /*

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType.FØRSTEGANGS
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType.REVURDERING
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import java.time.LocalDate
 
 object BehandlingUtil {
 
@@ -15,6 +16,15 @@ object BehandlingUtil {
             REVURDERING
         } else {
             FØRSTEGANGSBEHANDLING
+        }
+    }
+
+    fun skalNullstilleBehandling(behandling: Behandling, nyRevurderFra: LocalDate?): Boolean {
+        val forrigeRevurdererFra = behandling.revurderFra
+        return when {
+            nyRevurderFra == null -> false
+            forrigeRevurdererFra == null -> true
+            else -> nyRevurderFra > forrigeRevurdererFra
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingService.kt
@@ -1,0 +1,63 @@
+package no.nav.tilleggsstonader.sak.behandling
+
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.VedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.SimuleringsresultatRepository
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NullstillBehandlingService(
+    private val behandlingService: BehandlingService,
+    private val gjennbrukDataRevurderingService: GjennbrukDataRevurderingService,
+    private val vilkårperiodeRepository: VilkårperiodeRepository,
+    private val stønadsperiodeRepository: StønadsperiodeRepository,
+    private val vilkårRepository: VilkårRepository,
+    private val tilsynBarnVedtakRepository: TilsynBarnVedtakRepository,
+    private val simuleringsresultatRepository: SimuleringsresultatRepository,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
+    private val vedtaksbrevRepository: VedtaksbrevRepository,
+) {
+
+    @Transactional
+    fun nullstillBehandling(behandlingId: BehandlingId) {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
+            "Behandling er låst for videre redigering og kan ikke nullstilles"
+        }
+        behandlingService.oppdaterStegPåBehandling(behandlingId, StegType.INNGANGSVILKÅR)
+
+        slettDataIBehandling(behandlingId)
+
+        gjenbrukData(behandling)
+    }
+
+    /**
+     * Nullstiller ikke barn, då barn gjenbrukes og har ev. med nye fra ny søknad
+     */
+    private fun slettDataIBehandling(behandlingId: BehandlingId) {
+        vilkårperiodeRepository.findByBehandlingId(behandlingId).let(vilkårperiodeRepository::deleteAll)
+        stønadsperiodeRepository.findAllByBehandlingId(behandlingId).let(stønadsperiodeRepository::deleteAll)
+        vilkårRepository.findByBehandlingId(behandlingId).let(vilkårRepository::deleteAll)
+
+        tilsynBarnVedtakRepository.deleteById(behandlingId)
+        tilkjentYtelseRepository.findByBehandlingId(behandlingId)?.let(tilkjentYtelseRepository::delete)
+        simuleringsresultatRepository.deleteById(behandlingId)
+        vedtaksbrevRepository.deleteById(behandlingId)
+    }
+
+    private fun gjenbrukData(behandling: Behandling) {
+        val behandlingIdForGjenbruk = gjennbrukDataRevurderingService.finnBehandlingIdForGjenbruk(behandling)
+            ?: error("Kan ikke nullstille behandling som ikke har behandlingIdForGjenbruk")
+        val barnMap = gjennbrukDataRevurderingService.finnNyttIdForBarn(behandling.id, behandlingIdForGjenbruk)
+        gjennbrukDataRevurderingService.gjenbrukData(behandling, behandlingIdForGjenbruk, barnMap)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/RevurderFraService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/RevurderFraService.kt
@@ -1,0 +1,34 @@
+package no.nav.tilleggsstonader.sak.behandling
+
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.skalNullstilleBehandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class RevurderFraService(
+    private val behandlingRepository: BehandlingRepository,
+    private val nullstillBehandlingService: NullstillBehandlingService,
+) {
+
+    @Transactional
+    fun oppdaterRevurderFra(behandlingId: BehandlingId, revurderFra: LocalDate?): Saksbehandling {
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+
+        feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke oppdatere revurder fra når behandlingen er låst"
+        }
+
+        behandlingRepository.update(behandling.copy(revurderFra = revurderFra))
+        if (skalNullstilleBehandling(behandling, revurderFra)) {
+            nullstillBehandlingService.nullstillBehandling(behandlingId)
+        }
+
+        return behandlingRepository.finnSaksbehandling(behandlingId)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtilTest.kt
@@ -1,0 +1,43 @@
+package no.nav.tilleggsstonader.sak.behandling
+
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.skalNullstilleBehandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.util.behandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class BehandlingUtilTest {
+
+    @Nested
+    inner class SkalNullstilleBehandling {
+
+        val behandling = behandling(type = BehandlingType.REVURDERING)
+
+        @Test
+        fun `skal nullstille dersom revurderFra ikke finnes fra før`() {
+            assertThat(skalNullstilleBehandling(behandling, nyRevurderFra = LocalDate.now())).isTrue
+            assertThat(skalNullstilleBehandling(behandling, nyRevurderFra = LocalDate.now().minusDays(10))).isTrue
+            assertThat(skalNullstilleBehandling(behandling, nyRevurderFra = LocalDate.now().plusDays(10))).isTrue
+        }
+
+        @Test
+        fun `skal nullstille dersom revurderFra endres til etter tidligere revurderingsdato`() {
+            val behandling = behandling.copy(revurderFra = LocalDate.now())
+            assertThat(skalNullstilleBehandling(behandling, nyRevurderFra = LocalDate.now().plusDays(10))).isTrue
+        }
+
+        @Test
+        fun `skal ikke nullstille dersom revurderFra endres til null ettersom man då viser alle perioder`() {
+            val behandling = behandling.copy(revurderFra = LocalDate.now())
+            assertThat(skalNullstilleBehandling(behandling, nyRevurderFra = null)).isFalse
+        }
+
+        @Test
+        fun `skal ikke nullstille dersom revurderFra endres til før tidligere revurderingsdato ettersom man då viser flere perioder`() {
+            val behandling = behandling.copy(revurderFra = LocalDate.now())
+            assertThat(skalNullstilleBehandling(behandling, nyRevurderFra = LocalDate.now().minusDays(1))).isFalse
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
@@ -1,0 +1,242 @@
+package no.nav.tilleggsstonader.sak.behandling
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.brev.VedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.felles.domain.BarnId
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringTestUtil.simuleringsresultat
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.SimuleringsresultatRepository
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.behandlingBarn
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.stønadsperiode
+import no.nav.tilleggsstonader.sak.util.vedtaksbrev
+import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgetVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
+import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Opphavsvilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+
+class NullstillBehandlingServiceTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var nullstillBehandlingService: NullstillBehandlingService
+
+    @Autowired
+    lateinit var vilkårperiodeRepository: VilkårperiodeRepository
+
+    @Autowired
+    lateinit var stønadsperiodeRepository: StønadsperiodeRepository
+
+    @Autowired
+    lateinit var vilkårRepository: VilkårRepository
+
+    @Autowired
+    lateinit var barnService: BarnService
+
+    @Autowired
+    lateinit var tilkjentYtelseRepository: TilkjentYtelseRepository
+
+    @Autowired
+    lateinit var vedtaksbrevRepository: VedtaksbrevRepository
+
+    @Autowired
+    lateinit var tilsynBarnVedtakRepository: TilsynBarnVedtakRepository
+
+    @Autowired
+    lateinit var simuleringsresultatRepository: SimuleringsresultatRepository
+
+    val fagsak = fagsak()
+    val behandling = behandling(fagsak, status = BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET)
+    val revurdering = behandling(fagsak, forrigeBehandlingId = behandling.id)
+
+    val behandlingBarn1 = behandlingBarn(behandlingId = behandling.id, personIdent = "1")
+    val revurderingBarn1 = behandlingBarn(behandlingId = revurdering.id, personIdent = "1")
+    val revurderingBarn2 = behandlingBarn(behandlingId = revurdering.id, personIdent = "2")
+
+    @BeforeEach
+    fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+        testoppsettService.lagre(behandling, opprettGrunnlagsdata = false)
+        testoppsettService.lagre(revurdering, opprettGrunnlagsdata = false)
+    }
+
+    @Test
+    fun `skal fjerne alt dersom forrigeBehandling ikke har noe`() {
+        opprettVilkårperiodeOgStønadsperiode(revurdering.id)
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertThat(vilkårperiodeRepository.findByBehandlingId(revurdering.id)).isEmpty()
+        assertThat(stønadsperiodeRepository.findAllByBehandlingId(revurdering.id)).isEmpty()
+        assertThat(vilkårRepository.findByBehandlingId(revurdering.id)).isEmpty()
+    }
+
+    @Test
+    fun `skal legge inn data fra forrige behandling på nytt`() {
+        opprettBarn()
+        opprettVilkårperiodeOgStønadsperiode(behandling.id)
+        opprettVilkår(behandling.id, barnId = behandlingBarn1.id)
+
+        val vilkårperiode = vilkårperiodeRepository.findByBehandlingId(behandling.id).single()
+        val stønadsperiode = stønadsperiodeRepository.findAllByBehandlingId(behandling.id).single()
+        val vilkår = vilkårRepository.findByBehandlingId(behandling.id).single()
+
+        assertIngenDataPåRevurdering()
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertVilkårPeriodeErGjenbrukt(vilkårperiode)
+        assertStønadsperiodeErGjenbrukt(stønadsperiode)
+        assertVilkårErGjenbrukt(vilkår)
+    }
+
+    @Test
+    fun `barnen skal beholdes som tidligere`() {
+        opprettBarn()
+
+        val barnBehandling = barnService.finnBarnPåBehandling(behandling.id)
+        val barnRevurdering = barnService.finnBarnPåBehandling(revurdering.id)
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertThat(barnService.finnBarnPåBehandling(behandling.id))
+            .hasSize(1)
+            .containsExactlyInAnyOrderElementsOf(barnBehandling)
+
+        assertThat(barnService.finnBarnPåBehandling(revurdering.id))
+            .hasSize(2)
+            .containsExactlyInAnyOrderElementsOf(barnRevurdering)
+    }
+
+    @Test
+    fun `skal slette tilkjent ytelse`() {
+        tilkjentYtelseRepository.insert(tilkjentYtelse(behandling.id, andelTilkjentYtelse(behandling.id)))
+        tilkjentYtelseRepository.insert(tilkjentYtelse(revurdering.id, andelTilkjentYtelse(revurdering.id)))
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertThat(tilkjentYtelseRepository.findByBehandlingId(behandling.id)).isNotNull
+        assertThat(tilkjentYtelseRepository.findByBehandlingId(revurdering.id)).isNull()
+    }
+
+    @Test
+    fun `skal slette vedtak`() {
+        tilsynBarnVedtakRepository.insert(innvilgetVedtak(behandlingId = behandling.id))
+        tilsynBarnVedtakRepository.insert(innvilgetVedtak(behandlingId = revurdering.id))
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertThat(tilsynBarnVedtakRepository.findByIdOrNull(behandling.id)).isNotNull
+        assertThat(tilsynBarnVedtakRepository.findByIdOrNull(revurdering.id)).isNull()
+    }
+
+    @Test
+    fun `skal slette brev`() {
+        vedtaksbrevRepository.insert(vedtaksbrev(behandling.id))
+        vedtaksbrevRepository.insert(vedtaksbrev(revurdering.id))
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertThat(vedtaksbrevRepository.findByIdOrNull(behandling.id)).isNotNull
+        assertThat(vedtaksbrevRepository.findByIdOrNull(revurdering.id)).isNull()
+    }
+
+    @Test
+    fun `skal slette simuleringsresultat`() {
+        simuleringsresultatRepository.insert(simuleringsresultat(behandling.id))
+        simuleringsresultatRepository.insert(simuleringsresultat(revurdering.id))
+
+        nullstillBehandlingService.nullstillBehandling(revurdering.id)
+
+        assertThat(simuleringsresultatRepository.findByIdOrNull(behandling.id)).isNotNull
+        assertThat(simuleringsresultatRepository.findByIdOrNull(revurdering.id)).isNull()
+    }
+
+    @Test
+    fun `kan ikke nullstille er behandling som er ferdigstilt`() {
+        assertThatThrownBy {
+            nullstillBehandlingService.nullstillBehandling(behandling.id)
+        }.hasMessageContaining("Behandling er låst for videre redigering og kan ikke nullstilles")
+    }
+
+    private fun assertVilkårPeriodeErGjenbrukt(vilkårperiode: Vilkårperiode) {
+        with(vilkårperiodeRepository.findByBehandlingId(revurdering.id).single()) {
+            assertThat(this)
+                .usingRecursiveComparison()
+                .ignoringFields("id", "sporbar", "behandlingId", "forrigeVilkårperiodeId", "status")
+                .isEqualTo(vilkårperiode)
+            assertThat(forrigeVilkårperiodeId).isEqualTo(vilkårperiode.id)
+            assertThat(status).isEqualTo(Vilkårstatus.UENDRET)
+        }
+    }
+
+    private fun assertStønadsperiodeErGjenbrukt(stønadsperiode: Stønadsperiode) {
+        with(stønadsperiodeRepository.findAllByBehandlingId(revurdering.id).single()) {
+            assertThat(this)
+                .usingRecursiveComparison()
+                .ignoringFields("id", "sporbar", "behandlingId")
+                .isEqualTo(stønadsperiode)
+        }
+    }
+
+    private fun assertVilkårErGjenbrukt(vilkår: Vilkår) {
+        with(vilkårRepository.findByBehandlingId(revurdering.id).single()) {
+            assertThat(this)
+                .usingRecursiveComparison()
+                .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkår", "status")
+                .isEqualTo(vilkår)
+            assertThat(barnId).isEqualTo(revurderingBarn1.id)
+            assertThat(opphavsvilkår).isEqualTo(Opphavsvilkår(behandling.id, vilkår.sporbar.endret.endretTid))
+            assertThat(status).isEqualTo(VilkårStatus.UENDRET)
+        }
+    }
+
+    private fun assertIngenDataPåRevurdering() {
+        assertThat(vilkårperiodeRepository.findByBehandlingId(revurdering.id)).isEmpty()
+        assertThat(stønadsperiodeRepository.findAllByBehandlingId(revurdering.id)).isEmpty()
+        assertThat(vilkårRepository.findByBehandlingId(revurdering.id)).isEmpty()
+    }
+
+    private fun opprettBarn() {
+        barnService.opprettBarn(listOf(behandlingBarn1))
+        barnService.opprettBarn(listOf(revurderingBarn1, revurderingBarn2))
+    }
+
+    private fun opprettVilkårperiodeOgStønadsperiode(behandlingId: BehandlingId) {
+        vilkårperiodeRepository.insert(målgruppe(behandlingId = behandlingId))
+        stønadsperiodeRepository.insert(
+            stønadsperiode(
+                behandlingId = behandlingId,
+                fom = LocalDate.now(),
+                tom = LocalDate.now(),
+            ),
+        )
+    }
+
+    private fun opprettVilkår(behandlingId: BehandlingId, barnId: BarnId) {
+        vilkårRepository.insert(vilkår(behandlingId = behandlingId, type = VilkårType.PASS_BARN, barnId = barnId))
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/RevurderFraServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/RevurderFraServiceTest.kt
@@ -1,0 +1,82 @@
+package no.nav.tilleggsstonader.sak.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class RevurderFraServiceTest {
+
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val nullstillBehandlingService = mockk<NullstillBehandlingService>(relaxed = true)
+
+    private val service = RevurderFraService(
+        behandlingRepository = behandlingRepository,
+        nullstillBehandlingService = nullstillBehandlingService,
+    )
+
+    private val oppdaterBehandlingSlot = slot<Behandling>()
+
+    @BeforeEach
+    fun setUp() {
+        oppdaterBehandlingSlot.clear()
+        every { behandlingRepository.update(capture(oppdaterBehandlingSlot)) } answers { firstArg() }
+    }
+
+    @Test
+    fun `skal ikke kunne endre en behandling som er ferdigstilt`() {
+        val behandling = mockBehandling(behandling(status = BehandlingStatus.FERDIGSTILT))
+
+        val revurderFra = LocalDate.of(2024, 3, 1)
+        assertThatThrownBy {
+            service.oppdaterRevurderFra(behandling.id, revurderFra)
+        }.hasMessageContaining("Kan ikke oppdatere revurder fra når behandlingen er låst")
+        verify(exactly = 0) { nullstillBehandlingService.nullstillBehandling(any()) }
+    }
+
+    @Nested
+    inner class Nullstilling {
+
+        @Test
+        fun `skal nullstille hvis revurderFra ikke er satt fra før`() {
+            val behandling = mockBehandling(behandling(type = BehandlingType.REVURDERING))
+
+            val revurderFra = LocalDate.of(2024, 3, 1)
+            service.oppdaterRevurderFra(behandling.id, revurderFra)
+
+            assertThat(oppdaterBehandlingSlot.captured.revurderFra).isEqualTo(revurderFra)
+            verify(exactly = 1) { nullstillBehandlingService.nullstillBehandling(behandling.id) }
+        }
+
+        @Test
+        fun `skal ikke nullstille revurderingsdato settes bak i tiden`() {
+            val revurderFra = LocalDate.of(2024, 3, 1)
+            val behandling =
+                mockBehandling(behandling(type = BehandlingType.REVURDERING, revurderFra = revurderFra.plusDays(1)))
+
+            service.oppdaterRevurderFra(behandling.id, revurderFra)
+
+            assertThat(oppdaterBehandlingSlot.captured.revurderFra).isEqualTo(revurderFra)
+            verify(exactly = 0) { nullstillBehandlingService.nullstillBehandling(any()) }
+        }
+    }
+
+    private fun mockBehandling(behandling: Behandling): Behandling {
+        every { behandlingRepository.findByIdOrThrow(behandling.id) } returns behandling
+        every { behandlingRepository.finnSaksbehandling(behandling.id) } returns saksbehandling(behandling = behandling)
+        return behandling
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringTestUtil.kt
@@ -1,0 +1,13 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.SimuleringJson
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.Simuleringsresultat
+
+object SimuleringTestUtil {
+
+    fun simuleringsresultat(
+        behandlingId: BehandlingId = BehandlingId.random(),
+        data: SimuleringJson? = null,
+    ) = Simuleringsresultat(behandlingId, data = data)
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Endepunkt for å kunne endre `revurderFra` på en behandling
Tatt med nullstilling i en egen commit, som brukes for å nullstille en behandling og gjenbruke data fra forrige behandling på nytt. 
Dette fordi når man endrer revurder fra eventuelt har endret på data som er før det nye revurder-fra datoet.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22502

Fortsettelse på 
* https://github.com/navikt/tilleggsstonader-sak/pull/431