### PR TITLE
🦺 Valider ingen overlapp i vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøn
 import no.nav.tilleggsstonader.sak.util.toYearMonth
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregningValideringUtil.validerIngenOverlapp
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregningValideringUtil.validerPerioderForInnvilgelse
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBeregningUtil.splitFraRevurderFra
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBeregningUtil.tilAktiviteterPerMånedPerType
@@ -80,7 +81,8 @@ class TilsynBarnBeregningService(
         feilHvis(typeVedtak == TypeVedtak.AVSLAG) {
             "Skal ikke beregne for avslag"
         }
-        // TODO Valider ingen overlapp mellom vedtaksperioderDto
+
+        validerIngenOverlapp(vedtaksperioderDto)
 
         val vedtaksperioder =
             vedtaksperioderDto.tilVedtaksperiode().sorted().splitFraRevurderFra(behandling.revurderFra)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningValideringUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningValideringUtil.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBeregningU
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBeregningUtil.brukPerioderFraOgMedRevurderFraMåned
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Aktivitet
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 import java.time.LocalDate
 
 object TilsynBarnBeregningValideringUtil {
@@ -30,6 +31,12 @@ object TilsynBarnBeregningValideringUtil {
         validerAktiviteter(aktiviteter)
         validerUtgifter(utgifter)
         validerOverlappendePeriodeOgUtgiftEtterRevurderFra(vedtaksperioder, utgifter, revurderFra)
+    }
+
+    fun validerIngenOverlapp(vedtaksperioder: List<VedtaksperiodeDto>) {
+        brukerfeilHvis(vedtaksperioder.overlapper()) {
+            "Vedtaksperioder kan ikke overlappe"
+        }
     }
 
     private fun <P> validerOverlappendePeriodeOgUtgiftEtterRevurderFra(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningValideringUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningValideringUtilTest.kt
@@ -1,0 +1,51 @@
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning
+
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregningValideringUtil.validerIngenOverlapp
+import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+class TilsynBarnBeregningValideringUtilTest {
+    @Nested
+    inner class ValiderIngenOverlapp {
+        val vedtaksperiodeJan =
+            VedtaksperiodeDto(
+                fom = LocalDate.of(2025, 1, 1),
+                tom = LocalDate.of(2025, 1, 31),
+                målgruppeType = MålgruppeType.AAP,
+                aktivitetType = AktivitetType.TILTAK,
+            )
+        val vedtaksperiodeFeb =
+            VedtaksperiodeDto(
+                fom = LocalDate.of(2025, 2, 1),
+                tom = LocalDate.of(2025, 2, 28),
+                målgruppeType = MålgruppeType.AAP,
+                aktivitetType = AktivitetType.TILTAK,
+            )
+        val vedtaksperiodeJanFeb =
+            VedtaksperiodeDto(
+                fom = LocalDate.of(2025, 1, 1),
+                tom = LocalDate.of(2025, 2, 28),
+                målgruppeType = MålgruppeType.AAP,
+                aktivitetType = AktivitetType.TILTAK,
+            )
+
+        @Test
+        fun `kaster feil hvis vedtaksperioderDto overlapper`() {
+            val feil = assertThrows<ApiFeil> { validerIngenOverlapp(listOf(vedtaksperiodeJan, vedtaksperiodeJanFeb)) }
+            assertThat(feil.feil).contains("Vedtaksperioder kan ikke overlappe")
+        }
+
+        @Test
+        fun `kaster ikke feil hvis vedtaksperioderDto ikke overlapper`() {
+            assertDoesNotThrow { validerIngenOverlapp(listOf(vedtaksperiodeJan, vedtaksperiodeFeb)) }
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Overlapp i vedtaksperioder kan medføre feil utbetaling. Dette ønsker vi ikke