### PR TITLE
Beregning med revurderFra

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
@@ -1,0 +1,89 @@
+package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
+import java.time.LocalDate
+
+object TilkjentYtelseRevurderingUtil {
+
+    fun validerNyeAndelerBegynnerEtterRevurderFra(
+        saksbehandling: Saksbehandling,
+        andeler: List<AndelTilkjentYtelse>,
+    ) {
+        val revurderFra = saksbehandling.revurderFra?.tilFørsteDagIMåneden() ?: return
+        val andelerSomBegynnerFørRevurderFra = andeler.filter { it.fom < revurderFra }
+        feilHvis(andelerSomBegynnerFørRevurderFra.isNotEmpty()) {
+            secureLogger.error(
+                "Kan ikke opprette andeler som begynner før revurderFra($revurderFra)" +
+                    " andeler=$andelerSomBegynnerFørRevurderFra",
+            )
+            "Kan ikke opprette andeler som begynner før revurderFra"
+        }
+    }
+
+    fun gjenbrukAndelerFraForrigeTilkjentYtelse(
+        saksbehandling: Saksbehandling,
+        tilkjentYtelse: TilkjentYtelse,
+        revurderFra: LocalDate,
+    ): List<AndelTilkjentYtelse> {
+        val revurderFraMåned = revurderFra.tilFørsteDagIMåneden()
+
+        validerGjenbruk(saksbehandling)
+        validerAndeler(tilkjentYtelse.andelerTilkjentYtelse)
+
+        return tilkjentYtelse.andelerTilkjentYtelse
+            .filterNot { andel -> andel.type == TypeAndel.UGYLDIG }
+            .filter { andel -> andel.tom < revurderFraMåned }
+            .map {
+                AndelTilkjentYtelse(
+                    beløp = it.beløp,
+                    fom = it.fom,
+                    tom = it.tom,
+                    satstype = it.satstype,
+                    type = it.type,
+                    kildeBehandlingId = it.kildeBehandlingId,
+                )
+            }
+    }
+
+    /**
+     * For tilsyn barn har man lagd andeler som har lik fom og tom, der hele beløpet for en periode legges på et dato.
+     * Dette er på grunn av aktivitetsdager der det er utydelig lengde på perioden.
+     * Eks man kan ha et tiltak 1.8-31.8 med 1 aktivitetsdag, man får då utbetalt 1 dag per uke, dvs 4 dager i august.
+     *
+     * Hvis man revurderer fra 15 aug, og endrer aktivitetsdager så må man korrigere utbetalingen
+     * som er satt på 1.8 fra 4 til 2 dager, og ev legge inn en ny andel fra og med 15 aug.
+     * Eks der man endrer til 4 aktivitetsdager fra 15 aug (10kr per innvilget dag)
+     * Behandling 1: 1.8 aug 4 dager, 40kr
+     * Behandling 2: 1.8 aug 2 dager, 20kr. 15 aug 4 dager, 40kr
+     *
+     * For andre stønader har man kanskje annet behov og laget andeler på annen måte. Må av den grunnen ta stilling til hvert enkelt tilfelle,
+     */
+    private fun validerGjenbruk(saksbehandling: Saksbehandling) {
+        feilHvis(saksbehandling.stønadstype != Stønadstype.BARNETILSYN) {
+            "Har ikke tatt stilling til hvordan andre stønasdtyper enn barnetilsyn skal gjenbruke andeler"
+        }
+    }
+
+    /**
+     * Koblet til validering av at det kun gjelder [Stønadstype.BARNETILSYN]
+     * Se kommentar på [validerGjenbruk]
+     */
+    private fun validerAndeler(andelerTilkjentYtelse: Set<AndelTilkjentYtelse>) {
+        andelerTilkjentYtelse.forEach {
+            feilHvis(it.fom != it.tom) {
+                "Forventer at andeler har fom=tom"
+            }
+            feilHvis(it.satstype != Satstype.DAG) {
+                "Håndterer ikke type=${it.satstype}"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
@@ -4,6 +4,8 @@ import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseRevurderingUtil.gjenbrukAndelerFraForrigeTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseRevurderingUtil.validerNyeAndelerBegynnerEtterRevurderFra
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Iverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
@@ -13,7 +15,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtel
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import org.springframework.stereotype.Service
 import java.time.YearMonth
-import java.util.*
 
 @Service
 class TilkjentYtelseService(
@@ -29,8 +30,28 @@ class TilkjentYtelseService(
             ?: error("Fant ikke tilkjent ytelse med behandlingsid $behandlingId")
     }
 
-    fun opprettTilkjentYtelse(nyTilkjentYtelse: TilkjentYtelse): TilkjentYtelse {
-        return tilkjentYtelseRepository.insert(nyTilkjentYtelse)
+    fun opprettTilkjentYtelse(
+        saksbehandling: Saksbehandling,
+        andeler: List<AndelTilkjentYtelse>,
+    ): TilkjentYtelse {
+        validerNyeAndelerBegynnerEtterRevurderFra(saksbehandling, andeler)
+
+        val andelerSomSkalBeholdes = finnAndelerSomSkalBeholdes(saksbehandling)
+
+        return tilkjentYtelseRepository.insert(
+            TilkjentYtelse(
+                behandlingId = saksbehandling.id,
+                andelerTilkjentYtelse = (andelerSomSkalBeholdes + andeler).toSet(),
+            ),
+        )
+    }
+
+    private fun finnAndelerSomSkalBeholdes(saksbehandling: Saksbehandling): List<AndelTilkjentYtelse> {
+        val revurderFra = saksbehandling.revurderFra ?: return emptyList()
+        val forrigeBehandlingId = saksbehandling.forrigeBehandlingId ?: return emptyList()
+
+        val forrigeTilkjentYtelse = hentForBehandling(forrigeBehandlingId)
+        return gjenbrukAndelerFraForrigeTilkjentYtelse(saksbehandling, forrigeTilkjentYtelse, revurderFra)
     }
 
     fun harLøpendeUtbetaling(behandlingId: BehandlingId): Boolean {
@@ -53,7 +74,11 @@ class TilkjentYtelseService(
      *
      * @return den nye nullandelen som man kan sjekke status på iverksetting for
      */
-    fun leggTilNullAndel(tilkjentYtelse: TilkjentYtelse, iverksetting: Iverksetting, måned: YearMonth): AndelTilkjentYtelse {
+    fun leggTilNullAndel(
+        tilkjentYtelse: TilkjentYtelse,
+        iverksetting: Iverksetting,
+        måned: YearMonth,
+    ): AndelTilkjentYtelse {
         val nullAndel = AndelTilkjentYtelse(
             beløp = 0,
             fom = måned.atDay(1),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
@@ -97,4 +97,5 @@ fun LocalDate.datoEllerNesteMandagHvisLørdagEllerSøndag() = if (this.erLørdag
 fun LocalDate.erFørsteDagIMåneden() = this.dayOfMonth == 1
 
 fun LocalDate.erSisteDagIMåneden() = this.dayOfMonth == YearMonth.from(this).atEndOfMonth().dayOfMonth
+fun LocalDate.tilFørsteDagIMåneden() = YearMonth.from(this).atDay(1)
 fun LocalDate.tilSisteDagIMåneden() = YearMonth.from(this).atEndOfMonth()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -10,7 +10,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
-import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
@@ -103,14 +102,9 @@ class TilsynBarnBeregnYtelseSteg(
                     kildeBehandlingId = saksbehandling.id,
                 )
             }
-        }.toSet()
+        }
 
-        tilkjentytelseService.opprettTilkjentYtelse(
-            TilkjentYtelse(
-                behandlingId = saksbehandling.id,
-                andelerTilkjentYtelse = andelerTilkjentYtelse,
-            ),
-        )
+        tilkjentytelseService.opprettTilkjentYtelse(saksbehandling, andelerTilkjentYtelse)
     }
 
     private fun lagInnvilgetVedtak(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.vedtak.VedtakController
@@ -21,6 +22,7 @@ class TilsynBarnVedtakController(
     private val tilsynBarnBeregningService: TilsynBarnBeregningService,
     tilgangService: TilgangService,
     private val tilsynBarnVedtakService: TilsynBarnVedtakService,
+    private val behandlingService: BehandlingService,
 ) : VedtakController<VedtakTilsynBarnDto, VedtakTilsynBarn>(
     tilgangService,
     tilsynBarnVedtakService,
@@ -47,6 +49,7 @@ class TilsynBarnVedtakController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseTilsynBarnRequest,
     ): BeregningsresultatTilsynBarnDto {
-        return tilsynBarnBeregningService.beregn(behandlingId).tilDto()
+        val revurderFra = behandlingService.hentSaksbehandling(behandlingId).revurderFra
+        return tilsynBarnBeregningService.beregn(behandlingId).tilDto(revurderFra)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakService.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
@@ -14,13 +15,17 @@ class TilsynBarnVedtakService(
     repository: TilsynBarnVedtakRepository,
     stegService: StegService,
     tilsynBarnBeregnYtelseSteg: TilsynBarnBeregnYtelseSteg,
+    private val behandlingService: BehandlingService,
 ) : VedtakService<VedtakTilsynBarnDto, VedtakTilsynBarn>(stegService, tilsynBarnBeregnYtelseSteg, repository) {
 
     override fun mapTilDto(vedtak: VedtakTilsynBarn): VedtakTilsynBarnDto {
         return when (vedtak.type) {
-            TypeVedtak.INNVILGELSE -> InnvilgelseTilsynBarnDto(
-                beregningsresultat = vedtak.beregningsresultat?.tilDto(),
-            )
+            TypeVedtak.INNVILGELSE -> {
+                val behandling = behandlingService.hentSaksbehandling(vedtak.behandlingId)
+                InnvilgelseTilsynBarnDto(
+                    beregningsresultat = vedtak.beregningsresultat?.tilDto(revurderFra = behandling.revurderFra),
+                )
+            }
 
             TypeVedtak.AVSLAG -> AvslagTilsynBarnDto(
                 årsakerAvslag = vedtak.årsakerAvslag?.årsaker ?: error("Mangler årsak for avslag"),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
@@ -33,7 +33,7 @@ fun appLocal(): SpringApplicationBuilder =
             "mock-kodeverk",
             "mock-arbeidsfordeling",
             "mock-kafka",
-            "mock-familie-dokument",
+            // "mock-familie-dokument",
             "mock-ytelse-client",
             "mock-klage",
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtilTest.kt
@@ -1,0 +1,165 @@
+package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse
+
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseRevurderingUtil.gjenbrukAndelerFraForrigeTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseRevurderingUtil.validerNyeAndelerBegynnerEtterRevurderFra
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Iverksetting
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TilkjentYtelseRevurderingUtilTest {
+
+    val revurderFra = LocalDate.of(2024, 8, 6)
+
+    val revurdering = saksbehandling(revurderFra = revurderFra, type = BehandlingType.REVURDERING)
+
+    @Nested
+    inner class ValiderNyeAndelerBegynnerEtterRevurderFra {
+
+        @Test
+        fun `skal validere ok hvis revurderFra ikke er satt`() {
+            validerNyeAndelerBegynnerEtterRevurderFra(
+                saksbehandling(),
+                listOf(
+                    iverksattAndel(fom = revurderFra.minusDays(5)),
+                    iverksattAndel(fom = revurderFra),
+                    iverksattAndel(fom = revurderFra.plusDays(7)),
+                ),
+            )
+        }
+
+        @Test
+        fun `skal validere ok hvis andel begynner fra og med første i måneden for revurderFra`() {
+            validerNyeAndelerBegynnerEtterRevurderFra(
+                revurdering,
+                listOf(
+                    iverksattAndel(fom = revurderFra.tilFørsteDagIMåneden()),
+                    iverksattAndel(fom = revurderFra.plusDays(1)),
+                ),
+            )
+        }
+
+        @Test
+        fun `skal kaste feil hvis andel begynner før måneden for revurderFra`() {
+            assertThatThrownBy {
+                validerNyeAndelerBegynnerEtterRevurderFra(
+                    revurdering,
+                    listOf(
+                        iverksattAndel(fom = LocalDate.of(2024, 7, 30)),
+                    ),
+                )
+            }.hasMessageContaining("Kan ikke opprette andeler som begynner før revurderFra")
+        }
+    }
+
+    /**
+     * Problemet med gjenbruk er at dagsats-perioder kun løper 1 dag. Så det med "gjenbruk" virker ikke veldig bra.
+     */
+    @Nested
+    inner class GjenbrukAndelerFraForrigeTilkjentYtelse {
+
+        val behandling = saksbehandling()
+
+        @Test
+        fun `skal gjenbrukte andeler som slutter før måneden for revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 10)
+            val andel = iverksattAndel(
+                fom = LocalDate.of(2023, 12, 1),
+                type = TypeAndel.TILSYN_BARN_AAP,
+            )
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(behandling, tilkjentYtelse, revurderFra)
+
+            assertGjenbruktAndel(gjenbrukteAndeler, andel)
+        }
+
+        @Test
+        fun `skal ikke beholde andeler som er i den samme måneden som revurderFra, selv om de gjelder før revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 10)
+            val andel = iverksattAndel(
+                fom = revurderFra.minusDays(2),
+                type = TypeAndel.TILSYN_BARN_AAP,
+            )
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(behandling, tilkjentYtelse, revurderFra)
+
+            assertThat(gjenbrukteAndeler).isEmpty()
+        }
+
+        @Test
+        fun `skal filtrere vekk andeler som begynner etter revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 8)
+            val tilkjentYtelse = tilkjentYtelse(
+                BehandlingId.random(),
+                iverksattAndel(fom = revurderFra, type = TypeAndel.TILSYN_BARN_AAP),
+                iverksattAndel(fom = revurderFra.plusDays(1), type = TypeAndel.TILSYN_BARN_AAP),
+                iverksattAndel(fom = LocalDate.of(2024, 2, 6), type = TypeAndel.TILSYN_BARN_AAP),
+            )
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(behandling, tilkjentYtelse, revurderFra)
+
+            assertThat(gjenbrukteAndeler).isEmpty()
+        }
+
+        @Test
+        fun `skal filtrere vekk nullperioder av type ugyldig då de ikke skal iverksettes`() {
+            val revurderFra = LocalDate.of(2025, 1, 8) // mandag
+            val andel = iverksattAndel(
+                fom = LocalDate.of(2024, 1, 2),
+                type = TypeAndel.UGYLDIG,
+            )
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(behandling, tilkjentYtelse, revurderFra)
+
+            assertThat(gjenbrukteAndeler).isEmpty()
+        }
+
+        private fun assertGjenbruktAndel(
+            gjenbrukteAndeler: List<AndelTilkjentYtelse>,
+            andel: AndelTilkjentYtelse,
+        ) {
+            with(gjenbrukteAndeler.single()) {
+                assertThat(fom).isEqualTo(fom)
+                assertThat(tom).isEqualTo(tom)
+                assertThat(type).isEqualTo(andel.type)
+                assertThat(kildeBehandlingId).isEqualTo(andel.kildeBehandlingId)
+                assertThat(beløp).isEqualTo(andel.beløp)
+                assertThat(satstype).isEqualTo(andel.satstype)
+                assertThat(iverksetting).isNull()
+                assertThat(statusIverksetting).isEqualTo(StatusIverksetting.UBEHANDLET)
+            }
+        }
+    }
+
+    private fun iverksattAndel(
+        fom: LocalDate,
+        tom: LocalDate = fom,
+        type: TypeAndel = TypeAndel.TILSYN_BARN_AAP,
+    ) = andelTilkjentYtelse(
+        fom = fom,
+        tom = tom,
+        type = type,
+        kildeBehandlingId = BehandlingId.random(),
+        beløp = 100,
+        satstype = Satstype.DAG,
+        iverksetting = Iverksetting(UUID.randomUUID(), LocalDateTime.now()),
+        statusIverksetting = StatusIverksetting.SENDT,
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
@@ -22,7 +22,7 @@ object TilkjentYtelseUtil {
     }
 
     fun andelTilkjentYtelse(
-        kildeBehandlingId: BehandlingId,
+        kildeBehandlingId: BehandlingId = BehandlingId.random(),
         beløp: Int = 11554,
         fom: LocalDate = LocalDate.of(2021, 1, 1),
         tom: LocalDate = LocalDate.of(2021, 1, 31),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
@@ -61,6 +61,19 @@ class DatoUtilTest {
     }
 
     @Nested
+    inner class FørsteDagIMåneden {
+
+        @Test
+        fun `tilFørsteDagIMåneden skal endre dato til første dagen i måneden for inneværende måned`() {
+            val førsteJan2024 = LocalDate.of(2024, 1, 1)
+            assertThat(førsteJan2024.tilFørsteDagIMåneden()).isEqualTo(førsteJan2024)
+            assertThat(LocalDate.of(2024, 1, 31).tilFørsteDagIMåneden()).isEqualTo(førsteJan2024)
+            assertThat(LocalDate.of(2024, 1, 30).tilFørsteDagIMåneden()).isEqualTo(førsteJan2024)
+            assertThat(LocalDate.of(2024, 2, 4).tilFørsteDagIMåneden()).isEqualTo(LocalDate.of(2024, 2, 1))
+        }
+    }
+
+    @Nested
     inner class SisteDagIMåneden {
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -80,7 +80,7 @@ class TilsynBarnBeregnYtelseStegTest {
             simuleringService.slettSimuleringForBehandling(saksbehandling)
 
             repository.insert(any())
-            tilkjentYtelseService.opprettTilkjentYtelse(any())
+            tilkjentYtelseService.opprettTilkjentYtelse(saksbehandling, any())
         }
         verify(exactly = 0) {
             simuleringService.hentOgLagreSimuleringsresultat(any())

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
@@ -14,7 +15,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.util.stønadsperiode
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.barn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.UtgiftBeregning
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.YearMonth
-import java.util.*
 
 class TilsynBarnBeregnYtelseStegTest {
     private val repository = mockk<TilsynBarnVedtakRepository>(relaxed = true)
@@ -37,9 +36,14 @@ class TilsynBarnBeregnYtelseStegTest {
     private val stønadsperiodeService = mockk<StønadsperiodeRepository>(relaxed = true)
     private val vilkårperiodeRepository = mockk<VilkårperiodeRepository>(relaxed = true)
     private val tilsynBarnUtgiftService = mockk<TilsynBarnUtgiftService>(relaxed = true)
+    private val behandlingService = mockk<BehandlingService>()
 
-    val tilsynBarnBeregningService =
-        TilsynBarnBeregningService(stønadsperiodeService, vilkårperiodeRepository, tilsynBarnUtgiftService)
+    val tilsynBarnBeregningService = TilsynBarnBeregningService(
+        stønadsperiodeRepository = stønadsperiodeService,
+        vilkårperiodeRepository = vilkårperiodeRepository,
+        tilsynBarnUtgiftService = tilsynBarnUtgiftService,
+        behandlingService = behandlingService,
+    )
     val steg = TilsynBarnBeregnYtelseSteg(
         tilsynBarnBeregningService = tilsynBarnBeregningService,
         vedtakRepository = repository,
@@ -62,6 +66,7 @@ class TilsynBarnBeregnYtelseStegTest {
         mockVilkårperioder(fom, tom, saksbehandling.id)
         every { tilsynBarnUtgiftService.hentUtgifterTilBeregning(any()) } returns
             mapOf(barn.id to listOf(UtgiftBeregning(YearMonth.now(), YearMonth.now(), 1)))
+        every { behandlingService.hentSaksbehandling(saksbehandling.id) } returns saksbehandling
     }
 
     @Test
@@ -95,6 +100,7 @@ class TilsynBarnBeregnYtelseStegTest {
     @Test
     fun `skal returnere neste steg SIMULERING ved revurdering`() {
         val revurdering = saksbehandling(type = BehandlingType.REVURDERING)
+        every { behandlingService.hentSaksbehandling(revurdering.id) } returns revurdering
 
         val vedtak = innvilgelseDto()
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakServiceTest.kt
@@ -1,18 +1,28 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
+import io.mockk.every
 import io.mockk.mockk
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgetVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnDto
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
 
 class TilsynBarnVedtakServiceTest {
 
-    private val tilsynBarnVedtakService = TilsynBarnVedtakService(mockk(), mockk(), mockk())
+    val behandlingService = mockk<BehandlingService>()
+    val tilsynBarnVedtakService = TilsynBarnVedtakService(mockk(), mockk(), mockk(), behandlingService)
+
+    @BeforeEach
+    fun setUp() {
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns saksbehandling()
+    }
 
     @Test
     fun `skal mappe innvilget vedtak til dto`() {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/StepDefinitions.kt
@@ -273,6 +273,7 @@ class StepDefinitions {
                 throw e
             }
         }
+        assertThat(beløpsperioder).hasSize(forventedeBeløpsperioder.size)
     }
 
     private fun parseForventedeStønadsperioder(dataTable: DataTable): List<ForventedeStønadsperioder> {

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
@@ -62,13 +62,25 @@ Egenskap: Beregning - med revurderFra
       | 02.2024 | 29.53   | 14           | 1000   | 413         |
       | 03.2024 | 29.53   | 13           | 1000   | 384         |
 
+    Så forvent følgende beløpsperioder for: 02.2024
+      | Dato       | Beløp | Målgruppe |
+      | 01.02.2024 | 413   | AAP       |
+
     Når beregner med revurderFra=2024-02-15
 
-    ## TODO disse utgiftene burde være de samme for februar, men virker nesten som at man får ulike tall beroende på hvordan stønadsperiodene ser ut?
+    # Disse tallene skal være de samme som når man ikke bruker revurderFra,
+    # då beregningsresultatet skal gi de nye tallene for selve måneden, sånn at ev. andeler blir oppdaterte for den måneden
+    # Eks hvis man tidligere hadde en periode som var 01.01 - 31.01 så har hele beløpet blitt utbetalt på 01.01
+    # Når vi då revurderer fra 15.01 så skal beløpet splittes opp på 01.01 og 15.01
     Så forvent følgende beregningsresultat
       | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
-      | 02.2024 | 29.53   | 16           | 1000   | 472         |
+      | 02.2024 | 29.53   | 14           | 1000   | 413         |
       | 03.2024 | 29.53   | 13           | 1000   | 384         |
+
+    Så forvent følgende beløpsperioder for: 02.2024
+      | Dato       | Beløp | Målgruppe |
+      | 01.02.2024 | 236   | AAP       |
+      | 15.02.2024 | 177   | AAP       |
 
   # Når man revurder må man ta med alle perioder i inneværende måned fordi en andel får fom=fom og fom=fom dvs med samme fom og tom
   # Det betyr at hvis man tidligere har en periode fra 1.8-31.8 så er hele beløpet lagt inn på en andel med fom/tom = 1.8, med det fulle beløpet for hele den perioden
@@ -145,4 +157,4 @@ Egenskap: Beregning - med revurderFra
     Så forvent følgende stønadsperiodeGrunnlag for: 01.2024
       | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |
       | 02.01.2024 | 14.01.2024 | AAP       | TILTAK    | 1                  | 2            |
-      | 15.01.2024 | 31.01.2024 | AAP       | TILTAK    | 2                  | 9           |
+      | 15.01.2024 | 31.01.2024 | AAP       | TILTAK    | 2                  | 9            |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
@@ -54,11 +54,20 @@ Egenskap: Beregning - med revurderFra
       | Fom     | Tom     | Utgift |
       | 01.2024 | 03.2024 | 1000   |
 
-    Når beregner med revurderFra=2024-02-15
+    Når beregner
 
     Så forvent følgende beregningsresultat
       | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 01.2024 | 29.53   | 15           | 1000   | 443         |
       | 02.2024 | 29.53   | 14           | 1000   | 413         |
+      | 03.2024 | 29.53   | 13           | 1000   | 384         |
+
+    Når beregner med revurderFra=2024-02-15
+
+    ## TODO disse utgiftene burde være de samme for februar, men virker nesten som at man får ulike tall beroende på hvordan stønadsperiodene ser ut?
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 16           | 1000   | 472         |
       | 03.2024 | 29.53   | 13           | 1000   | 384         |
 
   # Når man revurder må man ta med alle perioder i inneværende måned fordi en andel får fom=fom og fom=fom dvs med samme fom og tom
@@ -83,5 +92,57 @@ Egenskap: Beregning - med revurderFra
 
     Så forvent følgende beregningsresultat
       | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
-      | 02.2024 | 29.53   | 14           | 1000   | 414         |
+      | 01.2024 | 29.53   | 14           | 1000   | 414         |
     # Antall dager = 1 + 13
+
+  Scenario: Skal splitte grunnlaget for stønadsperioder sånn at man kan filtrere ut de som endret seg til frontend
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 02.01.2024 | 31.01.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 02.01.2024 | 14.01.2024 | TILTAK    | 1               |
+      | 15.01.2024 | 31.01.2024 | TILTAK    | 5               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2024 | 01.2024 | 1000   |
+
+    Når beregner med revurderFra=2024-01-15
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 01.2024 | 29.53   | 15           | 1000   | 443         |
+    # Antall dager = 1 + 13
+
+    Så forvent følgende stønadsperiodeGrunnlag for: 01.2024
+      | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |
+      | 02.01.2024 | 14.01.2024 | AAP       | TILTAK    | 1                  | 2            |
+      | 15.01.2024 | 31.01.2024 | AAP       | TILTAK    | 1                  | 13           |
+
+  Scenario: Skal splitte stønadsperioder 2
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 02.01.2024 | 31.01.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 02.01.2024 | 31.01.2024 | TILTAK    | 1               |
+      | 17.01.2024 | 31.01.2024 | TILTAK    | 2               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2024 | 01.2024 | 1000   |
+
+    Når beregner med revurderFra=2024-01-15
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 01.2024 | 29.53   | 11           | 1000   | 325         |
+    # Antall dager = 1 + 13
+
+    Så forvent følgende stønadsperiodeGrunnlag for: 01.2024
+      | Fom        | Tom        | Målgruppe | Aktivitet | Antall aktiviteter | Antall dager |
+      | 02.01.2024 | 14.01.2024 | AAP       | TILTAK    | 1                  | 2            |
+      | 15.01.2024 | 31.01.2024 | AAP       | TILTAK    | 2                  | 9           |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
@@ -1,0 +1,87 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Beregning - med revurderFra
+
+  Scenario: Skal ikke ta med perioder som slutter før måneden for revurderFra
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 02.01.2024 | 21.01.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 02.01.2024 | 21.01.2024 | TILTAK    | 3               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2024 | 01.2024 | 1000   |
+
+    Når beregner med revurderFra=2024-02-15
+
+    Så forvent følgende beregningsresultat
+      | Måned | Dagsats | Antall dager | Utgift | Månedsbeløp |
+
+
+  Scenario: Skal ta med alle perioder som starter etter revurderFra
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 02.01.2024 | 21.01.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 02.01.2024 | 21.01.2024 | TILTAK    | 3               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2024 | 01.2024 | 1000   |
+
+    Når beregner med revurderFra=2023-12-15
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 01.2024 | 29.53   | 9            | 1000   | 266         |
+
+  Scenario: Skal ta med perioder fra og med den måneden man revurderer dersom de overlapper
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 02.01.2024 | 31.03.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 02.01.2024 | 31.03.2024 | TILTAK    | 3               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2024 | 03.2024 | 1000   |
+
+    Når beregner med revurderFra=2024-02-15
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 14           | 1000   | 413         |
+      | 03.2024 | 29.53   | 13           | 1000   | 384         |
+
+  # Når man revurder må man ta med alle perioder i inneværende måned fordi en andel får fom=fom og fom=fom dvs med samme fom og tom
+  # Det betyr at hvis man tidligere har en periode fra 1.8-31.8 så er hele beløpet lagt inn på en andel med fom/tom = 1.8, med det fulle beløpet for hele den perioden
+  # Når man då revurderer må man få et nytt beløp for 1.8 for å sen få ett nytt beløp fra og med 15.8
+  Scenario: Skal ta med perioder som er før revurderFra men fortsatt i den samme måneden
+    Gitt følgende støndsperioder
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 02.01.2024 | 02.01.2024 | TILTAK    | AAP       |
+      | 15.01.2024 | 31.01.2024 | TILTAK    | AAP       |
+
+    Gitt følgende aktiviteter
+      | Fom        | Tom        | Aktivitet | Aktivitetsdager |
+      | 02.01.2024 | 02.01.2024 | TILTAK    | 1               |
+      | 15.01.2024 | 31.01.2024 | TILTAK    | 5               |
+
+    Gitt følgende utgifter for barn med id: 1
+      | Fom     | Tom     | Utgift |
+      | 01.2024 | 01.2024 | 1000   |
+
+    Når beregner med revurderFra=2024-01-15
+
+    Så forvent følgende beregningsresultat
+      | Måned   | Dagsats | Antall dager | Utgift | Månedsbeløp |
+      | 02.2024 | 29.53   | 14           | 1000   | 414         |
+    # Antall dager = 1 + 13


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når man revurderer med revurdererFra så er det ikke ønskelig at man tar med tidligere perioder for å unngå at man ev. endrer noe på beregning på tidligere utbetalte perioder. 

Beregning med `revurderFra` skal bruke beregningsgrunnlaget for måneden man revurderer fra, pga at man i forrige behandling ev. har lagt hele månedens beløp første i måneden, selv om man har perioder i den perioden man revurderer fra.
Stønadsperioder må splittes på for at frontend enkelt skal kunne få filtrerte perioder fra og med `revurderFra`-datoet


### Henting til frontend filtrerer perioder etter revurderFra
Dersom man først har en periode som er `1.8 - 14.8`

#### Eksempel
* Førstegangsbehandling 
Stønadsperiode `1.8 - 31.8`
=> Andel med `fom=1.8`, `tom=1.8` med hele beløpet for hele perioden pga aktivitetsdager som gjør det vanskelig å lage perioder. 

* Revurdering fra 15.8
Legger til aktivitet eller endrer aktivitetsdager i perioden  `15.8 - 31.8`
Må ta med beregningsgrunnlag for hele august pga at andelen i forrige behandling har hele beløpet på 1.8
Sånn i revurderingen kommer beløpet bli justert for andelen 1.8 og en ny andel for 15.8 med det nye beløpet for den perioden.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22502
Fortsettelse på
* https://github.com/navikt/tilleggsstonader-sak/pull/438 
Se egen PR for andeler. 
* 