### PR TITLE
🦺 Valider ingen nye, endrede eller slettede vedtaksperioder etter revurder fra for tilsyn barn

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
@@ -27,8 +27,9 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.tilAktiviteter
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
 import no.nav.tilleggsstonader.sak.vedtak.domain.beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.domain.tilVedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
-import no.nav.tilleggsstonader.sak.vedtak.dto.tilVedtaksperiodeBeregning
+import no.nav.tilleggsstonader.sak.vedtak.dto.tilDomene
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.StønadsperiodeRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.tilVedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
@@ -82,18 +83,20 @@ class TilsynBarnBeregningService(
             "Skal ikke beregne for avslag"
         }
 
-        val vedtaksperioder =
-            vedtaksperioderDto.tilVedtaksperiodeBeregning().sorted().splitFraRevurderFra(behandling.revurderFra)
+        val vedtaksperioder = vedtaksperioderDto.tilDomene()
 
         val utgifterPerBarn = tilsynBarnUtgiftService.hentUtgifterTilBeregning(behandling.id)
 
         tilsynBarnVedtaksperiodeValidingerService.validerVedtaksperioder(
-            vedtaksperioder,
-            behandling,
-            utgifterPerBarn,
+            vedtaksperioder = vedtaksperioder,
+            behandling = behandling,
+            utgifter = utgifterPerBarn,
         )
 
-        val perioder = beregnAktuellePerioder(behandling, typeVedtak, vedtaksperioder)
+        val vedtaksperioderBeregning =
+            vedtaksperioder.tilVedtaksperiodeBeregning().sorted().splitFraRevurderFra(behandling.revurderFra)
+
+        val perioder = beregnAktuellePerioder(behandling, typeVedtak, vedtaksperioderBeregning)
         val relevantePerioderFraForrigeVedtak =
             finnRelevantePerioderFraForrigeVedtak(behandling)
         return BeregningsresultatTilsynBarn(relevantePerioderFraForrigeVedtak + perioder)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnBeregningService.kt
