### PR TITLE
Læremidler skal betales ut når vedtaksperioden begynner og ikke i starten på den måneden vedtaksperioden begynner

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
@@ -88,6 +88,7 @@ class TilkjentYtelseService(
             kildeBehandlingId = tilkjentYtelse.behandlingId,
             iverksetting = iverksetting,
             statusIverksetting = StatusIverksetting.SENDT,
+            utbetalingsdato = månedForNullutbetaling.atDay(1),
         )
 
         tilkjentYtelseRepository.update(tilkjentYtelse.copy(andelerTilkjentYtelse = tilkjentYtelse.andelerTilkjentYtelse + nullAndel))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.util.erFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.util.erLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.util.erSisteDagIMåneden
+import no.nav.tilleggsstonader.sak.util.toYearMonth
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.annotation.Version
@@ -42,6 +43,7 @@ data class AndelTilkjentYtelse(
     val iverksetting: Iverksetting? = null,
     @LastModifiedDate
     val endretTid: LocalDateTime = SporbarUtils.now(),
+    val utbetalingsdato: LocalDate,
 ) {
 
     init {
@@ -56,6 +58,9 @@ data class AndelTilkjentYtelse(
         }
 
         validerDataForType()
+        feilHvisIkke(utbetalingsdato.toYearMonth() == fom.toYearMonth()) {
+            "Må sette utbetalingsdato($utbetalingsdato) i den måned(${fom.toYearMonth()}) andelen gjelder for"
+        }
     }
 
     private fun validerDataForType() {
@@ -163,5 +168,5 @@ enum class StatusIverksetting {
     VENTER_PÅ_SATS_ENDRING,
     ;
 
-    fun erOk() = this == StatusIverksetting.OK || this == StatusIverksetting.OK_UTEN_UTBETALING
+    fun erOk() = this == OK || this == OK_UTEN_UTBETALING
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
@@ -17,11 +17,11 @@ interface AndelTilkjentYtelseRepository :
         SELECT DISTINCT ty.behandling_id from andel_tilkjent_ytelse aty
         JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse_id = ty.id
         JOIN behandling b ON b.id = ty.behandling_id
-        WHERE aty.tom <= :sisteDatoIMåned AND aty.status_iverksetting = 'UBEHANDLET'
+        WHERE aty.utbetalingsdato <= :utbetalingsdato AND aty.status_iverksetting = 'UBEHANDLET'
         AND b.status = 'FERDIGSTILT' AND b.resultat IN ('INNVILGET', 'OPPHØRT')
         """,
     )
-    fun finnBehandlingerForIverksetting(sisteDatoIMåned: LocalDate): List<BehandlingId>
+    fun finnBehandlingerForIverksetting(utbetalingsdato: LocalDate): List<BehandlingId>
 
     fun findAndelTilkjentYtelsesByKildeBehandlingId(behandlingId: BehandlingId): List<AndelTilkjentYtelse>
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -9,6 +9,8 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseServi
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
+import no.nav.tilleggsstonader.sak.util.toYearMonth
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
@@ -108,6 +110,8 @@ class TilsynBarnBeregnYtelseSteg(
                 feilHvis(ukedag == DayOfWeek.SATURDAY || ukedag == DayOfWeek.SUNDAY) {
                     "Skal ikke opprette perioder som begynner på en helgdag for satstype=$satstype"
                 }
+                val førsteDagIMåneden =
+                    beløpsperiode.dato.toYearMonth().atDay(1).datoEllerNesteMandagHvisLørdagEllerSøndag()
                 AndelTilkjentYtelse(
                     beløp = beløpsperiode.beløp,
                     fom = beløpsperiode.dato,
@@ -115,6 +119,7 @@ class TilsynBarnBeregnYtelseSteg(
                     satstype = satstype,
                     type = beløpsperiode.målgruppe.tilTypeAndel(),
                     kildeBehandlingId = saksbehandling.id,
+                    utbetalingsdato = førsteDagIMåneden,
                 )
             }
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -126,6 +126,7 @@ class LæremidlerBeregnYtelseSteg(
                     type = målgruppe.tilTypeAndel(),
                     kildeBehandlingId = saksbehandling.id,
                     statusIverksetting = statusIverksettingForSatsBekreftet(satsBekreftet),
+                    utbetalingsdato = utbetalingsdato,
                 )
             }
         tilkjentytelseService.opprettTilkjentYtelse(saksbehandling, andeler)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningService.kt
@@ -99,7 +99,7 @@ class LæremidlerBeregningService(
             studieprosent = aktivitet.prosent,
             sats = finnSatsForStudienivå(sats, aktivitet.studienivå),
             satsBekreftet = sats.bekreftet,
-            utbetalingsmåned = periode.utbetalingsmåned,
+            utbetalingsdato = periode.utbetalingsdato,
             målgruppe = målgruppe,
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningUtil.kt
@@ -4,7 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
 import no.nav.tilleggsstonader.kontrakter.felles.splitPerÅr
-import no.nav.tilleggsstonader.sak.util.toYearMonth
+import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.domain.StønadsperiodeBeregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerPeriodeUtil.splitPerLøpendeMåneder
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
@@ -21,6 +21,12 @@ import java.time.LocalDate
 import java.util.UUID
 
 object LæremidlerBeregningUtil {
+
+    /**
+     * Splitter vedtaksperiode per år. Sånn at man får en periode for høstterminen og en for vårterminen
+     * Dette for å kunne lage en periode for våren som ikke utbetales direkte, men når satsen for det nye året er satt.
+     * Eks 2024-08-15 - 2025-06-20 blir 2024-08-15 - 2024-12-31 og 2025-01-01 - 2025-06-20
+     */
     fun Periode<LocalDate>.delTilUtbetalingsPerioder(): List<UtbetalingPeriode> =
         splitPerÅr { fom, tom -> Vedtaksperiode(fom, tom) }
             .flatMap { periode ->
@@ -28,7 +34,7 @@ object LæremidlerBeregningUtil {
                     UtbetalingPeriode(
                         fom = fom,
                         tom = tom,
-                        utbetalingsmåned = periode.fom.toYearMonth(),
+                        utbetalingsdato = periode.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
                     )
                 }
             }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
@@ -7,12 +7,11 @@ import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
 import no.nav.tilleggsstonader.sak.vedtak.domain.StønadsperiodeBeregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import java.time.LocalDate
-import java.time.YearMonth
 
 data class UtbetalingPeriode(
     override val fom: LocalDate,
     override val tom: LocalDate,
-    val utbetalingsmåned: YearMonth,
+    val utbetalingsdato: LocalDate,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidler.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.vedtak.læremidler.domain
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
-import java.time.YearMonth
 
 data class BeregningsresultatLæremidler(
     val perioder: List<BeregningsresultatForMåned>,
@@ -17,7 +16,7 @@ data class BeregningsresultatForMåned(
 data class Beregningsgrunnlag(
     override val fom: LocalDate,
     override val tom: LocalDate,
-    val utbetalingsmåned: YearMonth,
+    val utbetalingsdato: LocalDate,
     val studienivå: Studienivå,
     val studieprosent: Int,
     val sats: Int,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/dto/BeregningsresultatLæremidlerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/dto/BeregningsresultatLæremidlerDto.kt
@@ -7,7 +7,6 @@ import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatF
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import java.time.LocalDate
-import java.time.YearMonth
 
 data class BeregningsresultatLæremidlerDto(
     val perioder: List<BeregningsresultatForPeriodeDto>,
@@ -21,7 +20,7 @@ data class BeregningsresultatForPeriodeDto(
     val studieprosent: Int,
     val beløp: Int,
     val stønadsbeløp: Int,
-    val utbetalingsmåned: YearMonth,
+    val utbetalingsdato: LocalDate,
 ) : Periode<LocalDate> {
     fun slåSammen(
         nestePeriode: BeregningsresultatForPeriodeDto,
@@ -39,7 +38,7 @@ data class BeregningsresultatForPeriodeDto(
         return this.studienivå == nestePeriode.studienivå &&
             this.studieprosent == nestePeriode.studieprosent &&
             this.beløp == nestePeriode.beløp &&
-            this.utbetalingsmåned == nestePeriode.utbetalingsmåned &&
+            this.utbetalingsdato == nestePeriode.utbetalingsdato &&
             this.påfølgesAv(nestePeriode)
     }
 }
@@ -63,6 +62,6 @@ fun BeregningsresultatForMåned.tilDto(): BeregningsresultatForPeriodeDto {
         studieprosent = grunnlag.studieprosent,
         beløp = beløp,
         stønadsbeløp = beløp,
-        utbetalingsmåned = grunnlag.utbetalingsmåned,
+        utbetalingsdato = grunnlag.utbetalingsdato,
     )
 }

--- a/src/main/resources/db/migration/V58__læremidler-utbetalingsdato.sql
+++ b/src/main/resources/db/migration/V58__læremidler-utbetalingsdato.sql
@@ -1,0 +1,33 @@
+/**
+  Erstatter utbetalingsmåned med utbetalingsdato.
+  Setter utbetalingsdato til første ukedag i måneden då det er det dato som tidligere blitt brukt for å opprette andeler
+ */
+UPDATE vedtak
+SET data = jsonb_set(
+        data,
+        '{beregningsresultat,perioder}',
+        (SELECT jsonb_agg(
+                        jsonb_set(
+                                periode #- '{grunnlag,utbetalingsmåned}', -- Sletter utbetalingsmåned,
+                                '{grunnlag,utbetalingsdato}', -- Legger til utbetalingsdato
+                        -- Setter utbetalingsdato til dato eller neste mandagen hvis helg
+                                to_jsonb(
+                                        (SELECT CASE
+                                                    WHEN EXTRACT(DOW FROM first_day_of_month) = 0
+                                                        THEN first_day_of_month + INTERVAL '1 day' -- Søndag -> Mandag
+                                                    WHEN EXTRACT(DOW FROM first_day_of_month) = 6
+                                                        THEN first_day_of_month + INTERVAL '2 days' -- Lørdag -> Mandag
+                                                    ELSE first_day_of_month
+                                                    END)::date
+                                )
+                        )
+                )
+         FROM jsonb_array_elements(data -> 'beregningsresultat' -> 'perioder') AS periode,
+              LATERAL (
+                       SELECT to_date(periode -> 'grunnlag' ->> 'utbetalingsmåned', 'YYYY-MM') AS first_day_of_month
+                  ))
+    , true -- legger til element hvis det mangler
+           )
+where data ->> 'type' = 'INNVILGELSE_LÆREMIDLER'
+  AND data::text LIKE '%utbetalingsmåned%'
+;

--- a/src/main/resources/db/migration/V59__andel-utbetalingsdato.sql
+++ b/src/main/resources/db/migration/V59__andel-utbetalingsdato.sql
@@ -1,0 +1,31 @@
+/**
+  Setter utbetalingsdato til første ukedag i måneden for eksisterende andeler
+  For fremtidige andeler kommer utbetalingsdatoet eks settes ulikt for læremidler
+ */
+ALTER TABLE andel_tilkjent_ytelse
+    ADD COLUMN utbetalingsdato DATE;
+
+-- noinspection SqlWithoutWhere
+UPDATE andel_tilkjent_ytelse
+SET utbetalingsdato=
+        CASE
+            WHEN EXTRACT(DOW FROM date_trunc('MONTH', fom)) = 0
+                THEN date_trunc('MONTH', fom) + INTERVAL '1 day' -- Hvis søndag
+            WHEN EXTRACT(DOW FROM date_trunc('MONTH', fom)) = 6
+                THEN date_trunc('MONTH', fom) + INTERVAL '2 days' -- Hvis lørdag
+            ELSE date_trunc('MONTH', fom)
+            END
+;
+
+ALTER TABLE andel_tilkjent_ytelse
+    ALTER COLUMN utbetalingsdato SET NOT NULL;
+
+/**
+  Endrer neste kjøring fra månedskjøring til daglig kjøring sånn at den kjører hver dag i stedet
+ */
+UPDATE TASK
+SET type        = 'DagligIverksett',
+    payload     = current_date,
+    trigger_tid = current_timestamp + interval '1 hour'
+WHERE type = 'IverksettMåned'
+  AND status = 'UBEHANDLET';

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/DagligIverksettBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/DagligIverksettBehandlingTaskTest.kt
@@ -11,19 +11,19 @@ import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.YearMonth
+import java.time.LocalDate
 import java.util.UUID
 
-class IverksettBehandlingMånedTaskTest {
+class DagligIverksettBehandlingTaskTest {
 
     private val behandlingService = mockk<BehandlingService>()
     private val iverksettService = mockk<IverksettService>(relaxed = true)
-    private val taskStep = IverksettBehandlingMånedTask(behandlingService, iverksettService)
+    private val taskStep = DagligIverksettBehandlingTask(behandlingService, iverksettService)
 
     val fagsak = fagsak()
     val behandling = behandling(fagsak, vedtakstidspunkt = osloNow().minusDays(1))
     val behandling2 = behandling(fagsak, forrigeBehandlingId = behandling.id, vedtakstidspunkt = osloNow())
-    val måned = YearMonth.now()
+    val utbetalingsdato = LocalDate.now()
 
     @BeforeEach
     fun setUp() {
@@ -33,19 +33,19 @@ class IverksettBehandlingMånedTaskTest {
     @Test
     fun `skal kalle på iverksetting`() {
         mockFinnSisteIverksatteBehandling(behandling)
-        val task = IverksettBehandlingMånedTask.opprettTask(behandling.id, måned)
+        val task = DagligIverksettBehandlingTask.opprettTask(behandling.id, utbetalingsdato)
         val iverksettingId = UUID.fromString(task.metadata.getProperty("iverksettingId"))
 
         taskStep.doTask(task)
 
-        verify(exactly = 1) { iverksettService.iverksett(behandling.id, iverksettingId, måned) }
+        verify(exactly = 1) { iverksettService.iverksett(behandling.id, iverksettingId, utbetalingsdato) }
     }
 
     @Test
     fun `skal feile hvis det finnes en behandling som er iverksatt etter behandlingen for tasken`() {
         mockFinnSisteIverksatteBehandling(behandling2)
 
-        val task = IverksettBehandlingMånedTask.opprettTask(behandlingId = behandling.id, måned)
+        val task = DagligIverksettBehandlingTask.opprettTask(behandlingId = behandling.id, utbetalingsdato)
         assertThatThrownBy {
             taskStep.doTask(task)
         }.hasMessageContaining("En revurdering har erstattet denne behandlingen.")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
@@ -30,6 +30,7 @@ object TilkjentYtelseUtil {
         type: TypeAndel = TypeAndel.TILSYN_BARN_AAP,
         statusIverksetting: StatusIverksetting = StatusIverksetting.UBEHANDLET,
         iverksetting: Iverksetting? = null,
+        utbetalingsdato: LocalDate = fom,
     ) = AndelTilkjentYtelse(
         beløp = beløp,
         fom = fom,
@@ -39,5 +40,6 @@ object TilkjentYtelseUtil {
         kildeBehandlingId = kildeBehandlingId,
         statusIverksetting = statusIverksetting,
         iverksetting = iverksetting,
+        utbetalingsdato = utbetalingsdato,
     )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -157,42 +157,49 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
             val dagsatsForUtgift200 = BigDecimal("5.91")
 
             val forventedeAndeler = listOf(
-                Pair(
-                    stønadsperiode1.medLikTomSomFom(),
-                    finnTotalbeløp(dagsatsForUtgift100, 5),
-                ),
-                Pair(
-                    stønadsperiode2.medLikTomSomFom(),
-                    finnTotalbeløp(dagsatsForUtgift100, 2),
-                ),
-                Pair(
-                    stønadsperiode3.medLikTomSomFom(),
-                    finnTotalbeløp(dagsatsForUtgift100, 6),
-                ),
-                Pair(
-                    stønadsperiode3.copy(fom = februar.atDay(1), tom = februar.atDay(1)),
-                    finnTotalbeløp(dagsatsForUtgift100, 3),
-                ),
-                Pair(
-                    stønadsperiode4.medLikTomSomFom(),
-                    finnTotalbeløp(dagsatsForUtgift100, 1),
-                ),
-                Pair(
-                    stønadsperiode4.copy(fom = mars.atDay(1), tom = mars.atDay(1)),
-                    finnTotalbeløp(dagsatsForUtgift200, 23),
-                ),
-                Pair(
-                    stønadsperiode4.copy(fom = april.atDay(3), tom = april.atDay(3)),
-                    finnTotalbeløp(dagsatsForUtgift200, 1),
-                ),
-            ).map {
                 andelTilkjentYtelse(
-                    fom = it.first.fom,
-                    tom = it.first.tom,
-                    beløp = it.second,
                     kildeBehandlingId = behandling.id,
-                )
-            }
+                    fom = stønadsperiode1.fom,
+                    beløp = finnTotalbeløp(dagsatsForUtgift100, 5),
+                    utbetalingsdato = januar.atDay(2),
+                ),
+                andelTilkjentYtelse(
+                    kildeBehandlingId = behandling.id,
+                    fom = stønadsperiode2.fom,
+                    beløp = finnTotalbeløp(dagsatsForUtgift100, 2),
+                    utbetalingsdato = januar.atDay(2),
+                ),
+                andelTilkjentYtelse(
+                    kildeBehandlingId = behandling.id,
+                    fom = stønadsperiode3.fom,
+                    beløp = finnTotalbeløp(dagsatsForUtgift100, 6),
+                    utbetalingsdato = januar.atDay(2),
+                ),
+                andelTilkjentYtelse(
+                    kildeBehandlingId = behandling.id,
+                    fom = februar.atDay(1),
+                    beløp = finnTotalbeløp(dagsatsForUtgift100, 3),
+                    utbetalingsdato = februar.atDay(1),
+                ),
+                andelTilkjentYtelse(
+                    kildeBehandlingId = behandling.id,
+                    fom = stønadsperiode4.fom,
+                    beløp = finnTotalbeløp(dagsatsForUtgift100, 1),
+                    utbetalingsdato = februar.atDay(1),
+                ),
+                andelTilkjentYtelse(
+                    kildeBehandlingId = behandling.id,
+                    fom = mars.atDay(1),
+                    beløp = finnTotalbeløp(dagsatsForUtgift200, 23),
+                    utbetalingsdato = mars.atDay(1),
+                ),
+                andelTilkjentYtelse(
+                    kildeBehandlingId = behandling.id,
+                    fom = april.atDay(3),
+                    beløp = finnTotalbeløp(dagsatsForUtgift200, 1),
+                    utbetalingsdato = april.atDay(3),
+                ),
+            )
             assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "endretTid")
                 .containsExactlyElementsOf(forventedeAndeler)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
@@ -48,7 +48,7 @@ class LæremidlerBeregnYtelseStegTest(
     fun `skal splitte andeler i 2, en for høsten og en for våren som ikke har bekreftet sats ennå`() {
         val fom = LocalDate.of(2025, 8, 15)
         val tom = LocalDate.of(2026, 4, 30)
-        val datoUtbetalingDel1 = LocalDate.of(2025, 8, 1)
+        val datoUtbetalingDel1 = LocalDate.of(2025, 8, 15)
         val datoUtbetalingDel2 = LocalDate.of(2026, 1, 1)
 
         lagreAktivitetOgStønadsperiode(fom, tom)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerTestUtil.kt
@@ -1,27 +1,25 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler
 
-import no.nav.tilleggsstonader.sak.util.toYearMonth
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Beregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.BeregningsresultatForPeriodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
-import java.time.YearMonth
 
 object LæremidlerTestUtil {
 
     fun beregningsresultatForMåned(
         fom: LocalDate,
         tom: LocalDate,
-        utbetalingMåned: YearMonth,
+        utbetalingsdato: LocalDate = fom,
     ): BeregningsresultatForMåned {
         return BeregningsresultatForMåned(
             beløp = 875,
             grunnlag = Beregningsgrunnlag(
                 fom = fom,
                 tom = tom,
-                utbetalingsmåned = utbetalingMåned,
+                utbetalingsdato = utbetalingsdato,
                 studienivå = Studienivå.HØYERE_UTDANNING,
                 studieprosent = 100,
                 sats = 875,
@@ -36,6 +34,7 @@ object LæremidlerTestUtil {
         tom: LocalDate,
         antallMåneder: Int = 1,
         stønadsbeløp: Int = 875,
+        utbetalingsdato: LocalDate = fom,
     ): BeregningsresultatForPeriodeDto {
         return BeregningsresultatForPeriodeDto(
             fom = fom,
@@ -45,7 +44,7 @@ object LæremidlerTestUtil {
             studieprosent = 100,
             beløp = 875,
             stønadsbeløp = stønadsbeløp,
-            utbetalingsmåned = fom.toYearMonth(),
+            utbetalingsdato = utbetalingsdato,
         )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/StepDefinitions.kt
@@ -15,7 +15,6 @@ import no.nav.tilleggsstonader.sak.cucumber.parseDato
 import no.nav.tilleggsstonader.sak.cucumber.parseInt
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriBoolean
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
-import no.nav.tilleggsstonader.sak.cucumber.parseÅrMåned
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.mapStønadsperioder
 import no.nav.tilleggsstonader.sak.vedtak.domain.tilSortertStønadsperiodeBeregningsgrunnlag
@@ -41,7 +40,7 @@ enum class BeregningNøkler(
     STUDIEPROSENT("Studieprosent"),
     SATS("Sats"),
     AKTIVITET("Aktivitet"),
-    UTBETALINGSMÅNED("Utbetalingsmåned"),
+    UTBETALINGSDATO("Utbetalingsdato"),
     MÅLGRUPPE("Målgruppe"),
     BEKREFTET_SATS("Bekreftet sats"),
 }
@@ -131,7 +130,7 @@ class StepDefinitions {
                     studieprosent = parseInt(BeregningNøkler.STUDIEPROSENT, rad),
                     sats = parseBigDecimal(BeregningNøkler.SATS, rad).toInt(),
                     satsBekreftet = parseValgfriBoolean(BeregningNøkler.BEKREFTET_SATS, rad) ?: true,
-                    utbetalingsmåned = parseÅrMåned(BeregningNøkler.UTBETALINGSMÅNED, rad),
+                    utbetalingsdato = parseDato(BeregningNøkler.UTBETALINGSDATO, rad),
                     målgruppe = parseValgfriEnum<MålgruppeType>(BeregningNøkler.MÅLGRUPPE, rad)
                         ?: MålgruppeType.AAP,
                 ),
@@ -169,7 +168,7 @@ class StepDefinitions {
             UtbetalingPeriode(
                 fom = parseDato(DomenenøkkelFelles.FOM, rad),
                 tom = parseDato(DomenenøkkelFelles.TOM, rad),
-                utbetalingsmåned = parseÅrMåned(BeregningNøkler.UTBETALINGSMÅNED, rad),
+                utbetalingsdato = parseDato(BeregningNøkler.UTBETALINGSDATO, rad),
             )
         }
         assertThat(vedtaksperioderSplittet).containsExactlyElementsOf(forventedePerioder)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/dto/BeregningsresultatLæremidlerDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/dto/BeregningsresultatLæremidlerDtoTest.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatL
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.YearMonth
 
 class BeregningsresultatLæremidlerDtoTest {
 
@@ -17,17 +16,15 @@ class BeregningsresultatLæremidlerDtoTest {
                 beregningsresultatForMåned(
                     LocalDate.of(2024, 1, 1),
                     LocalDate.of(2024, 1, 31),
-                    YearMonth.of(2024, 1),
                 ),
                 beregningsresultatForMåned(
                     LocalDate.of(2024, 2, 1),
                     LocalDate.of(2024, 2, 29),
-                    YearMonth.of(2024, 1),
+                    utbetalingsdato = LocalDate.of(2024, 1, 1),
                 ),
                 beregningsresultatForMåned(
                     LocalDate.of(2024, 5, 1),
                     LocalDate.of(2024, 5, 31),
-                    YearMonth.of(2024, 5),
                 ),
             ),
         ).tilDto()

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning.feature
@@ -20,10 +20,10 @@ Egenskap: Beregning av læremidler
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.01.2024 | 31.01.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 01.02.2024 | 29.02.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 01.03.2024 | 31.03.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 31.01.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
+      | 01.02.2024 | 29.02.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
+      | 01.03.2024 | 31.03.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
 
   Scenario: VGS - 25%
     Gitt følgende vedtaksperioder for læremidler
@@ -42,10 +42,10 @@ Egenskap: Beregning av læremidler
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.01.2024 | 31.01.2024 | 219   | VIDEREGÅENDE | 25            | 438  | AAP       | 01.2024          |
-      | 01.02.2024 | 29.02.2024 | 219   | VIDEREGÅENDE | 25            | 438  | AAP       | 01.2024          |
-      | 01.03.2024 | 31.03.2024 | 219   | VIDEREGÅENDE | 25            | 438  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 31.01.2024 | 219   | VIDEREGÅENDE | 25            | 438  | AAP       | 01.01.2024          |
+      | 01.02.2024 | 29.02.2024 | 219   | VIDEREGÅENDE | 25            | 438  | AAP       | 01.01.2024          |
+      | 01.03.2024 | 31.03.2024 | 219   | VIDEREGÅENDE | 25            | 438  | AAP       | 01.01.2024          |
 
   Scenario: HØYERE_UTDANNING - 51%
     Gitt følgende vedtaksperioder for læremidler
@@ -64,10 +64,10 @@ Egenskap: Beregning av læremidler
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.01.2024 | 31.01.2024 | 875   | HØYERE_UTDANNING | 51            | 875  | AAP       | 01.2024          |
-      | 01.02.2024 | 29.02.2024 | 875   | HØYERE_UTDANNING | 51            | 875  | AAP       | 01.2024          |
-      | 01.03.2024 | 31.03.2024 | 875   | HØYERE_UTDANNING | 51            | 875  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 31.01.2024 | 875   | HØYERE_UTDANNING | 51            | 875  | AAP       | 01.01.2024          |
+      | 01.02.2024 | 29.02.2024 | 875   | HØYERE_UTDANNING | 51            | 875  | AAP       | 01.01.2024          |
+      | 01.03.2024 | 31.03.2024 | 875   | HØYERE_UTDANNING | 51            | 875  | AAP       | 01.01.2024          |
 
   Scenario: HØYERE_UTDANNING - 50%
     Gitt følgende vedtaksperioder for læremidler
@@ -86,10 +86,10 @@ Egenskap: Beregning av læremidler
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.01.2024 | 31.01.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.2024          |
-      | 01.02.2024 | 29.02.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.2024          |
-      | 01.03.2024 | 31.03.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 31.01.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024          |
+      | 01.02.2024 | 29.02.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024          |
+      | 01.03.2024 | 31.03.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024          |
 
   Scenario: Flere vedtaksperioder
     Gitt følgende vedtaksperioder for læremidler
@@ -109,8 +109,8 @@ Egenskap: Beregning av læremidler
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 04.2024          |
-      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 04.2024          |
-      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 08.2024          |
-      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 08.2024          |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024          |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024          |
+      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024          |
+      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024          |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_begynner_slutt_på_måned.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_begynner_slutt_på_måned.feature
@@ -20,12 +20,12 @@ Egenskap: Beregning av læremidler - periode som begynner i sluttet på en måne
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 31.01.2024 | 28.02.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 29.02.2024 | 28.03.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 29.03.2024 | 28.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 29.04.2024 | 28.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 29.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 31.01.2024 | 28.02.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 31.01.2024          |
+      | 29.02.2024 | 28.03.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 31.01.2024          |
+      | 29.03.2024 | 28.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 31.01.2024          |
+      | 29.04.2024 | 28.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 31.01.2024          |
+      | 29.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 31.01.2024          |
 
   Scenario: Periode som begynner siste april skal påbegynne neste periode fra og med nest siste mai, som er en måned frem i tiden
     Gitt følgende vedtaksperioder for læremidler
@@ -44,6 +44,6 @@ Egenskap: Beregning av læremidler - periode som begynner i sluttet på en måne
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 30.04.2024 | 29.05.2024 | 875   | HØYERE_UTDANNING | 100           | 875  | AAP       | 04.2024          |
-      | 30.05.2024 | 31.05.2024 | 875   | HØYERE_UTDANNING | 100           | 875  | AAP       | 04.2024          |
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 30.04.2024 | 29.05.2024 | 875   | HØYERE_UTDANNING | 100           | 875  | AAP       | 30.04.2024          |
+      | 30.05.2024 | 31.05.2024 | 875   | HØYERE_UTDANNING | 100           | 875  | AAP       | 30.04.2024          |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
@@ -21,11 +21,11 @@ Egenskap: Beregning læremidler - flere aktiviteter
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.01.2024 | 31.01.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 01.2024          |
-      | 01.02.2024 | 29.02.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 01.2024          |
-      | 01.03.2024 | 31.03.2024 | 438   | HØYERE_UTDANNING | 50           | 875  | AAP       | 01.2024          |
-      | 01.04.2024 | 30.04.2024 | 438   | HØYERE_UTDANNING | 50           | 875  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 31.01.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 01.01.2024         |
+      | 01.02.2024 | 29.02.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 01.01.2024         |
+      | 01.03.2024 | 31.03.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024         |
+      | 01.04.2024 | 30.04.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024         |
 
   Scenario: Flere aktiviteter i samme måned - overlappende hele måneden
     Gitt følgende vedtaksperioder for læremidler
@@ -83,6 +83,6 @@ Egenskap: Beregning læremidler - flere aktiviteter
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 08.2024          |
-      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 08.2024          |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024         |
+      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024         |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
@@ -22,11 +22,11 @@ Egenskap: Beregning
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.01.2024 | 31.01.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 01.02.2024 | 29.02.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 01.03.2024 | 31.03.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
-      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.2024          |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 31.01.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
+      | 01.02.2024 | 29.02.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
+      | 01.03.2024 | 31.03.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024          |
 
   Scenario: Flere stønadsperioder og vedtaksperioder med opphold
     Gitt følgende vedtaksperioder for læremidler
@@ -49,11 +49,11 @@ Egenskap: Beregning
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsmåned |
-      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 04.2024          |
-      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 04.2024          |
-      | 01.08.2024 | 31.08.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | DAGPENGER | 08.2024          |
-      | 01.09.2024 | 30.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | DAGPENGER | 08.2024          |
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 01.04.2024          |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE     | 100           | 438  | AAP       | 01.04.2024          |
+      | 01.08.2024 | 31.08.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | DAGPENGER | 01.08.2024          |
+      | 01.09.2024 | 30.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | DAGPENGER | 01.08.2024          |
 
 
   Scenario: To uilke målgrupper samme aktivitet feiler i månedskiftet

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/vedtaksperioderTilMåned.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/vedtaksperioderTilMåned.feature
@@ -11,9 +11,9 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 01.08.2024 | 31.08.2024 | 08.2024          |
-      | 01.09.2024 | 30.09.2024 | 08.2024          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 01.08.2024 | 31.08.2024 | 01.08.2024          |
+      | 01.09.2024 | 30.09.2024 | 01.08.2024          |
 
   Scenario: En vedtaksperiode innenfor et år, start i midten av måneden
     Gitt følgende vedtaksperioder for læremidler
@@ -23,9 +23,9 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 15.08.2024 | 14.09.2024 | 08.2024          |
-      | 15.09.2024 | 30.09.2024 | 08.2024          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 15.08.2024          |
+      | 15.09.2024 | 30.09.2024 | 15.08.2024          |
 
   Scenario: En vedtaksperiode som treffer nytt år
     Gitt følgende vedtaksperioder for læremidler
@@ -35,10 +35,10 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 15.11.2024 | 14.12.2024 | 11.2024          |
-      | 15.12.2024 | 31.12.2024 | 11.2024          |
-      | 01.01.2025 | 14.01.2025 | 01.2025          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 15.11.2024 | 14.12.2024 | 15.11.2024          |
+      | 15.12.2024 | 31.12.2024 | 15.11.2024          |
+      | 01.01.2025 | 14.01.2025 | 01.01.2025          |
 
   Scenario: Flere vedtaksperioder
     Gitt følgende vedtaksperioder for læremidler
@@ -50,13 +50,13 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 17.04.2024 | 16.05.2024 | 04.2024          |
-      | 17.05.2024 | 20.05.2024 | 04.2024          |
-      | 18.08.2024 | 17.09.2024 | 08.2024          |
-      | 18.09.2024 | 04.10.2024 | 08.2024          |
-      | 13.12.2024 | 31.12.2024 | 12.2024          |
-      | 01.01.2025 | 31.01.2025 | 01.2025          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 17.04.2024 | 16.05.2024 | 17.04.2024          |
+      | 17.05.2024 | 20.05.2024 | 17.04.2024          |
+      | 18.08.2024 | 17.09.2024 | 19.08.2024          |
+      | 18.09.2024 | 04.10.2024 | 19.08.2024          |
+      | 13.12.2024 | 31.12.2024 | 13.12.2024          |
+      | 01.01.2025 | 31.01.2025 | 01.01.2025          |
 
   Scenario: Treffer rundt månedsskifte februar-mars - håndter spesialtilfelle
     Gitt følgende vedtaksperioder for læremidler
@@ -66,15 +66,15 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 31.01.2024 | 28.02.2024 | 01.2024          |
-      | 29.02.2024 | 28.03.2024 | 01.2024          |
-      | 29.03.2024 | 28.04.2024 | 01.2024          |
-      | 29.04.2024 | 28.05.2024 | 01.2024          |
-      | 29.05.2024 | 28.06.2024 | 01.2024          |
-      | 29.06.2024 | 28.07.2024 | 01.2024          |
-      | 29.07.2024 | 28.08.2024 | 01.2024          |
-      | 29.08.2024 | 31.08.2024 | 01.2024          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 31.01.2024 | 28.02.2024 | 31.01.2024          |
+      | 29.02.2024 | 28.03.2024 | 31.01.2024          |
+      | 29.03.2024 | 28.04.2024 | 31.01.2024          |
+      | 29.04.2024 | 28.05.2024 | 31.01.2024          |
+      | 29.05.2024 | 28.06.2024 | 31.01.2024          |
+      | 29.06.2024 | 28.07.2024 | 31.01.2024          |
+      | 29.07.2024 | 28.08.2024 | 31.01.2024          |
+      | 29.08.2024 | 31.08.2024 | 31.01.2024          |
 
   Scenario: Treffer rundt månedsskifte februar-mars - ingen spesialtilfelle
     Gitt følgende vedtaksperioder for læremidler
@@ -84,10 +84,10 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 28.01.2024 | 27.02.2024 | 01.2024          |
-      | 28.02.2024 | 27.03.2024 | 01.2024          |
-      | 28.03.2024 | 27.04.2024 | 01.2024          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 28.01.2024 | 27.02.2024 | 29.01.2024          |
+      | 28.02.2024 | 27.03.2024 | 29.01.2024          |
+      | 28.03.2024 | 27.04.2024 | 29.01.2024          |
 
 
   Scenario: Fra lenger til kortere måned
@@ -98,9 +98,9 @@ Egenskap: Splitt vedtaksperioder til utbetalingsperioder
     Når splitter vedtaksperioder for læremidler
 
     Så forvent følgende utbetalingsperioder
-      | Fom        | Tom        | Utbetalingsmåned |
-      | 31.03.2024 | 29.04.2024 | 03.2024          |
-      | 30.04.2024 | 29.05.2024 | 03.2024          |
-      | 30.05.2024 | 29.06.2024 | 03.2024          |
-      | 30.06.2024 | 29.07.2024 | 03.2024          |
-      | 30.07.2024 | 31.07.2024 | 03.2024          |
+      | Fom        | Tom        | Utbetalingsdato |
+      | 31.03.2024 | 29.04.2024 | 01.04.2024          |
+      | 30.04.2024 | 29.05.2024 | 01.04.2024          |
+      | 30.05.2024 | 29.06.2024 | 01.04.2024          |
+      | 30.06.2024 | 29.07.2024 | 01.04.2024          |
+      | 30.07.2024 | 31.07.2024 | 01.04.2024          |

--- a/src/test/resources/vedtak/LÆREMIDLER/INNVILGELSE_LÆREMIDLER.json
+++ b/src/test/resources/vedtak/LÆREMIDLER/INNVILGELSE_LÆREMIDLER.json
@@ -13,7 +13,7 @@
         "grunnlag": {
           "fom": "2024-01-01",
           "tom": "2024-01-31",
-          "utbetalingsmåned": "2024-01",
+          "utbetalingsdato": "2024-01-01",
           "studienivå": "HØYERE_UTDANNING",
           "studieprosent": 100,
           "sats": 875,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Tidligere betalte vi ut læremidler første ukesdagen i måneden.
- Det er nå ønskelig at vi utbetaler den det dato man oppretter en vedtaksperiode fra
- Hvis man den 2 januar innvilger periode fra 17 januar blir det då oppretter en andel som får FOM 17 januar som då utbetales 17 januar
- Hvis aktiviteten skulle bli stoppet før man begynner så får man ikke en ev. feilutbetaling
- Det blir mer korrekt med hva brevet forteller idag

❗ Litt av en sql for å oppdatere eksisterende data 😬 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23799
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/659

Del 2
* https://github.com/navikt/tilleggsstonader-sak/pull/539