### PR TITLE
Beregning: Ikke bruke aktivitetsdager 2 ganger i samme uke hvis 2 stønadsperioder finnes for samme uke

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
@@ -177,16 +177,29 @@ class TilsynBarnBeregningService(
         stønadsperiode: PeriodeMedDager,
         aktiviteter: List<PeriodeMedDager>,
     ): Int {
-        var maksAntallDagerIUke = stønadsperiode.antallDager
-
         return aktiviteter.filter { it.overlapper(stønadsperiode) }.fold(0) { acc, aktivitet ->
-            val maksAntallDagerSomKanTrekkesFra = minOf(maksAntallDagerIUke, aktivitet.antallDager)
+            // Tilgjengelige dager i uke i overlapp mellom stønadsperiode og aktivitet
+            val antallTilgjengeligeDager = minOf(stønadsperiode.antallDager, aktivitet.antallDager)
 
-            maksAntallDagerIUke -= maksAntallDagerSomKanTrekkesFra
-            aktivitet.antallDager -= maksAntallDagerSomKanTrekkesFra
+            trekkFraBrukteDager(stønadsperiode, aktivitet, antallTilgjengeligeDager)
 
-            acc + maksAntallDagerSomKanTrekkesFra
+            acc + antallTilgjengeligeDager
         }
+    }
+
+    /**
+     * Skal ikke kunne bruke en dager fra aktivitet eller stønadsperiode flere ganger.
+     * Trekker fra tilgjengelige dager fra antallDager
+     * Dersom stønadsperioden har 2 dager, og aktiviten 3 dager, så skal man kun totalt kunne bruke 2 dager
+     * Dersom stønadsperioden har 3 dager, og aktiviten 2 dager, så skal man kun totalt kunne bruke 2 dager
+     */
+    private fun trekkFraBrukteDager(
+        stønadsperiode: PeriodeMedDager,
+        aktivitet: PeriodeMedDager,
+        antallTilgjengeligeDager: Int,
+    ) {
+        aktivitet.antallDager -= antallTilgjengeligeDager
+        stønadsperiode.antallDager -= antallTilgjengeligeDager
     }
 
     private fun finnAktiviteter(behandlingId: BehandlingId): List<Aktivitet> {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBeregningUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBeregningUtil.kt
@@ -37,6 +37,7 @@ object TilsynBeregningUtil {
                 }
             }
             .groupBy({ it.first }, { it.second })
