### PR TITLE
Tar i bruk fellesmetode for å slå sammen perioder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20240916095727_7fab7b4"
 val tilleggsstønaderLibsVersion = "2024.10.23-11.17.9effeb9c75b5"
-val tilleggsstønaderKontrakterVersion = "2024.10.23-11.11.2c32dd0d96d6"
+val tilleggsstønaderKontrakterVersion = "2024.10.31-08.14.0aa82ccc218c"
 val tokenSupportVersion = "5.0.5"
 val wiremockVersion = "3.9.1"
 val mockkVersion = "1.13.12"

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/vilkår/stønadsperiode/foreslå_overlapsperiode.feature
@@ -258,6 +258,22 @@ Egenskap: Beregning av stønadsperioder
         | Fom        | Tom        | aktivitet | målgruppe |
         | 01.01.2023 | 01.04.2023 | TILTAK    | AAP       |
 
+    Scenario: En aktivitet og to like målgrupper som overlapper
+      Gitt følgende vilkårsperioder med aktiviteter
+        | Fom        | Tom        | type   |
+        | 01.01.2023 | 01.03.2023 | TILTAK |
+
+      Gitt følgende vilkårsperioder med målgrupper
+        | Fom        | Tom        | type |
+        | 01.01.2023 | 01.02.2023 | AAP  |
+        | 15.01.2023 | 01.04.2023 | AAP  |
+
+      Når forslag til stønadsperioder lages
+
+      Så forvent følgende stønadsperioder
+        | Fom        | Tom        | aktivitet | målgruppe |
+        | 01.01.2023 | 01.03.2023 | TILTAK    | AAP       |
+
     Scenario: En aktivitet og to like målgrupper som ikke er rett etter hverandre
       Gitt følgende vilkårsperioder med aktiviteter
         | Fom        | Tom        | type   |
@@ -287,15 +303,15 @@ Egenskap: Beregning av stønadsperioder
 
       Så forvent følgende beregningsfeil: Foreløpig håndterer vi kun tilfellet der målgruppe og aktivitet har ett sammenhengende overlapp.
 
-    Scenario: En aktivitet og to like målgrupper som overlapper
+    Scenario: En aktivitet og to ulike målgrupper som overlapper - skal ikke slå sammen perioder tvers ulike typer
       Gitt følgende vilkårsperioder med aktiviteter
         | Fom        | Tom        | type   |
-        | 01.01.2023 | 01.03.2023 | TILTAK |
+        | 01.01.2023 | 01.03.2023 | UTDANNING |
 
       Gitt følgende vilkårsperioder med målgrupper
         | Fom        | Tom        | type |
-        | 01.01.2023 | 01.02.2023 | AAP  |
-        | 15.01.2023 | 01.04.2023 | AAP  |
+        | 01.01.2023 | 31.01.2023 | AAP  |
+        | 01.02.2023 | 01.04.2023 | OVERGANGSSTØNAD  |
 
       Når forslag til stønadsperioder lages
 


### PR DESCRIPTION
Støtter nå også at de er overlappende i stedet for kun at v1.tom = v2.fom

### Hvorfor er denne endringen nødvendig? ✨
Fordelen med å bruke interfacet Periode er at vi får mulighet for å bruke en del fellesmetoder tvers disse objektene, eks slå sammen. Tidligere måtte også objektet utvide `Mergeable`, men la til støtte for å slå sammen de som ikke bruker den. 
* https://github.com/navikt/tilleggsstonader-kontrakter/commit/ef2a7bae652293c19aef012d0cc9835a8ca48c7c#diff-5189a0b5e09bd69855e8c823ee08761c01f26190aef5bc956152f1b9da6832f8R54

Lagt til test for å sjekke at ikke ulike typer slåes sammen
