### PR TITLE
Fjern feature toggle for sett-på-vent-kommentar

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtil.kt
@@ -14,11 +14,10 @@ object SettPåVentBeskrivelseUtil {
         settPåVent: SettPåVent,
         frist: LocalDate,
         tidspunkt: LocalDateTime = osloNow(),
-        inkluderKommentar: Boolean,
     ): String {
         val tilordnetSaksbehandlerBeskrivelse =
             utledTilordnetSaksbehandlerBeskrivelse(oppgave, "")
-        val kommentarRad = "Kommentar: ${settPåVent.kommentar}".takeIf { inkluderKommentar }
+        val kommentarRad = "Kommentar: ${settPåVent.kommentar}"
         return utledBeskrivelsePrefix(tidspunkt) +
             utledOppgavefristBeskrivelse(oppgave, frist).påNyRadEllerTomString() +
             tilordnetSaksbehandlerBeskrivelse.påNyRadEllerTomString() +
@@ -31,10 +30,9 @@ object SettPåVentBeskrivelseUtil {
         settPåVent: SettPåVent,
         frist: LocalDate,
         tidspunkt: LocalDateTime = osloNow(),
-        inkluderKommentar: Boolean,
     ): String {
         val fristBeskrivelse = utledOppgavefristBeskrivelse(oppgave, frist)
-        val kommentarRad = "Kommentar: ${settPåVent.kommentar}".takeIf { inkluderKommentar } ?: ""
+        val kommentarRad = "Kommentar: ${settPåVent.kommentar}"
         if (fristBeskrivelse.isEmpty() && kommentarRad.isEmpty()) {
             return oppgave.beskrivelse ?: ""
         }
@@ -51,11 +49,10 @@ object SettPåVentBeskrivelseUtil {
         oppgave: Oppgave,
         settPåVent: SettPåVent,
         tidspunkt: LocalDateTime = osloNow(),
-        inkluderKommentar: Boolean,
     ): String {
         val tilordnetSaksbehandlerBeskrivelse =
             utledTilordnetSaksbehandlerBeskrivelse(oppgave, SikkerhetContext.hentSaksbehandlerEllerSystembruker())
-        val kommentarRad = "Kommentar: ${settPåVent.taAvVentKommentar}".takeIf { inkluderKommentar }
+        val kommentarRad = "Kommentar: ${settPåVent.taAvVentKommentar}"
         return utledBeskrivelsePrefix(tidspunkt) +
             "\nTatt av vent" +
             tilordnetSaksbehandlerBeskrivelse.påNyRadEllerTomString() +

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -13,7 +13,6 @@ enum class Toggle(
     HENT_BEHANDLINGER_FOR_OPPFØLGING("sak.hent-behandlinger-for-oppfoelging"),
 
     SØKNAD_ROUTING_LÆREMIDLER("sak.soknad-routing.laremidler"),
-    PÅ_VENT_KOMMENTAR("sak.pa-vent-oppgave-kommentar"),
 
     KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN("sak.kan-bruke-vedtaksperioder-tilsyn-barn"),
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentBeskrivelseUtilTest.kt
@@ -45,7 +45,6 @@ class SettPåVentBeskrivelseUtilTest {
                     settPåVent,
                     LocalDate.of(2023, 1, 1),
                     tidspunkt,
-                    inkluderKommentar = true,
                 )
             assertThat(beskrivelse).isEqualTo(
                 """
@@ -70,7 +69,6 @@ class SettPåVentBeskrivelseUtilTest {
                     settPåVent,
                     LocalDate.of(2023, 1, 1),
                     tidspunkt,
-                    inkluderKommentar = true,
                 )
             assertThat(beskrivelse).isEqualTo(
                 """
@@ -92,7 +90,6 @@ class SettPåVentBeskrivelseUtilTest {
                     settPåVent,
                     frist,
                     tidspunkt,
-                    inkluderKommentar = true,
                 )
             assertThat(beskrivelse).isEqualTo(
                 """
@@ -112,7 +109,6 @@ class SettPåVentBeskrivelseUtilTest {
                     settPåVent,
                     LocalDate.of(2023, 1, 1),
                     tidspunkt,
-                    inkluderKommentar = true,
                 )
             assertThat(beskrivelse).isEqualTo(
                 """
@@ -134,7 +130,6 @@ class SettPåVentBeskrivelseUtilTest {
                     Oppgave(id = 0, versjon = 0, beskrivelse = "tidligere beskrivelse", tilordnetRessurs = null),
                     settPåVent,
                     tidspunkt,
-                    inkluderKommentar = true,
                 )
             assertThat(beskrivelse).isEqualTo(
                 """


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22956

Validert at endringen over fungerer som tiltenkt. Kan søppeltømme feature toggle.