### PR TITLE
Oppdater ordlyden i vilkåret om dokumentasjon av utgifter til pass 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelId.kt
@@ -10,7 +10,7 @@ enum class RegelId(val beskrivelse: String) {
 
     // PASSBARN
     ANNEN_FORELDER_MOTTAR_STØTTE("Mottar den andre forelderen støtte til pass av barnet?"),
-    UTGIFTER_DOKUMENTERT("Er utgiftene tilfredstillende dokumentert?"),
+    UTGIFTER_DOKUMENTERT("Har bruker dokumenterte utgifter til pass?"),
     HAR_FULLFØRT_FJERDEKLASSE("Er barnet ferdig med 4. skoleår?"),
     UNNTAK_ALDER("Har barnet behov for pass utover 4. skoleår, og er behovet tilfredsstillende dokumentert?"),
 }

--- a/src/test/resources/interntVedtak/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/internt_vedtak.json
@@ -108,7 +108,7 @@
     "delvilkår" : [ {
       "resultat" : "IKKE_TATT_STILLING_TIL",
       "vurderinger" : [ {
-        "regel" : "Er utgiftene tilfredstillende dokumentert?",
+        "regel" : "Har bruker dokumenterte utgifter til pass?",
         "svar" : "Ja",
         "begrunnelse" : null
       } ]
@@ -137,7 +137,7 @@
     "delvilkår" : [ {
       "resultat" : "IKKE_TATT_STILLING_TIL",
       "vurderinger" : [ {
-        "regel" : "Er utgiftene tilfredstillende dokumentert?",
+        "regel" : "Har bruker dokumenterte utgifter til pass?",
         "svar" : "Ja",
         "begrunnelse" : null
       } ]
@@ -166,7 +166,7 @@
     "delvilkår" : [ {
       "resultat" : "IKKE_TATT_STILLING_TIL",
       "vurderinger" : [ {
-        "regel" : "Er utgiftene tilfredstillende dokumentert?",
+        "regel" : "Har bruker dokumenterte utgifter til pass?",
         "svar" : "Ja",
         "begrunnelse" : null
       } ]


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vilkåret passer nå bedre med lovverket

Frontend:
![Screenshot 2024-10-31 at 10 47 09](https://github.com/user-attachments/assets/696dc0d7-101b-4148-bd6d-8fde02adb53f)
Pdf:
![Screenshot 2024-10-31 at 10 45 35](https://github.com/user-attachments/assets/dc99177b-8d77-4e9e-8811-864554cd9d86)

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22824
https://github.com/navikt/tilleggsstonader-sak-frontend/pull/561
