### PR TITLE
Skal gruppere beløp per måned då vi kan få flere perioder i den samme…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDto.kt
@@ -3,9 +3,10 @@ package no.nav.tilleggsstonader.sak.utbetaling.simulering.dto
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.OppsummeringForPeriode
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.Simuleringsresultat
 import java.time.LocalDate
+import java.time.YearMonth
 
 data class SimuleringDto(
-    val perioder: List<OppsummeringForPeriode>?,
+    val perioder: List<OppsummeringForPeriodeDto>?,
     val ingenEndringIUtbetaling: Boolean,
     val oppsummering: SimuleringOppsummering?,
 )
@@ -17,13 +18,49 @@ data class SimuleringOppsummering(
     val feilutbetaling: Int,
 )
 
+data class OppsummeringForPeriodeDto(
+    val måned: YearMonth,
+    @Deprecated("bruk måned når frontend tatt den i bruk")
+    val fom: LocalDate,
+    val tidligereUtbetalt: Int,
+    val nyUtbetaling: Int,
+    val totalEtterbetaling: Int,
+    val totalFeilutbetaling: Int,
+)
+
 fun Simuleringsresultat.tilDto(): SimuleringDto {
     return SimuleringDto(
-        perioder = this.data?.oppsummeringer,
+        perioder = this.data?.oppsummeringer?.map { it.tilDto() }?.summerPerMåned(),
         ingenEndringIUtbetaling = this.ingenEndringIUtbetaling,
         oppsummering = lagSimuleringOppsummering(this),
     )
 }
+
+private fun OppsummeringForPeriode.tilDto(): OppsummeringForPeriodeDto {
+    val måned = YearMonth.from(fom)
+    require(måned == YearMonth.from(tom))
+    return OppsummeringForPeriodeDto(
+        måned = måned,
+        fom = fom,
+        tidligereUtbetalt = tidligereUtbetalt,
+        nyUtbetaling = nyUtbetaling,
+        totalEtterbetaling = totalEtterbetaling,
+        totalFeilutbetaling = totalFeilutbetaling,
+    )
+}
+
+private fun List<OppsummeringForPeriodeDto>.summerPerMåned() =
+    groupBy { it.måned }
+        .mapValues {
+            it.value.reduce { acc, periode ->
+                acc.copy(
+                    tidligereUtbetalt = acc.tidligereUtbetalt + periode.tidligereUtbetalt,
+                    nyUtbetaling = acc.nyUtbetaling + periode.nyUtbetaling,
+                    totalEtterbetaling = acc.totalEtterbetaling + periode.totalEtterbetaling,
+                    totalFeilutbetaling = acc.totalFeilutbetaling + periode.totalFeilutbetaling,
+                )
+            }
+        }.values.toList()
 
 private fun lagSimuleringOppsummering(simulering: Simuleringsresultat): SimuleringOppsummering? {
     if (simulering.data == null) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringControllerTest.kt
@@ -56,7 +56,7 @@ internal class SimuleringControllerTest : IntegrationTest() {
         val respons: ResponseEntity<SimuleringDto> = simulerForBehandling(behandling.id)
 
         assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(respons.body!!.perioder).hasSize(16)
+        assertThat(respons.body!!.perioder).hasSize(15)
         val simuleringsresultat = simuleringsresultatRepository.findByIdOrThrow(behandling.id)
 
         // Verifiser at simuleringsresultatet er lagret

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDtoTest.kt
@@ -1,0 +1,75 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering.dto
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.OppsummeringForPeriode
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.SimuleringDetaljer
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.SimuleringJson
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.Simuleringsresultat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+class SimuleringDtoTest {
+
+    /**
+     * Perioder fra simulering er ikke gruppert per måned
+     * Hvis vi har en stønadsperiode for 2.1-14.1 og 25.1-31.1
+     * så vil det være 2 andeler med fom 2.1 og 25.1 som kommer tilbake fra simulering som 2 ulike perioder
+     */
+    @Test
+    fun `skal summere perioder gruppert per måned då simuleringen gir alle perioder i en måned som kan være flere`() {
+        assertThat(simuleringsresultat.tilDto().perioder!!)
+            .containsExactlyInAnyOrder(
+                OppsummeringForPeriodeDto(
+                    måned = YearMonth.of(2024, 1),
+                    fom = LocalDate.of(2024, 1, 2),
+                    tidligereUtbetalt = 11,
+                    nyUtbetaling = 22,
+                    totalEtterbetaling = 33,
+                    totalFeilutbetaling = 44,
+                ),
+                OppsummeringForPeriodeDto(
+                    måned = YearMonth.of(2024, 2),
+                    fom = LocalDate.of(2024, 2, 5),
+                    tidligereUtbetalt = 101,
+                    nyUtbetaling = 202,
+                    totalEtterbetaling = 303,
+                    totalFeilutbetaling = 404,
+                ),
+            )
+    }
+
+    val simuleringsresultat = Simuleringsresultat(
+        BehandlingId.random(),
+        data = SimuleringJson(
+            oppsummeringer = listOf(
+                OppsummeringForPeriode(
+                    fom = LocalDate.of(2024, 1, 2),
+                    tom = LocalDate.of(2024, 1, 2),
+                    tidligereUtbetalt = 10,
+                    nyUtbetaling = 20,
+                    totalEtterbetaling = 30,
+                    totalFeilutbetaling = 40,
+                ),
+                OppsummeringForPeriode(
+                    fom = LocalDate.of(2024, 1, 25),
+                    tom = LocalDate.of(2024, 1, 25),
+                    tidligereUtbetalt = 1,
+                    nyUtbetaling = 2,
+                    totalEtterbetaling = 3,
+                    totalFeilutbetaling = 4,
+                ),
+                OppsummeringForPeriode(
+                    fom = LocalDate.of(2024, 2, 5),
+                    tom = LocalDate.of(2024, 2, 5),
+                    tidligereUtbetalt = 101,
+                    nyUtbetaling = 202,
+                    totalEtterbetaling = 303,
+                    totalFeilutbetaling = 404,
+                ),
+            ),
+            detaljer = SimuleringDetaljer("", LocalDate.now(), 100, emptyList()),
+        ),
+    )
+}


### PR DESCRIPTION
… måneden

### Hvorfor er denne endringen nødvendig? ✨

Fikk 2 kolonner med en og samme måned i simulering pga at man får flere perioder for den samme måneden.
EF får ikke det då det er en månedsytelse