### PR TITLE
Lagt til mapping av kontrakter fra Søknadskjema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240916095727_7fab7b4"
 val tilleggsstønaderLibsVersion = "2024.09.13-14.55.90172c4319d3"
-val tilleggsstønaderKontrakterVersion = "2024.10.07-12.53.371f07a7c9de"
+val tilleggsstønaderKontrakterVersion = "2024.10.08-11.22.27e271896570"
 val tokenSupportVersion = "5.0.5"
 val wiremockVersion = "3.9.1"
 val mockkVersion = "1.13.12"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettTestBehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettTestBehandlingController.kt
@@ -151,6 +151,13 @@ class OpprettTestBehandlingController(
                 arbeidOgOpphold = arbeidOgOpphold(),
             ),
             utdanning = UtdanningAvsnitt(
+                aktiviteter = EnumFlereValgFelt(
+                    "Hvilken utdanning eller opplæring søker du om støtte til læremidler for",
+                    listOf(
+                        VerdiFelt("1", "Høyere utdfanning: 25. februar 2024 - 25. juli 2024"),
+                    ),
+                    listOf("Arbeidstrening: 25. februar 2024 - 25. juli 2024"),
+                ),
                 annenUtdanning = EnumFelt(
                     "Annen utdanning tekst",
                     AnnenUtdanningType.INGEN_UTDANNING,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/domain/Søknad.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/domain/Søknad.kt
@@ -94,6 +94,7 @@ data class SkjemaLæremidler(
     val dokumentasjon: List<Dokumentasjon>,
 )
 data class UtdanningAvsnitt(
+    val aktiviteter: List<ValgtAktivitet>?,
     val annenUtdanning: AnnenUtdanningType?,
     val mottarUtstyrsstipend: JaNei?,
     val harFunksjonsnedsettelse: JaNei,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/SøknadskjemaLæremidlerMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/mapper/SøknadskjemaLæremidlerMapper.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.HovedytelseAvsnit
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SkjemaLæremidler
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SøknadLæremidler
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.UtdanningAvsnitt
+import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.ValgtAktivitet
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.mapper.ArbeidOgOppholdMapper.mapArbeidOgOpphold
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.mapper.DokumentasjonMapper.mapDokumentasjon
 import java.time.LocalDateTime
@@ -28,6 +29,7 @@ object SøknadskjemaLæremidlerMapper {
                 arbeidOgOpphold = mapArbeidOgOpphold(skjema.hovedytelse.arbeidOgOpphold),
             ),
             utdanning = UtdanningAvsnitt(
+                aktiviteter = skjema.utdanning.aktiviteter?.verdier?.map { ValgtAktivitet(id = it.verdi, label = it.label) },
                 annenUtdanning = skjema.utdanning.annenUtdanning?.verdi,
                 mottarUtstyrsstipend = skjema.utdanning.mottarUtstyrsstipend?.verdi,
                 harFunksjonsnedsettelse = skjema.utdanning.harFunksjonsnedsettelse.verdi,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadUtil.kt
@@ -86,6 +86,11 @@ object SøknadUtil {
             ),
             dokumentasjon = dokumentasjon,
             utdanning = UtdanningAvsnitt(
+                aktiviteter = EnumFlereValgFelt(
+                    "Hvilken utdanning eller opplæring søker du om støtte til læremidler for",
+                    listOf(VerdiFelt("ANNET", "Annet")),
+                    listOf("Arbeidstrening: 25. februar 2024 - 25. juli 2024"),
+                ),
                 annenUtdanning = EnumFelt("Annen utdanning tekst", AnnenUtdanningType.INGEN_UTDANNING, "Ja", emptyList()),
                 mottarUtstyrsstipend = EnumFelt("Har mottarUtstyrsstipend?", JaNei.JA, "Ja", emptyList()),
                 harFunksjonsnedsettelse = EnumFelt("Har funksjonsnedsettelse?", JaNei.JA, "Ja", emptyList()),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Henter ut info om aktiviteter som er valgte i søknaden

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22341

Avhengig av:
* https://github.com/navikt/tilleggsstonader-kontrakter/pull/89
* 
Koblet til
* https://github.com/navikt/tilleggsstonader-soknad-api/pull/144

❗ Burde legges til i fakta og vises i frontend når denne er klar
* https://github.com/navikt/tilleggsstonader-sak/pull/452