### PR TITLE
La Vurderinger utlede sitt eget resultat 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
@@ -17,27 +17,8 @@ sealed interface FaktaOgVurdering : FaktaOgVurderingJson {
         if (type.vilkårperiodeType.girIkkeRettPåStønadsperiode()) {
             return ResultatVilkårperiode.IKKE_OPPFYLT
         }
-        return this.utledResultat(this.vurderinger.utledDelresultater())
+        return this.vurderinger.utledResultat()
     }
-
-    private fun utledResultat(resultater: List<ResultatDelvilkårperiode>) =
-        when {
-            resultater.contains(ResultatDelvilkårperiode.IKKE_VURDERT) -> {
-                ResultatVilkårperiode.IKKE_VURDERT
-            }
-
-            resultater.contains(ResultatDelvilkårperiode.IKKE_OPPFYLT) -> {
-                ResultatVilkårperiode.IKKE_OPPFYLT
-            }
-
-            resultater.all { it == ResultatDelvilkårperiode.OPPFYLT } -> {
-                ResultatVilkårperiode.OPPFYLT
-            }
-
-            else -> {
-                error("Ugyldig resultat ($resultater)")
-            }
-        }
 }
 
 sealed interface MålgruppeFaktaOgVurdering : FaktaOgVurdering
@@ -70,9 +51,9 @@ data object IngenFakta : Fakta
  * Vurderinger, som kan inneholde ulike vurderinger, eks lønnet
  */
 sealed interface Vurderinger {
-    fun utledDelresultater(): List<ResultatDelvilkårperiode>
+    fun utledResultat(): ResultatVilkårperiode
 }
 
 data object IngenVurderinger : Vurderinger {
-    override fun utledDelresultater() = emptyList<ResultatDelvilkårperiode>()
+    override fun utledResultat() = ResultatVilkårperiode.OPPFYLT
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/SammenstillDelresultater.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/SammenstillDelresultater.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
+
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+
+fun sammenstillDelresultater(vararg delresultater: ResultatDelvilkårperiode) = when {
+    delresultater.contains(ResultatDelvilkårperiode.IKKE_VURDERT) -> {
+        ResultatVilkårperiode.IKKE_VURDERT
+    }
+
+    delresultater.contains(ResultatDelvilkårperiode.IKKE_OPPFYLT) -> {
+        ResultatVilkårperiode.IKKE_OPPFYLT
+    }
+
+    delresultater.all { it == ResultatDelvilkårperiode.OPPFYLT } -> {
+        ResultatVilkårperiode.OPPFYLT
+    }
+
+    else -> {
+        error("Ugyldig resultat ($delresultater)")
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -87,15 +87,16 @@ data class VurderingTiltakLæremidler(
     override val harRettTilUtstyrsstipend: VurderingHarRettTilUtstyrsstipend,
 ) : HarUtgifterVurdering, HarRettTilUtstyrsstipendVurdering {
 
-    override fun utledDelresultater(): List<ResultatDelvilkårperiode> =
-        listOf(harUtgifter.resultat, harRettTilUtstyrsstipend.resultat)
+    override fun utledResultat() = sammenstillDelresultater(
+        harUtgifter.resultat, harRettTilUtstyrsstipend.resultat
+    )
 }
 
 data class VurderingerUtdanningLæremidler(
     override val harRettTilUtstyrsstipend: VurderingHarRettTilUtstyrsstipend,
 ) : HarRettTilUtstyrsstipendVurdering {
 
-    override fun utledDelresultater() = listOf(harRettTilUtstyrsstipend.resultat)
+    override fun utledResultat() = sammenstillDelresultater(harRettTilUtstyrsstipend.resultat)
 }
 
 data class FaktaAktivitetLæremidler(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -85,11 +85,18 @@ data object IngenAktivitetLæremidler : AktivitetLæremidler {
 data class VurderingTiltakLæremidler(
     override val harUtgifter: VurderingHarUtgifter,
     override val harRettTilUtstyrsstipend: VurderingHarRettTilUtstyrsstipend,
-) : HarUtgifterVurdering, HarRettTilUtstyrsstipendVurdering
+) : HarUtgifterVurdering, HarRettTilUtstyrsstipendVurdering {
+
+    override fun utledDelresultater(): List<ResultatDelvilkårperiode> =
+        listOf(harUtgifter.resultat, harRettTilUtstyrsstipend.resultat)
+}
 
 data class VurderingerUtdanningLæremidler(
     override val harRettTilUtstyrsstipend: VurderingHarRettTilUtstyrsstipend,
-) : HarRettTilUtstyrsstipendVurdering
+) : HarRettTilUtstyrsstipendVurdering {
+
+    override fun utledDelresultater() = listOf(harRettTilUtstyrsstipend.resultat)
+}
 
 data class FaktaAktivitetLæremidler(
     override val prosent: Int,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadTilsynBarnFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadTilsynBarnFaktaOgVurdering.kt
@@ -92,7 +92,7 @@ data class VurderingTiltakTilsynBarn(
     override val lønnet: VurderingLønnet,
 ) : LønnetVurdering {
 
-    override fun utledDelresultater() = listOf(lønnet.resultat)
+    override fun utledResultat() = sammenstillDelresultater(lønnet.resultat)
 }
 
 data class FaktaAktivitetTilsynBarn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadTilsynBarnFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadTilsynBarnFaktaOgVurdering.kt
@@ -90,7 +90,10 @@ data class ReellArbeidsøkerTilsynBarn(
 
 data class VurderingTiltakTilsynBarn(
     override val lønnet: VurderingLønnet,
-) : LønnetVurdering
+) : LønnetVurdering {
+
+    override fun utledDelresultater() = listOf(lønnet.resultat)
+}
 
 data class FaktaAktivitetTilsynBarn(
     override val aktivitetsdager: Int,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VurderingerMålgruppe.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VurderingerMålgruppe.kt
@@ -14,22 +14,34 @@ data class VurderingAAP(
     override val dekketAvAnnetRegelverk: VurderingDekketAvAnnetRegelverk,
 ) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering {
     override val medlemskap: VurderingMedlemskap = VurderingMedlemskap.IMPLISITT
+
+    override fun utledDelresultater() = listOf(medlemskap.resultat)
 }
 
 data class VurderingUføretrygd(
     override val medlemskap: VurderingMedlemskap,
     override val dekketAvAnnetRegelverk: VurderingDekketAvAnnetRegelverk,
-) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering
+) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering {
+
+    override fun utledDelresultater() = listOf(medlemskap.resultat, dekketAvAnnetRegelverk.resultat)
+}
 
 data class VurderingNedsattArbeidsevne(
     override val medlemskap: VurderingMedlemskap,
     override val dekketAvAnnetRegelverk: VurderingDekketAvAnnetRegelverk,
-) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering
+) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering {
+
+    override fun utledDelresultater() = listOf(medlemskap.resultat, dekketAvAnnetRegelverk.resultat)
+}
 
 data class VurderingOmstillingsstønad(
     override val medlemskap: VurderingMedlemskap,
-) : MedlemskapVurdering
+) : MedlemskapVurdering {
+    override fun utledDelresultater() = listOf(medlemskap.resultat)
+}
 
 data object VurderingOvergangsstønad : MedlemskapVurdering {
     override val medlemskap: VurderingMedlemskap = VurderingMedlemskap.IMPLISITT
+
+    override fun utledDelresultater() = listOf(medlemskap.resultat)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VurderingerMålgruppe.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VurderingerMålgruppe.kt
@@ -15,7 +15,7 @@ data class VurderingAAP(
 ) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering {
     override val medlemskap: VurderingMedlemskap = VurderingMedlemskap.IMPLISITT
 
-    override fun utledDelresultater() = listOf(medlemskap.resultat)
+    override fun utledResultat() = sammenstillDelresultater(medlemskap.resultat)
 }
 
 data class VurderingUføretrygd(
@@ -23,7 +23,9 @@ data class VurderingUføretrygd(
     override val dekketAvAnnetRegelverk: VurderingDekketAvAnnetRegelverk,
 ) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering {
 
-    override fun utledDelresultater() = listOf(medlemskap.resultat, dekketAvAnnetRegelverk.resultat)
+    override fun utledResultat() = sammenstillDelresultater(
+        medlemskap.resultat, dekketAvAnnetRegelverk.resultat
+    )
 }
 
 data class VurderingNedsattArbeidsevne(
@@ -31,17 +33,19 @@ data class VurderingNedsattArbeidsevne(
     override val dekketAvAnnetRegelverk: VurderingDekketAvAnnetRegelverk,
 ) : MedlemskapVurdering, DekketAvAnnetRegelverkVurdering {
 
-    override fun utledDelresultater() = listOf(medlemskap.resultat, dekketAvAnnetRegelverk.resultat)
+    override fun utledResultat() = sammenstillDelresultater(
+        medlemskap.resultat, dekketAvAnnetRegelverk.resultat
+    )
 }
 
 data class VurderingOmstillingsstønad(
     override val medlemskap: VurderingMedlemskap,
 ) : MedlemskapVurdering {
-    override fun utledDelresultater() = listOf(medlemskap.resultat)
+    override fun utledResultat() = sammenstillDelresultater(medlemskap.resultat)
 }
 
 data object VurderingOvergangsstønad : MedlemskapVurdering {
     override val medlemskap: VurderingMedlemskap = VurderingMedlemskap.IMPLISITT
 
-    override fun utledDelresultater() = listOf(medlemskap.resultat)
+    override fun utledResultat() = sammenstillDelresultater(medlemskap.resultat)
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gir noen fordeler:

- Kompilatoren sier nå fra dersom vi har glemt å implementere en utledResultat for en klasse som implementerer Vurderinger. Slik var det ikke tidligere, og da var det lett å glemme å legge til nye elementer i finnResultatetFraVurderinger. Det var det som var opphavet til valideringsfeilen vi så på demo i dag. 
- Nå er `IngenVurderinger` eksplisitt satt til `Oppfylt`, i stedet for å bli implisitt oppfylt fordi en tom liste i teorien evaluerer true på  `delresultater.all { it == ResultatDelvilkårperiode.OPPFYLT }` 