### PR TITLE
Brevmottakere frittstående brev

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerFrittståendeBrevRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerFrittståendeBrevRepository.kt
@@ -1,0 +1,17 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker
+
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface BrevmottakerFrittståendeBrevRepository :
+    RepositoryInterface<BrevmottakerFrittståendeBrev, UUID>, InsertUpdateRepository<BrevmottakerFrittståendeBrev> {
+
+    fun existsByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(fagsakId: FagsakId, opprettetAv: String): Boolean
+
+    fun findByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(fagsakId: FagsakId, opprettetAv: String): List<BrevmottakerFrittståendeBrev>
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.brev.brevmottaker
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 class BrevmottakereController(
     private val tilgangService: TilgangService,
     private val brevmottakereService: BrevmottakereService,
+    private val brevmottakereFrittståendeBrevService: BrevmottakereFrittståendeBrevService,
 ) {
 
     @GetMapping("/{behandlingId}")
@@ -35,5 +37,23 @@ class BrevmottakereController(
         tilgangService.validerHarSaksbehandlerrolle()
 
         return brevmottakereService.lagreBrevmottakere(behandlingId, brevmottakere)
+    }
+
+    @GetMapping("fagsak/{fagsakId}")
+    fun hentBrevmottakere(@PathVariable fagsakId: FagsakId): BrevmottakereDto {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+
+        return brevmottakereFrittståendeBrevService.hentEllerOpprettBrevmottakere(fagsakId).tilBrevmottakereDto()
+    }
+
+    @PostMapping("fagsak/{fagsakId}")
+    fun velgBrevmottakere(
+        @PathVariable fagsakId: FagsakId,
+        @RequestBody brevmottakere: BrevmottakereDto,
+    ) {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return brevmottakereFrittståendeBrevService.lagreBrevmottakere(fagsakId, brevmottakere)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereDto.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.brev.brevmottaker
 import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerDto
 import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerOrganisasjonDto
 import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerPersonDto
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
@@ -40,6 +41,11 @@ private fun brevmottakereDto(mottakere: List<Pair<UUID, Mottaker>>) =
         personer = mottakere.mapPersoner(),
         organisasjoner = mottakere.mapOrganisasjoner(),
     )
+
+@JvmName("tilFrittståendeBrevmottakereDto")
+fun List<BrevmottakerFrittståendeBrev>.tilBrevmottakereDto(): BrevmottakereDto = this
+    .map { it.id to it.mottaker }
+    .let(::brevmottakereDto)
 
 private fun List<Pair<UUID, Mottaker>>.mapOrganisasjoner() = mapNotNull { (id, mottaker) ->
     if (mottaker.mottakerType == MottakerType.ORGANISASJON) mottaker.tilOrganisasjonDto(id) else null

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereFrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereFrittståendeBrevService.kt
@@ -1,0 +1,110 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker
+
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerDto
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerUtil.validerAntallBrevmottakere
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerUtil.validerUnikeBrevmottakere
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerType
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * Brevmottakere for frittstående brev
+ * Disse fjernes i det at man sender et frittstående brev, men det opprettes en task for hver mottaker som håndterer utsendelsen
+ */
+@Service
+class BrevmottakereFrittståendeBrevService(
+    private val brevmottakereRepository: BrevmottakerFrittståendeBrevRepository,
+    private val fagsakService: FagsakService,
+) {
+
+    @Transactional
+    fun lagreBrevmottakere(fagsakId: FagsakId, brevmottakereDto: BrevmottakereDto) {
+        validerAntallBrevmottakere(brevmottakereDto)
+        validerUnikeBrevmottakere(brevmottakereDto)
+        fjernMottakereIkkeIDto(brevmottakereDto, fagsakId)
+
+        brevmottakereDto.organisasjoner.forEach { lagreEllerOppdater(fagsakId, it) }
+        brevmottakereDto.personer.forEach { lagreEllerOppdater(fagsakId, it) }
+    }
+
+    @Transactional
+    fun hentEllerOpprettBrevmottakere(fagsakId: FagsakId): List<BrevmottakerFrittståendeBrev> {
+        val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
+
+        if (!brevmottakereRepository.existsByFagsakIdAndSporbarOpprettetAvIdIsNull(fagsakId, saksbehandlerIdent)) {
+            opprettInitiellBrevmottakerForFagsak(fagsakId)
+        }
+
+        return brevmottakereRepository.findByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(fagsakId, saksbehandlerIdent)
+    }
+
+    fun hentBrevmottakere(id: UUID) = brevmottakereRepository.findByIdOrThrow(id)
+
+    @Transactional
+    fun oppdaterBrevmottakere(brevmottaker: BrevmottakerFrittståendeBrev) {
+        brevmottakereRepository.update(brevmottaker)
+    }
+
+    private fun fjernMottakereIkkeIDto(
+        brevmottakereDto: BrevmottakereDto,
+        fagsakId: FagsakId,
+    ) {
+        val nyeBrevmottakere = brevmottakereDto.personer.map { it.id } + brevmottakereDto.organisasjoner.map { it.id }
+        brevmottakereRepository.findByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(
+            fagsakId,
+            SikkerhetContext.hentSaksbehandler(),
+        )
+            .filter { it.id !in nyeBrevmottakere }
+            .forEach { brevmottakereRepository.deleteById(it.id) }
+    }
+
+    private fun lagreEllerOppdater(
+        fagsakId: FagsakId,
+        dto: BrevmottakerDto,
+    ) {
+        val brevmottaker = brevmottakereRepository.findByIdOrNull(dto.id)
+
+        if (brevmottaker != null) {
+            oppdaterBrevmottaker(brevmottaker, dto)
+        } else {
+            opprettNyBrevmottaker(fagsakId, dto)
+        }
+    }
+
+    private fun opprettNyBrevmottaker(fagsakId: FagsakId, it: BrevmottakerDto) {
+        brevmottakereRepository.insert(
+            BrevmottakerFrittståendeBrev(
+                id = it.id,
+                fagsakId = fagsakId,
+                mottaker = it.tilMottaker(),
+            ),
+        )
+    }
+
+    private fun oppdaterBrevmottaker(brevmottaker: BrevmottakerFrittståendeBrev, it: BrevmottakerDto) {
+        brevmottakereRepository.update(brevmottaker.copy(mottaker = it.tilMottaker()))
+    }
+
+    private fun opprettInitiellBrevmottakerForFagsak(fagsakId: FagsakId): BrevmottakerFrittståendeBrev {
+        val ident = fagsakService.hentAktivIdent(fagsakId)
+
+        val brevmottaker = BrevmottakerFrittståendeBrev(
+            fagsakId = fagsakId,
+            mottaker = Mottaker(
+                ident = ident,
+                mottakerRolle = MottakerRolle.BRUKER,
+                mottakerType = MottakerType.PERSON,
+            ),
+        )
+        return brevmottakereRepository.insert(brevmottaker)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereFrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereFrittståendeBrevService.kt
@@ -40,7 +40,7 @@ class BrevmottakereFrittståendeBrevService(
     fun hentEllerOpprettBrevmottakere(fagsakId: FagsakId): List<BrevmottakerFrittståendeBrev> {
         val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
 
-        if (!brevmottakereRepository.existsByFagsakIdAndSporbarOpprettetAvIdIsNull(fagsakId, saksbehandlerIdent)) {
+        if (!brevmottakereRepository.existsByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(fagsakId, saksbehandlerIdent)) {
             opprettInitiellBrevmottakerForFagsak(fagsakId)
         }
 
@@ -50,8 +50,8 @@ class BrevmottakereFrittståendeBrevService(
     fun hentBrevmottakere(id: UUID) = brevmottakereRepository.findByIdOrThrow(id)
 
     @Transactional
-    fun oppdaterBrevmottakere(brevmottaker: BrevmottakerFrittståendeBrev) {
-        brevmottakereRepository.update(brevmottaker)
+    fun oppdaterBrevmottaker(brevmottaker: BrevmottakerFrittståendeBrev): BrevmottakerFrittståendeBrev {
+        return brevmottakereRepository.update(brevmottaker)
     }
 
     private fun fjernMottakereIkkeIDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/MottakerUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/MottakerUtil.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker
+
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.AvsenderMottaker
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerType
+
+object MottakerUtil {
+
+    fun Mottaker.tilAvsenderMottaker() = AvsenderMottaker(
+        id = ident,
+        idType = when (mottakerType) {
+            MottakerType.PERSON -> BrukerIdType.FNR
+            MottakerType.ORGANISASJON -> BrukerIdType.ORGNR
+        },
+        navn = when (mottakerType) {
+            MottakerType.PERSON -> null
+            MottakerType.ORGANISASJON -> mottakerNavn
+        },
+    )
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/domain/BrevmottakerFrittståendeBrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/domain/BrevmottakerFrittståendeBrev.kt
@@ -1,0 +1,24 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker.domain
+
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Embedded
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("brevmottaker_frittstaende_brev")
+data class BrevmottakerFrittståendeBrev(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val fagsakId: FagsakId,
+    val brevId: UUID? = null,
+    val journalpostId: String? = null,
+    val bestillingId: String? = null,
+
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val mottaker: Mottaker,
+
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar(),
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
@@ -7,10 +7,12 @@ import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
 import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereFrittståendeBrevService
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
 import org.springframework.stereotype.Service
 import java.util.Properties
+import java.util.UUID
 
 @Service
 @TaskStepBeskrivelse(
@@ -22,12 +24,13 @@ import java.util.Properties
 )
 class DistribuerFrittståendeBrevTask(
     private val journalpostClient: JournalpostClient,
+    private val brevmottakereFrittståendeBrevService: BrevmottakereFrittståendeBrevService,
 ) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue(task.payload, DistribuerFrittståendeBrevPayload::class.java)
 
-        journalpostClient.distribuerJournalpost(
+        val bestillingId = journalpostClient.distribuerJournalpost(
             DistribuerJournalpostRequest(
                 journalpostId = payload.journalpostId,
                 bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
@@ -35,22 +38,27 @@ class DistribuerFrittståendeBrevTask(
                 distribusjonstype = Distribusjonstype.VIKTIG,
             ),
         )
+        brevmottakereFrittståendeBrevService.hentBrevmottakere(payload.mottakerId)
+            .copy(bestillingId = bestillingId)
+            .let { brevmottakereFrittståendeBrevService.oppdaterBrevmottaker(it) }
     }
 
     companion object {
 
-        fun opprettTask(fagsakId: FagsakId, journalpostId: String): Task =
+        fun opprettTask(fagsakId: FagsakId, journalpostId: String, mottakerId: UUID): Task =
             Task(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(
                     DistribuerFrittståendeBrevPayload(
                         fagsakId = fagsakId,
                         journalpostId = journalpostId,
+                        mottakerId = mottakerId,
                     ),
                 ),
                 properties = Properties().apply {
                     setProperty("fagsakId", fagsakId.toString())
                     setProperty("journalpostId", journalpostId)
+                    setProperty("mottakerId", mottakerId.toString())
                 },
             )
 
@@ -61,4 +69,5 @@ class DistribuerFrittståendeBrevTask(
 data class DistribuerFrittståendeBrevPayload(
     val fagsakId: FagsakId,
     val journalpostId: String,
+    val mottakerId: UUID,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
@@ -62,7 +62,7 @@ class DistribuerFrittståendeBrevTask(
                 },
             )
 
-        const val TYPE = "frittståendeBrev"
+        const val TYPE = "distribuerFrittståendeBrev"
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
@@ -27,9 +27,6 @@ class DistribuerFrittståendeBrevTask(
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue(task.payload, DistribuerFrittståendeBrevPayload::class.java)
 
-        // TODO finn brevmottakere
-        // val brevmottakere = brevmottakerRepository.findByBehandlingId(behandlingId)
-
         journalpostClient.distribuerJournalpost(
             DistribuerJournalpostRequest(
                 journalpostId = payload.journalpostId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrev.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.sak.brev.frittstående
+
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
+import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Table("frittstaende_brev")
+data class FrittståendeBrev(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val fagsakId: FagsakId,
+    val pdf: Fil,
+    val tittel: String,
+    val saksbehandlerIdent: String = SikkerhetContext.hentSaksbehandler(),
+    val opprettetTid: LocalDateTime = SporbarUtils.now(),
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevRepository.kt
@@ -1,0 +1,10 @@
+package no.nav.tilleggsstonader.sak.brev.frittstående
+
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface FrittståendeBrevRepository :
+    RepositoryInterface<FrittståendeBrev, UUID>, InsertUpdateRepository<FrittståendeBrev>

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -54,7 +54,7 @@ class JournalførFrittståendeBrevTask(
 
         val journalpostId = arkiverDokumentResponse.journalpostId
         brevmottakereFrittståendeBrevService.oppdaterBrevmottaker(brevmottaker.copy(journalpostId = journalpostId))
-        taskService.save(DistribuerFrittståendeBrevTask.opprettTask(brev.fagsakId, journalpostId))
+        taskService.save(DistribuerFrittståendeBrevTask.opprettTask(brev.fagsakId, journalpostId, mottakerId))
     }
 
     private fun journalførBrev(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -1,0 +1,144 @@
+package no.nav.tilleggsstonader.sak.brev.frittstående
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.AvsenderMottaker
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokumenttype
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereFrittståendeBrevService
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerType
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.journalføring.ArkiverDokumentConflictException
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.Properties
+import java.util.UUID
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = JournalførFrittståendeBrevTask.TYPE,
+    maxAntallFeil = 50,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 31L,
+    beskrivelse = "Journalfører vedtaksbrev",
+)
+class JournalførFrittståendeBrevTask(
+    private val taskService: TaskService,
+    private val fagsakService: FagsakService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val journalpostService: JournalpostService,
+    private val frittståendeBrevService: FrittståendeBrevService,
+    private val brevmottakereFrittståendeBrevService: BrevmottakereFrittståendeBrevService,
+) : AsyncTaskStep {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        val mottakerId = UUID.fromString(task.payload)
+
+        val brevmottaker = brevmottakereFrittståendeBrevService.hentBrevmottakere(mottakerId)
+        val brevId = brevmottaker.brevId ?: error("Mangler brevId på brevmottaker=$mottakerId")
+        val brev = frittståendeBrevService.hentFrittståendeBrev(brevId)
+
+        val arkiverDokumentResponse = journalførBrev(brev, brevmottaker)
+
+        val journalpostId = arkiverDokumentResponse.journalpostId
+        brevmottakereFrittståendeBrevService.oppdaterBrevmottaker(brevmottaker.copy(journalpostId = journalpostId))
+        taskService.save(DistribuerFrittståendeBrevTask.opprettTask(brev.fagsakId, journalpostId))
+    }
+
+    private fun journalførBrev(
+        brev: FrittståendeBrev,
+        brevmottaker: BrevmottakerFrittståendeBrev,
+    ): ArkiverDokumentResponse {
+        val fagsak = fagsakService.hentFagsak(brev.fagsakId)
+        val dokument = Dokument(
+            dokument = brev.pdf.bytes,
+            filtype = Filtype.PDFA,
+            dokumenttype = utledDokumenttype(fagsak.stønadstype),
+            tittel = brev.tittel,
+        )
+
+        val eksternReferanseId = brevmottaker.id.toString()
+        val arkiverDokumentRequest = ArkiverDokumentRequest(
+            fnr = fagsak.hentAktivIdent(),
+            forsøkFerdigstill = true,
+            hoveddokumentvarianter = listOf(dokument),
+            fagsakId = fagsak.eksternId.id.toString(),
+            journalførendeEnhet = arbeidsfordelingService.hentNavEnhet(brev.saksbehandlerIdent)?.enhetNr
+                ?: error("Fant ikke arbeidsfordelingsenhet"),
+            eksternReferanseId = eksternReferanseId,
+            avsenderMottaker = lagAvsenderMottaker(brevmottaker.mottaker),
+        )
+
+        return opprettJournalpost(arkiverDokumentRequest, brevmottaker, brev)
+    }
+
+    private fun opprettJournalpost(
+        arkviverDokumentRequest: ArkiverDokumentRequest,
+        brevmottaker: BrevmottakerFrittståendeBrev,
+        brev: FrittståendeBrev,
+    ): ArkiverDokumentResponse {
+        val response = try {
+            journalpostService.opprettJournalpost(arkviverDokumentRequest)
+        } catch (e: ArkiverDokumentConflictException) {
+            logger.warn(
+                "Konflikt ved arkivering av dokument. Brevet=${brev.id} og mottaker=${brevmottaker.id}" +
+                    " har allerede blitt journalført med eksternReferanseId=${arkviverDokumentRequest.eksternReferanseId}",
+            )
+            e.response
+        }
+        feilHvisIkke(response.ferdigstilt) {
+            "Journalposten ble ikke ferdigstilt og kan derfor ikke distribueres"
+        }
+        return response
+    }
+
+    private fun lagAvsenderMottaker(brevmottaker: Mottaker) = AvsenderMottaker(
+        id = brevmottaker.ident,
+        idType = when (brevmottaker.mottakerType) {
+            MottakerType.PERSON -> BrukerIdType.FNR
+            MottakerType.ORGANISASJON -> BrukerIdType.ORGNR
+        },
+        navn = when (brevmottaker.mottakerType) {
+            MottakerType.PERSON -> null
+            MottakerType.ORGANISASJON -> brevmottaker.mottakerNavn
+        },
+    )
+
+    private fun utledDokumenttype(stønadstype: Stønadstype) =
+        when (stønadstype) {
+            Stønadstype.BARNETILSYN -> Dokumenttype.BARNETILSYN_FRITTSTÅENDE_BREV
+            Stønadstype.LÆREMIDLER -> Dokumenttype.LÆREMIDLER_FRITTSTÅENDE_BREV
+            else -> error("Utledning av dokumenttype er ikke implementert for $stønadstype")
+        }
+
+    companion object {
+
+        fun opprettTask(fagsakId: FagsakId, brevId: UUID, mottakerId: UUID): Task =
+            Task(
+                type = TYPE,
+                payload = mottakerId.toString(),
+                properties = Properties().apply {
+                    setProperty("fagsakId", fagsakId.toString())
+                    setProperty("brevId", brevId.toString())
+                    setProperty("mottakerId", mottakerId.toString())
+                },
+            )
+
+        const val TYPE = "journalførFrittståendeBrev"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -69,7 +69,7 @@ class JournalførFrittståendeBrevTask(
             tittel = brev.tittel,
         )
 
-        val eksternReferanseId = "frittstående-brev-${brevmottaker.id}"
+        val eksternReferanseId = "frittstaende-brev-${brevmottaker.id}"
         val arkiverDokumentRequest = ArkiverDokumentRequest(
             fnr = fagsak.hentAktivIdent(),
             forsøkFerdigstill = true,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -30,7 +30,7 @@ import java.util.UUID
     maxAntallFeil = 50,
     settTilManuellOppfølgning = true,
     triggerTidVedFeilISekunder = 31L,
-    beskrivelse = "Journalfører vedtaksbrev",
+    beskrivelse = "Journalfører frittstående brev",
 )
 class JournalførFrittståendeBrevTask(
     private val taskService: TaskService,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -6,17 +6,14 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.AvsenderMottaker
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokumenttype
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
-import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereFrittståendeBrevService
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerType
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
@@ -81,7 +78,7 @@ class JournalførFrittståendeBrevTask(
             journalførendeEnhet = arbeidsfordelingService.hentNavEnhet(brev.saksbehandlerIdent)?.enhetNr
                 ?: error("Fant ikke arbeidsfordelingsenhet"),
             eksternReferanseId = eksternReferanseId,
-            avsenderMottaker = lagAvsenderMottaker(brevmottaker.mottaker),
+            avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),
         )
 
         return opprettJournalpost(arkiverDokumentRequest, brevmottaker, brev)
@@ -106,18 +103,6 @@ class JournalførFrittståendeBrevTask(
         }
         return response
     }
-
-    private fun lagAvsenderMottaker(brevmottaker: Mottaker) = AvsenderMottaker(
-        id = brevmottaker.ident,
-        idType = when (brevmottaker.mottakerType) {
-            MottakerType.PERSON -> BrukerIdType.FNR
-            MottakerType.ORGANISASJON -> BrukerIdType.ORGNR
-        },
-        navn = when (brevmottaker.mottakerType) {
-            MottakerType.PERSON -> null
-            MottakerType.ORGANISASJON -> brevmottaker.mottakerNavn
-        },
-    )
 
     private fun utledDokumenttype(stønadstype: Stønadstype) =
         when (stønadstype) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -69,7 +69,7 @@ class JournalførFrittståendeBrevTask(
             tittel = brev.tittel,
         )
 
-        val eksternReferanseId = brevmottaker.id.toString()
+        val eksternReferanseId = "frittstående-brev-${brevmottaker.id}"
         val arkiverDokumentRequest = ArkiverDokumentRequest(
             fnr = fagsak.hentAktivIdent(),
             forsøkFerdigstill = true,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/JournalførFrittståendeBrevTask.kt
@@ -75,7 +75,7 @@ class JournalførFrittståendeBrevTask(
             forsøkFerdigstill = true,
             hoveddokumentvarianter = listOf(dokument),
             fagsakId = fagsak.eksternId.id.toString(),
-            journalførendeEnhet = arbeidsfordelingService.hentNavEnhet(brev.saksbehandlerIdent)?.enhetNr
+            journalførendeEnhet = arbeidsfordelingService.hentNavEnhet(fagsak.hentAktivIdent())?.enhetNr
                 ?: error("Fant ikke arbeidsfordelingsenhet"),
             eksternReferanseId = eksternReferanseId,
             avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTask.kt
@@ -6,19 +6,16 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.AvsenderMottaker
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokumenttype
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
-import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
@@ -85,7 +82,7 @@ class JournalførVedtaksbrevTask(
             journalførendeEnhet = arbeidsfordelingService.hentNavEnhet(saksbehandling.ident)?.enhetNr
                 ?: error("Fant ikke arbeidsfordelingsenhet"),
             eksternReferanseId = eksternReferanseId,
-            avsenderMottaker = lagAvsenderMottaker(brevmottaker.mottaker),
+            avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),
         )
 
         val arkiverDokumentResponse = opprettJournalpost(arkviverDokumentRequest, saksbehandling, eksternReferanseId)
@@ -111,18 +108,6 @@ class JournalførVedtaksbrevTask(
         }
         return response
     }
-
-    private fun lagAvsenderMottaker(brevmottaker: Mottaker) = AvsenderMottaker(
-        id = brevmottaker.ident,
-        idType = when (brevmottaker.mottakerType) {
-            MottakerType.PERSON -> BrukerIdType.FNR
-            MottakerType.ORGANISASJON -> BrukerIdType.ORGNR
-        },
-        navn = when (brevmottaker.mottakerType) {
-            MottakerType.PERSON -> null
-            MottakerType.ORGANISASJON -> brevmottaker.mottakerNavn
-        },
-    )
 
     private fun utledBrevtittel(saksbehandling: Saksbehandling) = when (saksbehandling.stønadstype) {
         Stønadstype.BARNETILSYN -> "Vedtak om stønad til tilsyn barn" // TODO

--- a/src/main/resources/db/migration/V51__frittstående_brev.sql
+++ b/src/main/resources/db/migration/V51__frittstående_brev.sql
@@ -1,0 +1,44 @@
+CREATE TABLE frittstaende_brev
+(
+    id                  UUID PRIMARY KEY,
+    fagsak_id           UUID         NOT NULL REFERENCES fagsak (id),
+    pdf                 BYTEA        NOT NULL,
+    tittel              VARCHAR      NOT NULL,
+    saksbehandler_ident VARCHAR      NOT NULL,
+    opprettet_tid       TIMESTAMP(3) NOT NULL
+);
+
+CREATE TABLE brevmottaker_frittstaende_brev
+(
+    id                 UUID PRIMARY KEY,
+    fagsak_id          UUID         NOT NULL REFERENCES fagsak (id),
+    brev_id            UUID REFERENCES frittstaende_brev (id),
+    journalpost_id     VARCHAR,
+    bestilling_id      VARCHAR,
+
+    ident              VARCHAR      NOT NULL,
+    mottaker_rolle     VARCHAR      NOT NULL,
+    mottaker_type      VARCHAR      NOT NULL,
+    organisasjons_navn VARCHAR,
+    mottaker_navn      VARCHAR,
+
+    opprettet_av       VARCHAR      NOT NULL,
+    opprettet_tid      TIMESTAMP(3) NOT NULL,
+    endret_av          VARCHAR      NOT NULL,
+    endret_tid         TIMESTAMP(3) NOT NULL
+);
+
+/**
+  CONSTRAINT unik_mottaker_per_saksbehandler UNIQUE (fagsak_id, brev_id, ident, opprettet_av)
+  Kan ikke brukes fordi brev_id = null ignoreres,
+  og det skal ikke være mulig med duplikat av brevmottakere når brevet ennå ikke er opprettet
+ */
+
+CREATE UNIQUE INDEX unik_brevmottaker_frittstaende_not_null_idx
+    ON brevmottaker_frittstaende_brev (fagsak_id, brev_id, ident, opprettet_av)
+    WHERE brev_id IS NOT NULL;
+
+CREATE UNIQUE INDEX unik_brevmottaker_frittstaende_null_idx
+    ON brevmottaker_frittstaende_brev (fagsak_id, ident, opprettet_av)
+    WHERE brev_id IS NULL;
+

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -11,7 +11,9 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Behandlingsjournalpost
 import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingId
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.Behandlingshistorikk
 import no.nav.tilleggsstonader.sak.behandling.vent.SettPåVent
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretBrev
 import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretFrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.Vedtaksbrev
@@ -127,6 +129,9 @@ abstract class IntegrationTest {
             Task::class,
 
             SøknadRouting::class,
+
+            BrevmottakerFrittståendeBrev::class,
+            FrittståendeBrev::class,
 
             Grunnlagsdata::class,
             VedtakTilsynBarn::class,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
@@ -19,7 +19,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.brev.GenererPdfRequest
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.BrevController
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerFrittståendeBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerFrittståendeBrevRepositoryTest.kt
@@ -1,0 +1,165 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
+import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.repository.findByIdOrNull
+import java.time.temporal.ChronoUnit
+
+class BrevmottakerFrittståendeBrevRepositoryTest : IntegrationTest() {
+
+    @Autowired
+    private lateinit var repository: BrevmottakerFrittståendeBrevRepository
+
+    @Autowired
+    private lateinit var frittståendeBrevRepository: FrittståendeBrevRepository
+
+    val fagsak = fagsak()
+
+    @BeforeEach
+    fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+    }
+
+    @Test
+    fun `lagre og hent brevmottaker`() {
+        val frittståendeBrev = lagFrittståendeBrev()
+        val brevmottaker = BrevmottakerFrittståendeBrev(
+            fagsakId = fagsak.id,
+            mottaker = mottakerPerson(ident = fagsak.hentAktivIdent()),
+            journalpostId = "123",
+            brevId = frittståendeBrev.id,
+            bestillingId = "bestillingId",
+        )
+
+        repository.insert(brevmottaker)
+
+        val journalpostResultatFraDb = repository.findByIdOrThrow(brevmottaker.id)
+
+        assertThat(journalpostResultatFraDb)
+            .usingRecursiveComparison()
+            .ignoringFields("opprettetTid", "sporbar.endret.endretTid")
+            .isEqualTo(brevmottaker)
+        assertThat(journalpostResultatFraDb.sporbar.opprettetTid)
+            .isCloseTo(brevmottaker.sporbar.opprettetTid, Assertions.within(2, ChronoUnit.SECONDS))
+        assertThat(journalpostResultatFraDb.sporbar.endret.endretTid)
+            .isCloseTo(brevmottaker.sporbar.endret.endretTid, Assertions.within(2, ChronoUnit.SECONDS))
+    }
+
+    @Test
+    fun `skal ikke kunne lagre to journalpostResultat på samme fagsak med samme mottaker`() {
+        val brevmottaker1 = BrevmottakerFrittståendeBrev(
+            fagsakId = fagsak.id,
+            mottaker = mottakerPerson(
+                ident = "ident",
+                mottakerRolle = MottakerRolle.VERGE,
+            ),
+        )
+
+        val brevmottaker2 = BrevmottakerFrittståendeBrev(
+            fagsakId = fagsak.id,
+            mottaker = mottakerPerson(
+                ident = "ident",
+                mottakerRolle = MottakerRolle.VERGE,
+            ),
+        )
+
+        repository.insert(brevmottaker1)
+        assertThatThrownBy {
+            repository.insert(brevmottaker2)
+        }.hasCauseInstanceOf(DuplicateKeyException::class.java)
+    }
+
+    @Test
+    fun `skal kunne lagre to journalpostResultat på samme fagsak med forskjellige mottakere`() {
+        val brevmottaker = BrevmottakerFrittståendeBrev(
+            fagsakId = fagsak.id,
+            mottaker = mottakerPerson(ident = fagsak.hentAktivIdent()),
+        )
+
+        val brevmottakerAnnenMottaker = BrevmottakerFrittståendeBrev(
+            fagsakId = fagsak.id,
+            mottaker = mottakerPerson(
+                ident = "ident",
+                mottakerRolle = MottakerRolle.VERGE,
+            ),
+        )
+
+        repository.insert(brevmottaker)
+        repository.insert(brevmottakerAnnenMottaker)
+
+        val hentetResultat = repository.findByIdOrNull(brevmottaker.id)
+        val hentetResultatAnnenMottaker = repository.findByIdOrNull(brevmottakerAnnenMottaker.id)
+
+        assertThat(hentetResultat).isNotNull
+        assertThat(hentetResultat).usingRecursiveComparison()
+            .ignoringFields("opprettetTid", "sporbar.endret.endretTid")
+            .isEqualTo(brevmottaker)
+
+        assertThat(hentetResultat).isNotNull
+        assertThat(hentetResultatAnnenMottaker).usingRecursiveComparison()
+            .ignoringFields("opprettetTid", "sporbar.endret.endretTid")
+            .isEqualTo(brevmottakerAnnenMottaker)
+    }
+
+    @Nested
+    inner class ExistsByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull {
+
+        @Test
+        fun `skal ikke finne brev når brevId er satt`() {
+            val frittståendeBrev = lagFrittståendeBrev()
+            val brev = repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = fagsak.id,
+                    mottaker = mottakerPerson(ident = fagsak.hentAktivIdent()),
+                    brevId = frittståendeBrev.id,
+                ),
+            )
+            val exists =
+                repository.existsByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(fagsak.id, brev.sporbar.opprettetAv)
+            assertThat(exists).isFalse
+        }
+    }
+
+    @Nested
+    inner class FindByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull {
+
+        @Test
+        fun `skal ikke finne brev når brevId er satt`() {
+            val frittståendeBrev = lagFrittståendeBrev()
+            val brev = repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = fagsak.id,
+                    mottaker = mottakerPerson(ident = fagsak.hentAktivIdent()),
+                    brevId = frittståendeBrev.id,
+                ),
+            )
+            val brevmottakere =
+                repository.findByFagsakIdAndSporbarOpprettetAvAndBrevIdIsNull(fagsak.id, brev.sporbar.opprettetAv)
+            assertThat(brevmottakere).isEmpty()
+        }
+    }
+
+    private fun lagFrittståendeBrev() = frittståendeBrevRepository.insert(
+        FrittståendeBrev(
+            fagsakId = fagsak.id,
+            pdf = Fil("123".toByteArray()),
+            tittel = "",
+            saksbehandlerIdent = "id",
+        ),
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerFrittståendeBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerFrittståendeBrevRepositoryTest.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.brev.brevmottaker
 
 import no.nav.tilleggsstonader.sak.IntegrationTest
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
 import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrev

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerVedtaksbrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakerVedtaksbrevRepositoryTest.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.sak.brev.brevmottaker
 
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
 import no.nav.tilleggsstonader.sak.util.behandling

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereFrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereFrittståendeBrevServiceTest.kt
@@ -1,0 +1,172 @@
+package no.nav.tilleggsstonader.sak.brev.brevmottaker
+
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.BrevmottakerPersonDto
+import no.nav.tilleggsstonader.kontrakter.brevmottaker.MottakerRolle
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Fil
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+
+class BrevmottakereFrittståendeBrevServiceTest : IntegrationTest() {
+
+    @Autowired
+    lateinit var service: BrevmottakereFrittståendeBrevService
+
+    @Autowired
+    lateinit var repository: BrevmottakerFrittståendeBrevRepository
+
+    @Autowired
+    lateinit var frittståendeBrevRepository: FrittståendeBrevRepository
+
+    val fagsak = fagsak()
+
+    @BeforeEach
+    fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+        BrukerContextUtil.mockBrukerContext("saksbehandler1")
+    }
+
+    @AfterEach
+    override fun tearDown() {
+        super.tearDown()
+        BrukerContextUtil.clearBrukerContext()
+    }
+
+    @Nested
+    inner class LagreBrevmottakere {
+
+        @Test
+        fun `skal fjerne tidligere brevmottakere og opprette nytt hvis id er ukjent`() {
+            service.hentEllerOpprettBrevmottakere(fagsak.id)
+            val nyBrevmottaker = BrevmottakerPersonDto(UUID.randomUUID(), "annenIdent", "navn", MottakerRolle.VERGE)
+
+            service.lagreBrevmottakere(
+                fagsak.id,
+                BrevmottakereDto(personer = listOf(nyBrevmottaker), organisasjoner = emptyList()),
+            )
+
+            assertThat(repository.findAll().map { it.id }).containsExactly(nyBrevmottaker.id)
+        }
+
+        @Test
+        fun `skal ikke fjerne brevmottakere på allerede sendte brev`() {
+            val frittståendeBrev = opprettFrittståendeBrev()
+            val brevmottakerForSendtBrev = repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = fagsak.id,
+                    brevId = frittståendeBrev.id,
+                    mottaker = mottakerPerson("ident2"),
+                ),
+            )
+
+            service.hentEllerOpprettBrevmottakere(fagsak.id)
+            val nyBrevmottaker = BrevmottakerPersonDto(UUID.randomUUID(), "annenIdent", "navn", MottakerRolle.VERGE)
+
+            service.lagreBrevmottakere(
+                fagsak.id,
+                BrevmottakereDto(personer = listOf(nyBrevmottaker), organisasjoner = emptyList()),
+            )
+
+            assertThat(repository.findAll().map { it.id })
+                .containsExactlyInAnyOrder(nyBrevmottaker.id, brevmottakerForSendtBrev.id)
+        }
+
+        @Test
+        fun `oppdaterer brevmottakere hvis id er beholdt`() {
+            val brevmottakere = service.hentEllerOpprettBrevmottakere(fagsak.id).single()
+
+            val brevmottakereDto = BrevmottakereDto(
+                personer = listOf(brevmottakere.mottaker.tilPersonDto(brevmottakere.id).copy(navn = "nytt navn")),
+                organisasjoner = emptyList(),
+            )
+            service.lagreBrevmottakere(fagsak.id, brevmottakereDto)
+
+            val alleBrevmottakere = repository.findAll()
+            assertThat(alleBrevmottakere).hasSize(1)
+
+            val oppdatertBrevmottakere = alleBrevmottakere.single()
+            assertThat(oppdatertBrevmottakere.id).isEqualTo(brevmottakere.id)
+            assertThat(oppdatertBrevmottakere.mottaker.mottakerNavn).isEqualTo("nytt navn")
+        }
+    }
+
+    @Nested
+    inner class HentEllerOpprettBrevmottakere {
+        @Test
+        fun `skal opprette og returnere brevmottakere hvis det ikke finnes noen`() {
+            val brevmottakere = service.hentEllerOpprettBrevmottakere(fagsak.id)
+
+            assertThat(brevmottakere).hasSize(1)
+            assertThat(repository.findAll()).hasSize(1)
+        }
+
+        @Test
+        fun `oppretter ny brevmottakere dersom brev allerede er sendt`() {
+            val frittståendeBrev = opprettFrittståendeBrev()
+            val brevmottakerForSendtBrev = repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = fagsak.id,
+                    brevId = frittståendeBrev.id,
+                    mottaker = mottakerPerson("ident2"),
+                ),
+            )
+
+            val brevmottakere = service.hentEllerOpprettBrevmottakere(fagsak.id)
+
+            assertThat(brevmottakere.map { it.id }).doesNotContain(brevmottakerForSendtBrev.id)
+            assertThat(repository.findAll()).hasSize(2)
+        }
+
+        @Test
+        fun `skal ikke få opp brevmottakere til annen saksbehandler eller annen stønadstype`() {
+            val annenFagsak = testoppsettService.lagreFagsak(fagsak(stønadstype = Stønadstype.LÆREMIDLER))
+
+            repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = annenFagsak.id,
+                    mottaker = mottakerPerson("ident"),
+                ),
+            )
+
+            repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = annenFagsak.id,
+                    mottaker = mottakerPerson("ident"),
+                    sporbar = Sporbar(opprettetAv = "annenSaksbehandler"),
+                ),
+            )
+
+            val brevmottakerForSaksbehandler = repository.insert(
+                BrevmottakerFrittståendeBrev(
+                    fagsakId = fagsak.id,
+                    mottaker = mottakerPerson("ident"),
+                ),
+            )
+
+            assertThat(service.hentEllerOpprettBrevmottakere(fagsak.id).map { it.id })
+                .containsExactly(brevmottakerForSaksbehandler.id)
+        }
+    }
+
+    private fun opprettFrittståendeBrev() =
+        frittståendeBrevRepository.insert(
+            FrittståendeBrev(
+                fagsakId = fagsak.id,
+                pdf = Fil("".toByteArray()),
+                tittel = "tittel",
+            ),
+        )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/MottakerTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/MottakerTestUtil.kt
@@ -4,7 +4,7 @@ import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerType
 
-object MottakerUtil {
+object MottakerTestUtil {
 
     fun mottakerPerson(ident: String, mottakerRolle: MottakerRolle = MottakerRolle.BRUKER) = Mottaker(
         ident = ident,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevServiceTest.kt
@@ -2,7 +2,15 @@ package no.nav.tilleggsstonader.sak.brev.frittstående
 
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
+import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagerFrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretFrittståendeBrev
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
 import no.nav.tilleggsstonader.sak.util.fagsak
@@ -13,18 +21,28 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
 internal class FrittståendeBrevServiceTest : IntegrationTest() {
+
     @Autowired
     lateinit var frittståendeBrevService: FrittståendeBrevService
 
     @Autowired
+    lateinit var frittståendeBrevRepository: FrittståendeBrevRepository
+
+    @Autowired
+    lateinit var brevmottakerFrittståendeBrevRepository: BrevmottakerFrittståendeBrevRepository
+
+    @Autowired
+    lateinit var mellomlagerFrittståendeBrevRepository: MellomlagerFrittståendeBrevRepository
+
+    @Autowired
     lateinit var taskService: TaskService
 
-    private val fagsakTilknyttetPesonIdent123 = fagsak(setOf(PersonIdent("123")))
+    private val fagsak = fagsak(setOf(PersonIdent("123")))
 
     @BeforeEach
     fun setUp() {
         mockBrukerContext("456")
-        testoppsettService.lagreFagsak(fagsakTilknyttetPesonIdent123)
+        testoppsettService.lagreFagsak(fagsak)
     }
 
     @AfterEach
@@ -36,12 +54,72 @@ internal class FrittståendeBrevServiceTest : IntegrationTest() {
     @Test
     fun `skal opprette task for journalføring av frittstående brev`() {
         frittståendeBrevService.sendFrittståendeBrev(
-            fagsakId = fagsakTilknyttetPesonIdent123.id,
+            fagsakId = fagsak.id,
             request = FrittståendeBrevDto(pdf = "brev".toByteArray(), tittel = "Tittel"),
         )
 
         val task = taskService.findAll().single()
 
+        val brevmottakere = brevmottakerFrittståendeBrevRepository.findAll()
+        assertThat(brevmottakere).hasSize(1)
         assertThat(task.type).isEqualTo(JournalførFrittståendeBrevTask.TYPE)
+        assertThat(task.payload).contains(brevmottakere.single().id.toString())
     }
+
+    @Test
+    fun `skal opprette task for hver brevmottaker`() {
+        val mottaker1 =
+            brevmottakerFrittståendeBrevRepository.insert(brevmottakerFrittståendeBrev(mottakerPerson(ident = "ident1")))
+        val mottaker2 =
+            brevmottakerFrittståendeBrevRepository.insert(brevmottakerFrittståendeBrev(mottakerPerson(ident = "ident2")))
+
+        frittståendeBrevService.sendFrittståendeBrev(
+            fagsakId = fagsak.id,
+            request = FrittståendeBrevDto(pdf = "brev".toByteArray(), tittel = "Tittel"),
+        )
+
+        val tasks = taskService.findAll()
+
+        assertThat(tasks).hasSize(2)
+        assertThat(tasks.map { it.payload }.firstOrNull { it.contains(mottaker1.id.toString()) }).isNotNull
+        assertThat(tasks.map { it.payload }.firstOrNull { it.contains(mottaker2.id.toString()) }).isNotNull
+    }
+
+    @Test
+    fun `skal oppdatere brevmottaker med brevId når man sender frittstående brev sånn at brevmottakeren senere ikke lengre vises for saksbehandler for nytt brev`() {
+        val mottaker1 =
+            brevmottakerFrittståendeBrevRepository.insert(brevmottakerFrittståendeBrev(mottakerPerson(ident = "ident1")))
+
+        frittståendeBrevService.sendFrittståendeBrev(
+            fagsakId = fagsak.id,
+            request = FrittståendeBrevDto(pdf = "brev".toByteArray(), tittel = "Tittel"),
+        )
+        val frittståendeBrev = frittståendeBrevRepository.findAll().single()
+        val oppdatertBrevmottaker = brevmottakerFrittståendeBrevRepository.findByIdOrThrow(mottaker1.id)
+        assertThat(oppdatertBrevmottaker.brevId).isEqualTo(frittståendeBrev.id)
+    }
+
+    @Test
+    fun `skal fjerne mellomlagret brev for saksbehandler og fagsak når man sender brev`() {
+        val mellomlagretBrev = MellomlagretFrittståendeBrev(fagsakId = fagsak.id, brevmal = "", brevverdier = "")
+        mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev)
+
+        val annetMellomlagretBrev = opprettMellomlagretBrevForAnnenSaksbehandler()
+
+        frittståendeBrevService.sendFrittståendeBrev(
+            fagsakId = fagsak.id,
+            request = FrittståendeBrevDto(pdf = "brev".toByteArray(), tittel = "Tittel"),
+        )
+
+        val mellomlagredeBrev = mellomlagerFrittståendeBrevRepository.findAll().map { it.id }
+        assertThat(mellomlagredeBrev).containsExactly(annetMellomlagretBrev.id)
+    }
+
+    private fun opprettMellomlagretBrevForAnnenSaksbehandler(): MellomlagretFrittståendeBrev {
+        val mellomlagretBrev = MellomlagretFrittståendeBrev(fagsakId = fagsak.id, brevmal = "", brevverdier = "", sporbar = Sporbar(opprettetAv = "annen"))
+        return mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev)
+    }
+
+    private fun brevmottakerFrittståendeBrev(mottaker: Mottaker) =
+        BrevmottakerFrittståendeBrev(fagsakId = fagsak.id, mottaker = mottaker)
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevServiceTest.kt
@@ -44,6 +44,6 @@ internal class FrittståendeBrevServiceTest : IntegrationTest() {
 
         val res = taskService.findAll().single()
 
-        Assertions.assertThat(res.type).isEqualTo(DistribuerFrittståendeBrevTask.TYPE)
+        Assertions.assertThat(res.type).isEqualTo(JournalførFrittståendeBrevTask.TYPE)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/FrittståendeBrevServiceTest.kt
@@ -1,16 +1,15 @@
 package no.nav.tilleggsstonader.sak.brev.frittstående
 
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.libs.log.mdc.MDCConstants
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.clearBrukerContext
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.mockBrukerContext
 import no.nav.tilleggsstonader.sak.util.fagsak
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Autowired
 
 internal class FrittståendeBrevServiceTest : IntegrationTest() {
@@ -25,25 +24,24 @@ internal class FrittståendeBrevServiceTest : IntegrationTest() {
     @BeforeEach
     fun setUp() {
         mockBrukerContext("456")
-        MDC.put(MDCConstants.MDC_CALL_ID, "")
         testoppsettService.lagreFagsak(fagsakTilknyttetPesonIdent123)
     }
 
     @AfterEach
     override fun tearDown() {
         super.tearDown()
-        MDC.remove(MDCConstants.MDC_CALL_ID)
+        clearBrukerContext()
     }
 
     @Test
-    fun `skal opprette task for distribuering etter journalføring`() {
+    fun `skal opprette task for journalføring av frittstående brev`() {
         frittståendeBrevService.sendFrittståendeBrev(
             fagsakId = fagsakTilknyttetPesonIdent123.id,
             request = FrittståendeBrevDto(pdf = "brev".toByteArray(), tittel = "Tittel"),
         )
 
-        val res = taskService.findAll().single()
+        val task = taskService.findAll().single()
 
-        Assertions.assertThat(res.type).isEqualTo(JournalførFrittståendeBrevTask.TYPE)
+        assertThat(task.type).isEqualTo(JournalførFrittståendeBrevTask.TYPE)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskIntegrationTest.kt
@@ -5,7 +5,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.prosessering.internal.TaskWorker
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.JournalpostClientConfig

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
@@ -7,7 +7,7 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTaskTest.kt
@@ -12,7 +12,7 @@ import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingTestUtil
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.Mottaker
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For å kunne sende til flere brevmottakere for ett frittstående brev har vi behov for å flytte arkiveringen til hver mottaker i en egen task, sånn at ev. feilsituasjoner håndteres og blir rekjørt.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22536

Dette er kode som er gjenbrukt fra vanlig arkivering og distribuering av vedtaksbrev. 


* Når man sender et frittstående brev så legges brevId inn på brevmottakeren
* Når man arkiverer/journalfører så legges journalpostId inn på brevmottakeren
* Når man distribueret journalposten legges bestillingId inn

Fra før så ser ikke saksbehandler mellomlagret brev til en annen fagsak eller annen saksbehandler.
Samme sak gjelder brevmottakere.

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/521

Intressante commits:
* [Skal journalføre for hver mottaker og sen distribuere for hver journalpost](https://github.com/navikt/tilleggsstonader-sak/pull/453/commits/89a260d49e487c38c06c9f29c7ec23ce19a954e4)
* [Skal oppdatere brevmottakere med bestillingId når man har distribuert brevet](https://github.com/navikt/tilleggsstonader-sak/pull/453/commits/ebb3202f2b196d6c4d19dc2ac2aa2c4ca9a536ae)

* [Lagt til domeneobjekt for FrittståendeBrev og brevmottakere for frittstående brev](https://github.com/navikt/tilleggsstonader-sak/pull/453/commits/c75d8ac9239809832ed8ebe6bac73c99499e76fb)
