### PR TITLE
Ufordelt behandle sak oppgave manuell journalføring

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
@@ -37,7 +37,7 @@ class OpprettOppgaveForOpprettetBehandlingTask(
 
     data class OpprettOppgaveTaskData(
         val behandlingId: BehandlingId,
-        val saksbehandler: String,
+        val saksbehandler: String? = null,
         val beskrivelse: String? = null,
         val hendelseTidspunkt: LocalDateTime = osloNow(),
         val prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
@@ -88,7 +88,9 @@ class OpprettOppgaveForOpprettetBehandlingTask(
                 type = TYPE,
                 payload = objectMapper.writeValueAsString(data),
                 properties = Properties().apply {
-                    this["saksbehandler"] = data.saksbehandler
+                    if (data.saksbehandler != null) {
+                        this["saksbehandler"] = data.saksbehandler
+                    }
                     this["behandlingId"] = data.behandlingId.toString()
                 },
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
@@ -89,9 +89,9 @@ class OpprettOppgaveForOpprettetBehandlingTask(
                 payload = objectMapper.writeValueAsString(data),
                 properties = Properties().apply {
                     if (data.saksbehandler != null) {
-                        this["saksbehandler"] = data.saksbehandler
+                        setProperty("saksbehandler", data.saksbehandler)
                     }
-                    this["behandlingId"] = data.behandlingId.toString()
+                    setProperty("behandlingId", data.behandlingId.toString())
                 },
             )
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
@@ -129,7 +129,7 @@ class JournalføringService(
             OpprettOppgaveForOpprettetBehandlingTask.opprettTask(
                 OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData(
                     behandlingId = behandling.id,
-                    saksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker(),
+                    saksbehandler = null, // Behandle sak oppgaven skal være ufordelt
                     beskrivelse = oppgaveBeskrivelse,
                 ),
             ),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når man oppretter en behandling ved journalføring skal behandle sak oppgaven være ufordelt

Tidligere ble denne satt til sakebehandler som journalførte. Etter ønske fra de funksjonelle

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21968

