### PR TITLE
Læremidler beregning helg

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtil.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
 
+import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.kontrakter.felles.sisteDagIÅret
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
+import no.nav.tilleggsstonader.sak.util.lørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.sisteDagenILøpendeMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.splitPerLøpendeMåneder
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.splitVedtaksperiodePerÅr
@@ -24,7 +26,8 @@ object LæremidlerBeregnUtil {
                     val håndterNyUtbetalingsperiode = vedtaksperiode.håndterNyUtbetalingsperiode(acc)
                     acc + håndterNyUtbetalingsperiode
                 }
-            }.toList()
+            }.filter { it.vedtaksperioder.any { it.alleDatoer().any { !it.lørdagEllerSøndag() } } }
+            .toList()
 
     /**
      * Legger til periode som overlapper med forrige utbetalingsperiode

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtil.kt
@@ -1,9 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
 
-import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.kontrakter.felles.sisteDagIÅret
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
-import no.nav.tilleggsstonader.sak.util.lørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.sisteDagenILøpendeMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.splitPerLøpendeMåneder
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.splitVedtaksperiodePerÅr
@@ -26,8 +24,7 @@ object LæremidlerBeregnUtil {
                     val håndterNyUtbetalingsperiode = vedtaksperiode.håndterNyUtbetalingsperiode(acc)
                     acc + håndterNyUtbetalingsperiode
                 }
-            }.filter { it.vedtaksperioder.any { it.alleDatoer().any { !it.lørdagEllerSøndag() } } }
-            .toList()
+            }.filter { it.harDatoerIUkedager() }
 
     /**
      * Legger til periode som overlapper med forrige utbetalingsperiode

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerVedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerVedtaksperiodeUtil.kt
@@ -23,21 +23,12 @@ object LæremidlerVedtaksperiodeUtil {
      * eks 05.01.2024-29.02.24 blir listOf( P(fom=05.01.2024,tom=04.02.2024), P(fom=05.02.2024,tom=29.02.2024) )
      */
     fun <P : Periode<LocalDate>, VAL : Periode<LocalDate>> P.splitPerLøpendeMåneder(
-        skalKutteSistePeriode: Boolean = true,
         medNyPeriode: (fom: LocalDate, tom: LocalDate) -> VAL,
     ): List<VAL> {
         val perioder = mutableListOf<VAL>()
         var gjeldendeFom = fom
         while (gjeldendeFom <= tom) {
-            val nyTom =
-                if (skalKutteSistePeriode) {
-                    minOf(
-                        gjeldendeFom.sisteDagenILøpendeMåned(),
-                        tom,
-                    )
-                } else {
-                    gjeldendeFom.sisteDagenILøpendeMåned()
-                }
+            val nyTom = minOf(gjeldendeFom.sisteDagenILøpendeMåned(), tom)
 
             val nyPeriode = medNyPeriode(gjeldendeFom, nyTom)
             if (nyPeriode.harDatoerIUkedager()) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/UtbetalingPeriode.kt
@@ -1,11 +1,13 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.kontrakter.felles.overlapper
 import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
+import no.nav.tilleggsstonader.sak.util.lørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.domain.StønadsperiodeBeregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning.LæremidlerVedtaksperiodeUtil.sisteDagenILøpendeMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
@@ -81,6 +83,8 @@ data class LøpendeMåned(
         _vedtaksperioder.add(vedtaksperiode)
         return this
     }
+
+    fun harDatoerIUkedager(): Boolean = vedtaksperioder.any { it.alleDatoer().any { !it.lørdagEllerSøndag() } }
 
     /**
      * Finner hvilken stønadsperiode og aktivitet som skal brukes for den aktuelle utbetalingsperioden

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregnUtilTest.kt
@@ -37,6 +37,19 @@ class LæremidlerBeregnUtilTest {
     }
 
     @Nested
+    inner class Helg {
+        @Test
+        fun `skal lage løpende måned for vedtaksperiode som kun er under en helg`() {
+            val vedtaksperioder =
+                listOf(
+                    Vedtaksperiode(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 2, 2)),
+                )
+            val perioder = vedtaksperioder.grupperVedtaksperioderPerLøpendeMåned()
+            assertThat(perioder).isEmpty()
+        }
+    }
+
+    @Nested
     inner class FlereVedtaksperioderSammeMåned {
         @Test
         fun `skal håndtere en vedtaksperiode som løper innenfor en løpende måned`() {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LøpendeMånedTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LøpendeMånedTest.kt
@@ -1,0 +1,49 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler.beregning
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class LøpendeMånedTest {
+    @Nested
+    inner class HarDatoerIUkedager {
+        val vedtaksperiodeMandag =
+            VedtaksperiodeInnenforLøpendeMåned(LocalDate.of(2025, 2, 3), LocalDate.of(2025, 2, 3))
+        val vedtaksperiodeLørdag =
+            VedtaksperiodeInnenforLøpendeMåned(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 2, 1))
+        val vedtaksperiodeSøndag =
+            VedtaksperiodeInnenforLøpendeMåned(LocalDate.of(2025, 2, 9), LocalDate.of(2025, 2, 9))
+        val vedtaksperiodeHeleMåneden =
+            VedtaksperiodeInnenforLøpendeMåned(LocalDate.of(2025, 2, 1), LocalDate.of(2025, 2, 28))
+
+        @Test
+        fun `løpende måned uten perioder skal gi false`() {
+            assertThat(løpendeMåned().harDatoerIUkedager()).isFalse()
+        }
+
+        @Test
+        fun `skal gi false hvis det kun finnes perioder som er helgdager`() {
+            assertThat(løpendeMåned(vedtaksperiodeLørdag).harDatoerIUkedager()).isFalse()
+            assertThat(løpendeMåned(vedtaksperiodeLørdag, vedtaksperiodeSøndag).harDatoerIUkedager()).isFalse()
+        }
+
+        @Test
+        fun `skal gi true hvis det finnes perioder som er ukedager`() {
+            assertThat(løpendeMåned(vedtaksperiodeMandag).harDatoerIUkedager()).isTrue()
+            assertThat(løpendeMåned(vedtaksperiodeMandag, vedtaksperiodeLørdag).harDatoerIUkedager()).isTrue()
+            assertThat(løpendeMåned(vedtaksperiodeHeleMåneden).harDatoerIUkedager()).isTrue()
+        }
+    }
+
+    private fun løpendeMåned(vararg vedtaksperioder: VedtaksperiodeInnenforLøpendeMåned) =
+        LøpendeMåned(
+            fom = LocalDate.of(2025, 2, 1),
+            tom = LocalDate.of(2025, 2, 28),
+            utbetalingsdato = LocalDate.of(2025, 2, 1),
+        ).apply {
+            vedtaksperioder.forEach {
+                this.medVedtaksperiode(it)
+            }
+        }
+}

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_helger.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_helger.feature
@@ -1,0 +1,62 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Beregning av læremidler - helg
+
+  Scenario: Vedtaksperiode er kun over helg
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.02.2025 | 02.02.2025 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 01.01.2025 | 31.03.2025 | TILTAK    | HØYERE_UTDANNING | 50            |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 01.01.2025 | 31.03.2025 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom | Tom | Beløp | Studienivå | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+
+  Scenario: Vedtaksperioder er kun over helger
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.02.2025 | 02.02.2025 |
+      | 08.02.2025 | 09.02.2025 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 01.01.2025 | 31.03.2025 | TILTAK    | HØYERE_UTDANNING | 50            |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 01.01.2025 | 31.03.2025 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom | Tom | Beløp | Studienivå | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+
+  Scenario: Vedtaksperioder er over 2 helger og 1 ukesdag, men løpende måneden begynner første helgen
+    Gitt følgende vedtaksperioder for læremidler
+      | Fom        | Tom        |
+      | 01.02.2025 | 02.02.2025 |
+      | 08.02.2025 | 09.02.2025 |
+      | 11.02.2025 | 11.02.2025 |
+
+    Gitt følgende aktiviteter for læremidler
+      | Fom        | Tom        | Aktivitet | Studienivå       | Studieprosent |
+      | 01.01.2025 | 31.03.2025 | TILTAK    | HØYERE_UTDANNING | 100           |
+
+    Gitt følgende stønadsperioder for læremidler
+      | Fom        | Tom        | Målgruppe | Aktivitet |
+      | 01.01.2025 | 31.03.2025 | AAP       | TILTAK    |
+
+    Når beregner stønad for læremidler
+
+    Så skal stønaden være
+      | Fom        | Tom        | Beløp | Studienivå       | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
+      | 01.02.2025 | 11.02.2025 | 901   | HØYERE_UTDANNING | 100           | 901  | AAP       | 03.02.2025      |


### PR DESCRIPTION
…sperioder med helgdager

### Hvorfor er denne endringen nødvendig? ✨

Det ble ikke helt korrekt håndtert i det at vi innførte gruppering av vedtaksperioder innenfor en måned.
Vi håndterte denne tidligere i `splitPerLøpendeMåneder` med 
```kotlin
if (nyPeriode.harDatoerIUkedager()) {
                perioder.add(nyPeriode)
            }
```
Men TOM settes til TOM i løpende måned
```kotlin
return this.splitPerLøpendeMåneder { fom, tom ->
            LøpendeMåned(
                fom = fom,
                tom = minOf(fom.sisteDagenILøpendeMåned(), this.tom.sisteDagIÅret()),
                utbetalingsdato = this.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
            ).medVedtaksperiode(VedtaksperiodeInnenforLøpendeMåned(fom = fom, tom = tom))
        }
```
