### PR TITLE
🏷️ Lagre vedtaksperioder med id for innvilgelse tilsyn barn

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/ForeslåVedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/ForeslåVedtaksperiode.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import java.time.LocalDate
+import java.util.UUID
 
 object ForeslåVedtaksperiode {
     fun finnVedtaksperiode(
@@ -56,6 +57,7 @@ object ForeslåVedtaksperiode {
     ): Vedtaksperiode =
         if (stønadsperiode.overlapper(vilkår)) {
             Vedtaksperiode(
+                id = UUID.randomUUID(),
                 fom = maxOf(stønadsperiode.fom, vilkår.fom),
                 tom = minOf(stønadsperiode.tom, vilkår.tom),
                 målgruppe = stønadsperiode.målgruppe,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
@@ -44,7 +44,7 @@ object VedtakDtoMapper {
             is InnvilgelseTilsynBarn ->
                 InnvilgelseTilsynBarnResponse(
                     beregningsresultat = data.beregningsresultat.tilDto(revurderFra = revurderFra),
-                    vedtaksperioder = data.vedtaksperioder.tilDto(),
+                    vedtaksperioder = data.vedtaksperioder?.tilDto(),
                 )
 
             is OpphørTilsynBarn ->

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.domain.tilDto
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtakResponse
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerResponse
@@ -43,6 +44,7 @@ object VedtakDtoMapper {
             is InnvilgelseTilsynBarn ->
                 InnvilgelseTilsynBarnResponse(
                     beregningsresultat = data.beregningsresultat.tilDto(revurderFra = revurderFra),
+                    vedtaksperioder = data.vedtaksperioder.tilDto(),
                 )
 
             is OpphørTilsynBarn ->

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -80,7 +80,7 @@ class TilsynBarnBeregnYtelseSteg(
             lagInnvilgetVedtak(
                 behandling = saksbehandling,
                 beregningsresultat = beregningsresultat,
-                vedtaksperioder = vedtak.vedtaksperioder.tilDto(),
+                vedtaksperioder = vedtak.vedtaksperioder.tilDto().sorted(),
             ),
         )
         lagreAndeler(saksbehandling, beregningsresultat)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -27,6 +27,9 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtak
+import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vedtak.domain.tilVedtaksperioder
+import no.nav.tilleggsstonader.sak.vedtak.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
@@ -58,7 +61,13 @@ class TilsynBarnBeregnYtelseSteg(
 
     private fun beregnOgLagreInnvilgelse(saksbehandling: Saksbehandling) {
         val beregningsresultat = beregningService.beregn(saksbehandling, TypeVedtak.INNVILGELSE)
-        vedtakRepository.insert(lagInnvilgetVedtak(saksbehandling, beregningsresultat))
+        vedtakRepository.insert(
+            lagInnvilgetVedtak(
+                behandling = saksbehandling,
+                beregningsresultat = beregningsresultat,
+                vedtaksperioder = beregningsresultat.tilVedtaksperioder(),
+            ),
+        )
         lagreAndeler(saksbehandling, beregningsresultat)
     }
 
@@ -68,7 +77,13 @@ class TilsynBarnBeregnYtelseSteg(
     ) {
         val beregningsresultat =
             beregningService.beregnV2(vedtak.vedtaksperioder, saksbehandling, TypeVedtak.INNVILGELSE)
-        vedtakRepository.insert(lagInnvilgetVedtak(saksbehandling, beregningsresultat))
+        vedtakRepository.insert(
+            lagInnvilgetVedtak(
+                behandling = saksbehandling,
+                beregningsresultat = beregningsresultat,
+                vedtaksperioder = vedtak.vedtaksperioder.tilDto(),
+            ),
+        )
         lagreAndeler(saksbehandling, beregningsresultat)
     }
 
@@ -155,12 +170,14 @@ class TilsynBarnBeregnYtelseSteg(
     private fun lagInnvilgetVedtak(
         behandling: Saksbehandling,
         beregningsresultat: BeregningsresultatTilsynBarn,
+        vedtaksperioder: List<Vedtaksperiode>,
     ): Vedtak =
         GeneriskVedtak(
             behandlingId = behandling.id,
             type = TypeVedtak.INNVILGELSE,
             data =
                 InnvilgelseTilsynBarn(
+                    vedtaksperioder = vedtaksperioder,
                     beregningsresultat = BeregningsresultatTilsynBarn(beregningsresultat.perioder),
                 ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -110,6 +110,7 @@ class TilsynBarnBeregnYtelseSteg(
                         beregningsresultat = BeregningsresultatTilsynBarn(beregningsresultat.perioder),
                         årsaker = vedtak.årsakerOpphør,
                         begrunnelse = vedtak.begrunnelse,
+                        vedtaksperioder = null, // TODO håndter opphør med vedtaksperioder
                     ),
             ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -28,7 +28,6 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
-import no.nav.tilleggsstonader.sak.vedtak.domain.tilVedtaksperioder
 import no.nav.tilleggsstonader.sak.vedtak.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.springframework.stereotype.Service
@@ -65,7 +64,7 @@ class TilsynBarnBeregnYtelseSteg(
             lagInnvilgetVedtak(
                 behandling = saksbehandling,
                 beregningsresultat = beregningsresultat,
-                vedtaksperioder = beregningsresultat.tilVedtaksperioder(),
+                vedtaksperioder = null,
             ),
         )
         lagreAndeler(saksbehandling, beregningsresultat)
@@ -170,7 +169,7 @@ class TilsynBarnBeregnYtelseSteg(
     private fun lagInnvilgetVedtak(
         behandling: Saksbehandling,
         beregningsresultat: BeregningsresultatTilsynBarn,
-        vedtaksperioder: List<Vedtaksperiode>,
+        vedtaksperioder: List<Vedtaksperiode>?,
     ): Vedtak =
         GeneriskVedtak(
             behandlingId = behandling.id,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
@@ -5,7 +5,7 @@ import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 
 data class InnvilgelseTilsynBarnResponse(
     val beregningsresultat: BeregningsresultatTilsynBarnDto,
-    val vedtaksperioder: List<VedtaksperiodeDto>,
+    val vedtaksperioder: List<VedtaksperiodeDto>?,
 ) : VedtakTilsynBarnDto(TypeVedtak.INNVILGELSE),
     VedtakTilsynBarnResponse
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDto.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 
 data class InnvilgelseTilsynBarnResponse(
     val beregningsresultat: BeregningsresultatTilsynBarnDto,
+    val vedtaksperioder: List<VedtaksperiodeDto>,
 ) : VedtakTilsynBarnDto(TypeVedtak.INNVILGELSE),
     VedtakTilsynBarnResponse
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakTilsynBarn.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakTilsynBarn.kt
@@ -37,6 +37,7 @@ data class OpphørTilsynBarn(
     val beregningsresultat: BeregningsresultatTilsynBarn,
     override val årsaker: List<ÅrsakOpphør>,
     override val begrunnelse: String,
+    val vedtaksperioder: List<Vedtaksperiode>? = null,
 ) : VedtakTilsynBarn,
     Opphør {
     override val type: TypeVedtaksdata = TypeVedtakTilsynBarn.OPPHØR_TILSYN_BARN

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakTilsynBarn.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakTilsynBarn.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vedtak.domain
 
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeTilsynBarnMapper
 
 enum class TypeVedtakTilsynBarn(
     override val typeVedtak: TypeVedtak,
@@ -15,6 +16,8 @@ sealed interface VedtakTilsynBarn : Vedtaksdata
 
 data class InnvilgelseTilsynBarn(
     val beregningsresultat: BeregningsresultatTilsynBarn,
+    // For vedtak som ble gjort før vi innførte vedtaksperioder lager vi vedtaksperioder fra beregningsresultatet
+    val vedtaksperioder: List<Vedtaksperiode> = beregningsresultat.tilVedtaksperioder(),
 ) : VedtakTilsynBarn,
     Innvilgelse {
     override val type: TypeVedtaksdata = TypeVedtakTilsynBarn.INNVILGELSE_TILSYN_BARN
@@ -51,3 +54,15 @@ fun VedtakTilsynBarn.beregningsresultat(): BeregningsresultatTilsynBarn? =
         is OpphørTilsynBarn -> this.beregningsresultat
         is AvslagTilsynBarn -> null
     }
+
+fun BeregningsresultatTilsynBarn.tilVedtaksperioder(): List<Vedtaksperiode> {
+    val vedtaksperioder = VedtaksperiodeTilsynBarnMapper.mapTilVedtaksperiode(this.perioder)
+    return vedtaksperioder.map {
+        Vedtaksperiode(
+            fom = it.fom,
+            tom = it.tom,
+            målgruppe = it.målgruppe,
+            aktivitet = it.aktivitet,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakTilsynBarn.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakTilsynBarn.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.vedtak.domain
 
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeTilsynBarnMapper
 
 enum class TypeVedtakTilsynBarn(
     override val typeVedtak: TypeVedtak,
@@ -16,8 +15,7 @@ sealed interface VedtakTilsynBarn : Vedtaksdata
 
 data class InnvilgelseTilsynBarn(
     val beregningsresultat: BeregningsresultatTilsynBarn,
-    // For vedtak som ble gjort før vi innførte vedtaksperioder lager vi vedtaksperioder fra beregningsresultatet
-    val vedtaksperioder: List<Vedtaksperiode> = beregningsresultat.tilVedtaksperioder(),
+    val vedtaksperioder: List<Vedtaksperiode>? = null,
 ) : VedtakTilsynBarn,
     Innvilgelse {
     override val type: TypeVedtaksdata = TypeVedtakTilsynBarn.INNVILGELSE_TILSYN_BARN
@@ -54,15 +52,3 @@ fun VedtakTilsynBarn.beregningsresultat(): BeregningsresultatTilsynBarn? =
         is OpphørTilsynBarn -> this.beregningsresultat
         is AvslagTilsynBarn -> null
     }
-
-fun BeregningsresultatTilsynBarn.tilVedtaksperioder(): List<Vedtaksperiode> {
-    val vedtaksperioder = VedtaksperiodeTilsynBarnMapper.mapTilVedtaksperiode(this.perioder)
-    return vedtaksperioder.map {
-        Vedtaksperiode(
-            fom = it.fom,
-            tom = it.tom,
-            målgruppe = it.målgruppe,
-            aktivitet = it.aktivitet,
-        )
-    }
-}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/Vedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/Vedtaksperiode.kt
@@ -7,8 +7,10 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiod
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
+import java.util.UUID
 
 data class Vedtaksperiode(
+    val id: UUID = UUID.randomUUID(),
     override val fom: LocalDate,
     override val tom: LocalDate,
     val målgruppe: MålgruppeType,
@@ -23,6 +25,7 @@ data class Vedtaksperiode(
     )
 
     constructor(vedtaksperiodeDto: VedtaksperiodeDto) : this(
+        id = vedtaksperiodeDto.id,
         fom = vedtaksperiodeDto.fom,
         tom = vedtaksperiodeDto.tom,
         målgruppe = vedtaksperiodeDto.målgruppeType,
@@ -40,9 +43,12 @@ data class Vedtaksperiode(
 
     fun tilDto() =
         VedtaksperiodeDto(
+            id = id,
             fom = fom,
             tom = tom,
             målgruppeType = målgruppe,
             aktivitetType = aktivitet,
         )
 }
+
+fun List<Vedtaksperiode>.tilDto() = map { it.tilDto() }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/Vedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/Vedtaksperiode.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class Vedtaksperiode(
-    val id: UUID = UUID.randomUUID(),
+    val id: UUID,
     override val fom: LocalDate,
     override val tom: LocalDate,
     val målgruppe: MålgruppeType,
@@ -18,6 +18,7 @@ data class Vedtaksperiode(
 ) : Periode<LocalDate>,
     KopierPeriode<Vedtaksperiode> {
     constructor(stønadsperiode: Stønadsperiode) : this(
+        id = UUID.randomUUID(),
         fom = stønadsperiode.fom,
         tom = stønadsperiode.tom,
         målgruppe = stønadsperiode.målgruppe,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dto/VedtaksperiodeDto.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class VedtaksperiodeDto(
-    val id: UUID = UUID.randomUUID(),
+    val id: UUID,
     override val fom: LocalDate,
     override val tom: LocalDate,
     val målgruppeType: MålgruppeType,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dto/VedtaksperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dto/VedtaksperiodeDto.kt
@@ -6,8 +6,10 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
+import java.util.UUID
 
 data class VedtaksperiodeDto(
+    val id: UUID = UUID.randomUUID(),
     override val fom: LocalDate,
     override val tom: LocalDate,
     val målgruppeType: MålgruppeType,
@@ -18,6 +20,17 @@ data class VedtaksperiodeDto(
         fom: LocalDate,
         tom: LocalDate,
     ): VedtaksperiodeDto = this.copy(fom = fom, tom = tom)
+
+    fun tilDomene() =
+        Vedtaksperiode(
+            id = id,
+            fom = fom,
+            tom = tom,
+            målgruppe = målgruppeType,
+            aktivitet = aktivitetType,
+        )
 }
+
+fun List<VedtaksperiodeDto>.tilDto() = map { it.tilDomene() }
 
 fun List<VedtaksperiodeDto>.tilVedtaksperiode() = map { Vedtaksperiode(it) }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingsoversiktServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingsoversiktServiceTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 class BehandlingsoversiktServiceTest {
     val fagsakService = mockk<FagsakService>()
@@ -86,6 +87,7 @@ class BehandlingsoversiktServiceTest {
         val stønadsperiodeGrunnlag =
             StønadsperiodeGrunnlag(
                 Vedtaksperiode(
+                    id = UUID.randomUUID(),
                     fom = LocalDate.of(2024, 3, 1),
                     tom = LocalDate.of(2024, 3, 13),
                     målgruppe = MålgruppeType.AAP,
@@ -97,6 +99,7 @@ class BehandlingsoversiktServiceTest {
         val stønadsperiodeGrunnlag2 =
             StønadsperiodeGrunnlag(
                 Vedtaksperiode(
+                    id = UUID.randomUUID(),
                     fom = LocalDate.of(2024, 3, 2),
                     tom = LocalDate.of(2024, 3, 14),
                     målgruppe = MålgruppeType.AAP,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
@@ -202,7 +202,6 @@ object Testdata {
                 type = TypeVedtak.INNVILGELSE,
                 data =
                     InnvilgelseTilsynBarn(
-                        vedtaksperioder = listOf(vedtaksperiode),
                         beregningsresultat =
                             BeregningsresultatTilsynBarn(
                                 perioder =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
@@ -190,6 +190,7 @@ object Testdata {
 
         val vedtaksperiode =
             VedtaksperiodeBeregningsgrunnlag(
+                id = UUID.randomUUID(),
                 fom = LocalDate.of(2024, 1, 1),
                 tom = LocalDate.of(2024, 2, 1),
                 målgruppe = MålgruppeType.AAP,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
@@ -202,6 +202,7 @@ object Testdata {
                 type = TypeVedtak.INNVILGELSE,
                 data =
                     InnvilgelseTilsynBarn(
+                        vedtaksperioder = listOf(vedtaksperiode),
                         beregningsresultat =
                             BeregningsresultatTilsynBarn(
                                 perioder =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/UtbetalingerDvhV2Test.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/UtbetalingerDvhV2Test.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.statistikk.vedtak
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.UtbetalingerDvhV2
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.beregningsresultatForMåned
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.defaultVedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.stønadsperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
@@ -18,6 +19,7 @@ class UtbetalingerDvhV2Test {
         val innvilgelse =
             innvilgelseTilsynBarn(
                 InnvilgelseTilsynBarn(
+                    vedtaksperioder = listOf(defaultVedtaksperiode),
                     beregningsresultat =
                         BeregningsresultatTilsynBarn(
                             perioder =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/ForeslåVedtaksperiodeStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/ForeslåVedtaksperiodeStepDefinitions.kt
@@ -129,6 +129,7 @@ class ForeslåVedtaksperiodeStepDefinitions {
     private fun mapVedtaksperioder(dataTable: DataTable) =
         dataTable.mapRad { rad ->
             Vedtaksperiode(
+                id = UUID.randomUUID(),
                 fom = parseÅrMånedEllerDato(DomenenøkkelFelles.FOM, rad).datoEllerFørsteDagenIMåneden(),
                 tom = parseÅrMånedEllerDato(DomenenøkkelFelles.TOM, rad).datoEllerSisteDagenIMåneden(),
                 målgruppe = parseValgfriEnum<MålgruppeType>(DomenenøkkelForeslåVedtaksperioder.MÅLGRUPPE, rad)!!,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/ForeslåVedtaksperiodeStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/ForeslåVedtaksperiodeStepDefinitions.kt
@@ -27,6 +27,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeA
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import org.assertj.core.api.Assertions.assertThat
+import java.util.UUID
 
 enum class DomenenøkkelForeslåVedtaksperioder(
     override val nøkkel: String,
@@ -84,8 +85,10 @@ class ForeslåVedtaksperiodeStepDefinitions {
 
     @Så("forvent følgende vedtaksperioder")
     fun `forvent følgende vedtaksperioder`(dataTable: DataTable) {
-        val forventetVedtaksperioder = mapVedtaksperioder(dataTable)
-        assertThat(resultat).isEqualTo(forventetVedtaksperioder)
+        val uuid = UUID.randomUUID()
+        val forventetVedtaksperioderMedSammeId = mapVedtaksperioder(dataTable).map { it.copy(id = uuid) }
+        val resultatMedSammeId = resultat.map { it.copy(id = uuid) }
+        assertThat(resultatMedSammeId).isEqualTo(forventetVedtaksperioderMedSammeId)
     }
 
     private fun mapAktiviteter(dataTable: DataTable) =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -53,7 +53,6 @@ object TilsynBarnTestUtil {
 
     val defaultInnvilgelseTilsynBarn =
         InnvilgelseTilsynBarn(
-            vedtaksperioder = listOf(defaultVedtaksperiode),
             beregningsresultat =
                 BeregningsresultatTilsynBarn(
                     perioder =
@@ -113,7 +112,6 @@ object TilsynBarnTestUtil {
         type = TypeVedtak.INNVILGELSE,
         data =
             InnvilgelseTilsynBarn(
-                vedtaksperioder = emptyList(),
                 beregningsresultat = beregningsresultat,
             ),
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -53,6 +53,7 @@ object TilsynBarnTestUtil {
 
     val defaultInnvilgelseTilsynBarn =
         InnvilgelseTilsynBarn(
+            vedtaksperioder = listOf(defaultVedtaksperiode),
             beregningsresultat =
                 BeregningsresultatTilsynBarn(
                     perioder =
@@ -112,6 +113,7 @@ object TilsynBarnTestUtil {
         type = TypeVedtak.INNVILGELSE,
         data =
             InnvilgelseTilsynBarn(
+                vedtaksperioder = emptyList(),
                 beregningsresultat = beregningsresultat,
             ),
     )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -22,6 +22,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 object TilsynBarnTestUtil {
     fun innvilgelseDto() = InnvilgelseTilsynBarnRequest
@@ -33,6 +34,7 @@ object TilsynBarnTestUtil {
         )
 
     val defaultBehandling = behandling()
+    val defaultVedtaksperiodeId = UUID.randomUUID()
 
     val defaultBarn1 = BehandlingBarn(behandlingId = behandlingId, ident = "1")
     val defaultBarn2 = BehandlingBarn(behandlingId = behandlingId, ident = "2")
@@ -45,6 +47,7 @@ object TilsynBarnTestUtil {
 
     val defaultVedtaksperiode =
         Vedtaksperiode(
+            id = defaultVedtaksperiodeId,
             fom = LocalDate.of(2024, 1, 1),
             tom = LocalDate.of(2024, 1, 31),
             målgruppe = MålgruppeType.AAP,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakRepositoryTest.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.defaultVedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
@@ -28,7 +27,6 @@ class VedtakRepositoryTest : IntegrationTest() {
                 behandlingId = behandling.id,
                 data =
                     InnvilgelseTilsynBarn(
-                        vedtaksperioder = listOf(defaultVedtaksperiode),
                         beregningsresultat = beregningsresultat,
                     ),
             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/VedtakRepositoryTest.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.defaultVedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
@@ -27,6 +28,7 @@ class VedtakRepositoryTest : IntegrationTest() {
                 behandlingId = behandling.id,
                 data =
                     InnvilgelseTilsynBarn(
+                        vedtaksperioder = listOf(defaultVedtaksperiode),
                         beregningsresultat = beregningsresultat,
                     ),
             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 class TilsynBarnVedtaksperiodeValidingerUtilsTest {
     val vilkårperiodeService = mockk<VilkårperiodeService>()
@@ -352,6 +353,7 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
     inner class ValiderIngenOverlapp {
         val vedtaksperiodeJan =
             Vedtaksperiode(
+                id = UUID.randomUUID(),
                 fom = LocalDate.of(2025, 1, 1),
                 tom = LocalDate.of(2025, 1, 31),
                 målgruppe = MålgruppeType.AAP,
@@ -359,6 +361,7 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
             )
         val vedtaksperiodeFeb =
             Vedtaksperiode(
+                id = UUID.randomUUID(),
                 fom = LocalDate.of(2025, 2, 1),
                 tom = LocalDate.of(2025, 2, 28),
                 målgruppe = MålgruppeType.AAP,
@@ -366,6 +369,7 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
             )
         val vedtaksperiodeJanFeb =
             Vedtaksperiode(
+                id = UUID.randomUUID(),
                 fom = LocalDate.of(2025, 1, 1),
                 tom = LocalDate.of(2025, 2, 28),
                 målgruppe = MålgruppeType.AAP,
@@ -922,6 +926,7 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
         målgruppe: MålgruppeType = MålgruppeType.AAP,
         aktivitet: AktivitetType = AktivitetType.TILTAK,
     ) = Vedtaksperiode(
+        id = UUID.randomUUID(),
         fom = fom,
         tom = tom,
         målgruppe = målgruppe,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/domain/VedtaksperiodeTilsynBarnMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/domain/VedtaksperiodeTilsynBarnMapperTest.kt
@@ -10,10 +10,12 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.UUID
 
 class VedtaksperiodeTilsynBarnMapperTest {
     val periode1 =
         Vedtaksperiode(
+            id = UUID.randomUUID(),
             fom = LocalDate.of(2024, 1, 1),
             tom = LocalDate.of(2024, 1, 1),
             målgruppe = MålgruppeType.AAP,
@@ -22,6 +24,7 @@ class VedtaksperiodeTilsynBarnMapperTest {
 
     val periode2 =
         Vedtaksperiode(
+            id = UUID.randomUUID(),
             fom = LocalDate.of(2024, 1, 2),
             tom = LocalDate.of(2024, 1, 2),
             målgruppe = MålgruppeType.AAP,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/dto/InnvilgelseTilsynBarnDtoKtTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 class InnvilgelseTilsynBarnDtoKtTest {
     @Test
@@ -163,6 +164,7 @@ class InnvilgelseTilsynBarnDtoKtTest {
     ) = StønadsperiodeGrunnlag(
         stønadsperiode =
             Vedtaksperiode(
+                id = UUID.randomUUID(),
                 fom = fom,
                 tom = tom,
                 målgruppe = MålgruppeType.AAP,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtaksperiodeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtaksperiodeTest.kt
@@ -10,16 +10,19 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.UUID
 
 class VedtaksperiodeTest {
     val fom = LocalDate.of(2025, 1, 1)
     val tom = LocalDate.of(2025, 3, 1)
     val målgruppe = MålgruppeType.AAP
     val aktivitet = AktivitetType.TILTAK
+    val uuid = UUID.randomUUID()
 
     val vedtaksperiode =
         listOf(
             Vedtaksperiode(
+                id = uuid,
                 fom = fom,
                 tom = tom,
                 målgruppe = målgruppe,
@@ -32,6 +35,7 @@ class VedtaksperiodeTest {
         val vedtaksperiodeDto =
             listOf(
                 VedtaksperiodeDto(
+                    id = uuid,
                     fom = fom,
                     tom = tom,
                     målgruppeType = målgruppe,
@@ -54,7 +58,7 @@ class VedtaksperiodeTest {
                     aktivitet = aktivitet,
                 ),
             )
-        assertThat(stønadsperiodeBeregningsgrunnlag.tilVedtaksperiode()).isEqualTo(
+        assertThat(stønadsperiodeBeregningsgrunnlag.tilVedtaksperiode().map { it.copy(id = uuid) }).isEqualTo(
             vedtaksperiode,
         )
     }

--- a/src/test/resources/vedtak/TILSYN_BARN/INNVILGELSE_TILSYN_BARN.json
+++ b/src/test/resources/vedtak/TILSYN_BARN/INNVILGELSE_TILSYN_BARN.json
@@ -1,5 +1,4 @@
 {
-  "type": "INNVILGELSE_TILSYN_BARN",
   "beregningsresultat": {
     "perioder" : [ {
       "dagsats" : 10.11,
@@ -9,6 +8,7 @@
         "makssats" : 200,
         "stønadsperioderGrunnlag" : [ {
           "stønadsperiode" : {
+            "id" : "1b73454a-e9b4-441c-b405-d1e7cfc29447",
             "fom" : "2024-01-01",
             "tom" : "2024-01-02",
             "målgruppe" : "AAP",
@@ -36,5 +36,13 @@
         "målgruppe" : "AAP"
       } ]
     } ]
-  }
+  },
+  "type": "INNVILGELSE_TILSYN_BARN",
+  "vedtaksperioder" : [ {
+    "id" : "3580eb48-b676-49f1-9650-8b5062c2c604",
+    "fom" : "2024-01-01",
+    "tom" : "2024-01-02",
+    "målgruppe" : "AAP",
+    "aktivitet" : "TILTAK"
+  } ]
 }

--- a/src/test/resources/vedtak/TILSYN_BARN/OPPHØR_TILSYN_BARN.json
+++ b/src/test/resources/vedtak/TILSYN_BARN/OPPHØR_TILSYN_BARN.json
@@ -15,6 +15,7 @@
           "stønadsperioderGrunnlag": [
             {
               "stønadsperiode": {
+                "id" : "24613460-0b1b-4b8e-b83b-a3f2a5f314a8",
                 "fom": "2024-01-01",
                 "tom": "2024-01-02",
                 "målgruppe": "AAP",

--- a/src/test/resources/vedtak/TILSYN_BARN/OPPHØR_TILSYN_BARN.json
+++ b/src/test/resources/vedtak/TILSYN_BARN/OPPHØR_TILSYN_BARN.json
@@ -1,5 +1,6 @@
 {
   "type": "OPPHØR_TILSYN_BARN",
+  "vedtaksperioder" : null,
   "årsaker": [
     "ENDRING_AKTIVITET"
   ],


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne validere om vedtaksperiodene har oppdatert seg fra førstegangsbehandling til revurdering. Trenger derfor å lagre ned vedtaksperiodene med en id for å kunne sammenlikne de. 

Ønsker også å legge til en tag slik som her:
https://github.com/navikt/tilleggsstonader-sak/pull/581