### PR TITLE
👔 Ny valideringsflyt for læremiddel-aktiviteter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningUtil.kt
@@ -69,6 +69,6 @@ fun List<Vilkårperiode>.tilAktiviteter(): List<Aktivitet> =
                 fom = it.fom,
                 tom = it.tom,
                 prosent = fakta.takeIfFaktaOrThrow<FaktaAktivitetLæremidler>().prosent,
-                studienivå = fakta.takeIfFaktaOrThrow<FaktaAktivitetLæremidler>().studienivå,
+                studienivå = fakta.takeIfFaktaOrThrow<FaktaAktivitetLæremidler>().studienivå!!,
             )
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -144,9 +144,10 @@ fun mapAktiviteterLæremidler(
         AktivitetType.UTDANNING -> UtdanningLæremidler(
             fakta = FaktaAktivitetLæremidler(
                 prosent = faktaOgSvar.prosent!!,
-                studienivå = faktaOgSvar.studienivå!!,
+                studienivå = faktaOgSvar.studienivå,
             ),
             vurderinger = VurderingerUtdanningLæremidler(
+                harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter),
                 harRettTilUtstyrsstipend = VurderingHarRettTilUtstyrsstipend(faktaOgSvar.svarHarRettTilUtstyrsstipend),
             ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -133,7 +133,7 @@ fun mapAktiviteterLæremidler(
         AktivitetType.TILTAK -> TiltakLæremidler(
             fakta = FaktaAktivitetLæremidler(
                 prosent = faktaOgSvar.prosent!!,
-                studienivå = faktaOgSvar.studienivå!!,
+                studienivå = faktaOgSvar.studienivå,
             ),
             vurderinger = VurderingTiltakLæremidler(
                 harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -88,8 +88,9 @@ data class VurderingTiltakLæremidler(
 ) : HarUtgifterVurdering, HarRettTilUtstyrsstipendVurdering
 
 data class VurderingerUtdanningLæremidler(
+    override val harUtgifter: VurderingHarUtgifter,
     override val harRettTilUtstyrsstipend: VurderingHarRettTilUtstyrsstipend,
-) : HarRettTilUtstyrsstipendVurdering
+) : HarUtgifterVurdering, HarRettTilUtstyrsstipendVurdering
 
 data class FaktaAktivitetLæremidler(
     override val prosent: Int,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -3,6 +3,9 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurdering
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.ResultatDelvilkårperiode.IKKE_OPPFYLT
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.ResultatDelvilkårperiode.OPPFYLT
 
 sealed interface FaktaOgVurderingLæremidler : FaktaOgVurdering {
     override val type: TypeFaktaOgVurderingLæremidler
@@ -67,6 +70,17 @@ data class TiltakLæremidler(
     override val vurderinger: VurderingTiltakLæremidler,
 ) : AktivitetLæremidler {
     override val type: AktivitetLæremidlerType = AktivitetLæremidlerType.TILTAK_LÆREMIDLER
+    override fun utledResultat(): ResultatVilkårperiode {
+        if (vurderinger.harUtgifter.resultat == IKKE_OPPFYLT) {
+            return ResultatVilkårperiode.IKKE_OPPFYLT
+        }
+
+        if (vurderinger.harUtgifter.resultat == OPPFYLT && fakta.studienivå == Studienivå.HØYERE_UTDANNING) {
+            return ResultatVilkårperiode.OPPFYLT
+        }
+
+        return vurderinger.resultatVurderinger()
+    }
 }
 
 data class UtdanningLæremidler(
@@ -74,6 +88,17 @@ data class UtdanningLæremidler(
     override val vurderinger: VurderingerUtdanningLæremidler,
 ) : AktivitetLæremidler {
     override val type: AktivitetLæremidlerType = AktivitetLæremidlerType.UTDANNING_LÆREMIDLER
+    override fun utledResultat(): ResultatVilkårperiode {
+        if (vurderinger.harUtgifter.resultat == IKKE_OPPFYLT) {
+            return ResultatVilkårperiode.IKKE_OPPFYLT
+        }
+
+        if (vurderinger.harUtgifter.resultat == OPPFYLT && fakta.studienivå == Studienivå.HØYERE_UTDANNING) {
+            return ResultatVilkårperiode.OPPFYLT
+        }
+
+        return vurderinger.resultatVurderinger()
+    }
 }
 
 data object IngenAktivitetLæremidler : AktivitetLæremidler {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -79,7 +79,7 @@ data class TiltakLæremidler(
             return ResultatVilkårperiode.OPPFYLT
         }
 
-        return vurderinger.resultatVurderinger()
+        return super.utledResultat()
     }
 }
 
@@ -97,7 +97,7 @@ data class UtdanningLæremidler(
             return ResultatVilkårperiode.OPPFYLT
         }
 
-        return vurderinger.resultatVurderinger()
+        return super.utledResultat()
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadLæremidlerFaktaOgVurdering.kt
@@ -93,7 +93,7 @@ data class VurderingerUtdanningLæremidler(
 
 data class FaktaAktivitetLæremidler(
     override val prosent: Int,
-    override val studienivå: Studienivå,
+    override val studienivå: Studienivå?,
 ) : Fakta, FaktaProsent, FaktaStudienivå {
     init {
         require(prosent in 1..100) { "Prosent må være mellom 1 og 100" }

--- a/src/main/resources/db/migration/V57__utdanning_utgifter.sql
+++ b/src/main/resources/db/migration/V57__utdanning_utgifter.sql
@@ -1,0 +1,14 @@
+UPDATE vilkar_periode vp
+SET fakta_og_vurdering = jsonb_set(
+        vp.fakta_og_vurdering::jsonb,
+        '{vurderinger,harUtgifter}',
+        '{
+          "svar": "JA",
+          "resultat": "OPPFYLT"
+        }'::jsonb
+                         )
+    FROM behandling b
+JOIN fagsak f ON f.id = b.fagsak_id
+WHERE vp.behandling_id = b.id
+  AND f.stonadstype = 'LÆREMIDLER'
+  AND vp.type = 'UTDANNING';

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
@@ -189,9 +189,9 @@ class InterntVedtakServiceTest {
                 assertThat(resultat).isEqualTo(ResultatVilkårperiode.OPPFYLT)
                 with(faktaOgVurderinger as AktivitetLæremidlerFaktaOgVurderingerDto) {
                     assertThat(harUtgifter!!.svar).isEqualTo(SvarJaNei.JA)
-                    assertThat(harUtgifter!!.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
+                    assertThat(harUtgifter.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
                     assertThat(harRettTilUtstyrsstipend!!.svar).isEqualTo(SvarJaNei.NEI)
-                    assertThat(harRettTilUtstyrsstipend!!.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
+                    assertThat(harRettTilUtstyrsstipend.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
                     assertThat(prosent).isEqualTo(80)
                     assertThat(studienivå).isEqualTo(Studienivå.HØYERE_UTDANNING)
                 }
@@ -201,8 +201,9 @@ class InterntVedtakServiceTest {
                 assertThat(type).isEqualTo(AktivitetType.UTDANNING)
                 with(faktaOgVurderinger as AktivitetLæremidlerFaktaOgVurderingerDto) {
                     assertThat(harRettTilUtstyrsstipend!!.svar).isEqualTo(SvarJaNei.JA)
-                    assertThat(harRettTilUtstyrsstipend!!.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
-                    assertThat(harUtgifter).isNull()
+                    assertThat(harRettTilUtstyrsstipend.resultat).isEqualTo(ResultatDelvilkårperiode.IKKE_OPPFYLT)
+                    assertThat(harUtgifter!!.svar).isEqualTo(SvarJaNei.JA)
+                    assertThat(harUtgifter.resultat).isEqualTo(ResultatDelvilkårperiode.OPPFYLT)
                     assertThat(prosent).isEqualTo(80)
                     assertThat(studienivå).isEqualTo(Studienivå.VIDEREGÅENDE)
                 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -175,6 +175,7 @@ object VilkårperiodeTestUtil {
         AktivitetType.UTDANNING -> UtdanningLæremidler(
             fakta = FaktaAktivitetLæremidler(prosent, studienivå),
             vurderinger = VurderingerUtdanningLæremidler(
+                harUtgifter = harUtgifter,
                 harRettTilUtstyrsstipend = harRettTilUtstyrsstipend,
             ),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingAktivitetLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingAktivitetLæremidlerTest.kt
@@ -1,0 +1,185 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
+
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FaktaOgVurderingAktivitetLæremidlerTest {
+
+    @Test
+    fun `resultatet skal ikke være oppfylt hvis ikke aktivitetstypen gir rett på stønaden`() {
+        listOf(IngenAktivitetLæremidler).forEach { faktaOgVurdering ->
+            assertThat(faktaOgVurdering.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+        }
+    }
+
+    object HarUtgifterSvar {
+        val ikkeVurdert = VurderingHarUtgifter(svar = null)
+        val ja = VurderingHarUtgifter(svar = SvarJaNei.JA)
+        val nei = VurderingHarUtgifter(svar = SvarJaNei.NEI)
+    }
+
+    object HarRettTilUtstyrsstipendSvar {
+        val ikkeVurdert = VurderingHarRettTilUtstyrsstipend(svar = null)
+        val ja = VurderingHarRettTilUtstyrsstipend(svar = SvarJaNei.JA)
+        val nei = VurderingHarRettTilUtstyrsstipend(svar = SvarJaNei.NEI)
+        val alleSvar = listOf(ikkeVurdert, ja, nei)
+    }
+
+    object StudienivåSvar {
+        val ikkeSvart = FaktaAktivitetLæremidler(prosent = 100, studienivå = null)
+        val høyereUtdanning =
+            FaktaAktivitetLæremidler(prosent = 100, studienivå = Studienivå.HØYERE_UTDANNING)
+        val videregående =
+            FaktaAktivitetLæremidler(prosent = 100, studienivå = Studienivå.VIDEREGÅENDE)
+        val allePermutasjoner = listOf(ikkeSvart, høyereUtdanning, videregående)
+    }
+
+    @Nested
+    inner class Utdanning {
+        @Test
+        fun `hvis bruker ikke har utgifter skal resultatet alltid bli IKKE_OPPFYLT`() {
+            for (studienivå in StudienivåSvar.allePermutasjoner) {
+                for (harRettTilUtstyrsstipendSvar in HarRettTilUtstyrsstipendSvar.alleSvar) {
+                    val inngangsvilkår = UtdanningLæremidler(
+                        fakta = studienivå,
+                        vurderinger = VurderingerUtdanningLæremidler(
+                            harUtgifter = HarUtgifterSvar.nei,
+                            harRettTilUtstyrsstipend = harRettTilUtstyrsstipendSvar,
+                        ),
+                    )
+                    assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+                }
+            }
+        }
+
+        @Test
+        fun `hvis bruker har utgifter tar høyere utdanning, så skal resultatet bli OPPFYLT`() {
+            for (harRettTilUtstyrsstipendSvar in HarRettTilUtstyrsstipendSvar.alleSvar) {
+                val inngangsvilkår = UtdanningLæremidler(
+                    fakta = StudienivåSvar.høyereUtdanning,
+                    vurderinger = VurderingerUtdanningLæremidler(
+                        harUtgifter = HarUtgifterSvar.ja,
+                        harRettTilUtstyrsstipend = harRettTilUtstyrsstipendSvar,
+                    ),
+                )
+                assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.OPPFYLT)
+            }
+        }
+
+        @Test
+        fun `hvis bruker har utgifter og går på videregående skole uten rett til utstrysstipend, så skal resultatet bli OPPFYLT`() {
+            val inngangsvilkår = UtdanningLæremidler(
+                fakta = StudienivåSvar.videregående,
+                vurderinger = VurderingerUtdanningLæremidler(
+                    harUtgifter = HarUtgifterSvar.ja,
+                    harRettTilUtstyrsstipend = HarRettTilUtstyrsstipendSvar.nei,
+                ),
+            )
+            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.OPPFYLT)
+        }
+
+        @Test
+        fun `hvis bruker har utgifter og går på videregående, men har rett til utstrysstipend, så skal resultatet bli IKKE_OPPFYLT`() {
+            val inngangsvilkår = UtdanningLæremidler(
+                fakta = StudienivåSvar.videregående,
+                vurderinger = VurderingerUtdanningLæremidler(
+                    harUtgifter = HarUtgifterSvar.ja,
+                    harRettTilUtstyrsstipend = HarRettTilUtstyrsstipendSvar.ja,
+                ),
+            )
+            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+        }
+
+        @Test
+        fun `hvis bruker ikke har vurdert utgifter skal resultatet alltid bli IKKE_VURDERT`() {
+            for (studienivå in StudienivåSvar.allePermutasjoner) {
+                for (harRettTilUtstyrsstipendSvar in HarRettTilUtstyrsstipendSvar.alleSvar) {
+                    val inngangsvilkår = UtdanningLæremidler(
+                        fakta = studienivå,
+                        vurderinger = VurderingerUtdanningLæremidler(
+                            harUtgifter = HarUtgifterSvar.ikkeVurdert,
+                            harRettTilUtstyrsstipend = harRettTilUtstyrsstipendSvar,
+                        ),
+                    )
+                    assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
+                }
+            }
+        }
+    }
+
+    @Nested
+    inner class Tiltak {
+        @Test
+        fun `hvis bruker ikke har utgifter skal resultatet alltid bli IKKE_OPPFYLT`() {
+            for (studienivå in StudienivåSvar.allePermutasjoner) {
+                for (harRettTilUtstyrsstipendSvar in HarRettTilUtstyrsstipendSvar.alleSvar) {
+                    val inngangsvilkår = TiltakLæremidler(
+                        fakta = studienivå,
+                        vurderinger = VurderingTiltakLæremidler(
+                            harUtgifter = HarUtgifterSvar.nei,
+                            harRettTilUtstyrsstipend = harRettTilUtstyrsstipendSvar,
+                        ),
+                    )
+                    assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+                }
+            }
+        }
+
+        @Test
+        fun `hvis bruker har utgifter tar høyere utdanning, så skal resultatet bli OPPFYLT`() {
+            for (harRettTilUtstyrsstipendSvar in HarRettTilUtstyrsstipendSvar.alleSvar) {
+                val inngangsvilkår = TiltakLæremidler(
+                    fakta = StudienivåSvar.høyereUtdanning,
+                    vurderinger = VurderingTiltakLæremidler(
+                        harUtgifter = HarUtgifterSvar.ja,
+                        harRettTilUtstyrsstipend = harRettTilUtstyrsstipendSvar,
+                    ),
+                )
+                assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.OPPFYLT)
+            }
+        }
+
+        @Test
+        fun `hvis bruker har utgifter og går på videregående skole uten rett til utstrysstipend, så skal resultatet bli OPPFYLT`() {
+            val inngangsvilkår = TiltakLæremidler(
+                fakta = StudienivåSvar.videregående,
+                vurderinger = VurderingTiltakLæremidler(
+                    harUtgifter = HarUtgifterSvar.ja,
+                    harRettTilUtstyrsstipend = HarRettTilUtstyrsstipendSvar.nei,
+                ),
+            )
+            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.OPPFYLT)
+        }
+
+        @Test
+        fun `hvis bruker har utgifter og går på videregående, men har rett til utstrysstipend, så skal resultatet bli IKKE_OPPFYLT`() {
+            val inngangsvilkår = TiltakLæremidler(
+                fakta = StudienivåSvar.videregående,
+                vurderinger = VurderingTiltakLæremidler(
+                    harUtgifter = HarUtgifterSvar.ja,
+                    harRettTilUtstyrsstipend = HarRettTilUtstyrsstipendSvar.ja,
+                ),
+            )
+            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+        }
+
+        @Test
+        fun `hvis bruker ikke har vurdert utgifter skal resultatet alltid bli IKKE_VURDERT`() {
+            for (studienivå in StudienivåSvar.allePermutasjoner) {
+                for (harRettTilUtstyrsstipendSvar in HarRettTilUtstyrsstipendSvar.alleSvar) {
+                    val inngangsvilkår = TiltakLæremidler(
+                        fakta = studienivå,
+                        vurderinger = VurderingTiltakLæremidler(
+                            harUtgifter = HarUtgifterSvar.ikkeVurdert,
+                            harRettTilUtstyrsstipend = harRettTilUtstyrsstipendSvar,
+                        ),
+                    )
+                    assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingLæremidlerTest.kt
@@ -18,13 +18,6 @@ class FaktaOgVurderingLæremidlerTest {
                 assertThat(faktaOgVurdering.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
             }
         }
-
-        @Test
-        fun `resultatet skal ikke være oppfylt hvis ikke aktivitetstypen gir rett på stønaden`() {
-            listOf(IngenAktivitetLæremidler).forEach { faktaOgVurdering ->
-                assertThat(faktaOgVurdering.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
-            }
-        }
     }
 
     @Nested

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingMålgruppeLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingMålgruppeLæremidlerTest.kt
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class FaktaOgVurderingLæremidlerTest {
+class FaktaOgVurderingMålgruppeLæremidlerTest {
 
     @Nested
     inner class UtledningAvResultatBasertPåType {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDtoTest.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingDekketAvAnnetRegelverk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingHarRettTilUtstyrsstipend
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingHarUtgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingLønnet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingMedlemskap
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingerUtdanningLæremidler
@@ -110,6 +111,7 @@ class VilkårperiodeDtoTest {
                 faktaOgVurdering = UtdanningLæremidler(
                     fakta = FaktaAktivitetLæremidler(prosent = 60, studienivå = Studienivå.VIDEREGÅENDE),
                     vurderinger = VurderingerUtdanningLæremidler(
+                        harUtgifter = VurderingHarUtgifter(SvarJaNei.JA),
                         harRettTilUtstyrsstipend = VurderingHarRettTilUtstyrsstipend(
                             SvarJaNei.NEI,
                         ),
@@ -121,6 +123,7 @@ class VilkårperiodeDtoTest {
                 AktivitetLæremidlerFaktaOgVurderingerDto(
                     prosent = 60,
                     studienivå = Studienivå.VIDEREGÅENDE,
+                    harUtgifter = VurderingDto(svar = SvarJaNei.JA, resultat = OPPFYLT),
                     harRettTilUtstyrsstipend = VurderingDto(svar = SvarJaNei.NEI, resultat = OPPFYLT),
                 ),
             )

--- a/src/test/resources/interntVedtak/LÆREMIDLER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/LÆREMIDLER/internt_vedtak.json
@@ -80,7 +80,10 @@
       "@type" : "AKTIVITET_LÆREMIDLER",
       "prosent" : 80,
       "studienivå" : "VIDEREGÅENDE",
-      "harUtgifter" : null,
+      "harUtgifter" : {
+        "svar" : "JA",
+        "resultat" : "OPPFYLT"
+      },
       "harRettTilUtstyrsstipend" : {
         "svar" : "JA",
         "resultat" : "IKKE_OPPFYLT"

--- a/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/UTDANNING_LÆREMIDLER.json
+++ b/src/test/resources/vilkår/vilkårperiode/LÆREMIDLER/UTDANNING_LÆREMIDLER.json
@@ -5,6 +5,10 @@
     "studienivå": "HØYERE_UTDANNING"
   },
   "vurderinger": {
+    "harUtgifter": {
+      "svar": "JA",
+      "resultat": "OPPFYLT"
+    },
     "harRettTilUtstyrsstipend": {
       "svar": "NEI",
       "resultat": "OPPFYLT"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Ny flyt for læremidler ](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23714)

- Tillater at `studienivå` _ikke_ velges. `Utdanning = Høy` skal gi rett resultat **Oppfylt**
- Tillater at `harRettTilUtstyrsstipend` _ikke_ vurderes. Skal da få resultat = **Oppfylt** i stedet for **Mangelfull vurdering**
- Må kunne vurdere `harUtgifter` også på utdanning 

📯 Kan sees i sammenheng med https://github.com/navikt/tilleggsstonader-sak-frontend/pull/652
