### PR TITLE
Legg til støtte for å foreslå stønadsperiode for vilkårsperioder av samme type som kommer like etter hverandre.

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/ForeslåStønadsperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/ForeslåStønadsperiode.kt
@@ -34,7 +34,7 @@ object ForeslåStønadsperiode {
         brukerfeilHvis(
             sammenslåtteVilkårsperioder.aktiviteter.size > 1 || sammenslåtteVilkårsperioder.målgrupper.size > 1,
         ) {
-            "Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe"
+            "Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp."
         }
 
         val stønadsperiode = finnOverlapp(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/ForeslåStønadsperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/ForeslåStønadsperiode.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDt
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import java.time.LocalDate
 
@@ -25,23 +26,28 @@ object ForeslåStønadsperiode {
             "Det finnes ingen kombinasjon av aktiviteter og målgrupper som kan brukes til å lage perioder med overlapp"
         }
 
+        val sammenslåtteVilkårsperioder = Vilkårperioder(
+            aktiviteter = slåSammenVilkårsperioderSomErLikeEtterHverandre(filtrerteVilkårperioder.aktiviteter),
+            målgrupper = slåSammenVilkårsperioderSomErLikeEtterHverandre(filtrerteVilkårperioder.målgrupper),
+        )
+
         brukerfeilHvis(
-            filtrerteVilkårperioder.aktiviteter.size > 1 || filtrerteVilkårperioder.målgrupper.size > 1,
+            sammenslåtteVilkårsperioder.aktiviteter.size > 1 || sammenslåtteVilkårsperioder.målgrupper.size > 1,
         ) {
             "Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe"
         }
 
         val stønadsperiode = finnOverlapp(
-            filtrerteVilkårperioder.aktiviteter.first(),
-            filtrerteVilkårperioder.målgrupper.first(),
+            sammenslåtteVilkårsperioder.aktiviteter.first(),
+            sammenslåtteVilkårsperioder.målgrupper.first(),
         ).kuttTilMaksTreMånederTilbakeFraSøknadsdato(søknadsdato)
 
         return listOf(
             StønadsperiodeDto(
                 fom = stønadsperiode.fom,
                 tom = stønadsperiode.tom,
-                målgruppe = filtrerteVilkårperioder.målgrupper.first().type as MålgruppeType,
-                aktivitet = filtrerteVilkårperioder.aktiviteter.first().type as AktivitetType,
+                målgruppe = sammenslåtteVilkårsperioder.målgrupper.first().type as MålgruppeType,
+                aktivitet = sammenslåtteVilkårsperioder.aktiviteter.first().type as AktivitetType,
                 status = null,
             ),
         )
@@ -85,6 +91,26 @@ object ForeslåStønadsperiode {
             )
         } else {
             brukerfeil("Fant ingen gyldig overlapp mellom gitte aktiviteter og målgrupper")
+        }
+    }
+
+    private fun slåSammenVilkårsperioderSomErLikeEtterHverandre(vilkårperioder: List<Vilkårperiode>): List<Vilkårperiode> {
+        val sorterteVilkårsperioder = vilkårperioder.sortedBy { it.fom }
+        return sorterteVilkårsperioder.fold(mutableListOf<Vilkårperiode>()) { sammenslåtteVilkårperioder, vilkårperiode ->
+            sammenslåtteVilkårperioder.apply {
+                if (isEmpty()) {
+                    add(vilkårperiode)
+                } else {
+                    val sisteVilkårsperiode = last()
+                    if (sisteVilkårsperiode.type == vilkårperiode.type &&
+                        (sisteVilkårsperiode.tom == vilkårperiode.fom || sisteVilkårsperiode.tom.plusDays(1) == vilkårperiode.fom)
+                    ) {
+                        this[size - 1] = sisteVilkårsperiode.copy(tom = vilkårperiode.tom)
+                    } else {
+                        add(vilkårperiode)
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/ForeslåStønadsperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/ForeslåStønadsperiode.kt
@@ -103,7 +103,7 @@ object ForeslåStønadsperiode {
                 } else {
                     val sisteVilkårsperiode = last()
                     if (sisteVilkårsperiode.type == vilkårperiode.type &&
-                        (sisteVilkårsperiode.tom == vilkårperiode.fom || sisteVilkårsperiode.tom.plusDays(1) == vilkårperiode.fom)
+                        sisteVilkårsperiode.etterfølgesAv(vilkårperiode)
                     ) {
                         this[size - 1] = sisteVilkårsperiode.copy(tom = vilkårperiode.tom)
                     } else {
@@ -113,6 +113,10 @@ object ForeslåStønadsperiode {
             }
         }
     }
+
+    private fun Vilkårperiode.etterfølgesAv(
+        vilkårperiode: Vilkårperiode,
+    ) = (tom == vilkårperiode.fom || tom.plusDays(1) == vilkårperiode.fom)
 
     private data class Stønadsperiode(val fom: LocalDate, val tom: LocalDate) {
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
@@ -125,7 +125,7 @@ Egenskap: Beregning av stønadsperioder
       Gitt følgende vilkårsperioder med aktiviteter
         | Fom        | Tom        | type   |
         | 01.01.2023 | 28.02.2023 | TILTAK |
-        | 01.03.2023 | 31.03.2023 | TILTAK |
+        | 03.03.2023 | 31.03.2023 | TILTAK |
 
       Gitt følgende vilkårsperioder med målgrupper
         | Fom        | Tom        | type |
@@ -201,3 +201,116 @@ Egenskap: Beregning av stønadsperioder
       Når forslag til stønadsperioder lages
 
       Så forvent følgende beregningsfeil: Aktivitet og målgruppe ligger lengre enn tre månder tilbake i tid fra søknadsdato
+
+  Regel: Stønadsperioden skal foreslås for flere like aktiviteter eller målgrupper som er rett etter hverandre
+    Scenario: To like aktiviter som er rett etter hverandre og en målgruppe
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.02.2023 | TILTAK |
+        | 01.02.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.03.2023 | AAP  |
+
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende stønadsperioder
+        | Fom        | Tom        | aktivitet | målgruppe |
+        | 01.01.2023 | 01.03.2023 | TILTAK    | AAP       |
+
+
+    Scenario: En aktivit og to like målgrupper som er rett etter hverandre
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 02.02.2023 | 01.03.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende stønadsperioder
+        | Fom        | Tom        | aktivitet | målgruppe |
+        | 01.01.2023 | 01.03.2023 | TILTAK    | AAP       |
+
+    Scenario: To aktiviteter og to like målgrupper som er rett etter hverandre
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.02.2023 | TILTAK |
+        | 01.02.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 02.02.2023 | 01.03.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende stønadsperioder
+        | Fom        | Tom        | aktivitet | målgruppe |
+        | 01.01.2023 | 01.03.2023 | TILTAK    | AAP       |
+
+    Scenario: Tre aktiviteter og to like målgrupper som er rett etter hverandre
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.02.2023 | TILTAK |
+        | 01.02.2023 | 01.03.2023 | TILTAK |
+        | 02.03.2023 | 01.04.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 02.02.2023 | 01.04.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende stønadsperioder
+        | Fom        | Tom        | aktivitet | målgruppe |
+        | 01.01.2023 | 01.04.2023 | TILTAK    | AAP       |
+
+    Scenario: En aktivitet og to like målgrupper som ikke er rett etter hverandre
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 03.02.2023 | 01.04.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe
+
+    Scenario: En aktivitet og tre like målgrupper hvor to er like etter hverandre, men den siste er med opphold
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 03.02.2023 | 01.04.2023 | AAP  |
+        | 03.04.2023 | 01.05.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe
+
+    Scenario: En aktivitet og to like målgrupper som overlapper
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 15.01.2023 | 01.04.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
@@ -121,20 +121,6 @@ Egenskap: Beregning av stønadsperioder
         | Fom        | Tom        | aktivitet | målgruppe |
         | 01.01.2023 | 31.03.2023 | TILTAK    | AAP       |
 
-    Scenario: Flere gyldige sammenhengende aktiviter skal (foreløpig) gi feilmelding
-      Gitt følgende vilkårsperioder med aktiviteter
-        | Fom        | Tom        | type   |
-        | 01.01.2023 | 28.02.2023 | TILTAK |
-        | 03.03.2023 | 31.03.2023 | TILTAK |
-
-      Gitt følgende vilkårsperioder med målgrupper
-        | Fom        | Tom        | type |
-        | 01.01.2023 | 31.03.2023 | AAP  |
-
-      Når forslag til stønadsperioder lages
-
-      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp.
-
     Scenario: Én aktiviteter og flere målgrupper, men kun én gyldig kombinasjon
       Gitt følgende vilkårsperioder med aktiviteter
         | Fom        | Tom        | type   |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
@@ -231,8 +231,8 @@ Egenskap: Beregning av stønadsperioder
 
       Gitt følgende vilkårsperioder med målgrupper
         | Fom        | Tom        | type |
-        | 01.01.2023 | 01.02.2023 | AAP  |
         | 02.02.2023 | 01.03.2023 | AAP  |
+        | 01.01.2023 | 01.02.2023 | AAP  |
 
       Når forslag til stønadsperioder lages
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
@@ -133,7 +133,7 @@ Egenskap: Beregning av stønadsperioder
 
       Når forslag til stønadsperioder lages
 
-      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp.
 
     Scenario: Én aktiviteter og flere målgrupper, men kun én gyldig kombinasjon
       Gitt følgende vilkårsperioder med aktiviteter
@@ -221,7 +221,7 @@ Egenskap: Beregning av stønadsperioder
         | 01.01.2023 | 01.03.2023 | TILTAK    | AAP       |
 
 
-    Scenario: En aktivit og to like målgrupper som er rett etter hverandre
+    Scenario: En aktivitet og to like målgrupper som er rett etter hverandre
       Gitt følgende vilkårsperioder med aktiviteter
         | Fom        | Tom        | type   |
         | 01.01.2023 | 01.03.2023 | TILTAK |
@@ -284,7 +284,7 @@ Egenskap: Beregning av stønadsperioder
 
       Når forslag til stønadsperioder lages
 
-      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp.
 
     Scenario: En aktivitet og tre like målgrupper hvor to er like etter hverandre, men den siste er med opphold
       Gitt følgende vilkårsperioder med aktiviteter
@@ -299,7 +299,7 @@ Egenskap: Beregning av stønadsperioder
 
       Når forslag til stønadsperioder lages
 
-      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp.
 
     Scenario: En aktivitet og to like målgrupper som overlapper
       Gitt følgende vilkårsperioder med aktiviteter
@@ -313,4 +313,4 @@ Egenskap: Beregning av stønadsperioder
 
       Når forslag til stønadsperioder lages
 
-      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun én gyldig kombinasjon av aktivitet og målgruppe
+      Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp.


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gjøre det enklere for saksbehandlere å finne stønadsperiode.

Antagelse: To vilkårperioder kan slås sammen hvis de er av samme type og periode1 er ferdig samme dag eller dagen før periode2 starter.

Disse casene er nye:
![Screenshot 2024-10-24 at 16 46 23](https://github.com/user-attachments/assets/77ecb62c-5a24-440a-9d76-0c18768fd7ed)
![Screenshot 2024-10-24 at 16 46 20](https://github.com/user-attachments/assets/7d04a6cf-a545-407a-a61c-64e018572999)

I frontend ligger denne funksjonaliteten skjult bak en feature toggle. 