### PR TITLE
Opphørsvedtak utvides med beregningsresultat

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.sak.vedtak
 
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnResponse
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnResponse
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnResponse
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.tilDto
 import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagLæremidler
@@ -35,7 +35,8 @@ object VedtakDtoMapper {
             beregningsresultat = data.beregningsresultat.tilDto(revurderFra = revurderFra),
         )
 
-        is OpphørTilsynBarn -> OpphørTilsynBarnDto(
+        is OpphørTilsynBarn -> OpphørTilsynBarnResponse(
+            beregningsresultat = data.beregningsresultat.tilDto(revurderFra = revurderFra),
             årsakerOpphør = data.årsaker,
             begrunnelse = data.begrunnelse,
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -17,7 +17,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
@@ -46,7 +46,7 @@ class TilsynBarnBeregnYtelseSteg(
         when (vedtak) {
             is InnvilgelseTilsynBarnRequest -> beregnOgLagreInnvilgelse(saksbehandling)
             is AvslagTilsynBarnDto -> lagreAvslag(saksbehandling, vedtak)
-            is OpphørTilsynBarnDto -> beregnOgLagreOpphør(saksbehandling, vedtak)
+            is OpphørTilsynBarnRequest -> beregnOgLagreOpphør(saksbehandling, vedtak)
         }
     }
 
@@ -56,7 +56,7 @@ class TilsynBarnBeregnYtelseSteg(
         lagreAndeler(saksbehandling, beregningsresultat)
     }
 
-    private fun beregnOgLagreOpphør(saksbehandling: Saksbehandling, vedtak: OpphørTilsynBarnDto) {
+    private fun beregnOgLagreOpphør(saksbehandling: Saksbehandling, vedtak: OpphørTilsynBarnRequest) {
         brukerfeilHvis(saksbehandling.forrigeBehandlingId == null) {
             "Opphør er et ugyldig vedtaksresultat fordi behandlingen er en førstegangsbehandling"
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -12,7 +12,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.BeregningsresultatTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.tilDto
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtakResponse
@@ -52,7 +52,7 @@ class TilsynBarnVedtakController(
     @PostMapping("{behandlingId}/opphor")
     fun opphør(
         @PathVariable behandlingId: BehandlingId,
-        @RequestBody vedtak: OpphørTilsynBarnDto,
+        @RequestBody vedtak: OpphørTilsynBarnRequest,
     ) {
         lagreVedtak(behandlingId, vedtak)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/OpphørTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/OpphørTilsynBarnDto.kt
@@ -3,7 +3,13 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 
-data class OpphørTilsynBarnDto(
+data class OpphørTilsynBarnResponse(
+    val beregningsresultat: BeregningsresultatTilsynBarnDto,
     val årsakerOpphør: List<ÅrsakOpphør>,
     val begrunnelse: String,
-) : VedtakTilsynBarnRequest, VedtakTilsynBarnResponse, VedtakTilsynBarnDto(TypeVedtak.OPPHØR)
+) : VedtakTilsynBarnResponse, VedtakTilsynBarnDto(TypeVedtak.OPPHØR)
+
+data class OpphørTilsynBarnRequest(
+    val årsakerOpphør: List<ÅrsakOpphør>,
+    val begrunnelse: String,
+) : VedtakTilsynBarnRequest, VedtakTilsynBarnDto(TypeVedtak.OPPHØR)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/VedtakTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/VedtakTilsynBarnDto.kt
@@ -15,7 +15,7 @@ import no.nav.tilleggsstonader.sak.vedtak.dto.VedtakResponse
 @JsonSubTypes(
     JsonSubTypes.Type(InnvilgelseTilsynBarnRequest::class, name = "INNVILGELSE"),
     JsonSubTypes.Type(AvslagTilsynBarnDto::class, name = "AVSLAG"),
-    JsonSubTypes.Type(OpphørTilsynBarnDto::class, name = "OPPHØR"),
+    JsonSubTypes.Type(OpphørTilsynBarnRequest::class, name = "OPPHØR"),
     failOnRepeatedNames = true,
 )
 sealed class VedtakTilsynBarnDto(open val type: TypeVedtak)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -9,7 +9,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatT
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.StønadsperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
@@ -22,7 +22,7 @@ object TilsynBarnTestUtil {
 
     fun innvilgelseDto() = InnvilgelseTilsynBarnRequest
 
-    fun opphørDto() = OpphørTilsynBarnDto(
+    fun opphørDto() = OpphørTilsynBarnRequest(
         årsakerOpphør = listOf(ÅrsakOpphør.ENDRING_UTGIFTER),
         begrunnelse = "Endring i utgifter",
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -16,7 +16,7 @@ import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
@@ -126,7 +126,7 @@ class TilsynBarnVedtakControllerTest(
             fagsak = fagsak,
         )
 
-        val vedtak = OpphørTilsynBarnDto(
+        val vedtak = OpphørTilsynBarnRequest(
             årsakerOpphør = listOf(ÅrsakOpphør.ENDRING_UTGIFTER),
             begrunnelse = "endre utgifter opphør",
         )
@@ -135,7 +135,7 @@ class TilsynBarnVedtakControllerTest(
 
         val lagretDto = hentVedtak(behandlingLagreOpphør.id).body!!
 
-        assertThat((lagretDto as OpphørTilsynBarnDto).årsakerOpphør).isEqualTo(vedtak.årsakerOpphør)
+        assertThat((lagretDto as OpphørTilsynBarnRequest).årsakerOpphør).isEqualTo(vedtak.årsakerOpphør)
         assertThat(lagretDto.begrunnelse).isEqualTo(vedtak.begrunnelse)
         assertThat(lagretDto.type).isEqualTo(TypeVedtak.OPPHØR)
     }
@@ -164,7 +164,7 @@ class TilsynBarnVedtakControllerTest(
 
     private fun opphørVedtak(
         behandling: Behandling,
-        vedtak: OpphørTilsynBarnDto,
+        vedtak: OpphørTilsynBarnRequest,
     ) {
         restTemplate.exchange<Map<String, Any>?>(
             localhost("api/vedtak/tilsyn-barn/${behandling.id}/opphor"),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Utvider OpphørDto ved å splitte opp i Request og Response, slik som Innvilgelse. Utvider OpphørTilsynBarnResponse til å inneholde beregningsresultat. Dette for å kunne vise Vedtakshistorikk i frontend også for Opphør

Sees i sammenheng med:
FAVRO: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23089
PR SAK: https://github.com/navikt/tilleggsstonader-sak/pull/508
PR SAK FRONTEND: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/620
