### PR TITLE
Beregner utbetalingsperioder for læremidler.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20241112093526_694e258"
 val tilleggsstønaderLibsVersion = "2024.12.11-15.08.d370f00e88e3"
-val tilleggsstønaderKontrakterVersion = "2024.12.03-16.13.446dde2e3a5a"
+val tilleggsstønaderKontrakterVersion = "2024.12.16-12.43.36745efd328a"
 val tokenSupportVersion = "5.0.11"
 val wiremockVersion = "3.9.2"
 val mockkVersion = "1.13.12"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtil.kt
@@ -112,4 +112,6 @@ fun LocalDate.erSisteDagIMåneden() = this.dayOfMonth == YearMonth.from(this).at
 fun LocalDate.tilFørsteDagIMåneden() = YearMonth.from(this).atDay(1)
 fun LocalDate.tilSisteDagIMåneden() = YearMonth.from(this).atEndOfMonth()
 
+fun LocalDate.lørdagEllerSøndag() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY
+
 fun Periode<LocalDate>.formatertPeriodeNorskFormat() = "${this.fom.norskFormat()} - ${this.tom.norskFormat()}"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerPeriodeUtil.kt
@@ -1,0 +1,35 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
+
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
+import no.nav.tilleggsstonader.sak.util.lørdagEllerSøndag
+import java.time.LocalDate
+
+object LæremidlerPeriodeUtil {
+
+    /**
+     * Splitter en periode i løpende måneder. Løpende måned er fra dagens dato og en måned frem i tiden.
+     * eks 05.01.2024-29.02.24 blir listOf( P(fom=05.01.2024,tom=04.02.2024), P(fom=05.02.2024,tom=29.02.2024) )
+     */
+    fun <P : Periode<LocalDate>> P.splitPerLøpendeMåneder(medNyPeriode: (fom: LocalDate, tom: LocalDate) -> P): List<P> {
+        val perioder = mutableListOf<P>()
+        var gjeldendeFom = fom
+        while (gjeldendeFom <= tom) {
+            val nyTom = minOf(gjeldendeFom.sisteDagenILøpendeMåned(), tom)
+
+            val nyPeriode = medNyPeriode(gjeldendeFom, nyTom)
+            if (nyPeriode.harDatoerIUkedager()) {
+                perioder.add(nyPeriode)
+            }
+
+            gjeldendeFom = nyTom.plusDays(1)
+        }
+        return perioder
+    }
+
+    fun LocalDate.sisteDagenILøpendeMåned(): LocalDate =
+        this.plusMonths(1).minusDays(1)
+
+    private fun <P : Periode<LocalDate>> P.harDatoerIUkedager(): Boolean = this.alleDatoer()
+        .any { dato -> !dato.lørdagEllerSøndag() }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DatoUtilTest.kt
@@ -90,4 +90,23 @@ class DatoUtilTest {
             assertThat(LocalDate.of(2024, 2, 4).tilSisteDagIMåneden()).isEqualTo(LocalDate.of(2024, 2, 29))
         }
     }
