### PR TITLE
Legger til kildeId på inngangsvilkår for å kunne koble en aktivitet s…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -297,6 +297,9 @@ class VilkårperiodeService(
         validerBehandling(behandling)
 
         validerAktivitetsdager(vilkårPeriodeType = vilkårperiode.type, aktivitetsdager = vilkårperiode.aktivitetsdager)
+        feilHvis(eksisterendeVilkårperiode.kildeId != vilkårperiode.kildeId) {
+            "Kan ikke oppdatere kildeId på en allerede eksisterende vilkårperiode"
+        }
 
         val resultatEvaluering = evaulerVilkårperiode(eksisterendeVilkårperiode.type, vilkårperiode.delvilkår)
         val nyStatus = if (eksisterendeVilkårperiode.status == Vilkårstatus.NY) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -42,6 +42,9 @@ data class Vilkårperiode(
 
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
+
+    val kildeId: String? = null,
+
 ) : Periode<LocalDate> {
     init {
         validatePeriode()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -40,6 +40,7 @@ data class VilkårperiodeDto(
     val aktivitetsdager: Int? = null,
     val forrigeVilkårperiodeId: UUID?,
     val status: Vilkårstatus?,
+    val kildeId: String?,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
@@ -61,6 +62,7 @@ fun Vilkårperiode.tilDto() =
         sistEndret = this.sporbar.endret.endretTid,
         forrigeVilkårperiodeId = this.forrigeVilkårperiodeId,
         status = this.status,
+        kildeId = this.kildeId,
     )
 
 fun DelvilkårVilkårperiode.tilDto() = when (this) {
@@ -112,6 +114,7 @@ data class LagreVilkårperiode(
     val aktivitetsdager: Int? = null,
     val delvilkår: DelvilkårVilkårperiodeDto,
     val begrunnelse: String? = null,
+    val kildeId: String? = null,
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)

--- a/src/main/resources/db/migration/V53__vilkårperiode_kilde_id.sql
+++ b/src/main/resources/db/migration/V53__vilkårperiode_kilde_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vilkar_periode
+    ADD COLUMN kilde_id VARCHAR;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -135,6 +135,7 @@ object VilkårperiodeTestUtil {
         begrunnelse: String? = null,
         behandlingId: BehandlingId = BehandlingId.random(),
         aktivitetsdager: Int? = 5,
+        kildeId: String? = null,
     ) = LagreVilkårperiode(
         type = type,
         fom = fom,
@@ -143,5 +144,6 @@ object VilkårperiodeTestUtil {
         begrunnelse = begrunnelse,
         behandlingId = behandlingId,
         aktivitetsdager = aktivitetsdager,
+        kildeId = kildeId,
     )
 }


### PR DESCRIPTION
…om er lagt inn til grunnlaget

 - Muliggjør å kunne vise endringer og hente endringer for gitt aktivitet i inngangsvilkår
 - Det gir ikke mening å gjøre dette for ytelser då ytelser ikke har et unikt id, men er bare en periode av X ytelsestype

### Hvorfor er denne endringen nødvendig? ✨

For å senere kunne legge til "sporing" på inngangsvilkår

* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/544