### PR TITLE
Skal hente aktiviteter og ytelser fra startdato på første eksisterende vilkårperiode

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
@@ -120,7 +120,7 @@ class VilkårperiodeGrunnlagService(
     ): LocalDate {
         if (behandling.revurderFra != null) {
             return startdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder)
-                ?: behandling.revurderFra
+                ?: behandling.revurderFra.minusMonths(1).tilFørsteDagIMåneden()
         }
         val mottattTidspunkt =
             søknadService.hentSøknadMetadata(behandling.id)?.mottattTidspunkt

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
@@ -110,6 +110,8 @@ class VilkårperiodeGrunnlagService(
     private fun antallMånederBakITiden(behandling: Saksbehandling): LocalDate {
         if (behandling.revurderFra != null) {
             return behandling.revurderFra
+                .minusMonths(behandling.stønadstype.grunnlagAntallMånederBakITiden.toLong())
+                .tilFørsteDagIMåneden()
         }
         val mottattTidspunkt =
             søknadService.hentSøknadMetadata(behandling.id)?.mottattTidspunkt

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseService
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtelse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.HentetInformasjon
@@ -71,7 +72,10 @@ class VilkårperiodeGrunnlagService(
         logger.info("Oppdatert grunnlagsdata for behandling=$behandlingId timerSidenForrige=$tidSidenForrigeHenting")
     }
 
-    fun hentEllerOpprettGrunnlag(behandlingId: BehandlingId): VilkårperioderGrunnlag? {
+    fun hentEllerOpprettGrunnlag(
+        behandlingId: BehandlingId,
+        vilkårperioder: Vilkårperioder,
+    ): VilkårperioderGrunnlag? {
         val grunnlag = vilkårperioderGrunnlagRepository.findByBehandlingId(behandlingId)?.grunnlag
 
         if (grunnlag != null) {
@@ -82,16 +86,19 @@ class VilkårperiodeGrunnlagService(
         return if (behandling.status.behandlingErLåstForVidereRedigering()) {
             null
         } else {
-            opprettGrunnlagsdata(behandling).grunnlag
+            opprettGrunnlagsdata(behandling, vilkårperioder).grunnlag
         }
     }
 
-    private fun opprettGrunnlagsdata(behandling: Saksbehandling): VilkårperioderGrunnlagDomain {
+    private fun opprettGrunnlagsdata(
+        behandling: Saksbehandling,
+        vilkårperioder: Vilkårperioder,
+    ): VilkårperioderGrunnlagDomain {
         brukerfeilHvisIkke(tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER)) {
             "Behandlingen er ikke påbegynt. Kan ikke opprette vilkårperiode hvis man ikke er saksbehandler"
         }
 
-        val fom = antallMånederBakITiden(behandling)
+        val fom = antallMånederBakITiden(behandling, vilkårperioder)
         val tom = YearMonth.now().plusYears(1).atEndOfMonth()
 
         val grunnlag = hentGrunnlagsdata(behandling.id, fom, tom)
@@ -105,13 +112,15 @@ class VilkårperiodeGrunnlagService(
 
     /**
      * Vid en førstegangsbehandling skal man bruke mottatt tidspunkt minus antall måneder for gitt stønadstype
-     * Når man revurderer skal man hente grunnlag fra og med datoet man revurderer fra, uavhengig når man søker fra
+     * Når man revurderer skal man hente grunnlag fra og med den startdatoen til den første eksisterende vilkårperioden (målgruppe eller ytelse), uavhengig når man søker fra
      */
-    private fun antallMånederBakITiden(behandling: Saksbehandling): LocalDate {
+    private fun antallMånederBakITiden(
+        behandling: Saksbehandling,
+        vilkårperioder: Vilkårperioder,
+    ): LocalDate {
         if (behandling.revurderFra != null) {
-            return behandling.revurderFra
-                .minusMonths(behandling.stønadstype.grunnlagAntallMånederBakITiden.toLong())
-                .tilFørsteDagIMåneden()
+            return sluttdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder)
+                ?: behandling.revurderFra
         }
         val mottattTidspunkt =
             søknadService.hentSøknadMetadata(behandling.id)?.mottattTidspunkt
@@ -122,6 +131,9 @@ class VilkårperiodeGrunnlagService(
             .minusMonths(behandling.stønadstype.grunnlagAntallMånederBakITiden.toLong())
             .tilFørsteDagIMåneden()
     }
+
+    private fun sluttdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder: Vilkårperioder) =
+        (vilkårperioder.aktiviteter.map { it.fom } + vilkårperioder.målgrupper.map { it.fom }).minOrNull()
 
     private fun hentGrunnlagsdata(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
@@ -111,15 +111,15 @@ class VilkårperiodeGrunnlagService(
     }
 
     /**
-     * Vid en førstegangsbehandling skal man bruke mottatt tidspunkt minus antall måneder for gitt stønadstype
-     * Når man revurderer skal man hente grunnlag fra og med den startdatoen til den første eksisterende vilkårperioden (målgruppe eller ytelse), uavhengig når man søker fra
+     * Ved en førstegangsbehandling skal man bruke mottatt tidspunkt minus antall måneder for gitt stønadstype
+     * Når man revurderer skal man hente grunnlag fra og med startdatoen til den første eksisterende vilkårperioden (målgruppe eller aktivitet), uavhengig når man søker fra
      */
     private fun antallMånederBakITiden(
         behandling: Saksbehandling,
         vilkårperioder: Vilkårperioder,
     ): LocalDate {
         if (behandling.revurderFra != null) {
-            return sluttdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder)
+            return startdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder)
                 ?: behandling.revurderFra
         }
         val mottattTidspunkt =
@@ -132,7 +132,7 @@ class VilkårperiodeGrunnlagService(
             .tilFørsteDagIMåneden()
     }
 
-    private fun sluttdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder: Vilkårperioder) =
+    private fun startdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder: Vilkårperioder) =
         (vilkårperioder.aktiviteter.map { it.fom } + vilkårperioder.målgrupper.map { it.fom }).minOrNull()
 
     private fun hentGrunnlagsdata(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -56,7 +56,9 @@ class VilkårperiodeService(
     }
 
     fun hentVilkårperioderResponse(behandlingId: BehandlingId): VilkårperioderResponse {
-        val grunnlagsdataVilkårsperioder = vilkårperiodeGrunnlagService.hentEllerOpprettGrunnlag(behandlingId)
+        val vilkårperioder = hentVilkårperioder(behandlingId)
+        val grunnlagsdataVilkårsperioder =
+            vilkårperiodeGrunnlagService.hentEllerOpprettGrunnlag(behandlingId, vilkårperioder)
 
         return VilkårperioderResponse(
             vilkårperioder = hentVilkårperioder(behandlingId).tilDto(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -61,7 +61,7 @@ class VilkårperiodeService(
             vilkårperiodeGrunnlagService.hentEllerOpprettGrunnlag(behandlingId, vilkårperioder)
 
         return VilkårperioderResponse(
-            vilkårperioder = hentVilkårperioder(behandlingId).tilDto(),
+            vilkårperioder = vilkårperioder.tilDto(),
             grunnlag = grunnlagsdataVilkårsperioder?.tilDto(),
         )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
@@ -32,6 +32,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -202,7 +203,7 @@ class NullstillBehandlingServiceTest : IntegrationTest() {
 
         @Test
         fun `skal slette grunnlag for behandling under arbeid`() {
-            vilkårperiodeGrunnlagService.hentEllerOpprettGrunnlag(revurdering.id)
+            vilkårperiodeGrunnlagService.hentEllerOpprettGrunnlag(revurdering.id, Vilkårperioder(emptyList(), emptyList()))
 
             nullstillBehandlingService.slettVilkårperiodegrunnlag(revurdering.id)
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er nyttig å se aktiviteter og ytelser lenger tilbake enn akkurat revurder fra datoen. F.eks. hvis man skal opphøre så vil man gjerne se aktiviteten som faktisk har opphørt for å verifisere at man har valgt riktig sluttdato. 

Mål: Se alle aktiviteter og ytelser som er relevant for en behandling. Dvs. at man skal hente alle aktiviteter/ytelser som kan ha blitt brukt tidligere.

Holder dette? Burde man gjøre noe for å få inn flere aktiviteter på behandlinger som er åpne?