### PR TITLE
Læremidler flere aktiviteter målgrupper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20241112093526_694e258"
 val tilleggsstønaderLibsVersion = "2024.12.11-15.08.d370f00e88e3"
-val tilleggsstønaderKontrakterVersion = "2025.01.14-13.03.f9fabfa12c02"
+val tilleggsstønaderKontrakterVersion = "2025.01.16-08.34.10d3c882ca46"
 val tokenSupportVersion = "5.0.11"
 val wiremockVersion = "3.9.2"
 val mockkVersion = "1.13.12"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/StønadsperiodeBeregningsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/StønadsperiodeBeregningsgrunnlag.kt
@@ -1,9 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak.domain
 
+import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
-import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
@@ -17,13 +17,13 @@ data class StønadsperiodeBeregningsgrunnlag(
     override val tom: LocalDate,
     val målgruppe: MålgruppeType,
     val aktivitet: AktivitetType,
-) : Periode<LocalDate> {
+) : Periode<LocalDate>, KopierPeriode<StønadsperiodeBeregningsgrunnlag> {
     init {
         validatePeriode()
     }
 
-    fun snitt(other: Periode<LocalDate>): StønadsperiodeBeregningsgrunnlag? {
-        return this.beregnSnitt(other)?.let { this.copy(fom = it.fom, tom = it.tom) }
+    override fun medPeriode(fom: LocalDate, tom: LocalDate): StønadsperiodeBeregningsgrunnlag {
+        return this.copy(fom = fom, tom = tom)
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/StønadsperiodeBeregningsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/StønadsperiodeBeregningsgrunnlag.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.domain
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
+import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
@@ -19,6 +20,10 @@ data class StønadsperiodeBeregningsgrunnlag(
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
+    }
+
+    fun snitt(other: Periode<LocalDate>): StønadsperiodeBeregningsgrunnlag? {
+        return this.beregnSnitt(other)?.let { this.copy(fom = it.fom, tom = it.tom) }
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -27,6 +27,7 @@ import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.VedtakLæremidlerReque
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.tilDomene
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class LæremidlerBeregnYtelseSteg(
@@ -115,6 +116,7 @@ class LæremidlerBeregnYtelseSteg(
                     "Alle perioder for et utbetalingsdato må være bekreftet eller ikke bekreftet"
                 }
 
+                // TODO skal en annen målgruppe ha samme utbetalingsdato eller utbetales et annet dato?
                 feilHvisIkke(perioder.all { it.grunnlag.målgruppe == målgruppe }) {
                     "Alle perioder for et utbetalingsdato må ha den samme målgruppen"
                 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -19,6 +19,7 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtak
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerBeregningService
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
@@ -107,32 +108,44 @@ class LæremidlerBeregnYtelseSteg(
         val andeler = beregningsresultat.perioder.groupBy { it.grunnlag.utbetalingsdato }
             .entries
             .sortedBy { (utbetalingsdato, _) -> utbetalingsdato }
-            .map { (utbetalingsdato, perioder) ->
+            .flatMap { (utbetalingsdato, perioder) ->
                 val førstePerioden = perioder.first()
                 val satsBekreftet = førstePerioden.grunnlag.satsBekreftet
-                val målgruppe = førstePerioden.grunnlag.målgruppe
 
                 feilHvisIkke(perioder.all { it.grunnlag.satsBekreftet == satsBekreftet }) {
                     "Alle perioder for et utbetalingsdato må være bekreftet eller ikke bekreftet"
                 }
 
-                // TODO skal en annen målgruppe ha samme utbetalingsdato eller utbetales et annet dato?
-                feilHvisIkke(perioder.all { it.grunnlag.målgruppe == målgruppe }) {
-                    "Alle perioder for et utbetalingsdato må ha den samme målgruppen"
-                }
-                AndelTilkjentYtelse(
-                    beløp = perioder.sumOf { it.beløp },
-                    fom = utbetalingsdato,
-                    tom = utbetalingsdato,
-                    satstype = Satstype.DAG,
-                    type = målgruppe.tilTypeAndel(),
-                    kildeBehandlingId = saksbehandling.id,
-                    statusIverksetting = statusIverksettingForSatsBekreftet(satsBekreftet),
-                    utbetalingsdato = utbetalingsdato,
-                )
+                mapTilAndeler(perioder, saksbehandling, utbetalingsdato, satsBekreftet)
             }
         tilkjentytelseService.opprettTilkjentYtelse(saksbehandling, andeler)
     }
+
+    /**
+     * Andeler grupperes per [TypeAndel], sånn at hvis man har 2 ulike målgrupper men som er av samme [TypeAndel]
+     * så summeres beløpet sammen for disse 2 andelene
+     * Hvis man har 2 [BeregningsresultatForMåned] med med 2 ulike [TypeAndel]
+     * så blir det mappet til ulike andeler for at regnskapet i økonomi skal få riktig type for gitt utbetalingsmåned
+     */
+    private fun mapTilAndeler(
+        perioder: List<BeregningsresultatForMåned>,
+        saksbehandling: Saksbehandling,
+        utbetalingsdato: LocalDate,
+        satsBekreftet: Boolean,
+    ) = perioder
+        .groupBy { it.grunnlag.målgruppe.tilTypeAndel() }
+        .map { (typeAndel, perioder) ->
+            AndelTilkjentYtelse(
+                beløp = perioder.sumOf { it.beløp },
+                fom = utbetalingsdato,
+                tom = utbetalingsdato,
+                satstype = Satstype.DAG,
+                type = typeAndel,
+                kildeBehandlingId = saksbehandling.id,
+                statusIverksetting = statusIverksettingForSatsBekreftet(satsBekreftet),
+                utbetalingsdato = utbetalingsdato,
+            )
+        }
 
     private fun lagInnvilgetVedtak(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/AktivitetLæremidlerBeregningGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/AktivitetLæremidlerBeregningGrunnlag.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
@@ -18,7 +19,12 @@ data class AktivitetLæremidlerBeregningGrunnlag(
     override val tom: LocalDate,
     val prosent: Int,
     val studienivå: Studienivå,
-) : Periode<LocalDate>
+) : Periode<LocalDate> {
+
+    fun snitt(other: Periode<LocalDate>): AktivitetLæremidlerBeregningGrunnlag? {
+        return this.beregnSnitt(other)?.let { this.copy(fom = it.fom, tom = it.tom) }
+    }
+}
 
 fun List<Vilkårperiode>.tilAktiviteter(): List<AktivitetLæremidlerBeregningGrunnlag> =
     ofType<AktivitetLæremidler>()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/AktivitetLæremidlerBeregningGrunnlag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/AktivitetLæremidlerBeregningGrunnlag.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
 
+import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
-import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
@@ -19,10 +19,10 @@ data class AktivitetLæremidlerBeregningGrunnlag(
     override val tom: LocalDate,
     val prosent: Int,
     val studienivå: Studienivå,
-) : Periode<LocalDate> {
+) : Periode<LocalDate>, KopierPeriode<AktivitetLæremidlerBeregningGrunnlag> {
 
-    fun snitt(other: Periode<LocalDate>): AktivitetLæremidlerBeregningGrunnlag? {
-        return this.beregnSnitt(other)?.let { this.copy(fom = it.fom, tom = it.tom) }
+    override fun medPeriode(fom: LocalDate, tom: LocalDate): AktivitetLæremidlerBeregningGrunnlag {
+        return this.copy(fom = fom, tom = tom)
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtil.kt
@@ -73,6 +73,9 @@ object LæremidlerBeregnUtil {
 
     /**
      * tom settes til minOf tom og årets tom for å håndtere at den ikke går over 2 år
+     *
+     * I tilfelle man har 2 ulike målgrupper innenfor et og samme år, så vil begge resultere i at man betaler ut begge samme dato
+     * Men det vil gjøres som 2 ulike andeler då det skal regnskapsføres riktig mot økonomi.
      */
     private fun VedtaksperiodeInnenforÅr?.delTilUtbetalingPerioder(): List<LøpendeMåned> {
         if (this == null) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
@@ -123,6 +123,11 @@ data class LøpendeMåned(
             "Det finnes ingen aktiviteter av type ${stønadsperiode.aktivitet} som varer i hele perioden ${this.formatertPeriodeNorskFormat()}}"
         }
 
+        feilHvis(relevanteAktiviteter.size > 1) {
+            "Det er foreløpig ikke støtte for flere aktiviteter som overlapper (gjelder perioden ${this.formatertPeriodeNorskFormat()}). " +
+                "Ta kontakt med utviklerteamet for å forstå situasjonen og om det burde legges til støtte for det."
+        }
+
         return relevanteAktiviteter
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.overlapper
 import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
@@ -123,7 +124,7 @@ data class LøpendeMåned(
             "Det finnes ingen aktiviteter av type ${stønadsperiode.aktivitet} som varer i hele perioden ${this.formatertPeriodeNorskFormat()}}"
         }
 
-        feilHvis(relevanteAktiviteter.size > 1) {
+        feilHvis(relevanteAktiviteter.overlapper()) {
             "Det er foreløpig ikke støtte for flere aktiviteter som overlapper (gjelder perioden ${this.formatertPeriodeNorskFormat()}). " +
                 "Ta kontakt med utviklerteamet for å forstå situasjonen og om det burde legges til støtte for det."
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
@@ -103,14 +103,14 @@ data class LøpendeMåned(
     private fun VedtaksperiodeInnenforLøpendeMåned.finnRelevantMålgruppeOgAktivitet(
         stønadsperioder: List<StønadsperiodeBeregningsgrunnlag>,
         aktiviteter: List<AktivitetLæremidlerBeregningGrunnlag>,
-    ) = this.finnRelevantStønadsperiode(stønadsperioder)
+    ) = this.finnSnittAvRelevanteStønadsperioder(stønadsperioder)
         .flatMap { stønadsperiode ->
             this
-                .finnRelevanteAktivitet(aktiviteter, stønadsperiode)
+                .finnSnittAvRelevanteAktiviteter(aktiviteter, stønadsperiode)
                 .map { aktivitet -> MålgruppeOgAktivitet(stønadsperiode.målgruppe, aktivitet) }
         }
 
-    private fun VedtaksperiodeInnenforLøpendeMåned.finnRelevanteAktivitet(
+    private fun VedtaksperiodeInnenforLøpendeMåned.finnSnittAvRelevanteAktiviteter(
         aktiviteter: List<AktivitetLæremidlerBeregningGrunnlag>,
         stønadsperiode: StønadsperiodeBeregningsgrunnlag,
     ): List<AktivitetLæremidlerBeregningGrunnlag> {
@@ -126,7 +126,7 @@ data class LøpendeMåned(
         return relevanteAktiviteter
     }
 
-    private fun VedtaksperiodeInnenforLøpendeMåned.finnRelevantStønadsperiode(
+    private fun VedtaksperiodeInnenforLøpendeMåned.finnSnittAvRelevanteStønadsperioder(
         stønadsperioder: List<StønadsperiodeBeregningsgrunnlag>,
     ): List<StønadsperiodeBeregningsgrunnlag> {
         val relevanteStønadsperioderForPeriode = stønadsperioder

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
@@ -136,10 +136,6 @@ data class LøpendeMåned(
             "Det finnes ingen periode med overlapp mellom målgruppe og aktivitet for perioden ${this.formatertPeriodeNorskFormat()}"
         }
 
-        feilHvis(relevanteStønadsperioderForPeriode.size > 1) {
-            "Det er for mange stønadsperioder som inneholder utbetalingsperioden ${this.formatertPeriodeNorskFormat()}"
-        }
-
         return relevanteStønadsperioderForPeriode
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/Studienivå.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/Studienivå.kt
@@ -1,6 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.domain
 
-enum class Studienivå {
-    VIDEREGÅENDE,
-    HØYERE_UTDANNING,
+/**
+ * @param prioritet lavest er den som har høyest prioritet
+ */
+enum class Studienivå(val prioritet: Int) {
+    HØYERE_UTDANNING(0),
+    VIDEREGÅENDE(1),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeUtil.kt
@@ -1,6 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.domain
 
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.førsteOverlappendePeriode
+import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
+import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
@@ -16,15 +19,22 @@ object VedtaksperiodeUtil {
             brukerfeil("Periode=${overlappendePeriode.first.formatertPeriodeNorskFormat()} og ${overlappendePeriode.second.formatertPeriodeNorskFormat()} overlapper.")
         }
 
-        brukerfeilHvis(
-            vedtaksperioder.ingenOmfattesAvStønadsperioder(stønadsperioder),
-        ) {
+        brukerfeilHvis(vedtaksperioder.ingenOmfattesAvStønadsperioder(stønadsperioder)) {
             "Vedtaksperiode er ikke innenfor en overlappsperiode"
         }
     }
 
-    private fun List<Vedtaksperiode>.ingenOmfattesAvStønadsperioder(stønadsperioder: List<StønadsperiodeBeregningsgrunnlag>): Boolean =
-        any { vedtaksperiode ->
-            stønadsperioder.none { it.inneholder(vedtaksperiode) }
+    /**
+     * Når vi sjekker om vedtaksperioder omfattas av stønadsperioder så er vi ikke avhengig av hvilken målgruppe/aktivitet de har
+     * Alle må omfattes av stønadsperiode
+     */
+    private fun List<Vedtaksperiode>.ingenOmfattesAvStønadsperioder(stønadsperioder: List<StønadsperiodeBeregningsgrunnlag>): Boolean {
+        val sammenslåtteStønadsperioder = stønadsperioder
+            .sorted()
+            .map { Datoperiode(fom = it.fom, tom = it.tom) }
+            .mergeSammenhengende({ s1, s2 -> s1.påfølgesAv(s2) }, { s1, s2 -> Datoperiode(fom = s1.fom, tom = s2.tom) })
+        return any { vedtaksperiode ->
+            sammenslåtteStønadsperioder.none { it.inneholder(vedtaksperiode) }
         }
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/MålgruppeType.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/MålgruppeType.kt
@@ -1,15 +1,48 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
 
-enum class MålgruppeType(val gyldigeAktiviter: Set<AktivitetType>) : VilkårperiodeType {
-    AAP(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    DAGPENGER(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    OMSTILLINGSSTØNAD(setOf(AktivitetType.REELL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
-    OVERGANGSSTØNAD(setOf(AktivitetType.REELL_ARBEIDSSØKER, AktivitetType.UTDANNING)),
-    NEDSATT_ARBEIDSEVNE(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    UFØRETRYGD(setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING)),
-    SYKEPENGER_100_PROSENT(emptySet()),
-    INGEN_MÅLGRUPPE(emptySet()),
+/**
+ * @param prioritet lavest er den som har høyest prioritet
+ */
+enum class MålgruppeType(
+    private val prioritet: Int?,
+    val gyldigeAktiviter: Set<AktivitetType>,
+) : VilkårperiodeType {
+
+    AAP(
+        prioritet = 0,
+        gyldigeAktiviter = setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING),
+    ),
+    DAGPENGER(
+        prioritet = null, // Ikke satt prioritet ennå, ingen stønad gir rett på dagpenger ennå
+        gyldigeAktiviter = setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING),
+    ),
+    OMSTILLINGSSTØNAD(
+        prioritet = 5,
+        gyldigeAktiviter = setOf(AktivitetType.REELL_ARBEIDSSØKER, AktivitetType.UTDANNING),
+    ),
+    OVERGANGSSTØNAD(
+        prioritet = 4,
+        gyldigeAktiviter = setOf(AktivitetType.REELL_ARBEIDSSØKER, AktivitetType.UTDANNING),
+    ),
+    NEDSATT_ARBEIDSEVNE(
+        prioritet = 1,
+        gyldigeAktiviter = setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING),
+    ),
+    UFØRETRYGD(
+        prioritet = 2,
+        gyldigeAktiviter = setOf(AktivitetType.TILTAK, AktivitetType.UTDANNING),
+    ),
+    SYKEPENGER_100_PROSENT(
+        prioritet = NULL_IKKE_RETT_PÅ_STØNAD,
+        gyldigeAktiviter = emptySet(),
+    ),
+    INGEN_MÅLGRUPPE(
+        prioritet = NULL_IKKE_RETT_PÅ_STØNAD,
+        gyldigeAktiviter = emptySet(),
+    ),
     ;
+
+    fun prioritet() = prioritet ?: error("Målgruppe=${this.name} har ikke prioritet")
 
     override fun tilDbType(): String = this.name
 
@@ -19,3 +52,5 @@ enum class MålgruppeType(val gyldigeAktiviter: Set<AktivitetType>) : Vilkårper
         this == INGEN_MÅLGRUPPE ||
             this == SYKEPENGER_100_PROSENT
 }
+
+private val NULL_IKKE_RETT_PÅ_STØNAD: Int? = null

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
@@ -15,6 +15,8 @@ import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.VedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetLæremidler
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -44,6 +46,7 @@ class LæremidlerBeregnYtelseStegTest(
         testoppsettService.lagre(behandling, opprettGrunnlagsdata = false)
     }
 
+    // Ved ny sats må man oppdatere datoer her
     @Test
     fun `skal splitte andeler i 2, en for høsten og en for våren som ikke har bekreftet sats ennå`() {
         val fom = LocalDate.of(2025, 8, 15)
@@ -101,6 +104,106 @@ class LæremidlerBeregnYtelseStegTest(
             assertThat(type).isEqualTo(TypeAndel.LÆREMIDLER_AAP)
             assertThat(statusIverksetting).isEqualTo(StatusIverksetting.UBEHANDLET)
             assertThat(satstype).isEqualTo(Satstype.DAG)
+        }
+    }
+
+    @Test
+    fun `en vedtaksperiode med 2 ulike målgrupper skal bli 2 ulike andeler med ulike typer som betales ut samtidig`() {
+        val førsteJan = LocalDate.of(2025, 1, 1)
+        val sisteJan = LocalDate.of(2025, 1, 31)
+        val førsteFeb = LocalDate.of(2025, 2, 1)
+        val sisteFeb = LocalDate.of(2025, 2, 28)
+
+        val stønadsperiode = stønadsperiode(
+            behandlingId = behandling.id,
+            fom = førsteJan,
+            tom = sisteJan,
+            målgruppe = MålgruppeType.AAP,
+            aktivitet = AktivitetType.UTDANNING,
+        )
+        val stønadsperiode2 = stønadsperiode(
+            behandlingId = behandling.id,
+            fom = førsteFeb,
+            tom = sisteFeb,
+            målgruppe = MålgruppeType.OVERGANGSSTØNAD,
+            aktivitet = AktivitetType.UTDANNING,
+        )
+        val aktivitet = aktivitet(
+            behandlingId = behandling.id,
+            fom = førsteJan,
+            tom = sisteFeb,
+            faktaOgVurdering = faktaOgVurderingAktivitetLæremidler(type = AktivitetType.UTDANNING),
+        )
+        stønadsperiodeRepository.insertAll(listOf(stønadsperiode, stønadsperiode2))
+        vilkårperiodeRepository.insert(aktivitet)
+        val saksbehandling = testoppsettService.hentSaksbehandling(behandling.id)
+
+        val vedtaksperiode = VedtaksperiodeDto(fom = førsteJan, tom = sisteFeb)
+        steg.utførSteg(saksbehandling, InnvilgelseLæremidlerRequest(vedtaksperioder = listOf(vedtaksperiode)))
+
+        val andeler = tilkjentYtelseRepository.findByBehandlingId(behandling.id)!!.andelerTilkjentYtelse
+        assertThat(andeler).hasSize(2)
+        with(andeler.single { it.type == TypeAndel.LÆREMIDLER_AAP }) {
+            assertThat(this.fom).isEqualTo(førsteJan)
+            assertThat(this.tom).isEqualTo(førsteJan)
+            assertThat(beløp).isEqualTo(901)
+            assertThat(type).isEqualTo(TypeAndel.LÆREMIDLER_AAP)
+            assertThat(statusIverksetting).isEqualTo(StatusIverksetting.UBEHANDLET)
+            assertThat(satstype).isEqualTo(Satstype.DAG)
+            assertThat(utbetalingsdato).isEqualTo(førsteJan)
+        }
+        with(andeler.single { it.type == TypeAndel.LÆREMIDLER_ENSLIG_FORSØRGER }) {
+            assertThat(this.fom).isEqualTo(førsteJan)
+            assertThat(this.tom).isEqualTo(førsteJan)
+            assertThat(beløp).isEqualTo(901)
+            assertThat(type).isEqualTo(TypeAndel.LÆREMIDLER_ENSLIG_FORSØRGER)
+            assertThat(statusIverksetting).isEqualTo(StatusIverksetting.UBEHANDLET)
+            assertThat(satstype).isEqualTo(Satstype.DAG)
+            assertThat(utbetalingsdato).isEqualTo(førsteJan)
+        }
+    }
+
+    @Test
+    fun `en vedtaksperiode med 2 ulike målgrupper men samme type andel skal bli 1 andel`() {
+        val førsteJan = LocalDate.of(2025, 1, 1)
+        val sisteJan = LocalDate.of(2025, 1, 31)
+        val førsteFeb = LocalDate.of(2025, 2, 1)
+        val sisteFeb = LocalDate.of(2025, 2, 28)
+
+        val stønadsperiode = stønadsperiode(
+            behandlingId = behandling.id,
+            fom = førsteJan,
+            tom = sisteJan,
+            målgruppe = MålgruppeType.AAP,
+        )
+        val stønadsperiode2 = stønadsperiode(
+            behandlingId = behandling.id,
+            fom = førsteFeb,
+            tom = sisteFeb,
+            målgruppe = MålgruppeType.NEDSATT_ARBEIDSEVNE,
+        )
+        val aktivitet = aktivitet(
+            behandlingId = behandling.id,
+            fom = førsteJan,
+            tom = sisteFeb,
+            faktaOgVurdering = faktaOgVurderingAktivitetLæremidler(),
+        )
+        stønadsperiodeRepository.insertAll(listOf(stønadsperiode, stønadsperiode2))
+        vilkårperiodeRepository.insert(aktivitet)
+        val saksbehandling = testoppsettService.hentSaksbehandling(behandling.id)
+
+        val vedtaksperiode = VedtaksperiodeDto(fom = førsteJan, tom = sisteFeb)
+        steg.utførSteg(saksbehandling, InnvilgelseLæremidlerRequest(vedtaksperioder = listOf(vedtaksperiode)))
+
+        val andeler = tilkjentYtelseRepository.findByBehandlingId(behandling.id)!!.andelerTilkjentYtelse
+        with(andeler.single()) {
+            assertThat(this.fom).isEqualTo(førsteJan)
+            assertThat(this.tom).isEqualTo(førsteJan)
+            assertThat(beløp).isEqualTo(901 * 2)
+            assertThat(type).isEqualTo(TypeAndel.LÆREMIDLER_AAP)
+            assertThat(statusIverksetting).isEqualTo(StatusIverksetting.UBEHANDLET)
+            assertThat(satstype).isEqualTo(Satstype.DAG)
+            assertThat(utbetalingsdato).isEqualTo(førsteJan)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/MålgruppeOgAktivitetTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/MålgruppeOgAktivitetTest.kt
@@ -10,9 +10,18 @@ import java.time.LocalDate
 import java.util.UUID
 
 class MålgruppeOgAktivitetTest {
-
     @Nested
     inner class Sortering {
+
+        @Test
+        fun `prioritet på målgruppe trumfer`() {
+            val aap = målgruppeOgAktivitet(målgruppe = MålgruppeType.AAP)
+            val overgangsstønad = målgruppeOgAktivitet(målgruppe = MålgruppeType.OVERGANGSSTØNAD)
+
+            val aktiviteter = listOf(aap, overgangsstønad)
+
+            aktiviteter.assertSortIsEqualTo(aap)
+        }
 
         @Test
         fun `høyest utdanning trumfer`() {
@@ -42,6 +51,34 @@ class MålgruppeOgAktivitetTest {
             val aktiviteter = listOf(aktivitet1, aktivitet2)
 
             aktiviteter.assertSortIsEqualTo(aktivitet2)
+        }
+
+        @Test
+        fun `skal først sortere etter studienivå, prosent og målgruppe`() {
+            val forventetTreff = målgruppeOgAktivitet(
+                prosent = 61,
+                studienivå = Studienivå.HØYERE_UTDANNING,
+                målgruppe = MålgruppeType.AAP,
+            )
+            val aktiviteter = listOf(
+                målgruppeOgAktivitet(
+                    prosent = 100,
+                    studienivå = Studienivå.VIDEREGÅENDE,
+                    målgruppe = MålgruppeType.AAP,
+                ),
+                målgruppeOgAktivitet(
+                    prosent = 51,
+                    studienivå = Studienivå.HØYERE_UTDANNING,
+                    målgruppe = MålgruppeType.AAP,
+                ),
+                målgruppeOgAktivitet(
+                    prosent = 61,
+                    studienivå = Studienivå.HØYERE_UTDANNING,
+                    målgruppe = MålgruppeType.OVERGANGSSTØNAD,
+                ),
+                forventetTreff,
+            )
+            aktiviteter.assertSortIsEqualTo(forventetTreff)
         }
 
         private fun List<MålgruppeOgAktivitet>.assertSortIsEqualTo(expected: MålgruppeOgAktivitet) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/MålgruppeOgAktivitetTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/MålgruppeOgAktivitetTest.kt
@@ -1,0 +1,69 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
+
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+
+class MålgruppeOgAktivitetTest {
+
+    @Nested
+    inner class Sortering {
+
+        @Test
+        fun `høyest utdanning trumfer`() {
+            val høyereUtdanning = målgruppeOgAktivitet(studienivå = Studienivå.HØYERE_UTDANNING)
+            val videregående = målgruppeOgAktivitet(studienivå = Studienivå.VIDEREGÅENDE)
+
+            val aktiviteter = listOf(høyereUtdanning, videregående)
+
+            aktiviteter.assertSortIsEqualTo(høyereUtdanning)
+        }
+
+        @Test
+        fun `høyest studieprosent trumfer`() {
+            val prosent100 = målgruppeOgAktivitet(prosent = 100)
+            val prosent50 = målgruppeOgAktivitet(prosent = 50)
+
+            val aktiviteter = listOf(prosent100, prosent50)
+
+            aktiviteter.assertSortIsEqualTo(prosent100)
+        }
+
+        @Test
+        fun `nivå trumfer prosent`() {
+            val aktivitet1 = målgruppeOgAktivitet(prosent = 100, studienivå = Studienivå.VIDEREGÅENDE)
+            val aktivitet2 = målgruppeOgAktivitet(prosent = 50, studienivå = Studienivå.HØYERE_UTDANNING)
+
+            val aktiviteter = listOf(aktivitet1, aktivitet2)
+
+            aktiviteter.assertSortIsEqualTo(aktivitet2)
+        }
+
+        private fun List<MålgruppeOgAktivitet>.assertSortIsEqualTo(expected: MålgruppeOgAktivitet) {
+            assertThat(this.minOf { it }).isEqualTo(expected)
+            assertThat(this.reversed().minOf { it }).isEqualTo(expected)
+        }
+    }
+
+    private fun målgruppeOgAktivitet(
+        målgruppe: MålgruppeType = MålgruppeType.AAP,
+        aktivitet: AktivitetType = AktivitetType.TILTAK,
+        studienivå: Studienivå = Studienivå.HØYERE_UTDANNING,
+        prosent: Int = 100,
+    ) = MålgruppeOgAktivitet(
+        målgruppe = målgruppe,
+        aktivitet = AktivitetLæremidlerBeregningGrunnlag(
+            id = UUID.randomUUID(),
+            fom = LocalDate.now(),
+            tom = LocalDate.now(),
+            type = aktivitet,
+            studienivå = studienivå,
+            prosent = prosent,
+        ),
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/StepDefinitions.kt
@@ -146,17 +146,22 @@ class StepDefinitions {
                 throw e
             }
         }
-        assertThat(resultat!!.perioder).hasSize(forventetBeregningsresultat.perioder.size)
+        assertThat(resultat?.perioder).hasSize(forventetBeregningsresultat.perioder.size)
     }
 
     @Så("forvent følgende feil fra læremidlerberegning: {}")
     fun `forvent følgende feil`(forventetFeil: String) {
-        assertThat(beregningException!!).hasMessageContaining(forventetFeil)
+        assertThat(beregningException).hasMessageContaining(forventetFeil)
     }
 
     @Så("forvent følgende feil fra vedtaksperiode validering: {}")
     fun `skal resultat fra validering være`(forventetFeil: String) {
-        assertThat(valideringException!!).hasMessageContaining(forventetFeil)
+        assertThat(valideringException).hasMessageContaining(forventetFeil)
+    }
+
+    @Så("forvent ingen feil fra vedtaksperiode validering")
+    fun `forvent ingen feil fra vedtaksperiode validering`() {
+        assertThat(valideringException).isNull()
     }
 
     @Så("forvent følgende utbetalingsperioder")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriodeTest.kt
@@ -44,8 +44,7 @@ class UtbetalingPeriodeTest {
 
         val utbetalingPeriode = UtbetalingPeriode(
             løpendeMåned = grunnlagForUtbetalingPeriode.medVedtaksperiode(vedtaksperiode),
-            stønadsperiode = stønadsperiode,
-            aktivitet = aktivitet,
+            målgruppeOgAktivitet = MålgruppeOgAktivitet(stønadsperiode.målgruppe, aktivitet),
         )
 
         assertThat(utbetalingPeriode.fom).isEqualTo(JAN_FØRSTE)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/StudienivåTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/StudienivåTest.kt
@@ -1,0 +1,27 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class StudienivåTest {
+
+    @Nested
+    inner class Prioritet {
+
+        @Test
+        fun `må ha unike prioriteter`() {
+            val prioriteter = Studienivå.entries.map { it.prioritet }
+            assertThat(prioriteter).hasSize(prioriteter.distinct().size)
+        }
+
+        @Test
+        fun `høyere utdanning har høyere prioritet enn videregående`() {
+            assertThat(Studienivå.entries.sortedBy { it.prioritet })
+                .containsExactly(
+                    Studienivå.HØYERE_UTDANNING,
+                    Studienivå.VIDEREGÅENDE,
+                )
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/MålgruppeTypeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/MålgruppeTypeTest.kt
@@ -1,0 +1,40 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class MålgruppeTypeTest {
+
+    @Test
+    fun `prioritet skal være unik verdi per enum`() {
+        val entriesMedPrioritet = MålgruppeType.entries.mapNotNull {
+            try {
+                it.prioritet()
+            } catch (e: Exception) {
+                null
+            }
+        }
+        assertThat(entriesMedPrioritet).hasSize(entriesMedPrioritet.distinct().size)
+    }
+
+    @Test
+    fun `sorter målgrupper etter prioritet - høyest først`() {
+        val entries = MålgruppeType.entries.mapNotNull {
+            try {
+                it to it.prioritet()
+            } catch (e: Exception) {
+                null
+            }
+        }.sortedBy { it.second }
+            .map { it.first }
+
+        assertThat(entries)
+            .containsExactly(
+                MålgruppeType.AAP,
+                MålgruppeType.NEDSATT_ARBEIDSEVNE,
+                MålgruppeType.UFØRETRYGD,
+                MålgruppeType.OVERGANGSSTØNAD,
+                MålgruppeType.OMSTILLINGSSTØNAD,
+            )
+    }
+}

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
@@ -85,11 +85,10 @@ Egenskap: Beregning av læremidler - flere aktiviteter
 
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Det er foreløpig ikke støtte for flere aktiviteter
-    #Så skal stønaden være
-    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-    #  | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
-    #  | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter i samme måned - kun en gyldig type
     Gitt følgende vedtaksperioder for læremidler
@@ -176,3 +175,23 @@ Egenskap: Beregning av læremidler - flere aktiviteter
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
       | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 50            | 438  | AAP       | 15.08.2024      |
+
+  Scenario: Flere aktiviteter med ulike datoer innenfor en og samme vedtaksperiode
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.01.2025 | 31.01.2025 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 01.01.2025 | 09.01.2025 | TILTAK    | VIDEREGÅENDE     | 50            |
+      | 10.01.2025 | 31.01.2025 | TILTAK    | HØYERE_UTDANNING | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 01.01.2025 | 31.01.2025 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2025 | 31.01.2025 | 901   | HØYERE_UTDANNING | 100           | 901  | AAP       | 01.01.2025      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
@@ -1,7 +1,7 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Beregning læremidler - flere aktiviteter
+Egenskap: Beregning av læremidler - flere aktiviteter
 
   Scenario: Flere aktiviteter, kun en per utbetalingsperiode
     Gitt følgende vedtaksperioder for læremidler
@@ -16,7 +16,6 @@ Egenskap: Beregning læremidler - flere aktiviteter
     Gitt følgende stønadsperioder for læremidler
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 01.01.2024 | 30.04.2024 | AAP       | TILTAK    |
-
 
     Når beregner stønad for læremidler
 
@@ -41,10 +40,12 @@ Egenskap: Beregning læremidler - flere aktiviteter
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 15.08.2024 | 30.09.2024 | AAP       | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Det finnes mer enn 1 aktivitet i perioden
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter i samme måned - ingen dekker hele måneden som skal beregnes
     Gitt følgende vedtaksperioder for læremidler
@@ -60,10 +61,12 @@ Egenskap: Beregning læremidler - flere aktiviteter
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 15.08.2024 | 30.09.2024 | AAP       | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Det finnes mer enn 1 aktivitet i perioden
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter i samme måned - kun en gyldig type
     Gitt følgende vedtaksperioder for læremidler
@@ -79,10 +82,51 @@ Egenskap: Beregning læremidler - flere aktiviteter
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 15.08.2024 | 30.09.2024 | AAP       | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
       | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
       | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+
+  Scenario: Flere aktiviteter med ulike studieprosent og studienivå
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 15.08.2024 | 30.09.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 15.08.2024 | 14.09.2024 | TILTAK    | VIDEREGÅENDE     | 100           |
+      | 20.08.2024 | 30.09.2024 | TILTAK    | HØYERE_UTDANNING | 50            |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 15.08.2024 | 30.09.2024 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 15.08.2024      |
+      | 15.09.2024 | 30.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 15.08.2024      |
+
+  Scenario: Flere aktiviteter med ulike datoer innenfor en vedtaksperiode
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 15.08.2024 | 14.09.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
+      | 15.08.2024 | 16.09.2024 | TILTAK    | VIDEREGÅENDE | 100           |
+      | 17.08.2024 | 18.09.2024 | TILTAK    | VIDEREGÅENDE | 100           |
+      | 19.08.2024 | 14.09.2024 | TILTAK    | VIDEREGÅENDE | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 15.08.2024 | 14.09.2024 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
@@ -150,4 +150,4 @@ Egenskap: Beregning av læremidler - flere aktiviteter
 
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 50            | 438  | AAP       | 15.08.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
@@ -130,3 +130,24 @@ Egenskap: Beregning av læremidler - flere aktiviteter
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
       | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+
+  Scenario: Flere aktiviteter med ulike datoer innenfor løpende måned men utenfor vedtaksperiode
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 15.08.2024 | 15.08.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 15.08.2024 | 15.08.2024 | TILTAK    | VIDEREGÅENDE     | 50            |
+      # aktivitet 2 er innenfor løpende måned, men ikke overlapp med vedtaksperiode
+      | 20.08.2024 | 25.08.2024 | TILTAK    | HØYERE_UTDANNING | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 15.08.2024 | 14.09.2024 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_aktiviteter.feature
@@ -26,6 +26,27 @@ Egenskap: Beregning av læremidler - flere aktiviteter
       | 01.03.2024 | 31.03.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024      |
       | 01.04.2024 | 30.04.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 01.01.2024      |
 
+  Scenario: Flere aktiviteter, kun en per vedtaksperiode innenfor en måned
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.01.2024 | 05.01.2024 |
+      | 08.01.2024 | 12.01.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
+      | 01.01.2024 | 01.01.2024 | TILTAK    | VIDEREGÅENDE | 30            |
+      | 08.01.2024 | 12.01.2024 | TILTAK    | VIDEREGÅENDE | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 01.01.2024 | 31.01.2024 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 12.01.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024      |
+
   Scenario: Flere aktiviteter i samme måned - overlappende hele måneden
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
@@ -42,10 +63,11 @@ Egenskap: Beregning av læremidler - flere aktiviteter
 
     Når beregner stønad for læremidler
 
-    Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
-      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+    Så forvent følgende feil fra læremidlerberegning: Det er foreløpig ikke støtte for flere aktiviteter
+    #Så skal stønaden være
+    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+    #  | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+    #  | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter i samme måned - ingen dekker hele måneden som skal beregnes
     Gitt følgende vedtaksperioder for læremidler
@@ -63,10 +85,11 @@ Egenskap: Beregning av læremidler - flere aktiviteter
 
     Når beregner stønad for læremidler
 
-    Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
-      | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+    Så forvent følgende feil fra læremidlerberegning: Det er foreløpig ikke støtte for flere aktiviteter
+    #Så skal stønaden være
+    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+    #  | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+    #  | 15.09.2024 | 30.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter i samme måned - kun en gyldig type
     Gitt følgende vedtaksperioder for læremidler
@@ -105,10 +128,11 @@ Egenskap: Beregning av læremidler - flere aktiviteter
 
     Når beregner stønad for læremidler
 
-    Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 14.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 15.08.2024      |
-      | 15.09.2024 | 30.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 15.08.2024      |
+    Så forvent følgende feil fra læremidlerberegning: Det er foreløpig ikke støtte for flere aktiviteter
+    #Så skal stønaden være
+    #  | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+    #  | 15.08.2024 | 14.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 15.08.2024      |
+    #  | 15.09.2024 | 30.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter med ulike datoer innenfor en vedtaksperiode
     Gitt følgende vedtaksperioder for læremidler
@@ -127,9 +151,10 @@ Egenskap: Beregning av læremidler - flere aktiviteter
 
     Når beregner stønad for læremidler
 
-    Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+    Så forvent følgende feil fra læremidlerberegning: Det er foreløpig ikke støtte for flere aktiviteter
+    #Så skal stønaden være
+    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+    #  | 15.08.2024 | 14.09.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
 
   Scenario: Flere aktiviteter med ulike datoer innenfor løpende måned men utenfor vedtaksperiode
     Gitt følgende vedtaksperioder for læremidler

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
@@ -55,29 +55,28 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
       | 01.08.2024 | 31.08.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | DAGPENGER | 01.08.2024      |
       | 01.09.2024 | 30.09.2024 | 438   | HØYERE_UTDANNING | 50            | 875  | DAGPENGER | 01.08.2024      |
 
-  Scenario: En vedtaksperiode som løper over flere stønadsperioder med ulike målgrupper
+  Scenario: En vedtaksperiode som løper over flere løpende måneder med ulike målgrupper skal utbetales i fom for vedtaksperioden
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
       | 01.01.2025 | 28.02.2025 |
 
     Gitt følgende aktiviteter for læremidler
       | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
-      | 01.01.2025 | 28.02.2025 | TILTAK    | VIDEREGÅENDE | 100           |
+      | 01.01.2025 | 28.02.2025 | UTDANNING | VIDEREGÅENDE | 100           |
 
     Gitt følgende stønadsperioder for læremidler
       | Fom        | Tom        | Målgruppe       | Aktivitet |
-      | 01.01.2025 | 31.01.2025 | AAP             | TILTAK    |
-      | 01.02.2025 | 28.02.2025 | OVERGANGSSTØNAD | TILTAK    |
+      | 01.01.2025 | 31.01.2025 | AAP             | UTDANNING |
+      | 01.02.2025 | 28.02.2025 | OVERGANGSSTØNAD | UTDANNING |
 
     Når beregner stønad for læremidler
 
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
       | 01.01.2025 | 31.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP             | 01.01.2025      |
-      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | 03.02.2025      |
+      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | 01.01.2025      |
 
-
-  Scenario: To ulike målgrupper samme aktivitet
+  Scenario: To ulike målgrupper av typen nedsatt arbeidsevne innenfor en vedtaksperiode men ulike løpende måneder
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
       | 01.04.2024 | 31.05.2024 |
@@ -87,54 +86,34 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
       | 01.01.2024 | 31.05.2024 | TILTAK    | VIDEREGÅENDE | 100           |
 
     Gitt følgende stønadsperioder for læremidler
-      | Fom        | Tom        | Målgruppe | Aktivitet |
-      | 01.04.2024 | 31.04.2024 | AAP       | TILTAK    |
-      | 01.05.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
+      | Fom        | Tom        | Målgruppe           | Aktivitet |
+      | 01.04.2024 | 31.04.2024 | AAP                 | TILTAK    |
+      | 01.05.2024 | 31.05.2024 | NEDSATT_ARBEIDSEVNE | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe           | Utbetalingsdato |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP                 | 01.04.2024      |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | NEDSATT_ARBEIDSEVNE | 01.04.2024      |
+
+  Scenario: To ulike målgrupper der målgruppe 1 løper inn i måneden for nr 2, samme aktivitet skal bruke målgruppen som har høyest prioritet
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.04.2024 | 31.05.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
+      | 01.01.2024 | 31.05.2024 | UTDANNING | VIDEREGÅENDE | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe       | Aktivitet |
+      | 01.04.2024 | 04.05.2024 | AAP             | UTDANNING |
+      | 05.05.2024 | 31.05.2024 | OVERGANGSSTØNAD | UTDANNING |
 
     Når beregner stønad for læremidler
 
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
       | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
-      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | DAGPENGER | 01.05.2024      |
-
-
-  Scenario: To ulike målgrupper samme aktivitet feiler når ikke i månedskiftet
-    Gitt følgende vedtaksperioder for læremidler
-      | Fom        | Tom        |
-      | 01.04.2024 | 31.05.2024 |
-
-    Gitt følgende aktiviteter for læremidler
-      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
-      | 01.01.2024 | 31.05.2024 | TILTAK    | VIDEREGÅENDE | 100           |
-
-    Gitt følgende stønadsperioder for læremidler
-      | Fom        | Tom        | Målgruppe | Aktivitet |
-      | 01.04.2024 | 04.05.2024 | AAP       | TILTAK    |
-      | 05.05.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
-
-    Når beregner stønad for læremidler
-
-    Så forvent følgende feil fra læremidlerberegning: Vedtaksperiode er ikke innenfor en overlappsperiode
-
-  Scenario: Stønadsperioder i ulike løpende måneder
-    Gitt følgende vedtaksperioder for læremidler
-      | Fom        | Tom        |
-      | 01.04.2024 | 31.05.2024 |
-
-    Gitt følgende aktiviteter for læremidler
-      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
-      | 01.01.2024 | 31.05.2024 | TILTAK    | VIDEREGÅENDE | 100           |
-
-    Gitt følgende stønadsperioder for læremidler
-      | Fom        | Tom        | Målgruppe       | Aktivitet |
-      | 01.04.2024 | 31.04.2024 | AAP             | TILTAK    |
-      | 01.05.2024 | 31.05.2024 | OVERGANGSSTØNAD | TILTAK    |
-      | 01.04.2024 | 31.05.2024 | OVERGANGSSTØNAD | TILTAK    |
-
-    Når beregner stønad for læremidler
-
-    Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
-      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP             | 01.04.2024      |
-      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | OVERGANGSSTØNAD | 01.05.2024      |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
@@ -71,17 +71,13 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
 
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Vedtaksperiode er ikke innenfor en overlappsperiode
-
-    #Så skal stønaden være
-    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
-    #  | 01.01.2025 | 31.01.2025 | 438   | VIDEREGÅENDE | 100           | 438  | AAP             | 01.01.2025      |
-    #  | 01.02.2025 | 28.02.2025 | 438   | VIDEREGÅENDE | 100           | 438  | OVERGANGSSTØNAD | 03.02.2025      |
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
+      | 01.01.2025 | 31.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP             | 01.01.2025      |
+      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | 03.02.2025      |
 
 
-  Scenario: To uilke målgrupper samme aktivitet feiler i månedskiftet
-    # TODO når man støtter flere målgrupper
-    #  Scenario: To ulike målgrupper samme aktivitet
+  Scenario: To ulike målgrupper samme aktivitet
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
       | 01.04.2024 | 31.05.2024 |
@@ -97,12 +93,10 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
 
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Vedtaksperiode er ikke innenfor en overlappsperiode
-    # TODO når man støtter flere målgrupper
-    # Så skal stønaden være
-    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-    #  | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
-    #  | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | DAGPENGER | 01.05.2024      |
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | DAGPENGER | 01.05.2024      |
 
 
   Scenario: To ulike målgrupper samme aktivitet feiler når ikke i månedskiftet
@@ -133,16 +127,14 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
       | 01.01.2024 | 31.05.2024 | TILTAK    | VIDEREGÅENDE | 100           |
 
     Gitt følgende stønadsperioder for læremidler
-      | Fom        | Tom        | Målgruppe | Aktivitet |
-      | 01.04.2024 | 31.04.2024 | AAP       | TILTAK    |
-      | 01.05.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
-      | 01.04.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
+      | Fom        | Tom        | Målgruppe       | Aktivitet |
+      | 01.04.2024 | 31.04.2024 | AAP             | TILTAK    |
+      | 01.05.2024 | 31.05.2024 | OVERGANGSSTØNAD | TILTAK    |
+      | 01.04.2024 | 31.05.2024 | OVERGANGSSTØNAD | TILTAK    |
 
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Det er for mange stønadsperioder som inneholder utbetalingsperioden
-    # TODO når man støtter flere målgrupper
-    # Så skal stønaden være
-    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-    #  | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
-    #  | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP             | 01.04.2024      |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | OVERGANGSSTØNAD | 01.05.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
@@ -1,7 +1,7 @@
 # language: no
 # encoding: UTF-8
 
-Egenskap: Beregning
+Egenskap: Beregning av læremidler - flere stønadsperioder
 
   Scenario: Flere stønadsperioder
     Gitt følgende vedtaksperioder for læremidler
@@ -80,6 +80,8 @@ Egenskap: Beregning
 
 
   Scenario: To uilke målgrupper samme aktivitet feiler i månedskiftet
+    # TODO når man støtter flere målgrupper
+    #  Scenario: To ulike målgrupper samme aktivitet
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
       | 01.04.2024 | 31.05.2024 |
@@ -93,13 +95,17 @@ Egenskap: Beregning
       | 01.04.2024 | 31.04.2024 | AAP       | TILTAK    |
       | 01.05.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
     Så forvent følgende feil fra læremidlerberegning: Vedtaksperiode er ikke innenfor en overlappsperiode
+    # TODO når man støtter flere målgrupper
+    # Så skal stønaden være
+    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+    #  | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
+    #  | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | DAGPENGER | 01.05.2024      |
 
 
-  Scenario: To uilke målgrupper samme aktivitet feiler når ikke i månedskiftet
+  Scenario: To ulike målgrupper samme aktivitet feiler når ikke i månedskiftet
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
       | 01.04.2024 | 31.05.2024 |
@@ -113,12 +119,11 @@ Egenskap: Beregning
       | 01.04.2024 | 04.05.2024 | AAP       | TILTAK    |
       | 05.05.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
     Så forvent følgende feil fra læremidlerberegning: Vedtaksperiode er ikke innenfor en overlappsperiode
 
-  Scenario: Flere stønadsperioder som unneholder utbeatlingsperioden
+  Scenario: Stønadsperioder i ulike løpende måneder
     Gitt følgende vedtaksperioder for læremidler
       | Fom        | Tom        |
       | 01.04.2024 | 31.05.2024 |
@@ -127,14 +132,17 @@ Egenskap: Beregning
       | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
       | 01.01.2024 | 31.05.2024 | TILTAK    | VIDEREGÅENDE | 100           |
 
-
     Gitt følgende stønadsperioder for læremidler
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 01.04.2024 | 31.04.2024 | AAP       | TILTAK    |
       | 01.05.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
       | 01.04.2024 | 31.05.2024 | DAGPENGER | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
     Så forvent følgende feil fra læremidlerberegning: Det er for mange stønadsperioder som inneholder utbetalingsperioden
+    # TODO når man støtter flere målgrupper
+    # Så skal stønaden være
+    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+    #  | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
+    #  | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
@@ -47,4 +47,4 @@ Egenskap: Beregning læremidler - flere målgrupper - flere aktiviteter
 
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |
+      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 50           | 438  | AAP       | 15.08.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
@@ -22,11 +22,9 @@ Egenskap: Beregning læremidler - flere målgrupper - flere aktiviteter
 
     Når beregner stønad for læremidler
 
-    Så forvent følgende feil fra læremidlerberegning: Vedtaksperiode er ikke innenfor en overlappsperiode
-
-    #Så skal stønaden være
-    #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-    #  | 07.01.2025 | 08.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP       | 06.01.2025      |
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 07.01.2025 | 08.01.2025 | 226   | VIDEREGÅENDE | 50            | 451  | AAP       | 07.01.2025      |
 
   Scenario: Flere aktiviteter med ulike datoer innenfor løpende måned men utenfor vedtaksperiode
     Gitt følgende vedtaksperioder for læremidler
@@ -47,4 +45,4 @@ Egenskap: Beregning læremidler - flere målgrupper - flere aktiviteter
 
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 50           | 438  | AAP       | 15.08.2024      |
+      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 50            | 438  | AAP       | 15.08.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
@@ -27,3 +27,24 @@ Egenskap: Beregning læremidler - flere målgrupper - flere aktiviteter
     #Så skal stønaden være
     #  | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
     #  | 07.01.2025 | 08.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP       | 06.01.2025      |
+
+  Scenario: Flere aktiviteter med ulike datoer innenfor løpende måned men utenfor vedtaksperiode
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 15.08.2024 | 15.08.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 15.08.2024 | 15.08.2024 | TILTAK    | VIDEREGÅENDE     | 50            |
+      # aktivitet 2 er innenfor løpende måned, men ikke overlapp med vedtaksperiode, men overlapp med stønadsperiode
+      | 20.08.2024 | 25.08.2024 | TILTAK    | HØYERE_UTDANNING | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 15.08.2024 | 14.09.2024 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 100           | 438  | AAP       | 15.08.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder_flere_aktiviteter.feature
@@ -46,3 +46,26 @@ Egenskap: Beregning læremidler - flere målgrupper - flere aktiviteter
     Så skal stønaden være
       | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
       | 15.08.2024 | 15.08.2024 | 219   | VIDEREGÅENDE | 50            | 438  | AAP       | 15.08.2024      |
+
+  Scenario: Flere målgrupper, skal prioritere målgruppe med høyest prioritet
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.01.2024 | 15.01.2024 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
+      | 01.01.2024 | 03.01.2024 | UTDANNING | VIDEREGÅENDE | 100           |
+      | 04.01.2024 | 07.01.2024 | TILTAK    | VIDEREGÅENDE | 100           |
+      | 08.01.2024 | 15.01.2024 | UTDANNING | VIDEREGÅENDE | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe       | Aktivitet |
+      | 01.01.2024 | 04.01.2024 | OVERGANGSSTØNAD | UTDANNING |
+      | 05.01.2024 | 07.01.2024 | AAP             | TILTAK    |
+      | 08.01.2024 | 15.01.2024 | OVERGANGSSTØNAD | UTDANNING |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.01.2024 | 15.01.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.01.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_vedtaksperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_vedtaksperioder.feature
@@ -41,7 +41,6 @@ Egenskap: Beregning av læremidler - flere vedtaksperioder
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 01.01.2024 | 31.03.2025 | AAP       | TILTAK    |
 
-
     Når beregner stønad for læremidler
 
     Så skal stønaden være

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_ulike_år.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_ulike_år.feature
@@ -1,0 +1,25 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Beregning av læremidler - ulike år
+
+  Scenario: En vedtaksperiode som løper innenfor en løpende måned men i 2 ulike år vil bli splittet opp
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 12.12.2024 | 11.01.2025 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå   | Studieprosent |
+      | 01.01.2024 | 31.12.2025 | TILTAK    | VIDEREGÅENDE | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 01.12.2024 | 31.03.2025 | AAP       | TILTAK    |
+
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 12.12.2024 | 31.12.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 12.12.2024      |
+      | 01.01.2025 | 11.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP       | 01.01.2025      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/valider_vedtaksperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/valider_vedtaksperioder.feature
@@ -13,7 +13,6 @@ Egenskap: Validering av vedtaksperioder for læremidler
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 01.01.2024 | 31.04.2024 | AAP       | UTDANNING |
 
-
     Når validerer vedtaksperiode for læremidler
 
     Så forvent følgende feil fra vedtaksperiode validering: Periode=01.01.2024 - 31.03.2024 og 31.03.2024 - 30.04.2024 overlapper.
@@ -27,7 +26,6 @@ Egenskap: Validering av vedtaksperioder for læremidler
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 01.01.2024 | 31.03.2024 | AAP       | UTDANNING |
       | 02.04.2024 | 31.04.2024 | AAP       | UTDANNING |
-
 
     Når validerer vedtaksperiode for læremidler
 
@@ -58,7 +56,23 @@ Egenskap: Validering av vedtaksperioder for læremidler
       | Fom        | Tom        | Målgruppe | Aktivitet |
       | 01.01.2024 | 30.03.2024 | AAP       | UTDANNING |
 
+    Når validerer vedtaksperiode for læremidler
+
+    Så forvent følgende feil fra vedtaksperiode validering: Vedtaksperiode er ikke innenfor en overlappsperiode
+
+  Scenario: Skal kunne lage en vedtaksperiode som stekker seg over flere stønadsperioder
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.01.2024 | 03.02.2024 |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe       | Aktivitet |
+      | 01.01.2024 | 15.01.2024 | AAP             | UTDANNING |
+      | 16.01.2024 | 01.02.2024 | OVERGANGSSTØNAD | UTDANNING |
+      | 02.02.2024 | 03.02.2024 | AAP             | UTDANNING |
 
     Når validerer vedtaksperiode for læremidler
 
+    # TODO
+    #Så forvent ingen feil fra vedtaksperiode validering
     Så forvent følgende feil fra vedtaksperiode validering: Vedtaksperiode er ikke innenfor en overlappsperiode

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/valider_vedtaksperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/valider_vedtaksperioder.feature
@@ -73,6 +73,4 @@ Egenskap: Validering av vedtaksperioder for læremidler
 
     Når validerer vedtaksperiode for læremidler
 
-    # TODO
-    #Så forvent ingen feil fra vedtaksperiode validering
-    Så forvent følgende feil fra vedtaksperiode validering: Vedtaksperiode er ikke innenfor en overlappsperiode
+    Så forvent ingen feil fra vedtaksperiode validering


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ennå en, dessverre, stor PR koblet til kompleks logikk. 

Fortsettelse på
* https://github.com/navikt/tilleggsstonader-sak/pull/544
Dokumentert
* https://github.com/navikt/tilleggsstonader-docs/pull/15

For å finne kombinasjoner av målgruppe og aktivitet har jeg lagt tatt i bruk snitt, for å kunne finne snittet mellom en vedtaksperiode og en målgruppe.
![image](https://github.com/user-attachments/assets/fc894e86-e8cd-4096-a622-51765f744503)
Det resulterer i en liste av `snittet av vedtaksperiode, stønadsperiode og målgruppe` som prioriteres opp innenfor en løpende måned for å bestemme hvilken som skal velges.

Det er mer beskrevet i dokumentasjons-PR men her er det kort beskrevet:
Det er lagt til mulighet for å håndtere flere ulike aktiviteter innenfor en vedtaksperiode. 
Høyere utdanning vil valgt føre vgs. Det vil sansynligvis aldri skje at man har 2 ulike innenfor en måned, det vil være mer vanlig at man tar korte tiltak. Eller der det er en pause mellom 2.

Hvis man har 2 av samme type utdanning og prosent vil målgruppen prioriteres.

2 ulike målgrupper må også håndteres sånn at de betales ut samtidig, men at det blir mappet til 2 ulike andeler.

Prøvd å ryddet i tester i samband med dette og fjernet et eller annet duplikat. 