### PR TITLE
Åpner for å opprette ny Klage fra Journalføringssiden.

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/dto/JournalføringRequest.kt
@@ -59,9 +59,6 @@ data class JournalføringRequest(
 }
 
 fun JournalføringRequest.valider() {
-    brukerfeilHvis(gjelderKlage() && skalJournalføreTilNyBehandling()) {
-        "Opprettelse av ny behandling er ikke støttet for klage. Du kan kun journalføre uten ny behandling, for så å opprette ny klagebehandling fra personoversikten."
-    }
     dokumentTitler?.let {
         brukerfeilHvis(
             it.containsValue(""),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -84,6 +84,7 @@ class DefaultRestTemplateConfiguration {
     "mock-arbeidsfordeling",
     "mock-kafka",
     "mock-ytelse-client",
+    "mock-klage",
 )
 @EnableMockOAuth2Server
 abstract class IntegrationTest {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.infrastruktur.mocks
 
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.kontrakter.felles.Tema
@@ -25,162 +26,165 @@ import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpStatus
 import java.time.format.DateTimeFormatter
-import java.util.Optional
+import java.util.*
 import kotlin.jvm.optionals.getOrNull
 
 @Configuration
 @Profile("mock-oppgave")
 class OppgaveClientConfig {
 
-    var maxOppgaveId = 0L
-    final var journalPostId = 0L
-    val oppgavelager = mutableMapOf<Long, Oppgave>()
-
     @Bean
     @Primary
     fun oppgaveClient(): OppgaveClient {
         val oppgaveClient = mockk<OppgaveClient>()
-
-        opprettOppgave(journalføringsoppgaveRequest)
-
-        every { oppgaveClient.hentOppgaver(any()) } answers {
-            val request = firstArg<FinnOppgaveRequest>()
-            val oppgaver = oppgavelager.values
-                .filter { it.status == StatusEnum.OPPRETTET }
-                .filter { oppgave -> request.behandlingstema?.let { oppgave.behandlingstema == it.value } ?: true }
-                .filter { oppgave -> request.oppgavetype?.let { oppgave.oppgavetype == it.value } ?: true }
-                .filter { oppgave -> request.behandlingstype?.let { oppgave.behandlingstype == it.value } ?: true }
-                .filter { oppgave -> request.erUtenMappe?.takeIf { it }?.let { oppgave.mappeId == null } ?: true }
-                .filter { oppgave -> request.mappeId?.let { oppgave.mappeId?.getOrNull() == it } ?: true }
-                .filter { oppgave ->
-                    request.aktørId?.let { aktørId ->
-                        // [PdlClientConfig] legger til prefix "00" på aktørId lokalt
-                        oppgave.identer?.any { it.ident == aktørId || "00${it.ident}" == aktørId } ?: false
-                    } ?: true
-                }
-                .toList()
-            val toIndex = minOf((request.offset + request.limit).toInt(), oppgaver.size)
-            val paginerteOppgaver = oppgaver.subList(request.offset.toInt(), toIndex)
-            FinnOppgaveResponseDto(antallTreffTotalt = oppgaver.size.toLong(), oppgaver = paginerteOppgaver)
-        }
-
-        every { oppgaveClient.finnOppgaveMedId(any()) } answers {
-            val oppgaveId = firstArg<Long>()
-            oppgavelager[oppgaveId] ?: error("Finner ikke oppgave=$oppgaveId")
-        }
-
-        val mapper = listOf(
-            MappeDto(MAPPE_ID_PÅ_VENT, OppgaveMappe.PÅ_VENT.navn, "4462"),
-            MappeDto(MAPPE_ID_KLAR, OppgaveMappe.KLAR.navn, "4462"),
-        )
-        every { oppgaveClient.finnMapper(any(), any()) } returns FinnMappeResponseDto(mapper.size, mapper)
-
-        every { oppgaveClient.opprettOppgave(any()) } answers {
-            val oppgave = opprettOppgave(firstArg<OpprettOppgaveRequest>())
-            oppgave.id
-        }
-
-        every { oppgaveClient.ferdigstillOppgave(any()) } answers {
-            val oppgave = oppgavelager.getValue(firstArg())
-            if (oppgave.status == StatusEnum.FERDIGSTILT) {
-                error("Allerede ferdigstilt")
-            }
-            val oppdatertOppgave = oppgave.copy(
-                versjon = oppgave.versjon + 1,
-                status = StatusEnum.FERDIGSTILT,
-                ferdigstiltTidspunkt = osloNow().format(DateTimeFormatter.ISO_DATE_TIME),
-            )
-            oppgavelager[oppgave.id] = oppdatertOppgave
-        }
-
-        every { oppgaveClient.oppdaterOppgave(any()) } answers {
-            val oppdaterOppgave = firstArg<Oppgave>().let {
-                val eksisterendeOppgave = oppgavelager[it.id]!!
-                val versjon = it.versjon
-                feilHvis(versjon != eksisterendeOppgave.versjon, HttpStatus.CONFLICT) {
-                    "Oppgaven har endret seg siden du sist hentet oppgaver. versjon=$versjon (${eksisterendeOppgave.versjon}) " +
-                        "For å kunne gjøre endringer må du hente oppgaver på nytt."
-                }
-                eksisterendeOppgave.copy(
-                    versjon = versjon + 1,
-                    beskrivelse = it.beskrivelse ?: eksisterendeOppgave.beskrivelse,
-                    tilordnetRessurs = (
-                        it.tilordnetRessurs
-                            ?: eksisterendeOppgave.tilordnetRessurs
-                        )?.takeIf { it.isNotBlank() },
-                    mappeId = it.mappeId ?: eksisterendeOppgave.mappeId,
-                    fristFerdigstillelse = it.fristFerdigstillelse ?: eksisterendeOppgave.fristFerdigstillelse,
-                )
-            }
-
-            oppgavelager[oppdaterOppgave.id] = oppdaterOppgave // Forenklet, dette er ikke det som skje ri integrasjoner
-            OppdatertOppgaveResponse(oppdaterOppgave.id, oppdaterOppgave.versjonEllerFeil())
-        }
-
-        mockFordeling(oppgaveClient, oppgavelager)
+        OppgaveClientConfig.resetMock(oppgaveClient)
         return oppgaveClient
     }
-
-    private fun opprettOppgave(
-        oppgaveDto: OpprettOppgaveRequest,
-    ): Oppgave {
-        val oppgave = Oppgave(
-            id = ++maxOppgaveId,
-            versjon = 1,
-            status = StatusEnum.OPPRETTET,
-            identer = oppgaveDto.ident!!.let { listOf(OppgaveIdentV2(it.ident!!, it.gruppe!!)) },
-            tildeltEnhetsnr = oppgaveDto.enhetsnummer,
-            saksreferanse = null,
-            journalpostId = oppgaveDto.journalpostId,
-            tema = oppgaveDto.tema,
-            oppgavetype = oppgaveDto.oppgavetype.value,
-            behandlingstema = oppgaveDto.behandlingstema,
-            tilordnetRessurs = oppgaveDto.tilordnetRessurs,
-            fristFerdigstillelse = oppgaveDto.fristFerdigstillelse,
-            aktivDato = oppgaveDto.aktivFra,
-            beskrivelse = oppgaveDto.beskrivelse,
-            prioritet = oppgaveDto.prioritet,
-            behandlingstype = oppgaveDto.behandlingstype,
-            behandlesAvApplikasjon = oppgaveDto.behandlesAvApplikasjon,
-            mappeId = oppgaveDto.mappeId?.let { Optional.of(it) },
-            opprettetTidspunkt = osloNow().format(DateTimeFormatter.ISO_DATE_TIME),
-        )
-        oppgavelager[oppgave.id] = oppgave
-        return oppgave
-    }
-
-    private fun mockFordeling(
-        oppgaveClient: OppgaveClient,
-        oppgaver: MutableMap<Long, Oppgave>,
-    ) {
-        every { oppgaveClient.fordelOppgave(any(), any(), any()) } answers {
-            val oppgaveId = firstArg<Long>()
-            val oppgave = oppgaver.getValue(oppgaveId)
-            val versjon = oppgave.versjon!!
-            feilHvis(versjon != thirdArg(), HttpStatus.CONFLICT) {
-                "Oppgaven har endret seg siden du sist hentet oppgaver. " +
-                    "For å kunne gjøre endringer må du hente oppgaver på nytt."
-            }
-            val oppdatertOppgave = oppgave.copy(versjon = versjon + 1, tilordnetRessurs = secondArg())
-            oppgaver[oppgaveId] = oppdatertOppgave
-            oppdatertOppgave
-        }
-    }
-
-    private val journalføringsoppgaveRequest = OpprettOppgaveRequest(
-        tema = Tema.TSO,
-        oppgavetype = Oppgavetype.Journalføring,
-        fristFerdigstillelse = osloDateNow().plusDays(14),
-        beskrivelse = "Dummy søknad",
-        behandlingstema = "ab0300",
-        enhetsnummer = "",
-        ident = OppgaveIdentV2(ident = "12345678910", gruppe = IdentGruppe.FOLKEREGISTERIDENT),
-        journalpostId = (++journalPostId).toString(),
-        mappeId = MAPPE_ID_KLAR,
-    )
 
     companion object {
         const val MAPPE_ID_PÅ_VENT = 10L
         const val MAPPE_ID_KLAR = 20L
+
+        fun resetMock(oppgaveClient: OppgaveClient) {
+            clearMocks(oppgaveClient)
+
+            opprettOppgave(journalføringsoppgaveRequest)
+
+            every { oppgaveClient.hentOppgaver(any()) } answers {
+                val request = firstArg<FinnOppgaveRequest>()
+                val oppgaver = oppgavelager.values
+                    .filter { it.status == StatusEnum.OPPRETTET }
+                    .filter { oppgave -> request.behandlingstema?.let { oppgave.behandlingstema == it.value } ?: true }
+                    .filter { oppgave -> request.oppgavetype?.let { oppgave.oppgavetype == it.value } ?: true }
+                    .filter { oppgave -> request.behandlingstype?.let { oppgave.behandlingstype == it.value } ?: true }
+                    .filter { oppgave -> request.erUtenMappe?.takeIf { it }?.let { oppgave.mappeId == null } ?: true }
+                    .filter { oppgave -> request.mappeId?.let { oppgave.mappeId?.getOrNull() == it } ?: true }
+                    .filter { oppgave ->
+                        request.aktørId?.let { aktørId ->
+                            // [PdlClientConfig] legger til prefix "00" på aktørId lokalt
+                            oppgave.identer?.any { it.ident == aktørId || "00${it.ident}" == aktørId } ?: false
+                        } ?: true
+                    }
+                    .toList()
+                val toIndex = minOf((request.offset + request.limit).toInt(), oppgaver.size)
+                val paginerteOppgaver = oppgaver.subList(request.offset.toInt(), toIndex)
+                FinnOppgaveResponseDto(antallTreffTotalt = oppgaver.size.toLong(), oppgaver = paginerteOppgaver)
+            }
+
+            every { oppgaveClient.finnOppgaveMedId(any()) } answers {
+                val oppgaveId = firstArg<Long>()
+                oppgavelager[oppgaveId] ?: error("Finner ikke oppgave=$oppgaveId")
+            }
+
+            val mapper = listOf(
+                MappeDto(MAPPE_ID_PÅ_VENT, OppgaveMappe.PÅ_VENT.navn, "4462"),
+                MappeDto(MAPPE_ID_KLAR, OppgaveMappe.KLAR.navn, "4462"),
+            )
+            every { oppgaveClient.finnMapper(any(), any()) } returns FinnMappeResponseDto(mapper.size, mapper)
+
+            every { oppgaveClient.opprettOppgave(any()) } answers {
+                val oppgave = opprettOppgave(firstArg<OpprettOppgaveRequest>())
+                oppgave.id
+            }
+
+            every { oppgaveClient.ferdigstillOppgave(any()) } answers {
+                val oppgave = oppgavelager.getValue(firstArg())
+                if (oppgave.status == StatusEnum.FERDIGSTILT) {
+                    error("Allerede ferdigstilt")
+                }
+                val oppdatertOppgave = oppgave.copy(
+                    versjon = oppgave.versjon + 1,
+                    status = StatusEnum.FERDIGSTILT,
+                    ferdigstiltTidspunkt = osloNow().format(DateTimeFormatter.ISO_DATE_TIME),
+                )
+                oppgavelager[oppgave.id] = oppdatertOppgave
+            }
+
+            every { oppgaveClient.oppdaterOppgave(any()) } answers {
+                val oppdaterOppgave = firstArg<Oppgave>().let {
+                    val eksisterendeOppgave = oppgavelager[it.id]!!
+                    val versjon = it.versjon
+                    feilHvis(versjon != eksisterendeOppgave.versjon, HttpStatus.CONFLICT) {
+                        "Oppgaven har endret seg siden du sist hentet oppgaver. versjon=$versjon (${eksisterendeOppgave.versjon}) " +
+                            "For å kunne gjøre endringer må du hente oppgaver på nytt."
+                    }
+                    eksisterendeOppgave.copy(
+                        versjon = versjon + 1,
+                        beskrivelse = it.beskrivelse ?: eksisterendeOppgave.beskrivelse,
+                        tilordnetRessurs = (
+                            it.tilordnetRessurs
+                                ?: eksisterendeOppgave.tilordnetRessurs
+                            )?.takeIf { it.isNotBlank() },
+                        mappeId = it.mappeId ?: eksisterendeOppgave.mappeId,
+                        fristFerdigstillelse = it.fristFerdigstillelse ?: eksisterendeOppgave.fristFerdigstillelse,
+                    )
+                }
+                oppgavelager[oppdaterOppgave.id] = oppdaterOppgave // Forenklet, dette er ikke det som skje ri integrasjoner
+                OppdatertOppgaveResponse(oppdaterOppgave.id, oppdaterOppgave.versjonEllerFeil())
+            }
+            mockFordeling(oppgaveClient, oppgavelager)
+        }
+
+        private fun mockFordeling(
+            oppgaveClient: OppgaveClient,
+            oppgaver: MutableMap<Long, Oppgave>,
+        ) {
+            every { oppgaveClient.fordelOppgave(any(), any(), any()) } answers {
+                val oppgaveId = firstArg<Long>()
+                val oppgave = oppgaver.getValue(oppgaveId)
+                val versjon = oppgave.versjon!!
+                feilHvis(versjon != thirdArg(), HttpStatus.CONFLICT) {
+                    "Oppgaven har endret seg siden du sist hentet oppgaver. " +
+                        "For å kunne gjøre endringer må du hente oppgaver på nytt."
+                }
+                val oppdatertOppgave = oppgave.copy(versjon = versjon + 1, tilordnetRessurs = secondArg())
+                oppgaver[oppgaveId] = oppdatertOppgave
+                oppdatertOppgave
+            }
+        }
+
+        var maxOppgaveId = 0L
+        final var journalPostId = 0L
+        val oppgavelager = mutableMapOf<Long, Oppgave>()
+
+        private val journalføringsoppgaveRequest = OpprettOppgaveRequest(
+            tema = Tema.TSO,
+            oppgavetype = Oppgavetype.Journalføring,
+            fristFerdigstillelse = osloDateNow().plusDays(14),
+            beskrivelse = "Dummy søknad",
+            behandlingstema = "ab0300",
+            enhetsnummer = "",
+            ident = OppgaveIdentV2(ident = "12345678910", gruppe = IdentGruppe.FOLKEREGISTERIDENT),
+            journalpostId = (++journalPostId).toString(),
+            mappeId = MAPPE_ID_KLAR,
+        )
+
+        private fun opprettOppgave(
+            oppgaveDto: OpprettOppgaveRequest,
+        ): Oppgave {
+            val oppgave = Oppgave(
+                id = ++maxOppgaveId,
+                versjon = 1,
+                status = StatusEnum.OPPRETTET,
+                identer = oppgaveDto.ident!!.let { listOf(OppgaveIdentV2(it.ident!!, it.gruppe!!)) },
+                tildeltEnhetsnr = oppgaveDto.enhetsnummer,
+                saksreferanse = null,
+                journalpostId = oppgaveDto.journalpostId,
+                tema = oppgaveDto.tema,
+                oppgavetype = oppgaveDto.oppgavetype.value,
+                behandlingstema = oppgaveDto.behandlingstema,
+                tilordnetRessurs = oppgaveDto.tilordnetRessurs,
+                fristFerdigstillelse = oppgaveDto.fristFerdigstillelse,
+                aktivDato = oppgaveDto.aktivFra,
+                beskrivelse = oppgaveDto.beskrivelse,
+                prioritet = oppgaveDto.prioritet,
+                behandlingstype = oppgaveDto.behandlingstype,
+                behandlesAvApplikasjon = oppgaveDto.behandlesAvApplikasjon,
+                mappeId = oppgaveDto.mappeId?.let { Optional.of(it) },
+                opprettetTidspunkt = osloNow().format(DateTimeFormatter.ISO_DATE_TIME),
+            )
+            oppgavelager[oppgave.id] = oppgave
+            return oppgave
+        }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringServiceTest.kt
@@ -35,6 +35,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.journalføring.dto.JournalføringRequest
 import no.nav.tilleggsstonader.sak.journalføring.dto.JournalføringRequest.Journalføringsaksjon
+import no.nav.tilleggsstonader.sak.klage.KlageService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdent
@@ -62,6 +63,7 @@ class JournalføringServiceTest {
     val personService = mockk<PersonService>()
     val oppgaveService = mockk<OppgaveService>()
     val gjennbrukDataRevurderingService = mockk<GjennbrukDataRevurderingService>(relaxed = true)
+    val klageService = mockk<KlageService>()
 
     val journalføringService = JournalføringService(
         behandlingService,
@@ -74,6 +76,7 @@ class JournalføringServiceTest {
         personService,
         oppgaveService,
         gjennbrukDataRevurderingService,
+        klageService,
     )
 
     val enhet = ArbeidsfordelingTestUtil.ENHET_NASJONAL_NAY.enhetNr

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostControllerTest.kt
@@ -4,18 +4,25 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.verify
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.BulkOppdaterLogiskVedleggRequest
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.journalpost.LogiskVedlegg
+import no.nav.tilleggsstonader.kontrakter.klage.OpprettKlagebehandlingRequest
+import no.nav.tilleggsstonader.libs.utils.osloDateNow
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.infrastruktur.mocks.JournalpostClientConfig
+import no.nav.tilleggsstonader.sak.infrastruktur.mocks.OppgaveClientConfig
 import no.nav.tilleggsstonader.sak.journalføring.dto.JournalføringRequest
+import no.nav.tilleggsstonader.sak.klage.KlageClient
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveClient
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,10 +50,21 @@ class JournalpostControllerTest : IntegrationTest() {
     @Autowired
     lateinit var oppgaveClient: OppgaveClient
 
+    @Autowired
+    lateinit var klageClient: KlageClient
+
     @BeforeEach
     fun setUp() {
         headers.setBearerAuth(onBehalfOfToken(saksbehandler = saksbehandler))
         testoppsettService.opprettPerson(ident)
+    }
+
+    @AfterEach
+    override fun tearDown() {
+        super.tearDown()
+
+        JournalpostClientConfig.resetMock(journalpostClient)
+        OppgaveClientConfig.resetMock(oppgaveClient)
     }
 
     @Test
@@ -85,6 +103,51 @@ class JournalpostControllerTest : IntegrationTest() {
                 bahandlesakOppgaveTask.payload,
             )
         assertThat(behandlesakOppgavePayload.behandlingId).isEqualTo(opprettetBehandling.id)
+
+        verify(exactly = 1) { journalpostClient.ferdigstillJournalpost("1", enhet, saksbehandler) }
+        verify(exactly = 1) {
+            journalpostClient.oppdaterLogiskeVedlegg(
+                "1",
+                BulkOppdaterLogiskVedleggRequest(listOf("ny tittel")),
+            )
+        }
+        verify(exactly = 1) { oppgaveClient.ferdigstillOppgave("123".toLong()) }
+    }
+
+    @Test
+    fun `fullfør journalpost - skal ferdigstille journalpost, og opprette klage`() {
+        val journalpostId = fullførJournalpost(
+            "1",
+            JournalføringRequest(
+                stønadstype = Stønadstype.BARNETILSYN,
+                aksjon = JournalføringRequest.Journalføringsaksjon.OPPRETT_BEHANDLING,
+                årsak = JournalføringRequest.Journalføringsårsak.KLAGE,
+                oppgaveId = "123",
+                journalførendeEnhet = enhet,
+                logiskeVedlegg = mapOf("1" to listOf(LogiskVedlegg("1", "ny tittel"))),
+            ),
+        )
+
+        assertThat(journalpostId).isEqualTo("1")
+
+        val fagsak = fagsakService.finnFagsak(setOf(ident), Stønadstype.BARNETILSYN)
+        assertThat(fagsak).isNotNull
+
+        val behandlinger = behandlingService.hentBehandlinger(fagsak!!.id)
+        assertThat(behandlinger).hasSize(0)
+
+        verify(exactly = 1) {
+            klageClient.opprettKlage(
+                OpprettKlagebehandlingRequest(
+                    ident = "12345678910",
+                    stønadstype = Stønadstype.BARNETILSYN,
+                    eksternFagsakId = fagsak.eksternId.id.toString(),
+                    fagsystem = Fagsystem.TILLEGGSSTONADER,
+                    klageMottatt = osloDateNow().minusDays(7),
+                    behandlendeEnhet = "4462",
+                ),
+            )
+        }
 
         verify(exactly = 1) { journalpostClient.ferdigstillJournalpost("1", enhet, saksbehandler) }
         verify(exactly = 1) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Åpner for å opprette ny Klage fra Journalføringssiden

Hvordan teste lokalt:

- Start nye instanser av SAK og KLAGEs databaser
- Kjør opp SAK med "mock-klage" utkommentert fra SakAppLocal.kt
- Kjør opp KLAGE

****
Åpne Dummy Journalføringsoppgaven:

![bilde 1](https://github.com/user-attachments/assets/7f54b0a1-59fc-42fd-a14c-e7d60c288324)
*****
- Velg "Type" = KLAGE
- Klikk på "Opprett ny behandling": KLAGE

![2](https://github.com/user-attachments/assets/55e0962a-1294-4635-badc-e4defc9e089c)
******

Klikk på "Journalføring" og observer at det har blitt opprettet en ny KLAGE-behandling på bruker med ident "12345678910"
