### PR TITLE
Skal iverksette beløp som dagsats for læremidler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -50,6 +50,9 @@ data class AndelTilkjentYtelse(
         feilHvisIkke(fom <= tom) {
             "Forventer at fom($fom) er mindre eller lik tom($tom)"
         }
+        if (satstype == Satstype.MÅNED) {
+            validerFørsteOgSisteIMåneden()
+        }
 
         validerDataForType()
     }
@@ -73,21 +76,24 @@ data class AndelTilkjentYtelse(
     private fun validerTilsynBarn() {
         validerSatstype(Satstype.DAG)
         validerLikFomOgTom()
-        feilHvis(satstype == Satstype.DAG && fom.erLørdagEllerSøndag()) {
-            "Dagsats som begynner en lørdag eller søndag vil ikke bli utbetalt"
-        }
+        validerFomIkkeLørdagEllerSøndag()
     }
 
     private fun validerLæremidler() {
-        validerSatstype(Satstype.MÅNED)
+        validerSatstype(Satstype.DAG)
+        validerLikFomOgTom()
+        validerFomIkkeLørdagEllerSøndag()
+    }
+
+    private fun validerFomIkkeLørdagEllerSøndag() {
+        feilHvis(fom.erLørdagEllerSøndag()) {
+            "Dagsats som begynner en lørdag eller søndag vil ikke bli utbetalt"
+        }
     }
 
     private fun validerSatstype(forventetSatstype: Satstype) {
         feilHvis(satstype != forventetSatstype) {
             "Ugyldig satstype=$satstype forventetSatsType=$forventetSatstype for type=$type"
-        }
-        if (satstype == Satstype.MÅNED) {
-            validerFørsteOgSisteIMåneden()
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
@@ -50,41 +51,53 @@ class AndelTilkjentYtelseTest {
     @Nested
     inner class Månedsandel {
 
-        val andel = {
-            andelTilkjentYtelse(
-                type = TypeAndel.LÆREMIDLER_AAP,
-                satstype = Satstype.MÅNED,
-                fom = måned.atDay(1),
-                tom = måned.atEndOfMonth(),
-            )
-        }
-
+        @Disabled // har ingen type som bruker måned ennå så denne kaster exception
         @Test
         fun `fom er første dag i måneden og tom er siste dag i måneden`() {
             assertThatCode {
-                andel()
+                andelTilkjentYtelse(
+                    type = TypeAndel.LÆREMIDLER_AAP,
+                    satstype = Satstype.MÅNED,
+                    fom = måned.atDay(1),
+                    tom = måned.atEndOfMonth(),
+                )
             }.doesNotThrowAnyException()
         }
 
         @Test
         fun `kast feil hvis FOM ikke er første dagen i måneden`() {
             assertThatThrownBy {
-                andel().copy(fom = måned.atDay(2))
+                andelTilkjentYtelse(
+                    type = TypeAndel.LÆREMIDLER_AAP,
+                    satstype = Satstype.MÅNED,
+                    fom = måned.atDay(2),
+                    tom = måned.atEndOfMonth(),
+                )
             }.hasMessageContaining("Forventer at fom(2024-01-02) er første dagen i måneden for type=LÆREMIDLER_AAP")
         }
 
         @Test
         fun `kast feil hvis TOM ikke er siste dagen i måneden`() {
             assertThatThrownBy {
-                andel().copy(fom = måned.atDay(2))
-            }.hasMessageContaining("Forventer at fom(2024-01-02) er første dagen i måneden for type=LÆREMIDLER_AAP")
+                andelTilkjentYtelse(
+                    type = TypeAndel.LÆREMIDLER_AAP,
+                    satstype = Satstype.MÅNED,
+                    fom = måned.atDay(1),
+                    tom = måned.atDay(2),
+                )
+            }.hasMessageContaining("Forventer at tom(2024-01-02) er siste dagen i måneden for type=LÆREMIDLER_AAP")
         }
 
         @Test
         fun `kast feil hvis FOM og TOM ikke er i den samme måneden`() {
             assertThatThrownBy {
-                andel().copy(fom = måned.plusMonths(1).atEndOfMonth())
-            }.hasMessageContaining("Forventer at fom(2024-02-29) og tom(2024-01-31) er i den samme måneden")
+                andelTilkjentYtelse(
+                    type = TypeAndel.LÆREMIDLER_AAP,
+                    satstype = Satstype.MÅNED,
+                    fom = måned.atDay(1),
+                    tom = måned.plusMonths(1).atEndOfMonth(),
+                )
+            }.hasMessageContaining("Forventer at fom(2024-01-01) og tom(2024-02-29) er i den samme måneden")
         }
     }
 
@@ -108,15 +121,15 @@ class AndelTilkjentYtelseTest {
     inner class LæremidlerAndel {
 
         @Test
-        fun `skal kaste feil hvis satstype ikke er måned`() {
+        fun `skal kaste feil hvis satstype ikke er dag`() {
             assertThatThrownBy {
                 andelTilkjentYtelse(
                     type = TypeAndel.LÆREMIDLER_AAP,
-                    satstype = Satstype.DAG,
+                    satstype = Satstype.MÅNED,
                     fom = måned.atDay(1),
-                    tom = måned.atDay(1),
+                    tom = måned.atEndOfMonth(),
                 )
-            }.hasMessageContaining("Ugyldig satstype=DAG forventetSatsType=MÅNED for type=LÆREMIDLER_AAP")
+            }.hasMessageContaining("Ugyldig satstype=MÅNED forventetSatsType=DAG for type=LÆREMIDLER_AAP")
         }
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi kan tydligen ikke iverksette læremidler som måneder der vi iverksetter flere måneder frem i tiden direkte, som en forskuddsutbetaling.
Endrer då til dag, på lik måte som arena gjør idag.

https://nav-it.slack.com/archives/C060V3ADLTD/p1733990516470109?thread_ts=1733824851.927059&cid=C060V3ADLTD