### PR TITLE
Ekstra tester behandlingsstatistikk

### DIFF
--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -50,6 +50,7 @@ class BehandlingsstatistikkMappingTest {
                 henvendelseTidspunkt = henvendelseTidspunkt,
                 hendelseTidspunkt = hendelseTidspunkt,
                 tekniskTid = tekniskTid,
+                hendelse = Hendelse.MOTTATT,
             )
 
         val expected =
@@ -304,12 +305,87 @@ class BehandlingsstatistikkMappingTest {
         assertThat(actual).isEqualTo(expected)
     }
 
+    @Test
+    fun `mapping ved henleggelse`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
+
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling =
+            saksbehandling(
+                behandlingId = behandlingId,
+                ident = aktørId,
+                eksternId = 7878L,
+                eksternFagId = 8989L,
+                kategori = BehandlingKategori.NASJONAL,
+                resultat = BehandlingResultat.HENLAGT,
+                henlagtÅrsak = HenlagtÅrsak.TRUKKET_TILBAKE,
+            )
+
+        val actual =
+            map(
+                saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelseTidspunkt = hendelseTidspunkt,
+                tekniskTid = tekniskTid,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = "7878",
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "8989",
+                sakId = "8989",
+                aktorId = aktørId,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = null,
+                endretTid = henvendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Nasjonal",
+                behandlingType = "FØRSTEGANGSBEHANDLING",
+                behandlingStatus = "MOTTATT",
+                behandlingMetode = "AUTOMATISK",
+                kravMottatt = null,
+                opprettetAv = "VL",
+                saksbehandler = saksbehandlerId,
+                ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "HENLAGT",
+                resultatBegrunnelse = "TRUKKET_TILBAKE",
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
     fun saksbehandling(
         behandlingId: BehandlingId,
         ident: String,
         eksternId: Long,
         eksternFagId: Long,
         kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
+        resultat: BehandlingResultat = BehandlingResultat.IKKE_SATT,
+        henlagtÅrsak: HenlagtÅrsak? = null,
     ) = Saksbehandling(
         id = behandlingId,
         eksternId = eksternId,
@@ -320,10 +396,10 @@ class BehandlingsstatistikkMappingTest {
         kategori = kategori,
         årsak = BehandlingÅrsak.SØKNAD,
         kravMottatt = null,
-        resultat = BehandlingResultat.IKKE_SATT,
+        resultat = resultat,
         vedtakstidspunkt = null,
-        henlagtÅrsak = null,
-        henlagtBegrunnelse = null,
+        henlagtÅrsak = henlagtÅrsak,
+        henlagtBegrunnelse = "<blir ikke mappet>",
         ident = ident,
         fagsakId = FagsakId(UUID.randomUUID()),
         fagsakPersonId = FagsakPersonId(UUID.randomUUID()),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.behandling.domain.HenlagtÅrsak
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -549,7 +549,7 @@ class BehandlingsstatistikkMappingTest {
         resultat = resultat,
         vedtakstidspunkt = null,
         henlagtÅrsak = henlagtÅrsak,
-        henlagtBegrunnelse = "<blir ikke mappet>",
+        henlagtBegrunnelse = null,
         ident = ident,
         fagsakId = FagsakId(UUID.randomUUID()),
         fagsakPersonId = FagsakPersonId(UUID.randomUUID()),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -306,6 +306,78 @@ class BehandlingsstatistikkMappingTest {
     }
 
     @Test
+    fun `mapping ved avslag`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
+
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling =
+            saksbehandling(
+                behandlingId = behandlingId,
+                ident = aktørId,
+                eksternId = 10L,
+                eksternFagId = 20L,
+                kategori = BehandlingKategori.NASJONAL,
+                resultat = BehandlingResultat.AVSLÅTT,
+            )
+
+        val actual =
+            map(
+                saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelseTidspunkt = hendelseTidspunkt,
+                tekniskTid = tekniskTid,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = "10",
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "20",
+                sakId = "20",
+                aktorId = aktørId,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = null,
+                endretTid = henvendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Nasjonal",
+                behandlingType = "FØRSTEGANGSBEHANDLING",
+                behandlingStatus = "MOTTATT",
+                behandlingMetode = "AUTOMATISK",
+                kravMottatt = null,
+                opprettetAv = "VL",
+                saksbehandler = saksbehandlerId,
+                ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "AVSLÅTT",
+                resultatBegrunnelse = "UKJENT",
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `mapping ved henleggelse`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
         val aktørId = "9876543210127"

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/behandling/BehandlingsstatistikkMappingTest.kt
@@ -306,6 +306,81 @@ class BehandlingsstatistikkMappingTest {
     }
 
     @Test
+    fun `mapping ved revurdering`() {
+        val behandlingId = BehandlingId(UUID.randomUUID())
+        val forrigeBehandlingId = BehandlingId(UUID.randomUUID())
+        val aktørId = "9876543210127"
+        val saksbehandlerId = "7873486250023"
+
+        val henvendelseTidspunkt = osloNow()
+        val hendelseTidspunkt = osloNow()
+        val tekniskTid = osloNow()
+
+        val saksbehandling =
+            saksbehandling(
+                behandlingId = behandlingId,
+                ident = aktørId,
+                eksternId = 24L,
+                eksternFagId = 48L,
+                forrigeBehandlingId = forrigeBehandlingId,
+                type = BehandlingType.REVURDERING,
+                kategori = BehandlingKategori.NASJONAL,
+                resultat = BehandlingResultat.INNVILGET,
+            )
+
+        val actual =
+            map(
+                saksbehandling = saksbehandling,
+                saksbehandlerId = saksbehandlerId,
+                henvendelseTidspunkt = henvendelseTidspunkt,
+                hendelseTidspunkt = hendelseTidspunkt,
+                tekniskTid = tekniskTid,
+            )
+
+        val expected =
+            BehandlingDVH(
+                behandlingId = "24",
+                behandlingUuid = behandlingId.id.toString(),
+                saksnummer = "48",
+                sakId = "48",
+                aktorId = aktørId,
+                mottattTid = henvendelseTidspunkt,
+                registrertTid = henvendelseTidspunkt,
+                ferdigBehandletTid = null,
+                endretTid = henvendelseTidspunkt,
+                tekniskTid = tekniskTid,
+                sakYtelse = SakYtelseDvh.TILLEGG_BARNETILSYN,
+                sakUtland = "Nasjonal",
+                behandlingType = "REVURDERING",
+                behandlingStatus = "MOTTATT",
+                behandlingMetode = "AUTOMATISK",
+                kravMottatt = null,
+                opprettetAv = "VL",
+                saksbehandler = saksbehandlerId,
+                ansvarligEnhet = ArbeidsfordelingService.MASKINELL_JOURNALFOERENDE_ENHET,
+                behandlingResultat = "INNVILGET",
+                resultatBegrunnelse = null,
+                avsender = "Nav Tilleggstønader",
+                versjon = Applikasjonsversjon.versjon,
+                relatertBehandlingId = null,
+                vedtakTid = null,
+                utbetaltTid = null,
+                forventetOppstartTid = null,
+                papirSøknad = null,
+                ansvarligBeslutter = null,
+                totrinnsbehandling = false,
+                vilkårsprøving = emptyList(),
+                venteAarsak = null,
+                behandlingBegrunnelse = null,
+                revurderingOpplysningskilde = null,
+                revurderingÅrsak = null,
+                behandlingÅrsak = "SØKNAD",
+            )
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
     fun `mapping ved avslag`() {
         val behandlingId = BehandlingId(UUID.randomUUID())
         val aktørId = "9876543210127"
@@ -455,14 +530,16 @@ class BehandlingsstatistikkMappingTest {
         ident: String,
         eksternId: Long,
         eksternFagId: Long,
+        forrigeBehandlingId: BehandlingId? = null,
+        type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
         kategori: BehandlingKategori = BehandlingKategori.NASJONAL,
         resultat: BehandlingResultat = BehandlingResultat.IKKE_SATT,
         henlagtÅrsak: HenlagtÅrsak? = null,
     ) = Saksbehandling(
         id = behandlingId,
         eksternId = eksternId,
-        forrigeBehandlingId = null,
-        type = BehandlingType.FØRSTEGANGSBEHANDLING,
+        forrigeBehandlingId = forrigeBehandlingId,
+        type = type,
         status = BehandlingStatus.OPPRETTET,
         steg = StegType.INNGANGSVILKÅR,
         kategori = kategori,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Fyller ut med flere enhetstester for å dekke flere brukstilfeller ved mapping av behandlingsstatistikk, ref kommentar på PR https://github.com/navikt/tilleggsstonader-sak/pull/612