+
+    @Nested
+    inner class LørdagEllerSøndag {
+        @Test
+        fun `ukesdager skal gi false`() {
+            assertThat(LocalDate.of(2025, 1, 1).lørdagEllerSøndag()).isFalse() // onsdag rød dag
+            assertThat(LocalDate.of(2025, 1, 2).lørdagEllerSøndag()).isFalse() // torsdag
+            assertThat(LocalDate.of(2025, 1, 3).lørdagEllerSøndag()).isFalse() // fredag
+
+            assertThat(LocalDate.of(2025, 2, 3).lørdagEllerSøndag()).isFalse() // mandag
+            assertThat(LocalDate.of(2025, 2, 4).lørdagEllerSøndag()).isFalse() // tirsdag
+        }
+
+        @Test
+        fun `lørdag og søndag skal gi true`() {
+            assertThat(LocalDate.of(2025, 1, 4).lørdagEllerSøndag()).isTrue() // lørdag
+            assertThat(LocalDate.of(2025, 1, 5).lørdagEllerSøndag()).isTrue() // søndag
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerPeriodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerPeriodeUtilTest.kt
@@ -1,0 +1,177 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
+
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerPeriodeUtil.sisteDagenILøpendeMåned
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerPeriodeUtil.splitPerLøpendeMåneder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class LæremidlerPeriodeUtilTest {
+    private val FØRSTE_JAN_2024 = LocalDate.of(2024, 1, 1)
+    private val SISTE_JAN_2024 = LocalDate.of(2024, 1, 31)
+    private val FØRSTE_FEB_2024 = LocalDate.of(2024, 2, 1)
+    private val SISTE_FEB_2024 = LocalDate.of(2024, 2, 29)
+    private val FØRSTE_MARS_2024 = LocalDate.of(2024, 3, 1)
+    private val SISTE_MARS_2024 = LocalDate.of(2024, 3, 31)
+    private val SISTE_APRIL_2024 = LocalDate.of(2024, 4, 30)
+
+    @Nested
+    inner class SplitPerLøpendeMåneder {
+        @Test
+        fun `skal splitte periode i løpende måneder 2024-01-01 til 2024-02-01`() {
+            val datoperiode = Datoperiode(FØRSTE_JAN_2024, FØRSTE_FEB_2024)
+            assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                .containsExactly(
+                    Datoperiode(FØRSTE_JAN_2024, SISTE_JAN_2024),
+                    Datoperiode(FØRSTE_FEB_2024, FØRSTE_FEB_2024),
+                )
+        }
+
+        @Test
+        fun `skal splitte periode i løpende måneder 2024-01-01 til 2024-03-15`() {
+            val tom = LocalDate.of(2024, 3, 15)
+            val datoperiode = Datoperiode(FØRSTE_JAN_2024, tom)
+            assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                .containsExactly(
+                    Datoperiode(FØRSTE_JAN_2024, SISTE_JAN_2024),
+                    Datoperiode(FØRSTE_FEB_2024, SISTE_FEB_2024),
+                    Datoperiode(FØRSTE_MARS_2024, tom),
+                )
+        }
+
+        @Test
+        fun `fra første dag i måneden`() {
+            val datoperiode = Datoperiode(FØRSTE_JAN_2024, SISTE_MARS_2024)
+            assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                .containsExactly(
+                    Datoperiode(FØRSTE_JAN_2024, SISTE_JAN_2024),
+                    Datoperiode(FØRSTE_FEB_2024, SISTE_FEB_2024),
+                    Datoperiode(FØRSTE_MARS_2024, SISTE_MARS_2024),
+                )
+        }
+
+        @Test
+        fun `fra midt i måneden`() {
+            val datoperiode = Datoperiode(LocalDate.of(2024, 1, 15), SISTE_APRIL_2024)
+            assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                .containsExactly(
+                    Datoperiode(LocalDate.of(2024, 1, 15), LocalDate.of(2024, 2, 14)),
+                    Datoperiode(LocalDate.of(2024, 2, 15), LocalDate.of(2024, 3, 14)),
+                    Datoperiode(LocalDate.of(2024, 3, 15), LocalDate.of(2024, 4, 14)),
+                    Datoperiode(LocalDate.of(2024, 4, 15), SISTE_APRIL_2024),
+                )
+        }
+
+        // 29 dager i februar i 2024
+        @Test
+        fun `fra sluttet på måneden`() {
+            val datoperiode = Datoperiode(SISTE_JAN_2024, SISTE_APRIL_2024)
+            assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                .containsExactly(
+                    Datoperiode(SISTE_JAN_2024, SISTE_FEB_2024.minusDays(1)),
+                    Datoperiode(SISTE_FEB_2024, LocalDate.of(2024, 3, 28)),
+                    Datoperiode(LocalDate.of(2024, 3, 29), LocalDate.of(2024, 4, 28)),
+                    Datoperiode(LocalDate.of(2024, 4, 29), SISTE_APRIL_2024),
+                )
+        }
+
+        // 28 dager i februar i 2025
+        // må inkludere en dag for februar også for å utbetale et beløp som gjelder for februar og
+        @Test
+        fun `siste dagen i januar skal løpe til nest siste dagen i februar sånn at man får innvilget for siste dagen i februar og`() {
+            val datoperiode = Datoperiode(LocalDate.of(2025, 1, 28), LocalDate.of(2025, 3, 31))
+            assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                .containsExactly(
+                    Datoperiode(LocalDate.of(2025, 1, 28), LocalDate.of(2025, 2, 27)),
+                    Datoperiode(LocalDate.of(2025, 2, 28), LocalDate.of(2025, 3, 27)),
+                    Datoperiode(LocalDate.of(2025, 3, 28), LocalDate.of(2025, 3, 31)),
+                )
+        }
+
+        @Nested
+        inner class SammeMåned {
+
+            @Test
+            fun `periode som kun gjelder rød dag men ikke helg får innvilget`() {
+                val datoperiode = Datoperiode(FØRSTE_JAN_2024, FØRSTE_JAN_2024)
+                assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                    .containsExactly(
+                        datoperiode,
+                    )
+            }
+
+            // Arena tar ikke med helgdager når man innvilger for lengre perioder, men tar med hvis man kun innvilger en kort periode
+            @Test
+            fun `periode som gjelder helg får ikke innvilget`() {
+                val datoperiode = Datoperiode(LocalDate.of(2025, 1, 4), LocalDate.of(2025, 1, 5))
+                assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                    .isEmpty()
+            }
+
+            @Test
+            fun `skal ikke splitte periode som som har fom = tom`() {
+                val datoperiode = Datoperiode(FØRSTE_FEB_2024, FØRSTE_FEB_2024)
+                assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                    .containsExactly(datoperiode)
+            }
+
+            @Test
+            fun `skal ikke splitte periode som er i samme måned`() {
+                val datoperiode = Datoperiode(FØRSTE_JAN_2024, SISTE_JAN_2024)
+                assertThat(datoperiode.splitPerLøpendeMåneder { fom, tom -> Datoperiode(fom = fom, tom = tom) })
+                    .containsExactly(datoperiode)
+            }
+        }
+    }
+
+    @Nested
+    inner class SisteDagenILøpendeMåned {
+        @Test
+        fun `skal finne dato i neste måned`() {
+            assertThat(LocalDate.of(2025, 1, 1).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 1, 31))
+            assertThat(LocalDate.of(2025, 2, 1).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 28))
+            assertThat(LocalDate.of(2025, 3, 1).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 3, 31))
+            assertThat(LocalDate.of(2025, 4, 1).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 4, 30))
+        }
+
+        @Test
+        fun `hvis neste måned har færre antall dager`() {
+            assertThat(LocalDate.of(2025, 2, 28).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 3, 27))
+            assertThat(LocalDate.of(2025, 4, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 5, 29))
+        }
+
+        @Test
+        fun `hvis dagens måned har flere dager enn neste skal man bruke siste dagen i måneden`() {
+            assertThat(LocalDate.of(2025, 1, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 27))
+            assertThat(LocalDate.of(2025, 1, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 27))
+            assertThat(LocalDate.of(2025, 1, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 2, 27))
+
+            assertThat(LocalDate.of(2025, 3, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2025, 4, 29))
+        }
+
+        @Nested
+        inner class Skuddår {
+
+            @Test
+            fun `skal finne dato i neste måned`() {
+                assertThat(LocalDate.of(2024, 1, 1).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 1, 31))
+                assertThat(LocalDate.of(2024, 2, 1).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 29))
+            }
+
+            @Test
+            fun `hvis neste måned har færre antall dager`() {
+                assertThat(LocalDate.of(2024, 2, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 3, 28))
+                assertThat(LocalDate.of(2024, 4, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 5, 29))
+            }
+
+            @Test
+            fun `hvis dagens måned har flere dager enn neste skal man bruke siste dagen i måneden`() {
+                assertThat(LocalDate.of(2024, 1, 29).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 28))
+                assertThat(LocalDate.of(2024, 1, 30).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 28))
+                assertThat(LocalDate.of(2024, 1, 31).sisteDagenILøpendeMåned()).isEqualTo(LocalDate.of(2024, 2, 28))
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Skal beregne tom ut fra fra fom i løpende periode.
- Hvis man innvilget fra 31 jan, så skal man få innvilget for ny periode fra og med siste feb.

### Hvorfor er denne endringen nødvendig? ✨
Erstatter
https://github.com/navikt/tilleggsstonader-kontrakter/pull/99

Trukket ut utils fra
https://github.com/navikt/tilleggsstonader-sak/pull/521