### PR TITLE
Omskrivning av valideringen rundt avkorting av utbetalingsperioder ved Opphør Læremidler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -56,18 +56,18 @@ class OpphørValideringService(
         val senesteTomIForrigeBeregning = forrigeBeregningsresultat.maxOf { it.tom }
 
         brukerfeilHvis(
-            revurderFraDato >= senesteTomIForrigeBeregning,
+            senesteTomIForrigeBeregning < revurderFraDato,
         ) { "Opphør er et ugyldig vedtaksresultat fordi ingen utbetalinger blir avkortet" }
     }
 
     fun validerVedtaksperioderAvkortetVedOpphør(
         forrigeBehandlingsVedtaksperioder: List<Vedtaksperiode>,
-        revurderFraDato: LocalDate
+        revurderFraDato: LocalDate,
     ) {
         val senesteTomIForrigeVedtaksperioder = forrigeBehandlingsVedtaksperioder.maxOf { it.tom }
 
         brukerfeilHvis(
-            revurderFraDato >= senesteTomIForrigeVedtaksperioder,
+            senesteTomIForrigeVedtaksperioder < revurderFraDato
         ) { "Opphør er et ugyldig vedtaksresultat fordi ingen vedtaksperioder har blitt avkortet" }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -67,7 +67,7 @@ class OpphørValideringService(
         val senesteTomIForrigeVedtaksperioder = forrigeBehandlingsVedtaksperioder.maxOf { it.tom }
 
         brukerfeilHvis(
-            senesteTomIForrigeVedtaksperioder < revurderFraDato
+            senesteTomIForrigeVedtaksperioder < revurderFraDato,
         ) { "Opphør er et ugyldig vedtaksresultat fordi ingen vedtaksperioder har blitt avkortet" }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.vedtak
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
@@ -47,17 +46,6 @@ class OpphørValideringService(
                 ) { "Opphør er et ugyldig vedtaksresultat fordi det er utbetalinger på eller etter revurder fra dato" }
             }
         }
