### PR TITLE
Fjern behandlingstema fra oppdater journalpost

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringHelper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringHelper.kt
@@ -56,7 +56,6 @@ object JournalføringHelper {
             DokarkivBruker(idType = BrukerIdType.valueOf(it.type.toString()), id = it.id)
         },
         tema = journalpost.tema?.let { Tema.valueOf(it) },
-//        behandlingstema = journalpost.behandlingstema?.let { Behandlingstema.fromValue(it) },
         tittel = journalpost.tittel,
         journalfoerendeEnhet = journalpost.journalforendeEnhet,
         sak = Sak(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det finnes journalposter med behandlingstema som vi ikke bruker. Derfor ønsker vi å vidreføre behandlingstema som allerede eksisterer på journalposten.