+            .mapValues { it.value.sorted() }
     }
 
     /**
@@ -122,7 +123,9 @@ object TilsynBeregningUtil {
             aktivitet.splitPerUke { fom, tom ->
                 min(aktivitet.aktivitetsdager, antallDagerIPeriodeInklusiv(fom, tom))
             }
-        }.flatMap { it.entries }.groupBy({ it.key }, { it.value })
+        }.flatMap { it.entries }
+            .groupBy({ it.key }, { it.value })
+            .mapValues { it.value.sorted() }
     }
 
     private fun antallDagerIPeriodeInklusiv(fom: LocalDate, tom: LocalDate): Int {
@@ -138,7 +141,7 @@ data class Uke(
 data class PeriodeMedDager(
     override val fom: LocalDate,
     override val tom: LocalDate,
-    val antallDager: Int,
+    var antallDager: Int,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/domain/BeregningsresultatTilsynBarn.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/domain/BeregningsresultatTilsynBarn.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 data class BeregningsresultatTilsynBarn(
     val perioder: List<BeregningsresultatForMåned>,
@@ -55,6 +56,7 @@ data class UtgiftBarn(
 )
 
 data class Aktivitet(
+    val id: UUID?, // Må være null pga bakåtkompatibilitet
     val type: AktivitetType,
     override val fom: LocalDate,
     override val tom: LocalDate,
@@ -65,6 +67,7 @@ fun List<Vilkårperiode>.tilAktiviteter(): List<Aktivitet> {
     return this.mapNotNull {
         if (it.type is AktivitetType) {
             Aktivitet(
+                id = it.id,
                 type = it.type,
                 fom = it.fom,
                 tom = it.tom,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/StepDefinitions.kt
@@ -201,7 +201,27 @@ class StepDefinitions {
                 assertThat(resultat.aktiviteter.size).isEqualTo(forventetResultat.antallAktiviteter)
                 assertThat(resultat.antallDager).isEqualTo(forventetResultat.antallDager)
             } catch (e: Throwable) {
-                logger.error("Feilet validering av rad ${index + 1}")
+                val actual = listOf(
+                    resultat.stønadsperiode.fom,
+                    resultat.stønadsperiode.tom,
+                    resultat.stønadsperiode.målgruppe,
+                    resultat.stønadsperiode.aktivitet,
+                    resultat.aktiviteter.size,
+                    resultat.antallDager,
+                ).joinToString(" | ")
+                val expected = listOf(
+                    forventetResultat.fom,
+                    forventetResultat.tom,
+                    forventetResultat.målgruppe,
+                    forventetResultat.aktivitet,
+                    forventetResultat.antallAktiviteter,
+                    forventetResultat.antallDager,
+                ).joinToString(" | ")
+                logger.error(
+                    "Feilet validering av rad ${index + 1}\n" +
+                        "expected = $expected\n" +
+                        "actual = $actual",
+                )
                 throw e
             }
         }

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
@@ -1,0 +1,45 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Beregning med stønadsperioder for februar med 3 aktivitetsdager. Hele februar og 2 oppsplittede perioder
+
+  Scenario: En periode for februar, 3 aktivitetsdager
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 01.02.2024 | 31.02.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 01.02.2024 | 29.02.2024 | TILTAK    | 3               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 02.2024 | 02.2024 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 14           | 1000   | 413         |
+
+  Scenario: Februar, uppsplittet med 3 stønadsperioder, 3 aktivitetsdager
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 01.02.2024 | 14.02.2024 | TILTAK    | AAP       |
+      | 15.02.2024 | 31.02.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 01.02.2024 | 29.02.2024 | TILTAK    | 3               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 02.2024 | 02.2024 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 14           | 1000   | 413         |
+      #| 02.2024 | 29.53   | 16           | 1000   | 472         |
+    # På grunn av at 15 februar treffer midt i en uke får man 3+2 dager den uken

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
@@ -41,3 +41,24 @@ Egenskap: Beregning med stønadsperioder for februar med 3 aktivitetsdager. Hele
     Så forvent følgende beregningsresultat
       | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
       | 02.2024 | 29.53   | 14           | 1000   | 413         |
+
+  Scenario: Skal trekke 1 dag for første aktiviteten og 1 fra den andre då den andre perioden kun overlapper med
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 05.02.2024 | 06.02.2024 | TILTAK    | AAP       |
+      | 07.02.2024 | 07.02.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 05.02.2024 | 07.02.2024 | TILTAK    | 1               |
+      | 07.02.2024 | 08.02.2024 | TILTAK    | 3               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 02.2024 | 02.2024 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 2            | 1000   | 60          |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
@@ -41,5 +41,3 @@ Egenskap: Beregning med stønadsperioder for februar med 3 aktivitetsdager. Hele
     Så forvent følgende beregningsresultat
       | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
       | 02.2024 | 29.53   | 14           | 1000   | 413         |
-      #| 02.2024 | 29.53   | 16           | 1000   | 472         |
-    # På grunn av at 15 februar treffer midt i en uke får man 3+2 dager den uken

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
@@ -6,7 +6,7 @@ Egenskap: Beregning med stønadsperioder for februar med 3 aktivitetsdager. Hele
   Scenario: En periode for februar, 3 aktivitetsdager
     Gitt følgende støndsperioder
       | Fom        | Tom        | Aktivitet | Målgruppe |
-      | 01.02.2024 | 31.02.2024 | TILTAK    | AAP       |
+      | 01.02.2024 | 29.02.2024 | TILTAK    | AAP       |
 
     Gitt følgende aktiviteter
       | Fom        | Tom        | Aktivitet | Aktivitetsdager |
@@ -26,7 +26,7 @@ Egenskap: Beregning med stønadsperioder for februar med 3 aktivitetsdager. Hele
     Gitt følgende støndsperioder
       | Fom        | Tom        | Aktivitet | Målgruppe |
       | 01.02.2024 | 14.02.2024 | TILTAK    | AAP       |
-      | 15.02.2024 | 31.02.2024 | TILTAK    | AAP       |
+      | 15.02.2024 | 29.02.2024 | TILTAK    | AAP       |
 
     Gitt følgende aktiviteter
       | Fom        | Tom        | Aktivitet | Aktivitetsdager |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/flere_aktiviteter.feature
@@ -94,3 +94,44 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
       | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
       | 01.2023 | 29.53   | 2            | 1000   | 59          |
       | 02.2023 | 29.53   | 3            | 1000   | 89          |
+
+  Scenario: Stønadsperiode skal bruke 1 dag fra aktivitet 1 og 1 fra aktivitet 2
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 05.02.2024 | 09.02.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 05.02.2024 | 08.02.2024 | TILTAK    | 1               |
+      | 09.02.2024 | 09.02.2024 | TILTAK    | 5               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 02.2024 | 02.2024 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 2            | 1000   | 59          |
+
+  Scenario: Skal bruke 1 dag fra første aktivitet og 1 dag fra den andre aktiviteten
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 05.02.2024 | 05.02.2024 | TILTAK    | AAP       |
+      | 09.02.2024 | 09.02.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 05.02.2024 | 09.02.2024 | TILTAK    | 1               |
+      | 05.02.2024 | 05.02.2024 | TILTAK    | 1               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 02.2024 | 02.2024 | 1000   |
+
+    Når beregner
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 2            | 1000   | 60          |


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi valgte å ikke forholde oss til aktivitetsdager i 2 ulike måneder.
Hvis en aktivitet har 5 aktivitetsdager
Og man har en uke som går 3 dager i januar, 2 dager i februar så får man 3 aktivitetsdager i januar, og 2 i februar

Jeg innså at det gjelder hvis man har splittet opp stønadsperioder i en og samme uke og.
Så hvis man har en stønadsperiode i januar, mån-ons, tors-fre så får man innvilget for 3+2 dager

Det tror jeg ikke var ønskelig?


## Løsning
Grupperer aktiviteter per uke, og trekker fra antall dager som kan brukes fra aktiviteten, sånn at man ikke gjenbruker 3 dager fra en aktivitet i 2 ulike stønadsperioder.

Sorterer aktiviteter og stønadsperioder, for at man skal trekke fra den aktivitet som begynner/slutter først hvis det er overlapp.