-    }
-
-    fun validerBeregningsresultatErAvkortetVedOpphør(
-        forrigeBeregningsresultat: List<BeregningsresultatForMåned>,
-        revurderFraDato: LocalDate,
-    ) {
-        val senesteTomIForrigeBeregning = forrigeBeregningsresultat.maxOf { it.tom }
-
-        brukerfeilHvis(
-            senesteTomIForrigeBeregning < revurderFraDato,
-        ) { "Opphør er et ugyldig vedtaksresultat fordi ingen utbetalinger blir avkortet" }
     }
 
     fun validerVedtaksperioderAvkortetVedOpphør(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -50,14 +50,13 @@ class OpphørValideringService(
     }
 
     fun validerBeregningsresultatErAvkortetVedOpphør(
-        beregningsresultatEtterOpphør: List<BeregningsresultatForMåned>,
         forrigeBeregningsresultat: List<BeregningsresultatForMåned>,
+        revurderFraDato: LocalDate,
     ) {
-        val senesteTomIOpphør = beregningsresultatEtterOpphør.maxOf { it.tom }
         val senesteTomIForrigeBeregning = forrigeBeregningsresultat.maxOf { it.tom }
 
         brukerfeilHvis(
-            senesteTomIOpphør >= senesteTomIForrigeBeregning,
+            revurderFraDato >= senesteTomIForrigeBeregning,
         ) { "Opphør er et ugyldig vedtaksresultat fordi ingen utbetalinger blir avkortet" }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -61,14 +61,13 @@ class OpphørValideringService(
     }
 
     fun validerVedtaksperioderAvkortetVedOpphør(
-        vedtaksperioderEtterOpphør: List<Vedtaksperiode>,
         forrigeBehandlingsVedtaksperioder: List<Vedtaksperiode>,
+        revurderFraDato: LocalDate
     ) {
-        val senesteTomINyeVedtaksperioder = vedtaksperioderEtterOpphør.maxOf { it.tom }
         val senesteTomIForrigeVedtaksperioder = forrigeBehandlingsVedtaksperioder.maxOf { it.tom }
 
         brukerfeilHvis(
-            senesteTomINyeVedtaksperioder >= senesteTomIForrigeVedtaksperioder,
+            revurderFraDato >= senesteTomIForrigeVedtaksperioder,
         ) { "Opphør er et ugyldig vedtaksresultat fordi ingen vedtaksperioder har blitt avkortet" }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -168,8 +168,8 @@ class LæremidlerBeregnYtelseSteg(
         )
 
         opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
-            vedtaksperioderEtterOpphør = avkortetVedtaksperioder,
             forrigeBehandlingsVedtaksperioder = forrigeVedtak.data.vedtaksperioder,
+            revurderFraDato = saksbehandling.revurderFra,
         )
 
         val beregningsresultat =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -163,8 +163,8 @@ class LæremidlerBeregnYtelseSteg(
         val avkortetVedtaksperioder = avkortVedtaksperiodeVedOpphør(forrigeVedtak, saksbehandling.revurderFra)
 
         opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
-            beregningsresultatEtterOpphør = avkortetBeregningsresultat.perioder,
             forrigeBeregningsresultat = forrigeVedtak.data.beregningsresultat.perioder,
+            revurderFraDato = saksbehandling.revurderFra,
         )
 
         opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -162,11 +162,6 @@ class LæremidlerBeregnYtelseSteg(
         val avkortetBeregningsresultat = avkortBeregningsresultatVedOpphør(forrigeVedtak, saksbehandling.revurderFra)
         val avkortetVedtaksperioder = avkortVedtaksperiodeVedOpphør(forrigeVedtak, saksbehandling.revurderFra)
 
-        opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
-            forrigeBeregningsresultat = forrigeVedtak.data.beregningsresultat.perioder,
-            revurderFraDato = saksbehandling.revurderFra,
-        )
-
         opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
             forrigeBehandlingsVedtaksperioder = forrigeVedtak.data.vedtaksperioder,
             revurderFraDato = saksbehandling.revurderFra,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -101,7 +101,7 @@ class OpphørValideringServiceLæremidlerTest {
             assertThatCode {
                 opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
                     forrigeBehandlingsVedtaksperioder = listOf(vedtaksperiodeJanuar, vedtaksperiodeFebruar),
-                    revurderFraDato = sisteFebruar
+                    revurderFraDato = sisteFebruar,
                 )
             }.doesNotThrowAnyException()
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -23,6 +23,9 @@ class OpphørValideringServiceLæremidlerTest {
     val fom = måned.atDay(1)
     val tom = måned.atEndOfMonth()
 
+    val førsteMars = YearMonth.of(2025, 3).atDay(1)
+    val førsteFebruar = YearMonth.of(2025, 2).atDay(1)
+
     val vedtaksperiodeJanuar = Vedtaksperiode(fom, tom)
     val vedtaksperiodeFebruar = Vedtaksperiode(fom.plusMonths(1), tom.plusMonths(1))
 
@@ -68,7 +71,7 @@ class OpphørValideringServiceLæremidlerTest {
     @Nested
     inner class `Valider beregningsresultat er avkortet ved opphør` {
         @Test
-        fun `Kaster ikke feil når beregningsresultatet i forrige behandling avkortes`() {
+        fun `Kaster ikke feil når beregningsresultat i forrige behandling avkortes`() {
             assertThatCode {
                 opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
                     forrigeBeregningsresultat = beregningsresultat.perioder,
@@ -78,11 +81,11 @@ class OpphørValideringServiceLæremidlerTest {
         }
 
         @Test
-        fun `Kaster feil når nytt beregeningsresultat ikke er avkortet`() {
+        fun `Kaster feil når nytt beregningsresultat ikke er avkortet`() {
             assertThatThrownBy {
                 opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
                     forrigeBeregningsresultat = beregningsresultat.perioder,
-                    revurderFraDato = tom.plusMonths(1),
+                    revurderFraDato = førsteMars,
                 )
             }.hasMessage("Opphør er et ugyldig vedtaksresultat fordi ingen utbetalinger blir avkortet")
         }
@@ -105,7 +108,7 @@ class OpphørValideringServiceLæremidlerTest {
             assertThatThrownBy {
                 opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
                     forrigeBehandlingsVedtaksperioder = listOf(vedtaksperiodeJanuar, vedtaksperiodeFebruar),
-                    revurderFraDato = tom.plusMonths(1),
+                    revurderFraDato = førsteMars,
                 )
             }.hasMessage("Opphør er et ugyldig vedtaksresultat fordi ingen vedtaksperioder har blitt avkortet")
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -19,23 +19,26 @@ class OpphørValideringServiceLæremidlerTest {
     private val vilkårperiodeService = mockk<VilkårperiodeService>()
     private val vilkårService = mockk<VilkårService>()
 
-    val måned = YearMonth.of(2025, 1)
-    val fom = måned.atDay(1)
-    val tom = måned.atEndOfMonth()
+    val februar = YearMonth.of(2025, 2)
+
+    val førsteJanuar = YearMonth.of(2025, 1).atDay(1)
+    val sisteJanuar = YearMonth.of(2025, 1).atEndOfMonth()
+
+    val førsteFebruar = YearMonth.of(2025, 2).atDay(1)
+    val sisteFebruar = YearMonth.of(2025, 2).atEndOfMonth()
+
+    val vedtaksperiodeJanuar = Vedtaksperiode(førsteJanuar, sisteJanuar)
+    val vedtaksperiodeFebruar = Vedtaksperiode(førsteFebruar, sisteFebruar)
 
     val førsteMars = YearMonth.of(2025, 3).atDay(1)
-    val førsteFebruar = YearMonth.of(2025, 2).atDay(1)
-
-    val vedtaksperiodeJanuar = Vedtaksperiode(fom, tom)
-    val vedtaksperiodeFebruar = Vedtaksperiode(fom.plusMonths(1), tom.plusMonths(1))
 
     val opphørValideringService = OpphørValideringService(vilkårperiodeService, vilkårService)
 
     val beregningsgrunnlag =
         Beregningsgrunnlag(
-            fom = fom,
-            tom = tom,
-            utbetalingsdato = fom,
+            fom = førsteJanuar,
+            tom = sisteJanuar,
+            utbetalingsdato = førsteJanuar,
             studienivå = Studienivå.HØYERE_UTDANNING,
             studieprosent = 100,
             sats = 100,
@@ -54,8 +57,8 @@ class OpphørValideringServiceLæremidlerTest {
             beløp = 100,
             grunnlag =
                 beregningsgrunnlag.copy(
-                    fom = fom.plusMonths(1),
-                    tom = tom.plusMonths(1),
+                    fom = førsteFebruar,
+                    tom = sisteFebruar,
                 ),
         )
 
@@ -75,7 +78,7 @@ class OpphørValideringServiceLæremidlerTest {
             assertThatCode {
                 opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
                     forrigeBeregningsresultat = beregningsresultat.perioder,
-                    revurderFraDato = tom.minusDays(1),
+                    revurderFraDato = sisteFebruar,
                 )
             }.doesNotThrowAnyException()
         }
@@ -98,7 +101,7 @@ class OpphørValideringServiceLæremidlerTest {
             assertThatCode {
                 opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
                     forrigeBehandlingsVedtaksperioder = listOf(vedtaksperiodeJanuar, vedtaksperiodeFebruar),
-                    revurderFraDato = tom.minusDays(1),
+                    revurderFraDato = sisteFebruar
                 )
             }.doesNotThrowAnyException()
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -1,14 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak
 
 import io.mockk.mockk
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Beregningsgrunnlag
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatForMåned
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatLæremidler
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
@@ -18,8 +13,6 @@ import java.time.YearMonth
 class OpphørValideringServiceLæremidlerTest {
     private val vilkårperiodeService = mockk<VilkårperiodeService>()
     private val vilkårService = mockk<VilkårService>()
-
-    val februar = YearMonth.of(2025, 2)
 
     val førsteJanuar = YearMonth.of(2025, 1).atDay(1)
     val sisteJanuar = YearMonth.of(2025, 1).atEndOfMonth()
@@ -33,66 +26,6 @@ class OpphørValideringServiceLæremidlerTest {
     val førsteMars = YearMonth.of(2025, 3).atDay(1)
 
     val opphørValideringService = OpphørValideringService(vilkårperiodeService, vilkårService)
-
-    val beregningsgrunnlag =
-        Beregningsgrunnlag(
-            fom = førsteJanuar,
-            tom = sisteJanuar,
-            utbetalingsdato = førsteJanuar,
-            studienivå = Studienivå.HØYERE_UTDANNING,
-            studieprosent = 100,
-            sats = 100,
-            satsBekreftet = true,
-            målgruppe = MålgruppeType.AAP,
-        )
-
-    val beregningsresultatForJanuar =
-        BeregningsresultatForMåned(
-            beløp = 100,
-            grunnlag = beregningsgrunnlag,
-        )
-
-    val beregningsresultatForFebruar =
-        BeregningsresultatForMåned(
-            beløp = 100,
-            grunnlag =
-                beregningsgrunnlag.copy(
-                    fom = førsteFebruar,
-                    tom = sisteFebruar,
-                ),
-        )
-
-    val beregningsresultat =
-        BeregningsresultatLæremidler(
-            perioder =
-                listOf(
-                    beregningsresultatForJanuar,
-                    beregningsresultatForFebruar,
-                ),
-        )
-
-    @Nested
-    inner class `Valider beregningsresultat er avkortet ved opphør` {
-        @Test
-        fun `Kaster ikke feil når beregningsresultat i forrige behandling avkortes`() {
-            assertThatCode {
-                opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
-                    forrigeBeregningsresultat = beregningsresultat.perioder,
-                    revurderFraDato = sisteFebruar,
-                )
-            }.doesNotThrowAnyException()
-        }
-
-        @Test
-        fun `Kaster feil når nytt beregningsresultat ikke er avkortet`() {
-            assertThatThrownBy {
-                opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
-                    forrigeBeregningsresultat = beregningsresultat.perioder,
-                    revurderFraDato = førsteMars,
-                )
-            }.hasMessage("Opphør er et ugyldig vedtaksresultat fordi ingen utbetalinger blir avkortet")
-        }
-    }
 
     @Nested
     inner class `Valider at vedtaksperioden er avkortet ved opphør` {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -14,18 +14,18 @@ class OpphørValideringServiceLæremidlerTest {
     private val vilkårperiodeService = mockk<VilkårperiodeService>()
     private val vilkårService = mockk<VilkårService>()
 
-    val førsteJanuar = YearMonth.of(2025, 1).atDay(1)
-    val sisteJanuar = YearMonth.of(2025, 1).atEndOfMonth()
-
-    val førsteFebruar = YearMonth.of(2025, 2).atDay(1)
-    val sisteFebruar = YearMonth.of(2025, 2).atEndOfMonth()
-
-    val vedtaksperiodeJanuar = Vedtaksperiode(førsteJanuar, sisteJanuar)
-    val vedtaksperiodeFebruar = Vedtaksperiode(førsteFebruar, sisteFebruar)
-
-    val førsteMars = YearMonth.of(2025, 3).atDay(1)
-
     val opphørValideringService = OpphørValideringService(vilkårperiodeService, vilkårService)
+
+    private val førsteJanuar = YearMonth.of(2025, 1).atDay(1)
+    private val sisteJanuar = YearMonth.of(2025, 1).atEndOfMonth()
+
+    private val førsteFebruar = YearMonth.of(2025, 2).atDay(1)
+    private val sisteFebruar = YearMonth.of(2025, 2).atEndOfMonth()
+
+    private val vedtaksperiodeJanuar = Vedtaksperiode(førsteJanuar, sisteJanuar)
+    private val vedtaksperiodeFebruar = Vedtaksperiode(førsteFebruar, sisteFebruar)
+
+    private val førsteMars = YearMonth.of(2025, 3).atDay(1)
 
     @Nested
     inner class `Valider at vedtaksperioden er avkortet ved opphør` {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -94,8 +94,8 @@ class OpphørValideringServiceLæremidlerTest {
         fun `Kaster ikke feil når vedtaksperioden er avkortet`() {
             assertThatCode {
                 opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
-                    vedtaksperioderEtterOpphør = listOf(vedtaksperiodeJanuar),
                     forrigeBehandlingsVedtaksperioder = listOf(vedtaksperiodeJanuar, vedtaksperiodeFebruar),
+                    revurderFraDato = tom.minusDays(1),
                 )
             }.doesNotThrowAnyException()
         }
@@ -104,8 +104,8 @@ class OpphørValideringServiceLæremidlerTest {
         fun `Kaster feil når vedtaksperioden ikke er avkortet`() {
             assertThatThrownBy {
                 opphørValideringService.validerVedtaksperioderAvkortetVedOpphør(
-                    vedtaksperioderEtterOpphør = listOf(vedtaksperiodeJanuar, vedtaksperiodeFebruar),
                     forrigeBehandlingsVedtaksperioder = listOf(vedtaksperiodeJanuar, vedtaksperiodeFebruar),
+                    revurderFraDato = tom.plusMonths(1),
                 )
             }.hasMessage("Opphør er et ugyldig vedtaksresultat fordi ingen vedtaksperioder har blitt avkortet")
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceLæremidlerTest.kt
@@ -65,22 +65,14 @@ class OpphørValideringServiceLæremidlerTest {
                 ),
         )
 
-    val avkortetBeregningsresultat =
-        BeregningsresultatLæremidler(
-            perioder =
-                listOf(
-                    beregningsresultatForJanuar,
-                ),
-        )
-
     @Nested
     inner class `Valider beregningsresultat er avkortet ved opphør` {
         @Test
         fun `Kaster ikke feil når beregningsresultatet i forrige behandling avkortes`() {
             assertThatCode {
                 opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
-                    beregningsresultatEtterOpphør = avkortetBeregningsresultat.perioder,
                     forrigeBeregningsresultat = beregningsresultat.perioder,
+                    revurderFraDato = tom.minusDays(1),
                 )
             }.doesNotThrowAnyException()
         }
@@ -89,8 +81,8 @@ class OpphørValideringServiceLæremidlerTest {
         fun `Kaster feil når nytt beregeningsresultat ikke er avkortet`() {
             assertThatThrownBy {
                 opphørValideringService.validerBeregningsresultatErAvkortetVedOpphør(
-                    beregningsresultatEtterOpphør = beregningsresultat.perioder,
                     forrigeBeregningsresultat = beregningsresultat.perioder,
+                    revurderFraDato = tom.plusMonths(1),
                 )
             }.hasMessage("Opphør er et ugyldig vedtaksresultat fordi ingen utbetalinger blir avkortet")
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Forenkling av koden i PR: https://github.com/navikt/tilleggsstonader-sak/pull/561
Kaster nå brukerfeil dersom saksbehandler setter RevurderFra-dato til å være senere i tid enn forrige behandlings TOM-dato

Skriver om testene for å gjøre de mer lesbare og for å teste grensetilfellene når TOM  er dagen før, og samme dag som, RevurderFra-dato

*****

![image](https://github.com/user-attachments/assets/486c7013-f187-4350-8109-d48ba4b82685)