@@ -89,7 +89,7 @@ class TilsynBarnBeregningService(
 
         tilsynBarnVedtaksperiodeValidingerService.validerVedtaksperioder(
             vedtaksperioder,
-            behandling.id,
+            behandling,
             utgifterPerBarn,
         )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValideringUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValideringUtils.kt
@@ -154,7 +154,10 @@ object TilsynBarnVedtaksperiodeValideringUtils {
                 vedtaksperioderForrigeBehandlingFørRevurderFra.map { vedtaksperiodeForrigeBehandling ->
                     val nyVedtaksperiode = vedtaksperioderMap[vedtaksperiodeForrigeBehandling.id]
 
-                    if (nyVedtaksperiode != null && nyVedtaksperiode.tom > vedtaksperiodeForrigeBehandling.tom) {
+                    if (nyVedtaksperiode != null &&
+                        nyVedtaksperiode.tom > vedtaksperiodeForrigeBehandling.tom &&
+                        vedtaksperiodeForrigeBehandling.tom > revurderFra
+                    ) {
                         vedtaksperiodeForrigeBehandling.copy(tom = nyVedtaksperiode.tom)
                     } else {
                         vedtaksperiodeForrigeBehandling

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValideringUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValideringUtils.kt
@@ -10,7 +10,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
 import no.nav.tilleggsstonader.sak.util.norskFormat
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
+import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
@@ -18,20 +18,20 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import java.time.LocalDate
 
 object TilsynBarnVedtaksperiodeValideringUtils {
-    fun validerVedtaksperioderEksisterer(vedtaksperioder: List<VedtaksperiodeBeregning>) {
+    fun validerVedtaksperioderEksisterer(vedtaksperioder: List<Vedtaksperiode>) {
         brukerfeilHvis(vedtaksperioder.isEmpty()) {
             "Kan ikke innvilge når det ikke finnes noen vedtaksperioder"
         }
     }
 
-    fun validerIngenOverlappMellomVedtaksperioder(vedtaksperioder: List<VedtaksperiodeBeregning>) {
+    fun validerIngenOverlappMellomVedtaksperioder(vedtaksperioder: List<Vedtaksperiode>) {
         brukerfeilHvis(vedtaksperioder.overlapper()) {
             "Vedtaksperioder kan ikke overlappe"
         }
     }
 
     fun validerUtgiftHeleVedtaksperioden(
-        vedtaksperioder: List<VedtaksperiodeBeregning>,
+        vedtaksperioder: List<Vedtaksperiode>,
         utgifter: Map<BarnId, List<UtgiftBeregning>>,
     ) {
         brukerfeilHvisIkke(
@@ -45,7 +45,7 @@ object TilsynBarnVedtaksperiodeValideringUtils {
     }
 
     private fun erUtgiftperiodeSomInneholderVedtaksperiode(
-        vedtaksperioder: List<VedtaksperiodeBeregning>,
+        vedtaksperioder: List<Vedtaksperiode>,
         utgifter: Map<BarnId, List<UtgiftBeregning>>,
     ): Boolean {
         val sammenslåtteUtgiftPerioder =
@@ -66,7 +66,7 @@ object TilsynBarnVedtaksperiodeValideringUtils {
      */
     fun validerAtVedtaksperioderIkkeOverlapperMedVilkårPeriodeUtenRett(
         vilkårperioder: Vilkårperioder,
-        vedtaksperioder: List<VedtaksperiodeBeregning>,
+        vedtaksperioder: List<Vedtaksperiode>,
     ) {
         val perioderSomIkkeGirRett =
             (vilkårperioder.målgrupper + vilkårperioder.aktiviteter)
@@ -76,7 +76,7 @@ object TilsynBarnVedtaksperiodeValideringUtils {
 
     private fun validerIkkeOverlapperMedPeriodeSomIkkeGirRettPåStønad(
         vilkårperioder: List<Vilkårperiode>,
-        vedtaksperiode: VedtaksperiodeBeregning,
+        vedtaksperiode: Vedtaksperiode,
     ) {
         vilkårperioder
             .firstOrNull { vilkårperiode -> vilkårperiode.overlapper(vedtaksperiode) }
@@ -89,7 +89,7 @@ object TilsynBarnVedtaksperiodeValideringUtils {
     }
 
     fun validerEnkeltperiode(
-        vedtaksperiode: VedtaksperiodeBeregning,
+        vedtaksperiode: Vedtaksperiode,
         målgruppePerioderPerType: Map<VilkårperiodeType, List<Datoperiode>>,
         aktivitetPerioderPerType: Map<VilkårperiodeType, List<Datoperiode>>,
         fødselsdato: LocalDate?,
@@ -119,7 +119,7 @@ object TilsynBarnVedtaksperiodeValideringUtils {
 
     private fun validerVedtaksperiodeErInnenfor18og67år(
         fødselsdato: LocalDate?,
-        vedtaksperiode: VedtaksperiodeBeregning,
+        vedtaksperiode: Vedtaksperiode,
     ) {
         if (fødselsdato != null && vedtaksperiode.målgruppe.gjelderNedsattArbeidsevne()) {
             val dato18år = fødselsdato.plusYears(18)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValideringUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValideringUtils.kt
@@ -152,12 +152,10 @@ object TilsynBarnVedtaksperiodeValideringUtils {
         } else {
             val vedtaksperioderForrigeBehandlingFørRevurderFraMedOppdatertTom =
                 vedtaksperioderForrigeBehandlingFørRevurderFra.map { vedtaksperiodeForrigeBehandling ->
-                    val tilhørendeNyVedtaksperiode = vedtaksperioderMap[vedtaksperiodeForrigeBehandling.id]
+                    val nyVedtaksperiode = vedtaksperioderMap[vedtaksperiodeForrigeBehandling.id]
 
-                    if (tilhørendeNyVedtaksperiode != null &&
-                        tilhørendeNyVedtaksperiode.tom > vedtaksperiodeForrigeBehandling.tom
-                    ) {
-                        vedtaksperiodeForrigeBehandling.copy(tom = tilhørendeNyVedtaksperiode.tom)
+                    if (nyVedtaksperiode != null && nyVedtaksperiode.tom > vedtaksperiodeForrigeBehandling.tom) {
+                        vedtaksperiodeForrigeBehandling.copy(tom = nyVedtaksperiode.tom)
                     } else {
                         vedtaksperiodeForrigeBehandling
                     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
-import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerAtVedtaksperioderIkkeOverlapperMedVilkårPeriodeUtenRett
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerEnkeltperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenEndringerFørRevurderFra
@@ -16,15 +16,14 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.mergeSammenhengendeOppfylteVilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
-import org.springframework.context.annotation.Lazy
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class TilsynBarnVedtaksperiodeValidingerService(
     private val vilkårperiodeService: VilkårperiodeService,
     private val grunnlagsdataService: GrunnlagsdataService,
-    @Lazy // For å unngå sirkulær avhenighet i spring
-    private val vedtakService: VedtakService,
+    private val vedtakRepository: VedtakRepository,
 ) {
     fun validerVedtaksperioder(
         vedtaksperioder: List<VedtaksperiodeBeregning>,
@@ -65,7 +64,7 @@ class TilsynBarnVedtaksperiodeValidingerService(
 
     private fun hentForrigeVedtaksperioder(behandling: Saksbehandling): List<Vedtaksperiode>? =
         behandling.forrigeBehandlingId?.let {
-            when (val forrigeVedtak = vedtakService.hentVedtak(it)?.data) {
+            when (val forrigeVedtak = vedtakRepository.findByIdOrNull(it)?.data) {
                 is InnvilgelseTilsynBarn -> forrigeVedtak.vedtaksperioder
                 is OpphørTilsynBarn -> forrigeVedtak.vedtaksperioder
                 is Avslag -> null

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenOverlappMellomVedtaksperioder
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerUtgiftHeleVedtaksperioden
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerVedtaksperioderEksisterer
+import no.nav.tilleggsstonader.sak.vedtak.domain.Avslag
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
@@ -64,10 +65,11 @@ class TilsynBarnVedtaksperiodeValidingerService(
 
     private fun hentForrigeVedtaksperioder(behandling: Saksbehandling): List<Vedtaksperiode>? =
         behandling.forrigeBehandlingId?.let {
-            when (val forrgigeBehandling = vedtakService.hentVedtak(it)?.data) {
-                is InnvilgelseTilsynBarn -> forrgigeBehandling.vedtaksperioder
-                is OpphørTilsynBarn -> forrgigeBehandling.vedtaksperioder
-                else -> null
+            when (val forrigeVedtak = vedtakService.hentVedtak(it)?.data) {
+                is InnvilgelseTilsynBarn -> forrigeVedtak.vedtaksperioder
+                is OpphørTilsynBarn -> forrigeVedtak.vedtaksperioder
+                is Avslag -> null
+                else -> error("Håndterer ikke ${forrigeVedtak?.javaClass?.simpleName}")
             }
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
@@ -13,7 +13,7 @@ import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.Avslag
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
+import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.mergeSammenhengendeOppfylteVilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import org.springframework.data.repository.findByIdOrNull
@@ -26,7 +26,7 @@ class TilsynBarnVedtaksperiodeValidingerService(
     private val vedtakRepository: VedtakRepository,
 ) {
     fun validerVedtaksperioder(
-        vedtaksperioder: List<VedtaksperiodeBeregning>,
+        vedtaksperioder: List<Vedtaksperiode>,
         behandling: Saksbehandling,
         utgifter: Map<BarnId, List<UtgiftBeregning>>,
     ) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
@@ -1,33 +1,40 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning
 
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
+import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerAtVedtaksperioderIkkeOverlapperMedVilkårPeriodeUtenRett
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerEnkeltperiode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenEndringerFørRevurderFra
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenOverlappMellomVedtaksperioder
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerUtgiftHeleVedtaksperioden
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerVedtaksperioderEksisterer
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.mergeSammenhengendeOppfylteVilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 
 @Service
 class TilsynBarnVedtaksperiodeValidingerService(
     private val vilkårperiodeService: VilkårperiodeService,
     private val grunnlagsdataService: GrunnlagsdataService,
+    @Lazy // For å unngå sirkulær avhenighet i spring
+    private val vedtakService: VedtakService,
 ) {
     fun validerVedtaksperioder(
         vedtaksperioder: List<VedtaksperiodeBeregning>,
-        behandlingId: BehandlingId,
+        behandling: Saksbehandling,
         utgifter: Map<BarnId, List<UtgiftBeregning>>,
     ) {
         validerVedtaksperioderEksisterer(vedtaksperioder)
         validerIngenOverlappMellomVedtaksperioder(vedtaksperioder)
         validerUtgiftHeleVedtaksperioden(vedtaksperioder, utgifter)
 
-        val vilkårperioder = vilkårperiodeService.hentVilkårperioder(behandlingId)
+        val vilkårperioder = vilkårperiodeService.hentVilkårperioder(behandling.id)
         validerAtVedtaksperioderIkkeOverlapperMedVilkårPeriodeUtenRett(vilkårperioder, vedtaksperioder)
 
         val målgrupper = vilkårperioder.målgrupper.mergeSammenhengendeOppfylteVilkårperioder()
@@ -35,7 +42,7 @@ class TilsynBarnVedtaksperiodeValidingerService(
 
         val fødselsdato =
             grunnlagsdataService
-                .hentGrunnlagsdata(behandlingId)
+                .hentGrunnlagsdata(behandling.id)
                 .grunnlag.fødsel
                 ?.fødselsdatoEller1JanForFødselsår()
 
@@ -47,5 +54,20 @@ class TilsynBarnVedtaksperiodeValidingerService(
                 fødselsdato,
             )
         }
+
+        validerIngenEndringerFørRevurderFra(
+            vedtaksperioder = vedtaksperioder,
+            vedtaksperioderForrigeBehandling = hentForrigeVedtaksperioder(behandling),
+            revurderFra = behandling.revurderFra,
+        )
     }
+
+    private fun hentForrigeVedtaksperioder(behandling: Saksbehandling): List<Vedtaksperiode>? =
+        behandling.forrigeBehandlingId?.let {
+            when (val forrgigeBehandling = vedtakService.hentVedtak(it)?.data) {
+                is InnvilgelseTilsynBarn -> forrgigeBehandling.vedtaksperioder
+                is OpphørTilsynBarn -> forrgigeBehandling.vedtaksperioder
+                else -> null
+            }
+        }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/Vedtaksperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/Vedtaksperiode.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
@@ -25,3 +26,13 @@ data class Vedtaksperiode(
 }
 
 fun List<Vedtaksperiode>.tilDto() = map { it.tilDto() }
+
+fun List<Vedtaksperiode>.tilVedtaksperiodeBeregning() =
+    map {
+        VedtaksperiodeBeregning(
+            fom = it.fom,
+            tom = it.tom,
+            målgruppe = it.målgruppe,
+            aktivitet = it.aktivitet,
+        )
+    }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
@@ -975,6 +975,45 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
                     }
                 assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
             }
+
+            @Test
+            fun `kaster feil ved fom og tom før revurder fra der tom flyttes fremover i tid, men fortsatt før revurder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = listOf(vedtaksperiodeJanFeb.copy(tom = LocalDate.of(2025, 3, 31))),
+                            vedtaksperioderForrigeBehandling = listOf(vedtaksperiodeJanFeb),
+                            revurderFra = førsteApril,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+
+            @Test
+            fun `kaster feil ved fom og tom før revurder fra der tom flyttes fremover i tid forbi revurder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = listOf(vedtaksperiodeJanFeb.copy(tom = LocalDate.of(2025, 5, 31))),
+                            vedtaksperioderForrigeBehandling = listOf(vedtaksperiodeJanFeb),
+                            revurderFra = førsteApril,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+
+            @Test
+            fun `kaster feil ved fom og tom før revurder fra der fom flyttes fremover i tid, men fortsatt før revurder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = listOf(vedtaksperiodeJanFeb.copy(fom = LocalDate.of(2025, 1, 3))),
+                            vedtaksperioderForrigeBehandling = listOf(vedtaksperiodeJanFeb),
+                            revurderFra = førsteApril,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
         }
 
         @Nested

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
@@ -10,6 +10,9 @@ import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlag
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlagsdata
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Navn
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenEndringerFørRevurderFra
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.mergeSammenhengendeOppfylteVilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
@@ -38,13 +41,15 @@ import java.time.YearMonth
 class TilsynBarnVedtaksperiodeValidingerUtilsTest {
     val vilkårperiodeService = mockk<VilkårperiodeService>()
     val grunnlagsdataService = mockk<GrunnlagsdataService>()
+    val vedtakService = mockk<VedtakService>()
     val tilsynBarnVedtaksperiodeValidingerService =
         TilsynBarnVedtaksperiodeValidingerService(
             vilkårperiodeService = vilkårperiodeService,
             grunnlagsdataService = grunnlagsdataService,
+            vedtakService = vedtakService,
         )
 
-    val behandlingId = BehandlingId.random()
+    val behandling = saksbehandling()
 
     val målgrupper =
         listOf(
@@ -96,7 +101,7 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
                     listOf(
                         vedtaksperiode,
                     ),
-                    behandlingId,
+                    behandling,
                     utgifter,
                 )
             }.doesNotThrowAnyException()
@@ -805,9 +810,217 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
         }
     }
 
+    @Nested
+    inner class ValiderIngenEndringerFørRevurderFra {
+        val vedtaksperiodeJanFeb =
+            lagVedtaksperiode(
+                fom = LocalDate.of(2025, 1, 1),
+                tom = LocalDate.of(2025, 2, 28),
+            )
+
+        val vedtaksperiodeMars =
+            lagVedtaksperiode(
+                fom = LocalDate.of(2025, 3, 1),
+                tom = LocalDate.of(2025, 3, 31),
+            )
+
+        val vedtaksperiodeApril =
+            lagVedtaksperiode(
+                fom = LocalDate.of(2025, 4, 1),
+                tom = LocalDate.of(2025, 4, 30),
+            )
+
+        val vedtaksperioderJanFeb = listOf(vedtaksperiodeJanFeb)
+        val vedtaksperioderJanMars = listOf(vedtaksperiodeJanFeb, vedtaksperiodeMars)
+        val førsteMars: LocalDate = LocalDate.of(2025, 3, 1)
+        val femtendeMars: LocalDate = LocalDate.of(2025, 3, 15)
+        val førsteApril: LocalDate = LocalDate.of(2025, 4, 1)
+
+        @Test
+        fun `kaster ikke feil ved ingen revurder fra og ingen gamle perioder (førstegangsbehandling)`() {
+            assertDoesNotThrow {
+                validerIngenEndringerFørRevurderFra(
+                    vedtaksperioder = vedtaksperioderJanMars,
+                    vedtaksperioderForrigeBehandling = emptyList(),
+                    revurderFra = null,
+                )
+            }
+        }
+
+        @Nested
+        inner class NyPeriode {
+            @Test
+            fun `kaster ikke feil ved ny periode som starter etter revurder fra`() {
+                assertDoesNotThrow {
+                    validerIngenEndringerFørRevurderFra(
+                        vedtaksperioder = vedtaksperioderJanMars,
+                        vedtaksperioderForrigeBehandling = vedtaksperioderJanFeb,
+                        revurderFra = førsteMars,
+                    )
+                }
+            }
+
+            @Test
+            fun `kaster feil ved ny periode med fom før revurder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = vedtaksperioderJanMars,
+                            vedtaksperioderForrigeBehandling = vedtaksperioderJanFeb,
+                            revurderFra = femtendeMars,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+
+            @Test
+            fun `kaster feil ved ny periode med fom og tom før revuder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = vedtaksperioderJanMars,
+                            vedtaksperioderForrigeBehandling = vedtaksperioderJanFeb,
+                            revurderFra = førsteApril,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+        }
+
+        @Test
+        fun `kaster feil ved ny periode som er lik eksisterende periode lagt til før revuder fra`() {
+            val nyeVedtaksperioder =
+                listOf(
+                    vedtaksperiodeJanFeb,
+                    vedtaksperiodeJanFeb.copy(id = UUID.randomUUID()),
+                )
+
+            val feil =
+                assertThrows<ApiFeil> {
+                    validerIngenEndringerFørRevurderFra(
+                        vedtaksperioder = nyeVedtaksperioder,
+                        vedtaksperioderForrigeBehandling = vedtaksperioderJanFeb,
+                        revurderFra = førsteMars,
+                    )
+                }
+            assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+        }
+
+        @Test
+        fun `kaster feil ved nye perioder før revurder fra etter opphør med ingen eksisterende vedtaksperioder`() {
+            val feil =
+                assertThrows<ApiFeil> {
+                    validerIngenEndringerFørRevurderFra(
+                        vedtaksperioder = vedtaksperioderJanMars,
+                        vedtaksperioderForrigeBehandling = emptyList(),
+                        revurderFra = førsteMars,
+                    )
+                }
+            assertThat(feil).hasMessage("Det er ikke tillat å legge til nye perioder før revurder fra dato")
+        }
+
+        @Nested
+        inner class EndretPeriode {
+            @Test
+            fun `kaster ikke feil ved fom før revurder fra og tom etter revurder fra, der tom flyttet fremover i tid`() {
+                val nyeVedtaksperioder =
+                    listOf(
+                        vedtaksperiodeJanFeb,
+                        vedtaksperiodeMars.copy(tom = LocalDate.of(2025, 4, 10)),
+                    )
+
+                assertDoesNotThrow {
+                    validerIngenEndringerFørRevurderFra(
+                        vedtaksperioder = nyeVedtaksperioder,
+                        vedtaksperioderForrigeBehandling = vedtaksperioderJanMars,
+                        revurderFra = femtendeMars,
+                    )
+                }
+            }
+
+            @Test
+            fun `kaster feil ved tom flyttet til før revurder fra`() {
+                val nyeVedtaksperioder =
+                    listOf(
+                        vedtaksperiodeJanFeb,
+                        vedtaksperiodeMars.copy(tom = LocalDate.of(2025, 3, 10)),
+                    )
+
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = nyeVedtaksperioder,
+                            vedtaksperioderForrigeBehandling = vedtaksperioderJanMars,
+                            revurderFra = femtendeMars,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+
+            @Test
+            fun `kaster feil ved fom og tom flyttet til før revurder fra`() {
+                val gamleVedtaksperioder =
+                    listOf(
+                        vedtaksperiodeJanFeb,
+                        vedtaksperiodeApril,
+                    )
+
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = vedtaksperioderJanMars,
+                            vedtaksperioderForrigeBehandling = gamleVedtaksperioder,
+                            revurderFra = førsteApril,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+        }
+
+        @Nested
+        inner class SlettetPeriode {
+            @Test
+            fun `kaster ikke feil ved slettet perioder etter revurder fra`() {
+                assertDoesNotThrow {
+                    validerIngenEndringerFørRevurderFra(
+                        vedtaksperioder = vedtaksperioderJanFeb,
+                        vedtaksperioderForrigeBehandling = vedtaksperioderJanMars,
+                        revurderFra = førsteMars,
+                    )
+                }
+            }
+
+            @Test
+            fun `kaster feil ved slettet periode med fom før revurder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = vedtaksperioderJanFeb,
+                            vedtaksperioderForrigeBehandling = vedtaksperioderJanMars,
+                            revurderFra = femtendeMars,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+
+            @Test
+            fun `kaster feil ved slettet periode med fom og tom før revurder fra`() {
+                val feil =
+                    assertThrows<ApiFeil> {
+                        validerIngenEndringerFørRevurderFra(
+                            vedtaksperioder = vedtaksperioderJanFeb,
+                            vedtaksperioderForrigeBehandling = vedtaksperioderJanMars,
+                            revurderFra = førsteApril,
+                        )
+                    }
+                assertThat(feil).hasMessage("Det er ikke tillat å legg til, endre eller slette perioder fra før revurder fra dato")
+            }
+        }
+    }
+
     private fun lagGrunnlagsdata(fødeslsdato: LocalDate = LocalDate.of(1990, 1, 1)) =
         Grunnlagsdata(
-            behandlingId = behandlingId,
+            behandlingId = behandling.id,
             grunnlag =
                 Grunnlag(
                     navn = Navn("fornavn", "mellomnavn", "etternavn"),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
@@ -13,7 +13,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Navn
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenEndringerFørRevurderFra
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
+import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.mergeSammenhengendeOppfylteVilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.YearMonth
+import java.util.UUID
 
 class TilsynBarnVedtaksperiodeValidingerUtilsTest {
     val vilkårperiodeService = mockk<VilkårperiodeService>()
@@ -98,11 +99,9 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
 
             assertThatCode {
                 tilsynBarnVedtaksperiodeValidingerService.validerVedtaksperioder(
-                    listOf(
-                        vedtaksperiode,
-                    ),
-                    behandling,
-                    utgifter,
+                    vedtaksperioder = listOf(vedtaksperiode),
+                    behandling = behandling,
+                    utgifter = utgifter,
                 )
             }.doesNotThrowAnyException()
         }
@@ -283,7 +282,8 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
 
         @Test
         fun `skal godta stønadsperiode på tvers av 2 godkjente sammenhengende vilkårsperioder`() {
-            val vedtaksperiode = lagVedtaksperiode(fom = LocalDate.of(2025, 1, 1), tom = LocalDate.of(2025, 1, 10))
+            val vedtaksperiode =
+                lagVedtaksperiode(fom = LocalDate.of(2025, 1, 1), tom = LocalDate.of(2025, 1, 10))
 
             assertThatCode {
                 TilsynBarnVedtaksperiodeValideringUtils.validerEnkeltperiode(
@@ -297,7 +297,8 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
 
         @Test
         fun `skal ikke godta stønadsperiode på tvers av 2 godkjente, men ikke sammenhengende vilkårsperioder`() {
-            val vedtaksperiode = lagVedtaksperiode(fom = LocalDate.of(2025, 1, 1), tom = LocalDate.of(2025, 1, 21))
+            val vedtaksperiode =
+                lagVedtaksperiode(fom = LocalDate.of(2025, 1, 1), tom = LocalDate.of(2025, 1, 21))
 
             assertThatCode {
                 TilsynBarnVedtaksperiodeValideringUtils.validerEnkeltperiode(
@@ -315,25 +316,19 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
     @Nested
     inner class ValiderIngenOverlapp {
         val vedtaksperiodeJan =
-            VedtaksperiodeBeregning(
+            lagVedtaksperiode(
                 fom = LocalDate.of(2025, 1, 1),
                 tom = LocalDate.of(2025, 1, 31),
-                målgruppe = MålgruppeType.AAP,
-                aktivitet = AktivitetType.TILTAK,
             )
         val vedtaksperiodeFeb =
-            VedtaksperiodeBeregning(
+            lagVedtaksperiode(
                 fom = LocalDate.of(2025, 2, 1),
                 tom = LocalDate.of(2025, 2, 28),
-                målgruppe = MålgruppeType.AAP,
-                aktivitet = AktivitetType.TILTAK,
             )
         val vedtaksperiodeJanFeb =
-            VedtaksperiodeBeregning(
+            lagVedtaksperiode(
                 fom = LocalDate.of(2025, 1, 1),
                 tom = LocalDate.of(2025, 2, 28),
-                målgruppe = MålgruppeType.AAP,
-                aktivitet = AktivitetType.TILTAK,
             )
 
         @Test
@@ -649,7 +644,10 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
             @Test
             fun `skal ikke kaste feil dersom overgangsstønad og under 18 år eller over 67 år`() {
                 val vedtaksperioder =
-                    lagVedtaksperiode(målgruppe = MålgruppeType.OVERGANGSSTØNAD, aktivitet = AktivitetType.UTDANNING)
+                    lagVedtaksperiode(
+                        målgruppe = MålgruppeType.OVERGANGSSTØNAD,
+                        aktivitet = AktivitetType.UTDANNING,
+                    )
 
                 val målgrupper =
                     listOf(
@@ -1074,7 +1072,8 @@ class TilsynBarnVedtaksperiodeValidingerUtilsTest {
         tom: LocalDate = LocalDate.of(2025, 1, 31),
         målgruppe: MålgruppeType = MålgruppeType.AAP,
         aktivitet: AktivitetType = AktivitetType.TILTAK,
-    ) = VedtaksperiodeBeregning(
+    ) = Vedtaksperiode(
+        id = UUID.randomUUID(),
         fom = fom,
         tom = tom,
         målgruppe = målgruppe,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerUtilsTest.kt
@@ -11,7 +11,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlagsdata
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Navn
 import no.nav.tilleggsstonader.sak.util.saksbehandling
-import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnVedtaksperiodeValideringUtils.validerIngenEndringerFørRevurderFra
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.mergeSammenhengendeOppfylteVilkårperioder
@@ -41,12 +41,12 @@ import java.time.YearMonth
 class TilsynBarnVedtaksperiodeValidingerUtilsTest {
     val vilkårperiodeService = mockk<VilkårperiodeService>()
     val grunnlagsdataService = mockk<GrunnlagsdataService>()
-    val vedtakService = mockk<VedtakService>()
+    val vedtakRepository = mockk<VedtakRepository>()
     val tilsynBarnVedtaksperiodeValidingerService =
         TilsynBarnVedtaksperiodeValidingerService(
             vilkårperiodeService = vilkårperiodeService,
             grunnlagsdataService = grunnlagsdataService,
-            vedtakService = vedtakService,
+            vedtakRepository = vedtakRepository,
         )
 
     val behandling = saksbehandling()


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Valider ingen endrede vedtaksperioder før revurder fra for tilsyn barn.

Kan også gjenbrukes for læremidler senere.