### PR TITLE
Renaming  Aktivitet til RegisterAktivitet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingService.kt
@@ -8,7 +8,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.dto.tilDto
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
-import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetService
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
@@ -20,7 +20,7 @@ import java.time.LocalDate
 class OppfølgingService(
     private val behandlingRepository: BehandlingRepository,
     private val stønadsperiodeService: StønadsperiodeService,
-    private val aktivitetService: AktivitetService,
+    private val registerAktivitetService: RegisterAktivitetService,
     private val fagsakService: FagsakService,
 ) {
 
@@ -43,7 +43,7 @@ class OppfølgingService(
 
             val stønadsperioder = stønadsperiodeService.hentStønadsperioder(behandling.id)
 
-            val registerAktivitet = aktivitetService.hentAktiviteter(
+            val registerAktivitet = registerAktivitetService.hentAktiviteter(
                 fagsak.fagsakPersonId,
                 stønadsperioder.minOf { it.fom },
                 stønadsperioder.maxOf { it.tom },

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetClient.kt
@@ -12,7 +12,7 @@ import java.net.URI
 import java.time.LocalDate
 
 @Service
-class AktivitetClient(
+class RegisterAktivitetClient(
     @Value("\${clients.integrasjoner.uri}") private val baseUrl: URI,
     @Qualifier("azureClientCredential") restTemplate: RestTemplate,
 ) : AbstractRestClient(restTemplate) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetController.kt
@@ -15,18 +15,18 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/api/aktivitet"])
 @ProtectedWithClaims(issuer = "azuread")
-class AktivitetController(
+class RegisterAktivitetController(
     private val tilgangService: TilgangService,
-    private val aktivitetService: AktivitetService,
+    private val registerAktivitetService: RegisterAktivitetService,
     private val behandlingService: BehandlingService,
 ) {
 
     @GetMapping("temp/{fagsakPersonId}")
     fun hentAktiviteter(
         @PathVariable fagsakPersonId: FagsakPersonId,
-    ): AktiviteterDto {
+    ): RegisterAktiviteterDto {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
-        return aktivitetService.hentAktiviteterMedPerioder(fagsakPersonId)
+        return registerAktivitetService.hentAktiviteterMedPerioder(fagsakPersonId)
     }
 
     @Deprecated("Byttes ut med hentAktiviteter, fordi vi trenger informasjon om for hvilken periode vi henter ut data.")
@@ -35,7 +35,7 @@ class AktivitetController(
         @PathVariable fagsakPersonId: FagsakPersonId,
     ): List<AktivitetArenaDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
-        return aktivitetService.hentAktiviteter(fagsakPersonId)
+        return registerAktivitetService.hentAktiviteter(fagsakPersonId)
     }
 
     @Deprecated("Skal fjernes. aktivitet skal hentes med vilkårperioder") // TODO: Fjern når aktivitet hentes med vilkårperioder
@@ -45,6 +45,6 @@ class AktivitetController(
     ): List<AktivitetArenaDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
-        return aktivitetService.hentAktiviteter(saksbehandling.fagsakPersonId)
+        return registerAktivitetService.hentAktiviteter(saksbehandling.fagsakPersonId)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping(path = ["/api/aktivitet"])
+@RequestMapping(path = ["/api/aktivitet", "/api/register-aktivitet"]) // TODO: Fjern /api/aktivitet etter at vi har migrert over.
 @ProtectedWithClaims(issuer = "azuread")
 class RegisterAktivitetController(
     private val tilgangService: TilgangService,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetService.kt
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Service
 import java.time.LocalDate
 
 @Service
-class AktivitetService(
+class RegisterAktivitetService(
     private val fagsakPersonService: FagsakPersonService,
-    private val aktivitetClient: AktivitetClient,
+    private val registerAktivitetClient: RegisterAktivitetClient,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -22,7 +22,7 @@ class AktivitetService(
         fagsakPersonId: FagsakPersonId,
         fom: LocalDate = osloDateNow().minusYears(3),
         tom: LocalDate = osloDateNow().plusYears(1),
-    ): AktiviteterDto = AktiviteterDto(
+    ): RegisterAktiviteterDto = RegisterAktiviteterDto(
         periodeHentetFra = fom,
         periodeHentetTil = tom,
         aktiviteter = hentAktiviteter(fagsakPersonId, fom, tom),
@@ -38,7 +38,7 @@ class AktivitetService(
     }
 
     fun hentAktiviteterForGrunnlagsdata(ident: String, fom: LocalDate, tom: LocalDate): List<AktivitetArenaDto> {
-        return aktivitetClient.hentAktiviteter(
+        return registerAktivitetClient.hentAktiviteter(
             ident = ident,
             fom = fom,
             tom = tom,
@@ -52,7 +52,7 @@ class AktivitetService(
         ident: String,
         fom: LocalDate,
         tom: LocalDate,
-    ) = aktivitetClient.hentAktiviteter(
+    ) = registerAktivitetClient.hentAktiviteter(
         ident = ident,
         fom = fom,
         tom = tom,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktiviteterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktiviteterDto.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.sak.opplysninger.aktivitet
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
 import java.time.LocalDate
 
-data class AktiviteterDto(
+data class RegisterAktiviteterDto(
     val periodeHentetFra: LocalDate,
     val periodeHentetTil: LocalDate,
     val aktiviteter: List<AktivitetArenaDto>,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -11,7 +11,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
-import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetService
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseService
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -68,7 +68,7 @@ class VilkårperiodeService(
     private val vilkårperiodeRepository: VilkårperiodeRepository,
     private val stønadsperiodeRepository: StønadsperiodeRepository,
     private val vilkårperioderGrunnlagRepository: VilkårperioderGrunnlagRepository,
-    private val aktivitetService: AktivitetService,
+    private val registerAktivitetService: RegisterAktivitetService,
     private val ytelseService: YtelseService,
     private val søknadService: SøknadService,
     private val tilgangService: TilgangService,
@@ -169,7 +169,7 @@ class VilkårperiodeService(
         fom: LocalDate,
         tom: LocalDate,
     ) = GrunnlagAktivitet(
-        aktiviteter = aktivitetService.hentAktiviteterForGrunnlagsdata(
+        aktiviteter = registerAktivitetService.hentAktiviteterForGrunnlagsdata(
             ident = behandlingService.hentSaksbehandling(behandlingId).ident,
             fom = fom,
             tom = tom,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -45,7 +45,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtelse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagAktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.RegisterAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.SlåSammenPeriodeGrunnlagYtelseUtil.slåSammenOverlappendeEllerPåfølgende
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlag
@@ -174,7 +174,7 @@ class VilkårperiodeService(
             fom = fom,
             tom = tom,
         ).map {
-            PeriodeGrunnlagAktivitet(
+            RegisterAktivitet(
                 id = it.id,
                 fom = it.fom,
                 tom = it.tom,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -45,8 +45,8 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtelse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.RegisterAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.PeriodeGrunnlagYtelse
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.RegisterAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.SlåSammenPeriodeGrunnlagYtelseUtil.slåSammenOverlappendeEllerPåfølgende
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagDomain

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlag.kt
@@ -29,7 +29,7 @@ data class VilkårperioderGrunnlagDomain(
 )
 
 data class GrunnlagAktivitet(
-    val aktiviteter: List<PeriodeGrunnlagAktivitet>,
+    val aktiviteter: List<RegisterAktivitet>,
 )
 
 data class GrunnlagYtelse(
@@ -39,7 +39,7 @@ data class GrunnlagYtelse(
 /**
  * Kopi av [no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto]
  */
-data class PeriodeGrunnlagAktivitet(
+data class RegisterAktivitet(
     val id: String,
     val fom: LocalDate?,
     val tom: LocalDate?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
@@ -44,7 +44,7 @@ fun GrunnlagAktivitet.tilDto() =
         aktiviteter = this.aktiviteter.map { it.tilDto() },
     )
 
-private fun PeriodeGrunnlagAktivitet.tilDto() =
+private fun RegisterAktivitet.tilDto() =
     AktivitetArenaDto(
         id = id,
         fom = fom,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -79,7 +79,7 @@ class DefaultRestTemplateConfiguration {
     "mock-featuretoggle",
     "mock-htmlify",
     "mock-arena",
-    "mock-aktivitet",
+    "mock-register-aktivitet",
     "mock-kodeverk",
     "mock-arbeidsfordeling",
     "mock-kafka",

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/SakAppLocal.kt
@@ -30,7 +30,7 @@ fun appLocal(): SpringApplicationBuilder =
             "mock-journalpost",
             "mock-htmlify",
             "mock-arena",
-            "mock-aktivitet",
+            "mock-register-aktivitet",
             "mock-kodeverk",
             "mock-arbeidsfordeling",
             "mock-kafka",

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/RegisterAktivitetClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/RegisterAktivitetClientConfig.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.sak.infrastruktur.mocks
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetClient
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetClient
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,19 +11,19 @@ import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 
 @Configuration
-@Profile("mock-aktivitet")
-class AktivitetClientConfig {
+@Profile("mock-register-aktivitet")
+class RegisterAktivitetClientConfig {
 
     @Bean
     @Primary
-    fun aktivitetClient(): AktivitetClient {
-        val client = mockk<AktivitetClient>()
+    fun registerAktivitetClient(): RegisterAktivitetClient {
+        val client = mockk<RegisterAktivitetClient>()
         resetMock(client)
         return client
     }
 
     companion object {
-        fun resetMock(client: AktivitetClient) {
+        fun resetMock(client: RegisterAktivitetClient) {
             clearMocks(client)
             every { client.hentAktiviteter(any(), any(), any()) } returns listOf(aktivitetArenaDto())
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/RegisterAktivitetClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/RegisterAktivitetClientConfig.kt
@@ -3,8 +3,8 @@ package no.nav.tilleggsstonader.sak.infrastruktur.mocks
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetClient
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/PeriodeGrunnlagAktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/PeriodeGrunnlagAktivitetServiceTest.kt
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test
 
 class PeriodeGrunnlagAktivitetServiceTest {
 
-    val aktivitetClient = mockk<AktivitetClient>()
+    val registerAktivitetClient = mockk<RegisterAktivitetClient>()
     val fagsakPersonService = mockk<FagsakPersonService>()
 
-    val service = AktivitetService(fagsakPersonService, aktivitetClient)
+    val service = RegisterAktivitetService(fagsakPersonService, registerAktivitetClient)
 
     val personId = FagsakPersonId.random()
 
@@ -29,7 +29,7 @@ class PeriodeGrunnlagAktivitetServiceTest {
     inner class HentAktiviteter {
         @Test
         fun `henting av aktiviteter skal filtrere vekk typer som ikke er av typen tiltak`() {
-            every { aktivitetClient.hentAktiviteter(any(), any(), any()) } returns listOf(
+            every { registerAktivitetClient.hentAktiviteter(any(), any(), any()) } returns listOf(
                 aktivitetArenaDto(type = TypeAktivitet.AMO.name, erStønadsberettiget = false),
                 aktivitetArenaDto(type = TypeAktivitet.AILOK.name, erStønadsberettiget = false),
             )
@@ -41,7 +41,7 @@ class PeriodeGrunnlagAktivitetServiceTest {
 
         @Test
         fun `skal ignorere typer som ikke er mappet`() {
-            every { aktivitetClient.hentAktiviteter(any(), any(), any()) } returns listOf(
+            every { registerAktivitetClient.hentAktiviteter(any(), any(), any()) } returns listOf(
                 aktivitetArenaDto(type = "FINNER_IKKE", erStønadsberettiget = false),
                 aktivitetArenaDto(type = TypeAktivitet.ARBRRHBAG.name, erStønadsberettiget = false),
             )
@@ -57,7 +57,7 @@ class PeriodeGrunnlagAktivitetServiceTest {
          */
         @Test
         fun `i tilfelle erStønadsberettiget er true så skal de aktivitetene være med, de settes kun til true for tiltak`() {
-            every { aktivitetClient.hentAktiviteter(any(), any(), any()) } returns listOf(
+            every { registerAktivitetClient.hentAktiviteter(any(), any(), any()) } returns listOf(
                 aktivitetArenaDto(type = "FINNER_IKKE", erStønadsberettiget = true),
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetServiceTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class PeriodeGrunnlagAktivitetServiceTest {
+class RegisterAktivitetServiceTest {
 
     val registerAktivitetClient = mockk<RegisterAktivitetClient>()
     val fagsakPersonService = mockk<FagsakPersonService>()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -16,8 +16,8 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.RegisterAktivitetClientConfig.Companion.resetMock
-import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetClient
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetClient
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseClient
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -15,8 +15,8 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
-import no.nav.tilleggsstonader.sak.infrastruktur.mocks.AktivitetClientConfig.Companion.resetMock
-import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.AktivitetClient
+import no.nav.tilleggsstonader.sak.infrastruktur.mocks.RegisterAktivitetClientConfig.Companion.resetMock
+import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.RegisterAktivitetClient
 import no.nav.tilleggsstonader.sak.opplysninger.aktivitet.ArenaKontraktUtil.aktivitetArenaDto
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseClient
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
@@ -94,7 +94,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
     lateinit var vilkårperioderGrunnlagRepository: VilkårperioderGrunnlagRepository
 
     @Autowired
-    lateinit var aktivitetClient: AktivitetClient
+    lateinit var registerAktivitetClient: RegisterAktivitetClient
 
     @Autowired
     lateinit var ytelseClient: YtelseClient
@@ -102,7 +102,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
     @AfterEach
     override fun tearDown() {
         super.tearDown()
-        resetMock(aktivitetClient)
+        resetMock(registerAktivitetClient)
     }
 
     @Nested
@@ -816,7 +816,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         fun `skal kun ta med aktiviteter som er stønadsberettiget i grunnlaget`() {
             val idStønadsberettiget = "1"
             every {
-                aktivitetClient.hentAktiviteter(any(), any(), any())
+                registerAktivitetClient.hentAktiviteter(any(), any(), any())
             } returns listOf(
                 aktivitetArenaDto(id = idStønadsberettiget, erStønadsberettiget = true),
                 aktivitetArenaDto(id = "2", erStønadsberettiget = false),
@@ -1008,7 +1008,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         @Test
         fun `skal kunne oppdatere grunnlaget når en behandling redigerbar og i riktig steg`() {
             every {
-                aktivitetClient.hentAktiviteter(any(), any(), any())
+                registerAktivitetClient.hentAktiviteter(any(), any(), any())
             } answers {
                 listOf(aktivitetArenaDto(id = "1", erStønadsberettiget = true))
             } andThenAnswer {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -269,7 +269,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
         }
 
         @Nested
-        inner class IngenPeriodeGrunnlagAktivitetMålgruppe {
+        inner class IngenRegisterAktivitetMålgruppe {
             @Test
             fun `skal kaste feil ved tom og null begrunnelse på ingen aktivitet`() {
                 val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagTestUtil.kt
@@ -22,7 +22,7 @@ object VilkårperioderGrunnlagTestUtil {
         erUtdanning: Boolean? = false,
         arrangør: String? = "Arrangør",
         kilde: Kilde = Kilde.ARENA,
-    ) = PeriodeGrunnlagAktivitet(
+    ) = RegisterAktivitet(
         id = id,
         fom = fom,
         tom = tom,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi ønsker å splitte målgruppe og aktivitet i api-et for å lagre vilkårperioder, men får ikke lov å lage `AktivitetController` fordi den alt eksisterer. Renamer derfor disse til `RegisterAktivitet` som også er et mer beskrivende navn, samt det som brukes i frontend ⭐ 