### PR TITLE
Legg til støtte for ingen utdanning som svar på læremidelvilkår

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingService.kt
@@ -82,6 +82,7 @@ class OppfølgingService(
         return when (stønadsperiode.aktivitet) {
             AktivitetType.REELL_ARBEIDSSØKER -> false
             AktivitetType.INGEN_AKTIVITET -> error("Skal ikke være mulig å ha en stønadsperiode med ingen aktivitet")
+            AktivitetType.INGEN_UTDANNING -> error("Skal ikke være mulig å ha en stønadsperiode med ingen utdanning")
             AktivitetType.TILTAK -> {
                 val tiltak = finnOverlappendePerioder(registerAktivitet.filterNot(::tiltakErUtdanning), stønadsperiode)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/Vedtaksstatistikk.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/Vedtaksstatistikk.kt
@@ -326,6 +326,7 @@ enum class AktivitetTypeDvh {
     UTDANNING,
     REELL_ARBEIDSSØKER,
     INGEN_AKTIVITET,
+    INGEN_UTDANNING,
     ;
 
     companion object {
@@ -334,6 +335,7 @@ enum class AktivitetTypeDvh {
             AktivitetType.UTDANNING -> UTDANNING
             AktivitetType.REELL_ARBEIDSSØKER -> REELL_ARBEIDSSØKER
             AktivitetType.INGEN_AKTIVITET -> INGEN_AKTIVITET
+            AktivitetType.INGEN_UTDANNING -> INGEN_UTDANNING // TODO Burde denne mappes til ingen aktivitet?
 
             is MålgruppeType -> throw IllegalArgumentException("$vilkårsperiodeType er ikke en gyldig type aktivitet.")
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/AktivitetType.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/AktivitetType.kt
@@ -5,10 +5,11 @@ enum class AktivitetType : VilkårperiodeType {
     UTDANNING,
     REELL_ARBEIDSSØKER,
     INGEN_AKTIVITET,
+    INGEN_UTDANNING,
     ;
 
     override fun tilDbType(): String = this.name
 
     override fun girIkkeRettPåStønadsperiode() =
-        this == INGEN_AKTIVITET
+        this == INGEN_AKTIVITET || this == INGEN_UTDANNING
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -11,10 +11,10 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurdering
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeTilsynBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenUtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeTilsynBarn
@@ -122,6 +122,10 @@ private fun mapAktiviteterBarnetilsyn(
             }
             IngenAktivitetTilsynBarn
         }
+
+        AktivitetType.INGEN_UTDANNING -> {
+            error("Skal ikke kunne velge ingen utdanning/opplæringstiltak på tilsyn barn")
+        }
     }
 }
 
@@ -151,7 +155,9 @@ fun mapAktiviteterLæremidler(
             ),
         )
 
-        AktivitetType.INGEN_AKTIVITET -> IngenAktivitetLæremidler
+        AktivitetType.INGEN_AKTIVITET -> error("Skal ikke kunne velge ingen aktivitet på læremidler")
+
+        AktivitetType.INGEN_UTDANNING -> IngenUtdanningLæremidler
 
         AktivitetType.REELL_ARBEIDSSØKER -> brukerfeil("Reell arbeidssøker er ikke en gyldig aktivitet for læremidler")
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -69,7 +69,7 @@ data class GeneriskVilkårperiode<T : FaktaOgVurdering>(
         validerBegrunnelse()
 
         feilHvis(faktaOgVurdering.type.vilkårperiodeType != type) {
-            "Ugyldig kombinasjon - type($type) må være lik faktaOgVurdering($faktaOgVurdering)"
+            "Ugyldig kombinasjon - type($type) må være lik faktaOgVurdering($faktaOgVurdering) som er ${faktaOgVurdering.type.vilkårperiodeType}"
         }
 
         // TODO endre aktivitetsdager til value class og legg inn sjekk der

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingJson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingJson.kt
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 
     JsonSubTypes.Type(UtdanningLæremidler::class, name = "UTDANNING_LÆREMIDLER"),
     JsonSubTypes.Type(TiltakLæremidler::class, name = "TILTAK_LÆREMIDLER"),
-    JsonSubTypes.Type(IngenAktivitetLæremidler::class, name = "INGEN_AKTIVITET_LÆREMIDLER"),
+    JsonSubTypes.Type(IngenUtdanningLæremidler::class, name = "INGEN_UTDANNING_LÆREMIDLER"),
 
     JsonSubTypes.Type(AAPLæremidler::class, name = "AAP_LÆREMIDLER"),
     JsonSubTypes.Type(OmstillingsstønadLæremidler::class, name = "OMSTILLINGSSTØNAD_LÆREMIDLER"),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -76,8 +76,8 @@ data class UtdanningLæremidler(
     override val type: AktivitetLæremidlerType = AktivitetLæremidlerType.UTDANNING_LÆREMIDLER
 }
 
-data object IngenAktivitetLæremidler : AktivitetLæremidler {
-    override val type: AktivitetLæremidlerType = AktivitetLæremidlerType.INGEN_AKTIVITET_LÆREMIDLER
+data object IngenUtdanningLæremidler : AktivitetLæremidler {
+    override val type: AktivitetLæremidlerType = AktivitetLæremidlerType.INGEN_UTDANNING_LÆREMIDLER
     override val fakta: Fakta = IngenFakta
     override val vurderinger: Vurderinger = IngenVurderinger
 }
@@ -108,7 +108,7 @@ enum class AktivitetLæremidlerType(
 
     UTDANNING_LÆREMIDLER(AktivitetType.UTDANNING),
     TILTAK_LÆREMIDLER(AktivitetType.TILTAK),
-    INGEN_AKTIVITET_LÆREMIDLER(AktivitetType.INGEN_AKTIVITET),
+    INGEN_UTDANNING_LÆREMIDLER(AktivitetType.INGEN_UTDANNING),
 }
 
 enum class MålgruppeLæremidlerType(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -155,6 +155,8 @@ object VilkårperiodeTestUtil {
         )
 
         AktivitetType.INGEN_AKTIVITET -> IngenAktivitetTilsynBarn
+
+        AktivitetType.INGEN_UTDANNING -> error("Skal ikke kunne velge ingen utdanning/opplæringstiltak for tilsyn barn")
     }
 
     fun faktaOgVurderingAktivitetLæremidler(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingLæremidlerTest.kt
@@ -21,7 +21,7 @@ class FaktaOgVurderingLæremidlerTest {
 
         @Test
         fun `resultatet skal ikke være oppfylt hvis ikke aktivitetstypen gir rett på stønaden`() {
-            listOf(IngenAktivitetLæremidler).forEach { faktaOgVurdering ->
+            listOf(IngenUtdanningLæremidler).forEach { faktaOgVurdering ->
                 assertThat(faktaOgVurdering.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
             }
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
@@ -192,7 +192,7 @@ class VilkårperiodeRepositoryJsonTest : IntegrationTest() {
                 when (type) {
                     AktivitetLæremidlerType.UTDANNING_LÆREMIDLER -> UtdanningLæremidler::class
                     AktivitetLæremidlerType.TILTAK_LÆREMIDLER -> TiltakLæremidler::class
-                    AktivitetLæremidlerType.INGEN_AKTIVITET_LÆREMIDLER -> IngenAktivitetLæremidler::class
+                    AktivitetLæremidlerType.INGEN_UTDANNING_LÆREMIDLER -> IngenUtdanningLæremidler::class
                 }
             }
         }.java

--- a/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/INGEN_AKTIVITET_LÆREMIDLER.json
+++ b/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/INGEN_AKTIVITET_LÆREMIDLER.json
@@ -1,5 +1,0 @@
-{
-  "type": "INGEN_AKTIVITET_LÆREMIDLER",
-  "fakta": {},
-  "vurderinger": {}
-}

--- a/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/INGEN_UTDANNING_LÆREMIDLER.json
+++ b/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/INGEN_UTDANNING_LÆREMIDLER.json
@@ -1,0 +1,5 @@
+{
+  "type": "INGEN_UTDANNING_LÆREMIDLER",
+  "fakta": {},
+  "vurderinger": {}
+}


### PR DESCRIPTION
Valgte å utvide eksisterende enum med ny aktivitet siden det var enklere for meg å lage en ny flyt enn å finne ta høyde for alle effekter ved å redigere en eksisterende flyt. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23719

### Hvorfor er denne endringen nødvendig? ✨
