### PR TITLE
Bidrag ønsker å vite om det finnes vedtak om tilsyn barn på en person

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -81,6 +81,8 @@ spec:
         - application: tilleggsstonader-prosessering
         - application: tilleggsstonader-soknad-api
         - application: tilleggsstonader-klage
+        - application: bidrag-grunnlag
+          namespace: bidrag
         - application: arena
           namespace: teamarenanais
           cluster: dev-fss

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -80,6 +80,8 @@ spec:
         - application: tilleggsstonader-prosessering
         - application: tilleggsstonader-soknad-api
         - application: tilleggsstonader-klage
+        - application: bidrag-grunnlag
+          namespace: bidrag
         - application: arena
           namespace: teamarenanais
           cluster: prod-fss

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/EksternVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/EksternVedtakController.kt
@@ -1,0 +1,34 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.ekstern.stønad.dto.IdentRequest
+import no.nav.tilleggsstonader.sak.ekstern.stønad.dto.VedtaksinformasjonTilsynBarnDto
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(
+    path = ["/api/ekstern/vedtak"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+class EksternVedtakController(
+    private val eksternVedtakService: EksternVedtakService,
+) {
+
+    @PostMapping("tilsyn-barn")
+    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
+    fun hentVedtaksinformasjon(@RequestBody request: IdentRequest): VedtaksinformasjonTilsynBarnDto {
+        feilHvisIkke(SikkerhetContext.kallKommerFra(EksternApplikasjon.BIDRAG_GRUNNLAG), HttpStatus.UNAUTHORIZED) {
+            "Kallet utføres ikke av en autorisert klient"
+        }
+        return eksternVedtakService.hentVedtaksinformasjonTilsynBarn(request)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/EksternVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/EksternVedtakService.kt
@@ -1,0 +1,41 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.ekstern.stønad.dto.IdentRequest
+import no.nav.tilleggsstonader.sak.ekstern.stønad.dto.VedtaksinformasjonTilsynBarnDto
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
+import org.springframework.stereotype.Service
+
+@Service
+class EksternVedtakService(
+    private val personService: PersonService,
+    private val arenaService: ArenaService,
+    private val fagsakService: FagsakService,
+    private val behandlingService: BehandlingService,
+) {
+
+    /**
+     * Henter foreløpig kun informasjon om det finnes et vedtak i ny løsning og/eller i arena
+     * Når vi legger inn informasjon om hvilke perioder det gjelder,
+     * så må vi slå sammen beregningsresultat tvers flere behandlinger pga revurderFra som ikke tar med perioder før måneden som det revurderes fra
+     */
+    fun hentVedtaksinformasjonTilsynBarn(request: IdentRequest): VedtaksinformasjonTilsynBarnDto {
+        return VedtaksinformasjonTilsynBarnDto(
+            harVedtak = harVedtak(request) || harVedtakIArena(request),
+        )
+    }
+
+    private fun harVedtak(request: IdentRequest): Boolean {
+        val identer = personService.hentPersonIdenter(request.ident).identer()
+        val sisteIverksatteBehandling = fagsakService.finnFagsak(identer, stønadstype = Stønadstype.BARNETILSYN)
+            ?.let { behandlingService.finnSisteIverksatteBehandling(it.id) }
+        return sisteIverksatteBehandling != null
+    }
+
+    private fun harVedtakIArena(request: IdentRequest) =
+        arenaService.hentStatus(request.ident, Stønadstype.BARNETILSYN).vedtak.harInnvilgetVedtak
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/dto/IdentRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/dto/IdentRequest.kt
@@ -1,0 +1,5 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad.dto
+
+data class IdentRequest(
+    val ident: String,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/dto/VedtaksinformasjonTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/dto/VedtaksinformasjonTilsynBarnDto.kt
@@ -1,0 +1,5 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad.dto
+
+data class VedtaksinformasjonTilsynBarnDto(
+    val harVedtak: Boolean,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
@@ -3,4 +3,5 @@ package no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet
 enum class EksternApplikasjon(val namespaceAppNavn: String) {
     SOKNAD_API("gcp:tilleggsstonader:tilleggsstonader-soknad-api"),
     ARENA("fss:teamarenanais:arena"),
+    BIDRAG_GRUNNLAG("gcp:bidrag:bidrag-grunnlag"),
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -44,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jdbc.core.JdbcAggregateOperations
@@ -107,6 +108,9 @@ abstract class IntegrationTest {
     @Autowired
     protected lateinit var unleashService: UnleashService
 
+    @Autowired
+    private lateinit var cacheManagers: List<CacheManager>
+
     val logger = LoggerFactory.getLogger(javaClass)
 
     @AfterEach
@@ -114,6 +118,7 @@ abstract class IntegrationTest {
         headers.clear()
         clearClientMocks()
         resetDatabase()
+        clearCaches()
     }
 
     private fun resetDatabase() {
@@ -158,6 +163,13 @@ abstract class IntegrationTest {
     }
 
     private fun clearClientMocks() {
+    }
+
+    private fun clearCaches() {
+        cacheManagers.forEach {
+            it.cacheNames.mapNotNull { cacheName -> it.getCache(cacheName) }
+                .forEach { cache -> cache.clear() }
+        }
     }
 
     protected fun localhost(path: String): String {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/EksternVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/EksternVedtakServiceTest.kt
@@ -1,0 +1,89 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
+import no.nav.tilleggsstonader.kontrakter.arena.VedtakStatus
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.ekstern.stønad.dto.IdentRequest
+import no.nav.tilleggsstonader.sak.infrastruktur.mocks.ArenaClientConfig.Companion.resetMock
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaClient
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class EksternVedtakServiceTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var arenaClient: ArenaClient
+
+    @Autowired
+    lateinit var service: EksternVedtakService
+
+    val fagsak = fagsak()
+    val request = IdentRequest(fagsak.hentAktivIdent())
+
+    @BeforeEach
+    fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+        mockArena(harInnvilgetVedtak = false)
+    }
+
+    @AfterEach
+    override fun tearDown() {
+        super.tearDown()
+        resetMock(arenaClient)
+    }
+
+    @Test
+    fun `har vedtak hvis personen har en iverksatt behandling`() {
+        val behandling = behandling(fagsak, status = BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET)
+        testoppsettService.lagre(behandling, opprettGrunnlagsdata = false)
+
+        val result = service.hentVedtaksinformasjonTilsynBarn(request)
+
+        assertThat(result.harVedtak).isTrue
+
+        verify(exactly = 0) { arenaClient.hentStatus(any()) }
+    }
+
+    @Test
+    fun `skal sjekke arena hvis personen ikke har en iverksatt behandling i ny løsning`() {
+        mockArena(harInnvilgetVedtak = true)
+
+        val result = service.hentVedtaksinformasjonTilsynBarn(request)
+
+        assertThat(result.harVedtak).isTrue
+
+        verify(exactly = 1) { arenaClient.hentStatus(any()) }
+    }
+
+    @Test
+    fun `har ikke vedtak hvis personen ikke har iverksatt behandling eller vedtak i arena`() {
+        val result = service.hentVedtaksinformasjonTilsynBarn(request)
+
+        assertThat(result.harVedtak).isFalse
+
+        verify(exactly = 1) { arenaClient.hentStatus(any()) }
+    }
+
+    private fun mockArena(harInnvilgetVedtak: Boolean) {
+        every { arenaClient.hentStatus(any()) } returns ArenaStatusDto(
+            sak = mockk(),
+            vedtak = VedtakStatus(
+                harVedtak = false,
+                harInnvilgetVedtak = harInnvilgetVedtak,
+                harAktivtVedtak = false,
+                harVedtakUtenUtfall = false,
+                vedtakTom = null,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Url: http://tilleggsstonader-sak.tilleggsstonader/api/ekstern/vedtak/tilsyn-barn
Post-json `{"ident:": "<ident>"}`

Vi henter alle identer til personen og ser om det finnes noen vedtak på personen i ny løsning.
Hvis det ikke finnes vedtak i ny løsning sjekker vi Arena om det finnes vedtak der.
Vi utgår fra at den som kaller på oss gjør tilgangskontroll av brukeren for den identen man spør på

Det er senere ønskelig å legge til flere detaljer i responsen, men foreløpig får de kun info om det finnes eller ikke finnes.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22625