### PR TITLE
Patcher beregningsresultat i læremidler med aktivitet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/VedtaksperioderDvhV2.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/VedtaksperioderDvhV2.kt
@@ -22,9 +22,9 @@ data class VedtaksperioderDvhV2(
     val fom: LocalDate,
     val tom: LocalDate,
     val målgruppe: MålgruppeTypeDvh,
+    val aktivitet: AktivitetTypeDvh,
     val lovverketsMålgruppe: LovverketsMålgruppeDvh,
     // Tilsyn barn
-    val aktivitet: AktivitetTypeDvh? = null,
     val antallBarn: Int? = null,
     val barn: BarnDvh.JsonWrapper? = null,
     // Løremidler
@@ -66,6 +66,7 @@ data class VedtaksperioderDvhV2(
                                 fom = it.fom,
                                 tom = it.tom,
                                 målgruppe = MålgruppeTypeDvh.fraDomene(it.målgruppe),
+                                aktivitet = AktivitetTypeDvh.fraDomene(it.aktivitet),
                                 lovverketsMålgruppe = LovverketsMålgruppeDvh.fraDomene(it.målgruppe),
                                 studienivå = StudienivåDvh.fraDomene(it.studienivå),
                             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/LæremidlerBeregningService.kt
@@ -88,6 +88,7 @@ class LæremidlerBeregningService(
             satsBekreftet = sats.bekreftet,
             utbetalingsdato = periode.utbetalingsdato,
             målgruppe = periode.målgruppe,
+            aktivitet = periode.aktivitet,
         )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidler.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.kontrakter.periode.avkortFraOgMed
 import no.nav.tilleggsstonader.kontrakter.periode.avkortPerioderFør
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørLæremidler
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
 
@@ -51,6 +52,7 @@ data class Beregningsgrunnlag(
     val sats: Int,
     val satsBekreftet: Boolean,
     val målgruppe: MålgruppeType,
+    val aktivitet: AktivitetType,
 )
 
 fun avkortBeregningsresultatVedOpphør(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeLæremidlerMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeLæremidlerMapper.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Mergeable
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
 
@@ -18,6 +19,7 @@ object VedtaksperiodeLæremidlerMapper {
         override val fom: LocalDate,
         override val tom: LocalDate,
         val målgruppe: MålgruppeType,
+        val aktivitet: AktivitetType,
         val studienivå: Studienivå,
     ) : Periode<LocalDate>,
         Mergeable<LocalDate, VedtaksperiodeLæremidler> {
@@ -30,6 +32,7 @@ object VedtaksperiodeLæremidlerMapper {
                 fom = beregningsgrunnlag.fom,
                 tom = beregningsgrunnlag.tom,
                 målgruppe = beregningsgrunnlag.målgruppe,
+                aktivitet = beregningsgrunnlag.aktivitet,
                 studienivå = beregningsgrunnlag.studienivå,
             )
 
@@ -41,6 +44,7 @@ object VedtaksperiodeLæremidlerMapper {
         fun erLikOgPåfølgesAv(other: VedtaksperiodeLæremidler): Boolean {
             val erLik =
                 this.målgruppe == other.målgruppe &&
+                    this.aktivitet == other.aktivitet &&
                     this.studienivå == other.studienivå
             return erLik && this.påfølgesAv(other)
         }

--- a/src/main/resources/db/migration/V67__læremidler_aktivitet.sql
+++ b/src/main/resources/db/migration/V67__læremidler_aktivitet.sql
@@ -1,0 +1,33 @@
+WITH stønadsperioderForLæremidler
+         AS (SELECT s.behandling_id, s.aktivitet
+             FROM stonadsperiode s
+                      JOIN behandling b ON b.id = s.behandling_id
+                      JOIN fagsak f ON b.fagsak_id = f.id
+             WHERE f.stonadstype = 'LÆREMIDLER'
+             GROUP BY s.behandling_id, s.aktivitet),
+     behandlinger_med_1_aktivitetstype
+         AS (SELECT behandling_id
+             FROM stønadsperioderForLæremidler q
+             GROUP BY behandling_id
+             HAVING count(*) = 1),
+     behandling_id_og_aktivitet
+         AS (SELECT q1.behandling_id, q2.aktivitet
+             FROM behandlinger_med_1_aktivitetstype q1
+                      JOIN stønadsperioderForLæremidler q2 ON q2.behandling_id = q1.behandling_id)
+UPDATE vedtak v
+SET data =
+        jsonb_set(
+                v.data,
+                '{beregningsresultat,perioder}',
+                (SELECT jsonb_agg(
+                                jsonb_set(
+                                        periode,
+                                        '{grunnlag,aktivitet}',
+                                        to_jsonb(ba.aktivitet)
+                                )
+                        )
+                 FROM jsonb_array_elements(v.data -> 'beregningsresultat' -> 'perioder') periode)
+        )
+FROM behandling_id_og_aktivitet ba
+WHERE v.behandling_id = ba.behandling_id
+  AND v.type IN ('INNVILGELSE', 'OPPHØR');

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
@@ -289,6 +289,7 @@ object Testdata {
                                     sats = 951,
                                     satsBekreftet = true,
                                     målgruppe = MålgruppeType.AAP,
+                                    aktivitet = AktivitetType.TILTAK,
                                 ),
                         ),
                         BeregningsresultatForMåned(
@@ -303,6 +304,7 @@ object Testdata {
                                     sats = 951,
                                     satsBekreftet = true,
                                     målgruppe = MålgruppeType.AAP,
+                                    aktivitet = AktivitetType.TILTAK,
                                 ),
                         ),
                     ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/VedtaksperioderDvhV2Test.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/VedtaksperioderDvhV2Test.kt
@@ -69,6 +69,7 @@ class VedtaksperioderDvhV2Test {
                             fom = LocalDate.of(2024, 1, 1),
                             tom = LocalDate.of(2024, 1, 7),
                             målgruppe = MålgruppeTypeDvh.AAP,
+                            aktivitet = AktivitetTypeDvh.TILTAK,
                             lovverketsMålgruppe = LovverketsMålgruppeDvh.NEDSATT_ARBEIDSEVNE,
                             studienivå = StudienivåDvh.HØYERE_UTDANNING,
                         ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerTestUtil.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatL
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.BeregningsresultatForPeriodeDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
 
@@ -109,6 +110,7 @@ object LæremidlerTestUtil {
                     sats = 875,
                     satsBekreftet = true,
                     målgruppe = MålgruppeType.AAP,
+                    aktivitet = AktivitetType.TILTAK,
                 ),
         )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/BeregningParser.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/BeregningParser.kt
@@ -53,6 +53,7 @@ fun mapBeregningsresultat(dataTable: DataTable) =
                     satsBekreftet = parseValgfriBoolean(BeregningNøkler.BEKREFTET_SATS, rad) ?: true,
                     utbetalingsdato = parseDato(BeregningNøkler.UTBETALINGSDATO, rad),
                     målgruppe = parseValgfriEnum<MålgruppeType>(BeregningNøkler.MÅLGRUPPE, rad) ?: MålgruppeType.AAP,
+                    aktivitet = parseValgfriEnum<AktivitetType>(BeregningNøkler.AKTIVITET, rad) ?: AktivitetType.TILTAK,
                 ),
         )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidlerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/BeregningsresultatLæremidlerTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.læremidler.domain
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil.beregningsresultatForMåned
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -80,6 +81,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
             ),
@@ -143,7 +145,7 @@ class BeregningsresultatLæremidlerTest {
         val kuttePerioderVedOpphør = avkortBeregningsresultatVedOpphør(forrigeVedtak, revurderFra).perioder
 
         assertThat(kuttePerioderVedOpphør).isEqualTo(
-            listOf<BeregningsresultatForMåned>(
+            listOf(
                 BeregningsresultatForMåned(
                     beløp = 875,
                     grunnlag =
@@ -156,6 +158,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
                 BeregningsresultatForMåned(
@@ -170,6 +173,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
                 BeregningsresultatForMåned(
@@ -184,6 +188,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
                 BeregningsresultatForMåned(
@@ -198,6 +203,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
             ),
@@ -211,7 +217,7 @@ class BeregningsresultatLæremidlerTest {
         val kuttePerioderVedOpphør = avkortBeregningsresultatVedOpphør(forrigeVedtak, revurderFra).perioder
 
         assertThat(kuttePerioderVedOpphør).isEqualTo(
-            listOf<BeregningsresultatForMåned>(
+            listOf(
                 BeregningsresultatForMåned(
                     beløp = 875,
                     grunnlag =
@@ -224,6 +230,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
             ),
@@ -287,7 +294,7 @@ class BeregningsresultatLæremidlerTest {
         val kuttePerioderVedOpphør = avkortBeregningsresultatVedOpphør(forrigeVedtak, revurderFra).perioder
 
         assertThat(kuttePerioderVedOpphør).isEqualTo(
-            listOf<BeregningsresultatForMåned>(
+            listOf(
                 BeregningsresultatForMåned(
                     beløp = 875,
                     grunnlag =
@@ -300,6 +307,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
                 BeregningsresultatForMåned(
@@ -314,6 +322,7 @@ class BeregningsresultatLæremidlerTest {
                             sats = 875,
                             satsBekreftet = true,
                             målgruppe = MålgruppeType.AAP,
+                            aktivitet = AktivitetType.TILTAK,
                         ),
                 ),
             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeLæremidlerMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeLæremidlerMapperTest.kt
@@ -41,6 +41,7 @@ class VedtaksperiodeLæremidlerMapperTest {
                 fom = beregningsresultatPeriode1.grunnlag.fom,
                 tom = beregningsresultatPeriode2.grunnlag.tom,
                 målgruppe = beregningsresultatPeriode1.grunnlag.målgruppe,
+                aktivitet = beregningsresultatPeriode1.grunnlag.aktivitet,
                 studienivå = beregningsresultatPeriode1.grunnlag.studienivå,
             ),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/domain/VedtaksperiodeUtilTest.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.util.stønadsperiode
 import no.nav.tilleggsstonader.sak.vedtak.domain.tilStønadsperiodeBeregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.VedtaksperiodeUtil.validerVedtaksperioder
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.VedtaksperiodeUtil.vedtaksperioderInnenforLøpendeMåned
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -199,6 +200,7 @@ class VedtaksperiodeUtilTest {
                     sats = 100,
                     satsBekreftet = true,
                     målgruppe = MålgruppeType.AAP,
+                    aktivitet = AktivitetType.TILTAK,
                 ),
         )
     }

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/beregning_flere_stønadsperioder.feature
@@ -72,9 +72,9 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
-      | 01.01.2025 | 31.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP             | 01.01.2025      |
-      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | 01.01.2025      |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Aktivitet | Utbetalingsdato |
+      | 01.01.2025 | 31.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP             | UTDANNING | 01.01.2025      |
+      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | UTDANNING | 01.01.2025      |
 
   Scenario: To ulike målgrupper av typen nedsatt arbeidsevne innenfor en vedtaksperiode men ulike løpende måneder
     Gitt følgende vedtaksperioder for læremidler
@@ -114,6 +114,6 @@ Egenskap: Beregning av læremidler - flere stønadsperioder
     Når beregner stønad for læremidler
 
     Så skal stønaden være
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Utbetalingsdato |
-      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
-      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | 01.04.2024      |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe | Aktivitet | Utbetalingsdato |
+      | 01.04.2024 | 30.04.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | UTDANNING | 01.04.2024      |
+      | 01.05.2024 | 31.05.2024 | 438   | VIDEREGÅENDE | 100           | 438  | AAP       | UTDANNING | 01.04.2024      |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/vedtak_innvilge_revurdering.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/vedtak_innvilge_revurdering.feature
@@ -143,9 +143,9 @@ Egenskap: Innvilgelse av læremidler - revurdering
 
     # Endrer målgruppe fra februar
     Så forvent beregningsresultatet for behandling=2
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
-      | 01.01.2025 | 31.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP             | 01.01.2025      |
-      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | 01.01.2025      |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Aktivitet | Utbetalingsdato |
+      | 01.01.2025 | 31.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | AAP             | UTDANNING | 01.01.2025      |
+      | 01.02.2025 | 28.02.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | UTDANNING | 01.01.2025      |
 
     Så forvent andeler for behandling=2
       | Fom        | Beløp | Type                        | Utbetalingsdato |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/vedtak_opphør.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/læremidler/vedtak_opphør.feature
@@ -94,8 +94,8 @@ Egenskap: Opphør av læremidler
     Når opphør behandling=2 med revurderFra=10.01.2025
 
     Så forvent beregningsresultatet for behandling=2
-      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Utbetalingsdato |
-      | 01.01.2025 | 09.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | 01.01.2025      |
+      | Fom        | Tom        | Beløp | Studienivå   | Studieprosent | Sats | Målgruppe       | Aktivitet | Utbetalingsdato |
+      | 01.01.2025 | 09.01.2025 | 451   | VIDEREGÅENDE | 100           | 451  | OVERGANGSSTØNAD | UTDANNING | 01.01.2025      |
 
     Så forvent andeler for behandling=2
       | Fom        | Beløp | Type                        | Utbetalingsdato |

--- a/src/test/resources/vedtak/LÆREMIDLER/INNVILGELSE_LÆREMIDLER.json
+++ b/src/test/resources/vedtak/LÆREMIDLER/INNVILGELSE_LÆREMIDLER.json
@@ -20,7 +20,8 @@
           "studieprosent": 100,
           "sats": 875,
           "satsBekreftet": true,
-          "målgruppe": "AAP"
+          "målgruppe": "AAP",
+          "aktivitet": "TILTAK"
         }
       }
     ]

--- a/src/test/resources/vedtak/LÆREMIDLER/OPPHØR_LÆREMIDLER.json
+++ b/src/test/resources/vedtak/LÆREMIDLER/OPPHØR_LÆREMIDLER.json
@@ -24,7 +24,8 @@
           "studieprosent": 100,
           "sats": 875,
           "satsBekreftet": true,
-          "målgruppe": "AAP"
+          "målgruppe": "AAP",
+          "aktivitet": "TILTAK"
         }
       }
     ]


### PR DESCRIPTION
- Begynner å sende aktivitet til DVH

### Hvorfor er denne endringen nødvendig? ✨
Legger inn type aktivitet på beregningsresultatet

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24362

* Oppdateringsspørringen oppdaterer alle vedtak til behandlinger som kun har 1 type aktivitet i stønadsperioder/overlappsperioder.

Akkurat nå finnes det ingen behandlinger i prod som har flere ulike typer aktiviteter. Det finnes 3 i dev.
```sql
WITH stønadsperioderForLæremidler
         AS (SELECT s.behandling_id, s.aktivitet
             FROM stonadsperiode s
                      JOIN behandling b ON b.id = s.behandling_id
                      JOIN fagsak f ON b.fagsak_id = f.id
             WHERE f.stonadstype = 'LÆREMIDLER'
             GROUP BY s.behandling_id, s.aktivitet)
select behandling_id
from stønadsperioderForLæremidler
group by behandling_id
having count(*) > 1
```


Hvis man ønsker å teste oppdateringsqueryn kan den testes med å endre til select
```sql
WITH stønadsperioderForLæremidler
         AS (SELECT s.behandling_id, s.aktivitet
             FROM stonadsperiode s
                      JOIN behandling b ON b.id = s.behandling_id
                      JOIN fagsak f ON b.fagsak_id = f.id
             WHERE f.stonadstype = 'LÆREMIDLER'
             GROUP BY s.behandling_id, s.aktivitet),
     behandlinger_med_1_aktivitetstype
         AS (SELECT behandling_id
             FROM (SELECT behandling_id FROM stønadsperioderForLæremidler) q
             GROUP BY behandling_id
             HAVING count(*) = 1),
     behandling_id_og_aktivitet
         AS (SELECT q1.behandling_id, q2.aktivitet
             FROM behandlinger_med_1_aktivitetstype q1
                      JOIN stønadsperioderForLæremidler q2 ON q2.behandling_id = q1.behandling_id)
select v.behandling_id, jsonb_set(
        v.data,
        '{beregningsresultat,perioder}',
        (SELECT jsonb_agg(
                        jsonb_set(
                                periode,
                                '{grunnlag,aktivitet}',
                                to_jsonb(ba.aktivitet)
                        )
                )
         FROM jsonb_array_elements(v.data -> 'beregningsresultat' -> 'perioder') periode)
           )
FROM vedtak v
         JOIN behandling_id_og_aktivitet ba ON ba.behandling_id = v.behandling_id
WHERE v.behandling_id = ba.behandling_id
  AND v.type IN ('INNVILGELSE', 'OPPHØR');
```