### PR TITLE
Slå sammen overlappende eller påfølgende perioder fra arena 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -44,7 +44,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtels
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse.Companion.slåSammenOverlappendeEllerPåfølgende
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.SlåSammenPeriodeGrunnlagYtelseUtil.slåSammenOverlappendeEllerPåfølgende
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagDomain
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagRepository

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -44,6 +44,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtels
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse.Companion.slåSammenOverlappendeEllerPåfølgende
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagDomain
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagRepository
@@ -57,6 +58,7 @@ import java.time.LocalDateTime
 import java.time.YearMonth
 import java.time.temporal.ChronoUnit
 import java.util.UUID
+import kotlin.collections.sortedWith
 
 @Service
 class VilkårperiodeService(
@@ -207,7 +209,8 @@ class VilkårperiodeService(
                         tom = it.tom,
                         ensligForsørgerStønadstype = it.ensligForsørgerStønadstype?.tilDomenetype(),
                     )
-                },
+                }
+                .slåSammenOverlappendeEllerPåfølgende(),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/SlåSammenPeriodeGrunnlagYtelseUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/SlåSammenPeriodeGrunnlagYtelseUtil.kt
@@ -1,0 +1,46 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
+
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
+import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
+import java.time.LocalDate
+import kotlin.collections.plus
+import kotlin.collections.sortedBy
+
+object SlåSammenPeriodeGrunnlagYtelseUtil {
+
+    fun List<PeriodeGrunnlagYtelse>.slåSammenOverlappendeEllerPåfølgende(): List<PeriodeGrunnlagYtelse> {
+        val (perioderMedTom, perioderUtenTom) = this.partition { it.tom != null }
+
+        val sammenslåttePerioder = perioderMedTom
+            .map { PeriodeGrunnlagYtelseHolder(it) }
+            .sortedWith(compareBy({ it.ytelse.type }, { it }))
+            .mergeSammenhengende(
+                skalMerges = { v1, v2 -> v1.kanSlåsSammen(v2) },
+                merge = { v1, v2 -> v1.slåSammen(v2) },
+            )
+            .map { it.ytelse }
+
+        return (sammenslåttePerioder + perioderUtenTom).sortedBy { it.fom }
+    }
+
+    private data class PeriodeGrunnlagYtelseHolder(
+        val ytelse: PeriodeGrunnlagYtelse,
+    ) : Periode<LocalDate> {
+        override val fom: LocalDate
+            get() = ytelse.fom
+        override val tom: LocalDate
+            get() = ytelse.tom ?: error("Mangler tom")
+
+        fun slåSammen(other: PeriodeGrunnlagYtelseHolder): PeriodeGrunnlagYtelseHolder =
+            PeriodeGrunnlagYtelseHolder(
+                ytelse.copy(
+                    fom = minOf(ytelse.fom, other.ytelse.fom),
+                    tom = maxOf(ytelse.tom!!, other.ytelse.tom!!),
+                ),
+            )
+
+        fun kanSlåsSammen(other: PeriodeGrunnlagYtelseHolder): Boolean =
+            ytelse.type == other.ytelse.type && ytelse.ensligForsørgerStønadstype == other.ytelse.ensligForsørgerStønadstype && overlapperEllerPåfølgesAv(other)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
@@ -2,9 +2,6 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.Kilde
 import no.nav.tilleggsstonader.kontrakter.aktivitet.StatusAktivitet
-import no.nav.tilleggsstonader.kontrakter.felles.Periode
-import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
-import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
@@ -14,8 +11,6 @@ import org.springframework.data.relational.core.mapping.Table
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
-import kotlin.collections.plus
-import kotlin.collections.sortedBy
 import no.nav.tilleggsstonader.kontrakter.ytelse.EnsligForsørgerStønadstype as EnsligForsørgerStønadstypeKontrakter
 
 data class VilkårperioderGrunnlag(
@@ -65,45 +60,7 @@ data class PeriodeGrunnlagYtelse(
     val fom: LocalDate,
     val tom: LocalDate?,
     val ensligForsørgerStønadstype: EnsligForsørgerStønadstype? = null,
-) {
-    companion object {
-
-        fun List<PeriodeGrunnlagYtelse>.slåSammenOverlappendeEllerPåfølgende(): List<PeriodeGrunnlagYtelse> {
-            val (perioderMedTom, perioderUtenTom) = this.partition { it.tom != null }
-
-            val sammenslåttePerioder = perioderMedTom
-                .map { PeriodeGrunnlagYtelseHolder(it) }
-                .sortedWith(compareBy({ it.ytelse.type }, { it }))
-                .mergeSammenhengende(
-                    skalMerges = { v1, v2 -> v1.kanSlåsSammen(v2) },
-                    merge = { v1, v2 -> v1.slåSammen(v2) },
-                )
-                .map { it.ytelse }
-
-            return (sammenslåttePerioder + perioderUtenTom).sortedBy { it.fom }
-        }
-    }
-}
-
-data class PeriodeGrunnlagYtelseHolder(
-    val ytelse: PeriodeGrunnlagYtelse,
-) : Periode<LocalDate> {
-    override val fom: LocalDate
-        get() = ytelse.fom
-    override val tom: LocalDate
-        get() = ytelse.tom ?: error("Mangler tom")
-
-    fun slåSammen(other: PeriodeGrunnlagYtelseHolder): PeriodeGrunnlagYtelseHolder =
-        PeriodeGrunnlagYtelseHolder(
-            ytelse.copy(
-                fom = minOf(ytelse.fom, other.ytelse.fom),
-                tom = maxOf(ytelse.tom!!, other.ytelse.tom!!),
-            ),
-        )
-
-    fun kanSlåsSammen(other: PeriodeGrunnlagYtelseHolder): Boolean =
-        ytelse.type == other.ytelse.type && ytelse.ensligForsørgerStønadstype == other.ytelse.ensligForsørgerStønadstype && overlapperEllerPåfølgesAv(other)
-}
+)
 
 data class HentetInformasjon(
     val fom: LocalDate,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/SlåSammenPeriodeGrunnlagYtelseStepDefinition.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/SlåSammenPeriodeGrunnlagYtelseStepDefinition.kt
@@ -14,7 +14,7 @@ import no.nav.tilleggsstonader.sak.cucumber.parseValgfriDato
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.EnsligForsørgerStønadstype
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse.Companion.slåSammenOverlappendeEllerPåfølgende
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.SlåSammenPeriodeGrunnlagYtelseUtil.slåSammenOverlappendeEllerPåfølgende
 import org.assertj.core.api.Assertions.assertThat
 
 enum class PeriodeGrunnlagYtelseNøkler(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/SlåSammenPeriodeGrunnlagYtelseStepDefinition.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/SlåSammenPeriodeGrunnlagYtelseStepDefinition.kt
@@ -1,0 +1,61 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
+
+import io.cucumber.datatable.DataTable
+import io.cucumber.java.no.Gitt
+import io.cucumber.java.no.Når
+import io.cucumber.java.no.Så
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
+import no.nav.tilleggsstonader.sak.cucumber.Domenenøkkel
+import no.nav.tilleggsstonader.sak.cucumber.DomenenøkkelFelles
+import no.nav.tilleggsstonader.sak.cucumber.mapRad
+import no.nav.tilleggsstonader.sak.cucumber.parseDato
+import no.nav.tilleggsstonader.sak.cucumber.parseEnum
+import no.nav.tilleggsstonader.sak.cucumber.parseValgfriDato
+import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.EnsligForsørgerStønadstype
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse.Companion.slåSammenOverlappendeEllerPåfølgende
+import org.assertj.core.api.Assertions.assertThat
+
+enum class PeriodeGrunnlagYtelseNøkler(
+    override val nøkkel: String,
+) : Domenenøkkel {
+    TYPE("Type"),
+    ENSLIG_FORSØRGER_STØNADSTYPE("Enslig forsørger stønadstype"),
+}
+
+class SlåSammenPeriodeGrunnlagYtelseStepDefinition {
+
+    var grunnlagsperioderforYtelse: List<PeriodeGrunnlagYtelse> = emptyList()
+    var resultat = emptyList<PeriodeGrunnlagYtelse>()
+
+    @Gitt("Følgende grunnlagsperioderfor ytelse")
+    fun `Følgende grunnlagsperioderfor ytelse`(dataTable: DataTable) {
+        grunnlagsperioderforYtelse = dataTable.mapRad { rad ->
+            PeriodeGrunnlagYtelse(
+                type = parseEnum<TypeYtelsePeriode>(PeriodeGrunnlagYtelseNøkler.TYPE, rad),
+                fom = parseDato(DomenenøkkelFelles.FOM, rad),
+                tom = parseValgfriDato(DomenenøkkelFelles.TOM, rad),
+                ensligForsørgerStønadstype = parseValgfriEnum<EnsligForsørgerStønadstype>(PeriodeGrunnlagYtelseNøkler.ENSLIG_FORSØRGER_STØNADSTYPE, rad),
+            )
+        }
+    }
+
+    @Når("Slår sammen")
+    fun `Slår sammen`() {
+        resultat = grunnlagsperioderforYtelse.slåSammenOverlappendeEllerPåfølgende()
+    }
+
+    @Så("Forvent grunnlagsperioderfor ytelse")
+    fun `Forvent grunnlagsperioderfor ytelse`(dataTable: DataTable) {
+        val forventet = dataTable.mapRad { rad ->
+            PeriodeGrunnlagYtelse(
+                type = parseEnum<TypeYtelsePeriode>(PeriodeGrunnlagYtelseNøkler.TYPE, rad),
+                fom = parseDato(DomenenøkkelFelles.FOM, rad),
+                tom = parseValgfriDato(DomenenøkkelFelles.TOM, rad),
+                ensligForsørgerStønadstype = parseValgfriEnum<EnsligForsørgerStønadstype>(PeriodeGrunnlagYtelseNøkler.ENSLIG_FORSØRGER_STØNADSTYPE, rad),
+            )
+        }
+        assertThat(resultat).isEqualTo(forventet)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/SlåSammenPeriodeGrunnlagYtelseStepDefinition.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/SlåSammenPeriodeGrunnlagYtelseStepDefinition.kt
@@ -41,8 +41,8 @@ class SlåSammenPeriodeGrunnlagYtelseStepDefinition {
         }
     }
 
-    @Når("Slår sammen")
-    fun `Slår sammen`() {
+    @Når("Slår sammen grunnlagsperioder")
+    fun `Slår sammen grunnlagsperioder`() {
         resultat = grunnlagsperioderforYtelse.slåSammenOverlappendeEllerPåfølgende()
     }
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vilkår/slå_sammen_periode_grunnlag_ytelse.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vilkår/slå_sammen_periode_grunnlag_ytelse.feature
@@ -11,7 +11,7 @@ Egenskap: Slå sammen periode grunnlag ytelse
       | 01.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
       | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
 
-    Når Slår sammen
+    Når Slår sammen grunnlagsperioder
 
     Så Forvent grunnlagsperioderfor ytelse
       | Fom        | Tom        | Type              |
@@ -19,7 +19,47 @@ Egenskap: Slå sammen periode grunnlag ytelse
       | 01.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
       | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
 
-  Scenario: Slå sammen overlappende og sammenhengende perioder som skilles av annen aktivitet
+
+  Scenario: Slå sammen påfølgende perioder av alle typer
+
+    Gitt Følgende grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.02.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+      | 02.02.2024 | 01.03.2024 | AAP               |
+      | 02.02.2024 | 01.03.2024 | ENSLIG_FORSØRGER  |
+      | 02.02.2024 | 01.03.2024 | OMSTILLINGSSTØNAD |
+
+    Når Slår sammen grunnlagsperioder
+
+    Så Forvent grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.03.2024 | AAP               |
+      | 01.01.2024 | 01.03.2024 | ENSLIG_FORSØRGER  |
+      | 01.01.2024 | 01.03.2024 | OMSTILLINGSSTØNAD |
+
+  Scenario: Slå sammen overlappende perioder av alle typer
+
+    Gitt Følgende grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.02.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+      | 01.02.2024 | 01.03.2024 | AAP               |
+      | 01.02.2024 | 01.03.2024 | ENSLIG_FORSØRGER  |
+      | 01.02.2024 | 01.03.2024 | OMSTILLINGSSTØNAD |
+
+    Når Slår sammen grunnlagsperioder
+
+    Så Forvent grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.03.2024 | AAP               |
+      | 01.01.2024 | 01.03.2024 | ENSLIG_FORSØRGER  |
+      | 01.01.2024 | 01.03.2024 | OMSTILLINGSSTØNAD |
+
+
+  Scenario: Slå sammen overlappende og sammenhengende perioder som skilles av annen ytelse
 
     Gitt Følgende grunnlagsperioderfor ytelse
       | Fom        | Tom        | Type              |
@@ -29,7 +69,7 @@ Egenskap: Slå sammen periode grunnlag ytelse
       | 20.01.2024 | 01.02.2024 | AAP               |
       | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
 
-    Når Slår sammen
+    Når Slår sammen grunnlagsperioder
 
     Så Forvent grunnlagsperioderfor ytelse
       | Fom        | Tom        | Type              |
@@ -46,7 +86,7 @@ Egenskap: Slå sammen periode grunnlag ytelse
       | 14.01.2024 |            | AAP               |
       | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
 
-    Når Slår sammen
+    Når Slår sammen grunnlagsperioder
 
     Så Forvent grunnlagsperioderfor ytelse
       | Fom        | Tom        | Type              |
@@ -65,7 +105,7 @@ Egenskap: Slå sammen periode grunnlag ytelse
       | 20.01.2024 | 01.02.2024 | AAP               | SKOLEPENGER                  |
       | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |                              |
 
-    Når Slår sammen
+    Når Slår sammen grunnlagsperioder
 
     Så Forvent grunnlagsperioderfor ytelse
       | Fom        | Tom        | Type              | Enslig forsørger stønadstype |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vilkår/slå_sammen_periode_grunnlag_ytelse.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vilkår/slå_sammen_periode_grunnlag_ytelse.feature
@@ -1,0 +1,78 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Slå sammen periode grunnlag ytelse
+
+  Scenario: Ingen perioder som skal slås sammen
+
+    Gitt Følgende grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.02.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+
+    Når Slår sammen
+
+    Så Forvent grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.02.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+
+  Scenario: Slå sammen overlappende og sammenhengende perioder som skilles av annen aktivitet
+
+    Gitt Følgende grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 15.01.2024 | AAP               |
+      | 14.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 14.01.2024 | 19.01.2024 | AAP               |
+      | 20.01.2024 | 01.02.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+
+    Når Slår sammen
+
+    Så Forvent grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 01.02.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+      | 14.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+
+  Scenario: Perioder med manglende tom
+
+    Gitt Følgende grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 15.01.2024 | AAP               |
+      | 14.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 14.01.2024 |            | AAP               |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+
+    Når Slår sammen
+
+    Så Forvent grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              |
+      | 01.01.2024 | 15.01.2024 | AAP               |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |
+      | 14.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |
+      | 14.01.2024 |            | AAP               |
+
+
+  Scenario: Perioder med ulik enslig forsørger stønadstype
+
+    Gitt Følgende grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              | Enslig forsørger stønadstype |
+      | 01.01.2024 | 20.01.2024 | AAP               | OVERGANGSSTØNAD              |
+      | 14.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |                              |
+      | 20.01.2024 | 01.02.2024 | AAP               | SKOLEPENGER                  |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |                              |
+
+    Når Slår sammen
+
+    Så Forvent grunnlagsperioderfor ytelse
+      | Fom        | Tom        | Type              | Enslig forsørger stønadstype |
+      | 01.01.2024 | 20.01.2024 | AAP               | OVERGANGSSTØNAD              |
+      | 01.01.2024 | 01.02.2024 | OMSTILLINGSSTØNAD |                              |
+      | 14.01.2024 | 01.02.2024 | ENSLIG_FORSØRGER  |                              |
+      | 20.01.2024 | 01.02.2024 | AAP               | SKOLEPENGER                  |
+
+
+


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal bli lettere å få oversikt over periodene for saksbehandler

Før:
![Screenshot 2024-11-04 at 14 39 45](https://github.com/user-attachments/assets/b9554604-6368-4c4c-886d-afa3c73323af)


Nå:
![Screenshot 2024-11-04 at 14 40 16](https://github.com/user-attachments/assets/af9bec1c-3c4e-4059-8678-d3415bf51242)
