### PR TITLE
Skal ikke gjenbruke vilkår som mangler periode eller er slettet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -280,7 +280,7 @@ class VilkårService(
         nyBehandlingsId: BehandlingId,
         barnIdMap: Map<TidligereBarnId, NyttBarnId>,
     ): List<Vilkår> =
-        tidligereVilkår.values.map { vilkår ->
+        tidligereVilkår.values.filter { it.skalKopieres() }.map { vilkår ->
             val barnIdINyBehandling = finnBarnId(vilkår.barnId, barnIdMap)
             vilkår.kopierTilBehandling(nyBehandlingsId, barnIdINyBehandling)
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -88,6 +88,13 @@ data class Vilkår(
         }
     }
 
+    fun skalKopieres(): Boolean {
+        if (status == VilkårStatus.SLETTET) return false
+        if (fom == null || tom == null) return false
+
+        return true
+    }
+
     fun kopierTilBehandling(nyBehandlingId: BehandlingId, barnIdINyBehandling: BarnId?): Vilkår {
         return copy(
             id = VilkårId.random(),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Siden perioder ble introdusert på pass av barn siden etter at systemet ble tatt i bruk så skaper det litt problemer hvis man revurderer en sak. Disse periodene kan ikke slettes av SB og man må hacke seg litt rundt for å få gjennomført en behandling. 

Forslag hvor man ikke gjenbruker vilkåret dersom det mangler periode eller er slettet i forrige behandling. 