### PR TITLE
Tilkjen ytelse revurder fra

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
@@ -8,8 +8,8 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjen
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
 import java.time.LocalDate
-import java.time.YearMonth
 
 object TilkjentYtelseRevurderingUtil {
 
@@ -17,7 +17,7 @@ object TilkjentYtelseRevurderingUtil {
         saksbehandling: Saksbehandling,
         andeler: List<AndelTilkjentYtelse>,
     ) {
-        val revurderFra = saksbehandling.revurderFra ?: return
+        val revurderFra = saksbehandling.revurderFra?.tilFørsteDagIMåneden() ?: return
         val andelerSomBegynnerFørRevurderFra = andeler.filter { it.fom < revurderFra }
         feilHvis(andelerSomBegynnerFørRevurderFra.isNotEmpty()) {
             secureLogger.error(
@@ -33,7 +33,7 @@ object TilkjentYtelseRevurderingUtil {
         tilkjentYtelse: TilkjentYtelse,
         revurderFra: LocalDate,
     ): List<AndelTilkjentYtelse> {
-        val revurderFraMåned = YearMonth.from(revurderFra).atDay(1)
+        val revurderFraMåned = revurderFra.tilFørsteDagIMåneden()
 
         validerGjenbruk(saksbehandling)
         validerAndeler(tilkjentYtelse.andelerTilkjentYtelse)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
@@ -1,10 +1,13 @@
 package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -25,24 +28,20 @@ object TilkjentYtelseRevurderingUtil {
         }
     }
 
-    /**
-     * Dette vil ikke virke så bra. Dagytelser har utbetaling av hele beløpet på 1 dag.
-     * Så når man gjør en revurder fra vill ikke dette virke veldig bra...
-     */
     fun gjenbrukAndelerFraForrigeTilkjentYtelse(
+        saksbehandling: Saksbehandling,
         tilkjentYtelse: TilkjentYtelse,
         revurderFra: LocalDate,
     ): List<AndelTilkjentYtelse> {
         val revurderFraMåned = YearMonth.from(revurderFra).atDay(1)
+
+        validerGjenbruk(saksbehandling)
+        validerAndeler(tilkjentYtelse.andelerTilkjentYtelse)
+
         return tilkjentYtelse.andelerTilkjentYtelse
-            .filter { andel ->
-                feilHvis(andel.fom != andel.tom) {
-                    "Håndterer foreløpig ikke at fom != tom"
-                }
-                andel.tom < revurderFraMåned
-            }
+            .filterNot { andel -> andel.type == TypeAndel.UGYLDIG }
+            .filter { andel -> andel.tom < revurderFraMåned }
             .map {
-                // TODO hvordan håndtere ugyldig satstype/type
                 AndelTilkjentYtelse(
                     beløp = it.beløp,
                     fom = it.fom,
@@ -52,5 +51,39 @@ object TilkjentYtelseRevurderingUtil {
                     kildeBehandlingId = it.kildeBehandlingId,
                 )
             }
+    }
+
+    /**
+     * For tilsyn barn har man lagd andeler som har lik fom og tom, der hele beløpet for en periode legges på et dato.
+     * Dette er på grunn av aktivitetsdager der det er utydelig lengde på perioden.
+     * Eks man kan ha et tiltak 1.8-31.8 med 1 aktivitetsdag, man får då utbetalt 1 dag per uke, dvs 4 dager i august.
+     *
+     * Hvis man revurderer fra 15 aug, og endrer aktivitetsdager så må man korrigere utbetalingen
+     * som er satt på 1.8 fra 4 til 2 dager, og ev legge inn en ny andel fra og med 15 aug.
+     * Eks der man endrer til 4 aktivitetsdager fra 15 aug (10kr per innvilget dag)
+     * Behandling 1: 1.8 aug 4 dager, 40kr
+     * Behandling 2: 1.8 aug 2 dager, 20kr. 15 aug 4 dager, 40kr
+     *
+     * For andre stønader har man kanskje annet behov og laget andeler på annen måte. Må av den grunnen ta stilling til hvert enkelt tilfelle,
+     */
+    private fun validerGjenbruk(saksbehandling: Saksbehandling) {
+        feilHvis(saksbehandling.stønadstype != Stønadstype.BARNETILSYN) {
+            "Har ikke tatt stilling til hvordan andre stønasdtyper enn barnetilsyn skal gjenbruke andeler"
+        }
+    }
+
+    /**
+     * Koblet til validering av at det kun gjelder [Stønadstype.BARNETILSYN]
+     * Se kommentar på [validerGjenbruk]
+     */
+    private fun validerAndeler(andelerTilkjentYtelse: Set<AndelTilkjentYtelse>) {
+        andelerTilkjentYtelse.forEach {
+            feilHvis(it.fom != it.tom) {
+                "Forventer at andeler har fom=tom"
+            }
+            feilHvis(it.satstype != Satstype.DAG) {
+                "Håndterer ikke type=${it.satstype}"
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
 import java.time.LocalDate
+import java.time.YearMonth
 
 object TilkjentYtelseRevurderingUtil {
 
@@ -32,17 +33,13 @@ object TilkjentYtelseRevurderingUtil {
         tilkjentYtelse: TilkjentYtelse,
         revurderFra: LocalDate,
     ): List<AndelTilkjentYtelse> {
+        val revurderFraMåned = YearMonth.from(revurderFra).atDay(1)
         return tilkjentYtelse.andelerTilkjentYtelse
-            .mapNotNull { andel ->
+            .filter { andel ->
                 feilHvis(andel.fom != andel.tom) {
                     "Håndterer foreløpig ikke at fom != tom"
                 }
-                if (andel.fom >= revurderFra) {
-                    null
-                } else {
-                    val nyttDato = minOf(andel.tom, revurderFra.minusDays(1))
-                    andel.copy(fom = nyttDato, tom = nyttDato)
-                }
+                andel.tom < revurderFraMåned
             }
             .map {
                 // TODO hvordan håndtere ugyldig satstype/type

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtil.kt
@@ -1,0 +1,59 @@
+package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse
+
+import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
+import java.time.LocalDate
+
+object TilkjentYtelseRevurderingUtil {
+
+    fun validerNyeAndelerBegynnerEtterRevurderFra(
+        saksbehandling: Saksbehandling,
+        andeler: List<AndelTilkjentYtelse>,
+    ) {
+        val revurderFra = saksbehandling.revurderFra ?: return
+        val andelerSomBegynnerFørRevurderFra = andeler.filter { it.fom < revurderFra }
+        feilHvis(andelerSomBegynnerFørRevurderFra.isNotEmpty()) {
+            secureLogger.error(
+                "Kan ikke opprette andeler som begynner før revurderFra($revurderFra)" +
+                    " andeler=$andelerSomBegynnerFørRevurderFra",
+            )
+            "Kan ikke opprette andeler som begynner før revurderFra"
+        }
+    }
+
+    /**
+     * Dette vil ikke virke så bra. Dagytelser har utbetaling av hele beløpet på 1 dag.
+     * Så når man gjør en revurder fra vill ikke dette virke veldig bra...
+     */
+    fun gjenbrukAndelerFraForrigeTilkjentYtelse(
+        tilkjentYtelse: TilkjentYtelse,
+        revurderFra: LocalDate,
+    ): List<AndelTilkjentYtelse> {
+        return tilkjentYtelse.andelerTilkjentYtelse
+            .mapNotNull { andel ->
+                feilHvis(andel.fom != andel.tom) {
+                    "Håndterer foreløpig ikke at fom != tom"
+                }
+                if (andel.fom >= revurderFra) {
+                    null
+                } else {
+                    val nyttDato = minOf(andel.tom, revurderFra.minusDays(1))
+                    andel.copy(fom = nyttDato, tom = nyttDato)
+                }
+            }
+            .map {
+                // TODO hvordan håndtere ugyldig satstype/type
+                AndelTilkjentYtelse(
+                    beløp = it.beløp,
+                    fom = it.fom,
+                    tom = it.tom,
+                    satstype = it.satstype,
+                    type = it.type,
+                    kildeBehandlingId = it.kildeBehandlingId,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
@@ -51,7 +51,7 @@ class TilkjentYtelseService(
         val forrigeBehandlingId = saksbehandling.forrigeBehandlingId ?: return emptyList()
 
         val forrigeTilkjentYtelse = hentForBehandling(forrigeBehandlingId)
-        return gjenbrukAndelerFraForrigeTilkjentYtelse(forrigeTilkjentYtelse, revurderFra)
+        return gjenbrukAndelerFraForrigeTilkjentYtelse(saksbehandling, forrigeTilkjentYtelse, revurderFra)
     }
 
     fun harLøpendeUtbetaling(behandlingId: BehandlingId): Boolean {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
@@ -97,4 +97,5 @@ fun LocalDate.datoEllerNesteMandagHvisLørdagEllerSøndag() = if (this.erLørdag
 fun LocalDate.erFørsteDagIMåneden() = this.dayOfMonth == 1
 
 fun LocalDate.erSisteDagIMåneden() = this.dayOfMonth == YearMonth.from(this).atEndOfMonth().dayOfMonth
+fun LocalDate.tilFørsteDagIMåneden() = YearMonth.from(this).atDay(1)
 fun LocalDate.tilSisteDagIMåneden() = YearMonth.from(this).atEndOfMonth()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -10,7 +10,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
-import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
@@ -103,14 +102,9 @@ class TilsynBarnBeregnYtelseSteg(
                     kildeBehandlingId = saksbehandling.id,
                 )
             }
-        }.toSet()
+        }
 
-        tilkjentytelseService.opprettTilkjentYtelse(
-            TilkjentYtelse(
-                behandlingId = saksbehandling.id,
-                andelerTilkjentYtelse = andelerTilkjentYtelse,
-            ),
-        )
+        tilkjentytelseService.opprettTilkjentYtelse(saksbehandling, andelerTilkjentYtelse)
     }
 
     private fun lagInnvilgetVedtak(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
@@ -33,7 +33,7 @@ fun appLocal(): SpringApplicationBuilder =
             "mock-kodeverk",
             "mock-arbeidsfordeling",
             "mock-kafka",
-            "mock-familie-dokument",
+            // "mock-familie-dokument",
             "mock-ytelse-client",
             "mock-klage",
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtilTest.kt
@@ -1,0 +1,171 @@
+package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse
+
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseRevurderingUtil.gjenbrukAndelerFraForrigeTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseRevurderingUtil.validerNyeAndelerBegynnerEtterRevurderFra
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Iverksetting
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TilkjentYtelseRevurderingUtilTest {
+
+    val revurdering = saksbehandling(revurderFra = LocalDate.now(), type = BehandlingType.REVURDERING)
+
+    @Nested
+    inner class ValiderNyeAndelerBegynnerEtterRevurderFra {
+
+        @Test
+        fun `skal validere ok hvis revurderFra ikke er satt`() {
+            validerNyeAndelerBegynnerEtterRevurderFra(
+                saksbehandling(),
+                listOf(andelTilkjentYtelse(kildeBehandlingId = BehandlingId.random())),
+            )
+        }
+
+        @Test
+        fun `skal validere ok hvis andel begynner fra revurderingsdato eller etter`() {
+            validerNyeAndelerBegynnerEtterRevurderFra(
+                revurdering,
+                listOf(
+                    andelTilkjentYtelse(fom = LocalDate.now(), tom = LocalDate.now().plusDays(1)),
+                    andelTilkjentYtelse(fom = LocalDate.now().plusDays(1), tom = LocalDate.now().plusDays(1)),
+                ),
+            )
+        }
+
+        @Test
+        fun `skal kaste feil hvis andel begynner fra revurderingsdato eller etter`() {
+            assertThatThrownBy {
+                validerNyeAndelerBegynnerEtterRevurderFra(
+                    revurdering,
+                    listOf(
+                        andelTilkjentYtelse(fom = LocalDate.now().minusDays(1), tom = LocalDate.now().plusDays(1)),
+                    ),
+                )
+            }.hasMessageContaining("Kan ikke opprette andeler som begynner før revurderFra")
+        }
+    }
+
+    /**
+     * Problemet med gjenbruk er at dagsats-perioder kun løper 1 dag. Så det med "gjenbruk" virker ikke veldig bra.
+     */
+    @Nested
+    inner class GjenbrukAndelerFraForrigeTilkjentYtelse {
+
+        @Test
+        fun `skal gjenbrukte felter fra andeler som overlapper med revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 10)
+            val andel = iverksattAndel(
+                fom = revurderFra.minusDays(7),
+                tom = revurderFra.plusDays(2),
+                type = TypeAndel.TILSYN_BARN_AAP,
+            )
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(tilkjentYtelse, revurderFra)
+
+            assertGjenbruktAndel(gjenbrukteAndeler, andel, nyTom = revurderFra.minusDays(1))
+        }
+
+        @Test
+        fun `skal beholde andeler som slutter før revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 10)
+            val andel = iverksattAndel(
+                fom = revurderFra.minusDays(2),
+                tom = revurderFra.minusDays(2),
+                type = TypeAndel.TILSYN_BARN_AAP,
+            )
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(tilkjentYtelse, revurderFra)
+
+            assertGjenbruktAndel(gjenbrukteAndeler, andel, nyTom = revurderFra.minusDays(2))
+        }
+
+        @Test
+        fun `skal avkorte en andel som slutter på lik dato som revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 10)
+            val andel =
+                iverksattAndel(fom = revurderFra.minusDays(2), tom = revurderFra, type = TypeAndel.TILSYN_BARN_AAP)
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(tilkjentYtelse, revurderFra)
+
+            assertThat(gjenbrukteAndeler.single().tom).isEqualTo(revurderFra.minusDays(1))
+        }
+
+        @Test
+        fun `skal filtrere vekk andeler som begynner etter revurderFra`() {
+            val revurderFra = LocalDate.of(2024, 1, 8)
+            val tilkjentYtelse = tilkjentYtelse(
+                BehandlingId.random(),
+                iverksattAndel(fom = revurderFra, tom = revurderFra, type = TypeAndel.TILSYN_BARN_AAP),
+                iverksattAndel(fom = revurderFra.plusDays(1), tom = revurderFra.plusDays(1), type = TypeAndel.TILSYN_BARN_AAP),
+            )
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(tilkjentYtelse, revurderFra)
+
+            assertThat(gjenbrukteAndeler).isEmpty()
+        }
+
+        @Test
+        fun `hvis man revurderer fra en mandag, så skal fredag som ny tom`() {
+            val revurderFra = LocalDate.of(2024, 1, 8) // mandag
+            val andel = iverksattAndel(
+                fom = LocalDate.of(2024, 1, 2),
+                tom = revurderFra.plusDays(2),
+                type = TypeAndel.TILSYN_BARN_AAP,
+            )
+            val tilkjentYtelse = tilkjentYtelse(BehandlingId.random(), andel)
+
+            val gjenbrukteAndeler = gjenbrukAndelerFraForrigeTilkjentYtelse(tilkjentYtelse, revurderFra)
+
+            assertGjenbruktAndel(gjenbrukteAndeler, andel, nyTom = LocalDate.of(2024, 1, 5))
+        }
+
+        private fun assertGjenbruktAndel(
+            gjenbrukteAndeler: List<AndelTilkjentYtelse>,
+            andel: AndelTilkjentYtelse,
+            nyTom: LocalDate,
+        ) {
+            with(gjenbrukteAndeler.single()) {
+                assertThat(fom).isEqualTo(andel.fom)
+                assertThat(tom).isEqualTo(nyTom)
+                assertThat(type).isEqualTo(andel.type)
+                assertThat(kildeBehandlingId).isEqualTo(andel.kildeBehandlingId)
+                assertThat(beløp).isEqualTo(andel.beløp)
+                assertThat(satstype).isEqualTo(andel.satstype)
+                assertThat(iverksetting).isNull()
+                assertThat(statusIverksetting).isEqualTo(StatusIverksetting.UBEHANDLET)
+            }
+        }
+
+        fun iverksattAndel(
+            fom: LocalDate,
+            tom: LocalDate,
+            type: TypeAndel,
+        ) = andelTilkjentYtelse(
+            fom = fom,
+            tom = tom,
+            type = type,
+            kildeBehandlingId = BehandlingId.random(),
+            beløp = 100,
+            satstype = Satstype.DAG,
+            iverksetting = Iverksetting(UUID.randomUUID(), LocalDateTime.now()),
+            statusIverksetting = StatusIverksetting.SENDT,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseRevurderingUtilTest.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
@@ -42,23 +43,23 @@ class TilkjentYtelseRevurderingUtilTest {
         }
 
         @Test
-        fun `skal validere ok hvis andel begynner fra revurderingsdato eller etter`() {
+        fun `skal validere ok hvis andel begynner fra og med første i måneden for revurderFra`() {
             validerNyeAndelerBegynnerEtterRevurderFra(
                 revurdering,
                 listOf(
-                    iverksattAndel(fom = revurderFra),
+                    iverksattAndel(fom = revurderFra.tilFørsteDagIMåneden()),
                     iverksattAndel(fom = revurderFra.plusDays(1)),
                 ),
             )
         }
 
         @Test
-        fun `skal kaste feil hvis andel begynner før revurderingsdato`() {
+        fun `skal kaste feil hvis andel begynner før måneden for revurderFra`() {
             assertThatThrownBy {
                 validerNyeAndelerBegynnerEtterRevurderFra(
                     revurdering,
                     listOf(
-                        iverksattAndel(fom = revurderFra.minusDays(1)),
+                        iverksattAndel(fom = LocalDate.of(2024, 7, 30)),
                     ),
                 )
             }.hasMessageContaining("Kan ikke opprette andeler som begynner før revurderFra")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
@@ -22,7 +22,7 @@ object TilkjentYtelseUtil {
     }
 
     fun andelTilkjentYtelse(
-        kildeBehandlingId: BehandlingId,
+        kildeBehandlingId: BehandlingId = BehandlingId.random(),
         beløp: Int = 11554,
         fom: LocalDate = LocalDate.of(2021, 1, 1),
         tom: LocalDate = LocalDate.of(2021, 1, 31),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
@@ -61,6 +61,19 @@ class DatoUtilTest {
     }
 
     @Nested
+    inner class FørsteDagIMåneden {
+
+        @Test
+        fun `tilFørsteDagIMåneden skal endre dato til første dagen i måneden for inneværende måned`() {
+            val førsteJan2024 = LocalDate.of(2024, 1, 1)
+            assertThat(førsteJan2024.tilFørsteDagIMåneden()).isEqualTo(førsteJan2024)
+            assertThat(LocalDate.of(2024, 1, 31).tilFørsteDagIMåneden()).isEqualTo(førsteJan2024)
+            assertThat(LocalDate.of(2024, 1, 30).tilFørsteDagIMåneden()).isEqualTo(førsteJan2024)
+            assertThat(LocalDate.of(2024, 2, 4).tilFørsteDagIMåneden()).isEqualTo(LocalDate.of(2024, 2, 1))
+        }
+    }
+
+    @Nested
     inner class SisteDagIMåneden {
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -80,7 +80,7 @@ class TilsynBarnBeregnYtelseStegTest {
             simuleringService.slettSimuleringForBehandling(saksbehandling)
 
             repository.insert(any())
-            tilkjentYtelseService.opprettTilkjentYtelse(any())
+            tilkjentYtelseService.opprettTilkjentYtelse(saksbehandling, any())
         }
         verify(exactly = 0) {
             simuleringService.hentOgLagreSimuleringsresultat(any())


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når man revurderer med `revurderFra` er det ønskelig å bruke andeler fra forrige behandling fram til og med måneden før måneden for `revurderFra`.

Dersom man har periode fra `1.7-14.8` og revurderer fra 15.8 så kommer vi gjenbruke andeler fra juli, og sen skrive over alt fra og med 1 aug. Det er pga at totalbeløpet for en måned for tilsyn barn er "regnskapsført" på en dag, 1.8 og egentligen gjelder for periode etter 15.8. 
Så her vil vi ev. redusere beløpet i 1.8 og legge til en nytt/høyere beløp i 15.8

Se eksempel 
* https://github.com/navikt/tilleggsstonader-sak/pull/439
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22502