### PR TITLE
Enhetstester for mapping av behandlingsstatistikk til datavarehus

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkService.kt
@@ -45,7 +45,7 @@ class BehandlingsstatistikkService(
     ) {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         val behandlingDVH =
-            mapTilBehandlingDVH(
+            hentDataOgMapTilBehandlingDVH(
                 behandlingId = behandlingId,
                 hendelse = hendelse,
                 hendelseTidspunkt = hendelseTidspunkt,
@@ -57,7 +57,7 @@ class BehandlingsstatistikkService(
         behandlingsstatistikkProducer.sendBehandling(behandlingDVH, saksbehandling.stønadstype)
     }
 
-    private fun mapTilBehandlingDVH(
+    private fun hentDataOgMapTilBehandlingDVH(
         saksbehandling: Saksbehandling,
         behandlingId: BehandlingId,
         hendelse: Hendelse,
@@ -72,70 +72,26 @@ class BehandlingsstatistikkService(
         val totrinnskontroll = totrinnskontrollService.hentTotrinnskontroll(behandlingId)
         val saksbehandlerId = finnSaksbehandler(hendelse, gjeldendeSaksbehandler, totrinnskontroll)
         val beslutterId = totrinnskontroll?.beslutter
+        val relatertBehandlingId = utledRelatertBehandling(saksbehandling)
 
-        return BehandlingDVH(
-            behandlingId = saksbehandling.eksternId.toString(),
-            behandlingUuid = behandlingId.toString(),
-            sakId = saksbehandling.eksternFagsakId.toString(),
-            aktorId = saksbehandling.ident,
-            registrertTid = henvendelseTidspunkt,
-            endretTid = if (Hendelse.MOTTATT == hendelse) henvendelseTidspunkt else hendelseTidspunkt,
-            tekniskTid = osloNow(),
-            behandlingStatus = hendelse.name,
-            opprettetAv =
-                maskerVerdiHvisStrengtFortrolig(
-                    erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
-                    verdi = saksbehandling.opprettetAv,
-                ),
-            saksnummer = saksbehandling.eksternFagsakId.toString(),
-            mottattTid = henvendelseTidspunkt,
-            kravMottatt = saksbehandling.kravMottatt,
-            saksbehandler =
-                maskerVerdiHvisStrengtFortrolig(
-                    erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
-                    verdi = saksbehandlerId,
-                ),
-            ansvarligEnhet =
-                maskerVerdiHvisStrengtFortrolig(
-                    erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
-                    verdi = sisteOppgaveForBehandling?.tildeltEnhetsnr ?: MASKINELL_JOURNALFOERENDE_ENHET,
-                ),
-            behandlingMetode = behandlingMetode?.name ?: "MANUELL",
-            behandlingÅrsak = saksbehandling.årsak.name,
-            avsender = "Nav Tilleggstønader",
-            behandlingType = saksbehandling.type.name,
-            sakYtelse = SakYtelseDvh.fraStønadstype(saksbehandling.stønadstype),
-            behandlingResultat = saksbehandling.resultat.name,
-            resultatBegrunnelse = utledResultatBegrunnelse(saksbehandling),
-            ansvarligBeslutter = finnAnsvarligBeslutter(beslutterId, søkerHarStrengtFortroligAdresse),
-            vedtakTid = if (Hendelse.VEDTATT == hendelse) hendelseTidspunkt else null,
-            ferdigBehandletTid = if (Hendelse.FERDIG == hendelse) hendelseTidspunkt else null,
-            totrinnsbehandling = beslutterId != null,
-            sakUtland = mapTilStreng(saksbehandling.kategori),
-            relatertBehandlingId = utledRelatertBehandling(saksbehandling),
-            versjon = Applikasjonsversjon.versjon,
-            vilkårsprøving = emptyList(), // TODO: Implementer dette i samarbeid med Team SAK. Ikke kritisk å ha med i starten.
-            revurderingÅrsak = null, // TODO aktiver når revurdering er implementert
-            revurderingOpplysningskilde = null, // TODO aktiver når revurdering er implementert
-            venteAarsak = null, // TODO?
-            papirSøknad = null, // TODO?
+        return mapTilBehandlingDVH(
+            saksbehandling,
+            behandlingId,
+            henvendelseTidspunkt,
+            hendelse,
+            hendelseTidspunkt,
+            søkerHarStrengtFortroligAdresse,
+            saksbehandlerId,
+            sisteOppgaveForBehandling,
+            behandlingMetode,
+            beslutterId,
+            osloNow(),
+            relatertBehandlingId,
         )
     }
 
     private fun utledRelatertBehandling(saksbehandling: Saksbehandling) =
         saksbehandling.forrigeBehandlingId?.let { behandlingService.hentEksternBehandlingId(it).id.toString() }
-
-    private fun finnAnsvarligBeslutter(
-        beslutterId: String?,
-        søkerHarStrengtFortroligAdresse: Boolean,
-    ) = if (!beslutterId.isNullOrEmpty()) {
-        maskerVerdiHvisStrengtFortrolig(
-            erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
-            verdi = beslutterId.toString(),
-        )
-    } else {
-        null
-    }
 
     private fun finnSisteOppgaveForBehandlingen(
         behandlingId: BehandlingId,
@@ -182,23 +138,112 @@ class BehandlingsstatistikkService(
         }
     }
 
-    private fun maskerVerdiHvisStrengtFortrolig(
-        erStrengtFortrolig: Boolean,
-        verdi: String,
-    ) = if (erStrengtFortrolig) "-5" else verdi // -5 er ein kode som dvh forstår som maskert med årsak i strengtfortrolig
+    companion object {
+        fun mapTilBehandlingDVH(
+            saksbehandling: Saksbehandling,
+            behandlingId: BehandlingId,
+            henvendelseTidspunkt: LocalDateTime,
+            hendelse: Hendelse,
+            hendelseTidspunkt: LocalDateTime,
+            søkerHarStrengtFortroligAdresse: Boolean,
+            saksbehandlerId: String,
+            sisteOppgaveForBehandling: Oppgave?,
+            behandlingMetode: BehandlingMetode?,
+            beslutterId: String?,
+            tekniskTid: LocalDateTime,
+            relatertBehandlingId: String?,
+        ) = BehandlingDVH(
+            behandlingId = saksbehandling.eksternId.toString(),
+            behandlingUuid = behandlingId.toString(),
+            sakId = saksbehandling.eksternFagsakId.toString(),
+            aktorId = saksbehandling.ident,
+            registrertTid = henvendelseTidspunkt,
+            endretTid = if (Hendelse.MOTTATT == hendelse) henvendelseTidspunkt else hendelseTidspunkt,
+            tekniskTid = tekniskTid,
+            behandlingStatus = hendelse.name,
+            opprettetAv =
+                maskerVerdiHvisStrengtFortrolig(
+                    erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
+                    verdi = saksbehandling.opprettetAv,
+                ),
+            saksnummer = saksbehandling.eksternFagsakId.toString(),
+            mottattTid = henvendelseTidspunkt,
+            kravMottatt = saksbehandling.kravMottatt,
+            saksbehandler =
+                maskerVerdiHvisStrengtFortrolig(
+                    erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
+                    verdi = saksbehandlerId,
+                ),
+            ansvarligEnhet =
+                maskerVerdiHvisStrengtFortrolig(
+                    erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
+                    verdi = sisteOppgaveForBehandling?.tildeltEnhetsnr ?: MASKINELL_JOURNALFOERENDE_ENHET,
+                ),
+            behandlingMetode = behandlingMetode?.name ?: "MANUELL",
+            behandlingÅrsak = saksbehandling.årsak.name,
+            avsender = "Nav Tilleggstønader",
+            behandlingType = saksbehandling.type.name,
+            sakYtelse = SakYtelseDvh.fraStønadstype(saksbehandling.stønadstype),
+            behandlingResultat = saksbehandling.resultat.name,
+            resultatBegrunnelse = utledResultatBegrunnelse(saksbehandling),
+            ansvarligBeslutter = finnAnsvarligBeslutter(beslutterId, søkerHarStrengtFortroligAdresse),
+            vedtakTid = if (Hendelse.VEDTATT == hendelse) hendelseTidspunkt else null,
+            ferdigBehandletTid = if (Hendelse.FERDIG == hendelse) hendelseTidspunkt else null,
+            totrinnsbehandling = beslutterId != null,
+            sakUtland = mapTilStreng(saksbehandling.kategori),
+            relatertBehandlingId = relatertBehandlingId, // utledRelatertBehandling(saksbehandling),
+            versjon = Applikasjonsversjon.versjon,
+            vilkårsprøving = emptyList(), // TODO: Implementer dette i samarbeid med Team SAK. Ikke kritisk å ha med i starten.
+            revurderingÅrsak = null, // TODO aktiver når revurdering er implementert
+            revurderingOpplysningskilde = null, // TODO aktiver når revurdering er implementert
+            venteAarsak = null, // TODO?
+            papirSøknad = null, // TODO?
+        )
 
-    private fun mapTilStreng(kategori: BehandlingKategori?) =
-        when (kategori) {
-            BehandlingKategori.EØS -> "Utland"
-            BehandlingKategori.NASJONAL -> "Nasjonal"
-            null -> "Nasjonal"
+        private fun finnAnsvarligBeslutter(
+            beslutterId: String?,
+            søkerHarStrengtFortroligAdresse: Boolean,
+        ) = if (!beslutterId.isNullOrEmpty()) {
+            maskerVerdiHvisStrengtFortrolig(
+                erStrengtFortrolig = søkerHarStrengtFortroligAdresse,
+                verdi = beslutterId.toString(),
+            )
+        } else {
+            null
         }
 
-    private fun utledResultatBegrunnelse(behandling: Saksbehandling): String? =
-        when (behandling.resultat) {
-            BehandlingResultat.HENLAGT -> behandling.henlagtÅrsak?.name
-            BehandlingResultat.AVSLÅTT -> "UKJENT" // TODO: Send riktig verdier når vi får en liste over avslagsårsaker
+        private fun finnSaksbehandler(
+            hendelse: Hendelse,
+            gjeldendeSaksbehandler: String?,
+            totrinnskontroll: Totrinnskontroll?,
+        ): String =
+            when (hendelse) {
+                Hendelse.MOTTATT, Hendelse.PÅBEGYNT, Hendelse.VENTER ->
+                    gjeldendeSaksbehandler ?: error("Mangler saksbehandler for hendelse=$hendelse")
 
-            else -> null
-        }
+                Hendelse.VEDTATT, Hendelse.BESLUTTET, Hendelse.FERDIG ->
+                    totrinnskontroll?.saksbehandler ?: gjeldendeSaksbehandler
+                        ?: error("Mangler totrinnskontroll for hendelse=$hendelse")
+            }
+
+        private fun maskerVerdiHvisStrengtFortrolig(
+            erStrengtFortrolig: Boolean,
+            verdi: String,
+        ) = if (erStrengtFortrolig) "-5" else verdi // -5 er ein kode som dvh forstår som maskert med årsak i strengtfortrolig
+
+        private fun mapTilStreng(kategori: BehandlingKategori?) =
+            when (kategori) {
+                BehandlingKategori.EØS -> "Utland"
+                BehandlingKategori.NASJONAL -> "Nasjonal"
+                null -> "Nasjonal"
+            }
+
+        private fun utledResultatBegrunnelse(behandling: Saksbehandling): String? =
+            when (behandling.resultat) {
+                BehandlingResultat.HENLAGT -> behandling.henlagtÅrsak?.name
+                BehandlingResultat.AVSLÅTT -> "UKJENT" // TODO: Send riktig verdier når vi får en liste over avslagsårsaker
+
+                else -> null
+            }
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkService.kt
@@ -212,20 +212,6 @@ class BehandlingsstatistikkService(
             null
         }
 
-        private fun finnSaksbehandler(
-            hendelse: Hendelse,
-            gjeldendeSaksbehandler: String?,
-            totrinnskontroll: Totrinnskontroll?,
-        ): String =
-            when (hendelse) {
-                Hendelse.MOTTATT, Hendelse.PÅBEGYNT, Hendelse.VENTER ->
-                    gjeldendeSaksbehandler ?: error("Mangler saksbehandler for hendelse=$hendelse")
-
-                Hendelse.VEDTATT, Hendelse.BESLUTTET, Hendelse.FERDIG ->
-                    totrinnskontroll?.saksbehandler ?: gjeldendeSaksbehandler
-                        ?: error("Mangler totrinnskontroll for hendelse=$hendelse")
-            }
-
         private fun maskerVerdiHvisStrengtFortrolig(
             erStrengtFortrolig: Boolean,
             verdi: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkService.kt
@@ -75,18 +75,18 @@ class BehandlingsstatistikkService(
         val relatertBehandlingId = utledRelatertBehandling(saksbehandling)
 
         return mapTilBehandlingDVH(
-            saksbehandling,
-            behandlingId,
-            henvendelseTidspunkt,
-            hendelse,
-            hendelseTidspunkt,
-            søkerHarStrengtFortroligAdresse,
-            saksbehandlerId,
-            sisteOppgaveForBehandling,
-            behandlingMetode,
-            beslutterId,
-            osloNow(),
-            relatertBehandlingId,
+            saksbehandling = saksbehandling,
+            behandlingId = behandlingId,
+            henvendelseTidspunkt = henvendelseTidspunkt,
+            hendelse = hendelse,
+            hendelseTidspunkt = hendelseTidspunkt,
+            søkerHarStrengtFortroligAdresse = søkerHarStrengtFortroligAdresse,
+            saksbehandlerId = saksbehandlerId,
+            sisteOppgaveForBehandling = sisteOppgaveForBehandling,
+            behandlingMetode = behandlingMetode,
+            beslutterId = beslutterId,
+            tekniskTid = osloNow(),
+            relatertBehandlingId = relatertBehandlingId,
         )
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -1,0 +1,84 @@
+package no.nav.tilleggsstonader.sak.statistikk.behandling
+
+import no.nav.tilleggsstonader.kontrakter.saksstatistikk.BehandlingDVH
+import no.nav.tilleggsstonader.kontrakter.saksstatistikk.SakYtelseDvh
+import no.nav.tilleggsstonader.libs.utils.osloNow
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.statistikk.behandling.dto.BehandlingMetode
+import no.nav.tilleggsstonader.sak.statistikk.behandling.dto.Hendelse
+import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class BehandlingsstatistikkMappingTest {
+    @Test
+    fun `mappy map`() {
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling = saksbehandling()
+        val behandlingId = BehandlingId(UUID.randomUUID())
+
+        val actual =
+            BehandlingsstatistikkService.mapTilBehandlingDVH(
+                saksbehandling,
+                behandlingId = behandlingId,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelse = Hendelse.MOTTATT,
+                hendelseTidspunkt = hendelseTidspunkt,
+                søkerHarStrengtFortroligAdresse = false,
+                saksbehandlerId = "<saksbehandler-test>",
+                sisteOppgaveForBehandling = null,
+                behandlingMetode = BehandlingMetode.MANUELL,
+                beslutterId = null,
+                tekniskTid = tekniskTid,
+                relatertBehandlingId = null,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = saksbehandling.eksternId.toString(),
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "0",
+                sakId = saksbehandling.eksternFagsakId.toString(),
+                aktorId = saksbehandling.ident,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = null,
+                endretTid = henvendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Nasjonal",
+                behandlingType = "FØRSTEGANGSBEHANDLING",
+                behandlingStatus = "MOTTATT",
+                behandlingMetode = "MANUELL",
+                kravMottatt = null,
+                opprettetAv = "VL",
+                saksbehandler = "<saksbehandler-test>",
+                ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "IKKE_SATT",
+                resultatBegrunnelse = null,
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -24,61 +24,6 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class BehandlingsstatistikkMappingTest {
-    fun saksbehandling(
-        behandlingId: BehandlingId,
-        saksbehandler: String,
-        eksternId: Long,
-        eksternFagId: Long,
-        kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
-    ) = Saksbehandling(
-        id = behandlingId,
-        eksternId = eksternId,
-        forrigeBehandlingId = null,
-        type = BehandlingType.FØRSTEGANGSBEHANDLING,
-        status = BehandlingStatus.OPPRETTET,
-        steg = StegType.INNGANGSVILKÅR,
-        kategori = kategori,
-        årsak = BehandlingÅrsak.SØKNAD,
-        kravMottatt = null,
-        resultat = BehandlingResultat.IKKE_SATT,
-        vedtakstidspunkt = null,
-        henlagtÅrsak = null,
-        henlagtBegrunnelse = null,
-        ident = saksbehandler,
-        fagsakId = FagsakId(UUID.randomUUID()),
-        fagsakPersonId = FagsakPersonId(UUID.randomUUID()),
-        eksternFagsakId = eksternFagId,
-        stønadstype = Stønadstype.BARNETILSYN,
-        revurderFra = null,
-        opprettetAv = "VL",
-        opprettetTid = LocalDateTime.now(),
-        endretAv = "<endret-av-test>",
-        endretTid = LocalDateTime.now(),
-    )
-
-    fun map(
-        saksbehandling: Saksbehandling,
-        henvendelseTidspunkt: LocalDateTime,
-        hendelseTidspunkt: LocalDateTime,
-        tekniskTid: LocalDateTime,
-        søkerHarStrengtFortroligAdresse: Boolean = false,
-        hendelse: Hendelse = Hendelse.MOTTATT,
-        behandlingMetode: BehandlingMetode = BehandlingMetode.AUTOMATISK,
-    ) = BehandlingsstatistikkService.mapTilBehandlingDVH(
-        saksbehandling,
-        behandlingId = saksbehandling.id,
-        henvendelseTidspunkt = henvendelseTidspunkt,
-        hendelse = hendelse,
-        hendelseTidspunkt = hendelseTidspunkt,
-        søkerHarStrengtFortroligAdresse = søkerHarStrengtFortroligAdresse,
-        saksbehandlerId = saksbehandling.ident,
-        sisteOppgaveForBehandling = null,
-        behandlingMetode = behandlingMetode,
-        beslutterId = null,
-        tekniskTid = tekniskTid,
-        relatertBehandlingId = null,
-    )
-
     @Test
     fun `mapping med hendelse MOTTATT`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
@@ -350,4 +295,59 @@ class BehandlingsstatistikkMappingTest {
 
         assertThat(actual).isEqualTo(expected)
     }
+
+    fun saksbehandling(
+        behandlingId: BehandlingId,
+        saksbehandler: String,
+        eksternId: Long,
+        eksternFagId: Long,
+        kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
+    ) = Saksbehandling(
+        id = behandlingId,
+        eksternId = eksternId,
+        forrigeBehandlingId = null,
+        type = BehandlingType.FØRSTEGANGSBEHANDLING,
+        status = BehandlingStatus.OPPRETTET,
+        steg = StegType.INNGANGSVILKÅR,
+        kategori = kategori,
+        årsak = BehandlingÅrsak.SØKNAD,
+        kravMottatt = null,
+        resultat = BehandlingResultat.IKKE_SATT,
+        vedtakstidspunkt = null,
+        henlagtÅrsak = null,
+        henlagtBegrunnelse = null,
+        ident = saksbehandler,
+        fagsakId = FagsakId(UUID.randomUUID()),
+        fagsakPersonId = FagsakPersonId(UUID.randomUUID()),
+        eksternFagsakId = eksternFagId,
+        stønadstype = Stønadstype.BARNETILSYN,
+        revurderFra = null,
+        opprettetAv = "VL",
+        opprettetTid = LocalDateTime.now(),
+        endretAv = "<endret-av-test>",
+        endretTid = LocalDateTime.now(),
+    )
+
+    fun map(
+        saksbehandling: Saksbehandling,
+        henvendelseTidspunkt: LocalDateTime,
+        hendelseTidspunkt: LocalDateTime,
+        tekniskTid: LocalDateTime,
+        søkerHarStrengtFortroligAdresse: Boolean = false,
+        hendelse: Hendelse = Hendelse.MOTTATT,
+        behandlingMetode: BehandlingMetode = BehandlingMetode.AUTOMATISK,
+    ) = BehandlingsstatistikkService.mapTilBehandlingDVH(
+        saksbehandling,
+        behandlingId = saksbehandling.id,
+        henvendelseTidspunkt = henvendelseTidspunkt,
+        hendelse = hendelse,
+        hendelseTidspunkt = hendelseTidspunkt,
+        søkerHarStrengtFortroligAdresse = søkerHarStrengtFortroligAdresse,
+        saksbehandlerId = saksbehandling.ident,
+        sisteOppgaveForBehandling = null,
+        behandlingMetode = behandlingMetode,
+        beslutterId = null,
+        tekniskTid = tekniskTid,
+        relatertBehandlingId = null,
+    )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -27,7 +27,8 @@ class BehandlingsstatistikkMappingTest {
     @Test
     fun `mapping med hendelse MOTTATT`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
-        val saksbehandlerId = "<saksbehandler-test>"
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
 
         val henvendelseTidspunkt = osloNow()
         val hendelseTidspunkt = osloNow()
@@ -36,7 +37,7 @@ class BehandlingsstatistikkMappingTest {
         val saksbehandling =
             saksbehandling(
                 behandlingId = behandlingId,
-                saksbehandler = saksbehandlerId,
+                ident = aktørId,
                 eksternId = 17L,
                 eksternFagId = 29L,
                 kategori = BehandlingKategori.NASJONAL,
@@ -45,6 +46,7 @@ class BehandlingsstatistikkMappingTest {
         val actual =
             map(
                 saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
                 henvendelseTidspunkt = henvendelseTidspunkt,
                 hendelseTidspunkt = hendelseTidspunkt,
                 tekniskTid = tekniskTid,
@@ -56,7 +58,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingUuid = behandlingId.id.toString(),
                 saksnummer = "29",
                 sakId = "29",
-                aktorId = saksbehandlerId,
+                aktorId = aktørId,
                 mottattTid = henvendelseTidspunkt,
                 registrertTid = henvendelseTidspunkt,
                 ferdigBehandletTid = null,
@@ -69,7 +71,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingMetode = "AUTOMATISK",
                 kravMottatt = null,
                 opprettetAv = "VL",
-                saksbehandler = "<saksbehandler-test>",
+                saksbehandler = saksbehandlerId,
                 ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
                 behandlingResultat = "IKKE_SATT",
                 resultatBegrunnelse = null,
@@ -96,18 +98,20 @@ class BehandlingsstatistikkMappingTest {
     @Test
     fun `mapping med hendelse FERDIG`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
-        val saksbehandlerId = "<saksbehandler-test>"
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
 
         val henvendelseTidspunkt = osloNow()
         val hendelseTidspunkt = osloNow()
         val tekniskTid = osloNow()
 
         val saksbehandling =
-            saksbehandling(behandlingId = behandlingId, saksbehandler = saksbehandlerId, eksternId = 1337L, eksternFagId = 8080L)
+            saksbehandling(behandlingId = behandlingId, ident = aktørId, eksternId = 1337L, eksternFagId = 8080L)
 
         val actual =
             map(
                 saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
                 henvendelseTidspunkt = henvendelseTidspunkt,
                 hendelseTidspunkt = hendelseTidspunkt,
                 tekniskTid = tekniskTid,
@@ -120,7 +124,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingUuid = behandlingId.id.toString(),
                 saksnummer = "8080",
                 sakId = "8080",
-                aktorId = saksbehandlerId,
+                aktorId = aktørId,
                 mottattTid = henvendelseTidspunkt,
                 registrertTid = henvendelseTidspunkt,
                 ferdigBehandletTid = hendelseTidspunkt,
@@ -133,7 +137,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingMetode = "AUTOMATISK",
                 kravMottatt = null,
                 opprettetAv = "VL",
-                saksbehandler = "<saksbehandler-test>",
+                saksbehandler = saksbehandlerId,
                 ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
                 behandlingResultat = "IKKE_SATT",
                 resultatBegrunnelse = null,
@@ -160,7 +164,8 @@ class BehandlingsstatistikkMappingTest {
     @Test
     fun `mapping med kategori EØS`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
-        val saksbehandler = "<saksbehandler-test>"
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
 
         val henvendelseTidspunkt = osloNow()
         val hendelseTidspunkt = osloNow()
@@ -169,7 +174,7 @@ class BehandlingsstatistikkMappingTest {
         val saksbehandling =
             saksbehandling(
                 behandlingId = behandlingId,
-                saksbehandler = saksbehandler,
+                ident = aktørId,
                 eksternId = 1999L,
                 eksternFagId = 5150L,
                 kategori = BehandlingKategori.EØS,
@@ -178,6 +183,7 @@ class BehandlingsstatistikkMappingTest {
         val actual =
             map(
                 saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
                 henvendelseTidspunkt = henvendelseTidspunkt,
                 hendelseTidspunkt = hendelseTidspunkt,
                 tekniskTid = tekniskTid,
@@ -189,7 +195,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingUuid = behandlingId.id.toString(),
                 saksnummer = "5150",
                 sakId = "5150",
-                aktorId = saksbehandler,
+                aktorId = aktørId,
                 mottattTid = henvendelseTidspunkt,
                 registrertTid = henvendelseTidspunkt,
                 ferdigBehandletTid = null,
@@ -202,7 +208,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingMetode = "AUTOMATISK",
                 kravMottatt = null,
                 opprettetAv = "VL",
-                saksbehandler = "<saksbehandler-test>",
+                saksbehandler = saksbehandlerId,
                 ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
                 behandlingResultat = "IKKE_SATT",
                 resultatBegrunnelse = null,
@@ -229,7 +235,8 @@ class BehandlingsstatistikkMappingTest {
     @Test
     fun `mapping med strengt fortrolig adresse`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
-        val saksbehandler = "<saksbehandler-test>"
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
 
         val henvendelseTidspunkt = osloNow()
         val hendelseTidspunkt = osloNow()
@@ -238,7 +245,7 @@ class BehandlingsstatistikkMappingTest {
         val saksbehandling =
             saksbehandling(
                 behandlingId = behandlingId,
-                saksbehandler = saksbehandler,
+                ident = aktørId,
                 eksternId = 33L,
                 eksternFagId = 99L,
                 kategori = BehandlingKategori.NASJONAL,
@@ -247,6 +254,7 @@ class BehandlingsstatistikkMappingTest {
         val actual =
             map(
                 saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
                 henvendelseTidspunkt = henvendelseTidspunkt,
                 hendelseTidspunkt = hendelseTidspunkt,
                 tekniskTid = tekniskTid,
@@ -259,7 +267,7 @@ class BehandlingsstatistikkMappingTest {
                 behandlingUuid = behandlingId.id.toString(),
                 saksnummer = "99",
                 sakId = "99",
-                aktorId = saksbehandler,
+                aktorId = aktørId,
                 mottattTid = henvendelseTidspunkt,
                 registrertTid = henvendelseTidspunkt,
                 ferdigBehandletTid = null,
@@ -298,7 +306,7 @@ class BehandlingsstatistikkMappingTest {
 
     fun saksbehandling(
         behandlingId: BehandlingId,
-        saksbehandler: String,
+        ident: String,
         eksternId: Long,
         eksternFagId: Long,
         kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
@@ -316,7 +324,7 @@ class BehandlingsstatistikkMappingTest {
         vedtakstidspunkt = null,
         henlagtÅrsak = null,
         henlagtBegrunnelse = null,
-        ident = saksbehandler,
+        ident = ident,
         fagsakId = FagsakId(UUID.randomUUID()),
         fagsakPersonId = FagsakPersonId(UUID.randomUUID()),
         eksternFagsakId = eksternFagId,
@@ -330,6 +338,7 @@ class BehandlingsstatistikkMappingTest {
 
     fun map(
         saksbehandling: Saksbehandling,
+        saksbehandlerId: String,
         henvendelseTidspunkt: LocalDateTime,
         hendelseTidspunkt: LocalDateTime,
         tekniskTid: LocalDateTime,
@@ -343,7 +352,7 @@ class BehandlingsstatistikkMappingTest {
         hendelse = hendelse,
         hendelseTidspunkt = hendelseTidspunkt,
         søkerHarStrengtFortroligAdresse = søkerHarStrengtFortroligAdresse,
-        saksbehandlerId = saksbehandling.ident,
+        saksbehandlerId = saksbehandlerId,
         sisteOppgaveForBehandling = null,
         behandlingMetode = behandlingMetode,
         beslutterId = null,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -1,50 +1,105 @@
 package no.nav.tilleggsstonader.sak.statistikk.behandling
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.saksstatistikk.BehandlingDVH
 import no.nav.tilleggsstonader.kontrakter.saksstatistikk.SakYtelseDvh
 import no.nav.tilleggsstonader.libs.utils.osloNow
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.behandling.domain.*
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.statistikk.behandling.dto.BehandlingMetode
 import no.nav.tilleggsstonader.sak.statistikk.behandling.dto.Hendelse
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
-import no.nav.tilleggsstonader.sak.util.saksbehandling
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
 import java.util.UUID
 
 class BehandlingsstatistikkMappingTest {
+    fun saksbehandling(
+        behandlingId: BehandlingId,
+        eksternId: Long,
+        eksternFagId: Long,
+        kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
+    ) = Saksbehandling(
+        id = behandlingId,
+        eksternId = eksternId,
+        forrigeBehandlingId = null,
+        type = BehandlingType.FØRSTEGANGSBEHANDLING,
+        status = BehandlingStatus.OPPRETTET,
+        steg = StegType.INNGANGSVILKÅR,
+        kategori = kategori,
+        årsak = BehandlingÅrsak.SØKNAD,
+        kravMottatt = null,
+        resultat = BehandlingResultat.IKKE_SATT,
+        vedtakstidspunkt = null,
+        henlagtÅrsak = null,
+        henlagtBegrunnelse = null,
+        ident = "<ident-test>",
+        fagsakId = FagsakId(UUID.randomUUID()),
+        fagsakPersonId = FagsakPersonId(UUID.randomUUID()),
+        eksternFagsakId = eksternFagId,
+        stønadstype = Stønadstype.BARNETILSYN,
+        revurderFra = null,
+        opprettetAv = "VL",
+        opprettetTid = LocalDateTime.now(),
+        endretAv = "<endret-av-test>",
+        endretTid = LocalDateTime.now(),
+    )
+
+    fun map(
+        behandlingId: BehandlingId,
+        saksbehandling: Saksbehandling,
+        henvendelseTidspunkt: LocalDateTime,
+        hendelseTidspunkt: LocalDateTime,
+        tekniskTid: LocalDateTime,
+        søkerHarStrengtFortroligAdresse: Boolean = false,
+        hendelse: Hendelse = Hendelse.MOTTATT,
+        behandlingMetode: BehandlingMetode = BehandlingMetode.AUTOMATISK,
+    ) = BehandlingsstatistikkService.mapTilBehandlingDVH(
+        saksbehandling,
+        behandlingId = behandlingId,
+        henvendelseTidspunkt = henvendelseTidspunkt,
+        hendelse = hendelse,
+        hendelseTidspunkt = hendelseTidspunkt,
+        søkerHarStrengtFortroligAdresse = søkerHarStrengtFortroligAdresse,
+        saksbehandlerId = "<saksbehandler-test>",
+        sisteOppgaveForBehandling = null,
+        behandlingMetode = behandlingMetode,
+        beslutterId = null,
+        tekniskTid = tekniskTid,
+        relatertBehandlingId = null,
+    )
+
     @Test
-    fun `mappy map`() {
+    fun `mapping med hendelse MOTTATT`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+
         val henvendelseTidspunkt = osloNow()
         val hendelseTidspunkt = osloNow()
         val tekniskTid = osloNow()
 
-        val saksbehandling = saksbehandling()
-        val behandlingId = BehandlingId(UUID.randomUUID())
+        val saksbehandling =
+            saksbehandling(behandlingId = behandlingId, eksternId = 17L, eksternFagId = 29L, kategori = BehandlingKategori.NASJONAL)
 
         val actual =
-            BehandlingsstatistikkService.mapTilBehandlingDVH(
-                saksbehandling,
+            map(
                 behandlingId = behandlingId,
+                saksbehandling = saksbehandling,
                 henvendelseTidspunkt = henvendelseTidspunkt,
-                hendelse = Hendelse.MOTTATT,
                 hendelseTidspunkt = hendelseTidspunkt,
-                søkerHarStrengtFortroligAdresse = false,
-                saksbehandlerId = "<saksbehandler-test>",
-                sisteOppgaveForBehandling = null,
-                behandlingMetode = BehandlingMetode.MANUELL,
-                beslutterId = null,
                 tekniskTid = tekniskTid,
-                relatertBehandlingId = null,
             )
 
         val expected =
             BehandlingDVH(
-                behandlingId = saksbehandling.eksternId.toString(),
+                behandlingId = "17",
                 behandlingUuid = behandlingId.id.toString(),
-                saksnummer = "0",
-                sakId = saksbehandling.eksternFagsakId.toString(),
+                saksnummer = "29",
+                sakId = "29",
                 aktorId = saksbehandling.ident,
                 mottattTid = henvendelseTidspunkt,
                 registrertTid = henvendelseTidspunkt,
@@ -55,11 +110,203 @@ class BehandlingsstatistikkMappingTest {
                 sakUtland = "Nasjonal",
                 behandlingType = "FØRSTEGANGSBEHANDLING",
                 behandlingStatus = "MOTTATT",
-                behandlingMetode = "MANUELL",
+                behandlingMetode = "AUTOMATISK",
                 kravMottatt = null,
                 opprettetAv = "VL",
                 saksbehandler = "<saksbehandler-test>",
                 ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "IKKE_SATT",
+                resultatBegrunnelse = null,
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `mapping med hendelse FERDIG`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling =
+            saksbehandling(behandlingId = behandlingId, eksternId = 1337L, eksternFagId = 8080L)
+
+        val actual =
+            map(
+                behandlingId = behandlingId,
+                saksbehandling = saksbehandling,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelseTidspunkt = hendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                hendelse = Hendelse.FERDIG,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = "1337",
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "8080",
+                sakId = "8080",
+                aktorId = saksbehandling.ident,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = hendelseTidspunkt,
+                endretTid = hendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Nasjonal",
+                behandlingType = "FØRSTEGANGSBEHANDLING",
+                behandlingStatus = "FERDIG",
+                behandlingMetode = "AUTOMATISK",
+                kravMottatt = null,
+                opprettetAv = "VL",
+                saksbehandler = "<saksbehandler-test>",
+                ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "IKKE_SATT",
+                resultatBegrunnelse = null,
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `mapping med kategori EØS`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling =
+            saksbehandling(behandlingId = behandlingId, eksternId = 1999L, eksternFagId = 5150L, kategori = BehandlingKategori.EØS)
+
+        val actual =
+            map(
+                behandlingId = behandlingId,
+                saksbehandling = saksbehandling,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelseTidspunkt = hendelseTidspunkt,
+                tekniskTid = tekniskTid,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = "1999",
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "5150",
+                sakId = "5150",
+                aktorId = saksbehandling.ident,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = null,
+                endretTid = henvendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Utland",
+                behandlingType = "FØRSTEGANGSBEHANDLING",
+                behandlingStatus = "MOTTATT",
+                behandlingMetode = "AUTOMATISK",
+                kravMottatt = null,
+                opprettetAv = "VL",
+                saksbehandler = "<saksbehandler-test>",
+                ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "IKKE_SATT",
+                resultatBegrunnelse = null,
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `mapping med strengt fortrolig adresse`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling = saksbehandling(behandlingId, 33L, 99L, kategori = BehandlingKategori.NASJONAL)
+
+        val actual =
+            map(
+                behandlingId = behandlingId,
+                saksbehandling = saksbehandling,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelse = Hendelse.MOTTATT,
+                hendelseTidspunkt = hendelseTidspunkt,
+                søkerHarStrengtFortroligAdresse = true,
+                behandlingMetode = BehandlingMetode.AUTOMATISK,
+                tekniskTid = tekniskTid,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = "33",
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "99",
+                sakId = "99",
+                aktorId = saksbehandling.ident,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = null,
+                endretTid = henvendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Nasjonal",
+                behandlingType = "FØRSTEGANGSBEHANDLING",
+                behandlingStatus = "MOTTATT",
+                behandlingMetode = "AUTOMATISK",
+                kravMottatt = null,
+                opprettetAv = "-5",
+                saksbehandler = "-5",
+                ansvarligEnhet = "-5",
                 behandlingResultat = "IKKE_SATT",
                 resultatBegrunnelse = null,
                 avsender = "Nav Tilleggstønader",


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Manger enhetstester for mapping av behandlingsstatistikk til datavarehus. 
Forberedende for denne oppgaven: 
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24053