### PR TITLE
Studienivå for læremidler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidler.kt
@@ -30,8 +30,3 @@ data class BeregningPeriode(
         validatePeriode()
     }
 }
-
-enum class Studienivå {
-    VIDEREGÅENDE,
-    HØYERE_UTDANNING,
-}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/Studienivå.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/Studienivå.kt
@@ -1,0 +1,6 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler.domain
+
+enum class Studienivå {
+    VIDEREGÅENDE,
+    HØYERE_UTDANNING,
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -129,12 +129,18 @@ fun mapAktiviteterLæremidler(
 ): AktivitetLæremidler {
     return when (type) {
         AktivitetType.TILTAK -> TiltakLæremidler(
-            fakta = FaktaAktivitetLæremidler(prosent = faktaOgSvar.prosent!!),
+            fakta = FaktaAktivitetLæremidler(
+                prosent = faktaOgSvar.prosent!!, // TODO: Det er ikke obligatorisk å sende inn studienivå for tiltak av variant "Høyere utdanning". Må deale med det.
+                studienivå = faktaOgSvar.studienivå!!,
+            ),
             vurderinger = VurderingTiltakLæremidler(harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter)),
         )
 
         AktivitetType.UTDANNING -> UtdanningLæremidler(
-            fakta = FaktaAktivitetLæremidler(prosent = faktaOgSvar.prosent!!),
+            fakta = FaktaAktivitetLæremidler(
+                prosent = faktaOgSvar.prosent!!,
+                studienivå = faktaOgSvar.studienivå!!,
+            ),
         )
 
         AktivitetType.INGEN_AKTIVITET -> IngenAktivitetLæremidler

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -130,8 +130,8 @@ fun mapAktiviteterLæremidler(
     return when (type) {
         AktivitetType.TILTAK -> TiltakLæremidler(
             fakta = FaktaAktivitetLæremidler(
-                prosent = faktaOgSvar.prosent!!, // TODO: Det er ikke obligatorisk å sende inn studienivå for tiltak av variant "Høyere utdanning". Må deale med det.
-                studienivå = faktaOgSvar.studienivå!!,
+                prosent = faktaOgSvar.prosent!!,
+                studienivå = faktaOgSvar.studienivå, // TODO: Det er ikke obligatorisk å sende inn studienivå for tiltak av variant "Høyere utdanning". Må deale med det.
             ),
             vurderinger = VurderingTiltakLæremidler(harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter)),
         )
@@ -139,7 +139,7 @@ fun mapAktiviteterLæremidler(
         AktivitetType.UTDANNING -> UtdanningLæremidler(
             fakta = FaktaAktivitetLæremidler(
                 prosent = faktaOgSvar.prosent!!,
-                studienivå = faktaOgSvar.studienivå!!,
+                studienivå = faktaOgSvar.studienivå,
             ),
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -131,7 +131,7 @@ fun mapAktiviteterLæremidler(
         AktivitetType.TILTAK -> TiltakLæremidler(
             fakta = FaktaAktivitetLæremidler(
                 prosent = faktaOgSvar.prosent!!,
-                studienivå = faktaOgSvar.studienivå, // TODO: Det er ikke obligatorisk å sende inn studienivå for tiltak av variant "Høyere utdanning". Må deale med det.
+                studienivå = faktaOgSvar.studienivå!!,
             ),
             vurderinger = VurderingTiltakLæremidler(harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter)),
         )
@@ -139,7 +139,7 @@ fun mapAktiviteterLæremidler(
         AktivitetType.UTDANNING -> UtdanningLæremidler(
             fakta = FaktaAktivitetLæremidler(
                 prosent = faktaOgSvar.prosent!!,
-                studienivå = faktaOgSvar.studienivå,
+                studienivå = faktaOgSvar.studienivå!!,
             ),
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaAktivitet.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaAktivitet.kt
@@ -11,5 +11,5 @@ sealed interface FaktaProsent : Fakta {
 }
 
 sealed interface FaktaStudienivå : Fakta {
-    val studienivå: Studienivå
+    val studienivå: Studienivå?
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaAktivitet.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaAktivitet.kt
@@ -1,9 +1,15 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
 
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
+
 sealed interface FaktaAktivitetsdager : Fakta {
     val aktivitetsdager: Int
 }
 
 sealed interface FaktaProsent : Fakta {
     val prosent: Int
+}
+
+sealed interface FaktaStudienivå : Fakta {
+    val studienivå: Studienivå
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -88,7 +88,7 @@ data class VurderingTiltakLæremidler(
 
 data class FaktaAktivitetLæremidler(
     override val prosent: Int,
-    override val studienivå: Studienivå?,
+    override val studienivå: Studienivå,
 ) : Fakta, FaktaProsent, FaktaStudienivå {
     init {
         require(prosent in 1..100) { "Prosent må være mellom 1 og 100" }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
 
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 
@@ -87,7 +88,8 @@ data class VurderingTiltakLæremidler(
 
 data class FaktaAktivitetLæremidler(
     override val prosent: Int,
-) : Fakta, FaktaProsent {
+    override val studienivå: Studienivå,
+) : Fakta, FaktaProsent, FaktaStudienivå {
     init {
         require(prosent in 1..100) { "Prosent må være mellom 1 og 100" }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -88,7 +88,7 @@ data class VurderingTiltakLæremidler(
 
 data class FaktaAktivitetLæremidler(
     override val prosent: Int,
-    override val studienivå: Studienivå,
+    override val studienivå: Studienivå?,
 ) : Fakta, FaktaProsent, FaktaStudienivå {
     init {
         require(prosent in 1..100) { "Prosent må være mellom 1 og 100" }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SvarJaNei
 import java.time.LocalDate
@@ -37,5 +38,6 @@ data class FaktaOgSvarAktivitetBarnetilsynDto(
 
 data class FaktaOgSvarAktivitetLæremidlerDto(
     val prosent: Int? = null,
+    val studienivå: Studienivå? = null,
     val svarHarUtgifter: SvarJaNei? = null,
 ) : FaktaOgSvarDto()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.util.norskFormat
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
@@ -22,6 +23,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfFakta
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfVurderinger
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaProsent
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaStudienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.HarUtgifterVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.LønnetVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MedlemskapVurdering
@@ -141,6 +143,7 @@ data class AktivitetBarnetilsynFaktaOgVurderingerDto(
 
 data class AktivitetLæremidlerFaktaOgVurderingerDto(
     val prosent: Int? = null,
+    val studienivå: Studienivå? = null,
     val harUtgifter: VurderingDto? = null,
 ) : FaktaOgVurderingerDto()
 
@@ -160,6 +163,7 @@ fun FaktaOgVurdering.tilFaktaOgVurderingDto(): FaktaOgVurderingerDto {
 
                 is FaktaOgVurderingLæremidler -> AktivitetLæremidlerFaktaOgVurderingerDto(
                     prosent = fakta.takeIfFakta<FaktaProsent>()?.prosent,
+                    studienivå = fakta.takeIfFakta<FaktaStudienivå>()?.studienivå,
                     harUtgifter = vurderinger.takeIfVurderinger<HarUtgifterVurdering>()?.harUtgifter?.tilDto(),
                 )
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto
 
 import no.nav.tilleggsstonader.libs.utils.osloDateNow
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.dekketAvAnnetRegelverk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeExtensions.medlemskap
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
@@ -105,12 +106,12 @@ class VilkårperiodeDtoTest {
         fun `mapper ut faktaOgVurderinger for utdanning læremidler`() {
             val utdanningLæremidler = VilkårperiodeTestUtil.aktivitet(
                 faktaOgVurdering = UtdanningLæremidler(
-                    fakta = FaktaAktivitetLæremidler(prosent = 60),
+                    fakta = FaktaAktivitetLæremidler(prosent = 60, studienivå = Studienivå.VIDEREGÅENDE),
                 ),
             ).tilDto()
 
             assertThat(utdanningLæremidler.faktaOgVurderinger).isEqualTo(
-                AktivitetLæremidlerFaktaOgVurderingerDto(prosent = 60),
+                AktivitetLæremidlerFaktaOgVurderingerDto(prosent = 60, studienivå = Studienivå.VIDEREGÅENDE),
             )
         }
     }

--- a/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/TILTAK_LÆREMIDLER.json
+++ b/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/TILTAK_LÆREMIDLER.json
@@ -1,7 +1,8 @@
 {
   "type": "TILTAK_LÆREMIDLER",
   "fakta": {
-    "prosent": 70
+    "prosent": 70,
+    "studienivå": "VIDEREGÅENDE"
   },
   "vurderinger": {
     "harUtgifter": {

--- a/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/UTDANNING_LÆREMIDLER.json
+++ b/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/UTDANNING_LÆREMIDLER.json
@@ -1,7 +1,8 @@
 {
   "type": "UTDANNING_LÆREMIDLER",
   "fakta": {
-    "prosent": 70
+    "prosent": 70,
+    "studienivå": "HØYERE_UTDANNING"
   },
   "vurderinger": {}
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Angående nullbarhet, så er det nå helt fritt fram å sende inn null, men det er åpenbart ikke en god løsning på sikt. 

1. Studienivå er obligatorisk for alle aktiviteter utenom **tiltak av variant "høyere utdanning"**. Da kan studienivå settes implisitt. Dette trenger vi åpenbart noe validering på når vi får inn varianter av aktiviteter. 
2. Hvis studienivå gjøres obligatorisk, hva gjør vi med eksisterende data i dev-basen? Bør vi oppdatere vilkårperiode-dataene, eller la eksisterende testdata seile sin egen sjø?