### PR TITLE
✨ Håndter aktivitet i inngangsvilkår for boutgifter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
@@ -27,6 +27,12 @@ class Feil(
     throwable: Throwable? = null,
 ) : RuntimeException(message, throwable)
 
+@Suppress("NOTHING_TO_INLINE")
+inline fun feil(
+    message: String,
+    httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
+): Nothing = throw Feil(message = message, httpStatus = httpStatus)
+
 @OptIn(ExperimentalContracts::class)
 inline fun feilHvis(
     boolean: Boolean,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -5,12 +5,15 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AAPLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AAPTilsynBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetTilsynBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeLæremidler
@@ -27,10 +30,12 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.ReellArbeidsøkerTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SykepengerLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SykepengerTilsynBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UføretrygdLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UføretrygdTilsynBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAAP
@@ -41,11 +46,13 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingMedlemskap
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingNedsattArbeidsevne
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingOmstillingsstønad
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUføretrygd
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingerUtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBarnetilsynDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBoutgifterDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetLæremidlerDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
@@ -79,7 +86,8 @@ private fun mapAktiviteter(
         }
 
         Stønadstype.BOUTGIFTER -> {
-            TODO("Ikke implementert mapping av aktiviteter for $stønadstype ennå")
+            require(faktaOgSvar is FaktaOgSvarAktivitetBoutgifterDto)
+            return mapAktiviteterBoutgifter(type, faktaOgSvar)
         }
     }
 }
@@ -174,6 +182,33 @@ fun mapAktiviteterLæremidler(
         AktivitetType.INGEN_AKTIVITET -> IngenAktivitetLæremidler
 
         AktivitetType.REELL_ARBEIDSSØKER -> brukerfeil("Reell arbeidssøker er ikke en gyldig aktivitet for læremidler")
+    }
+
+private fun mapAktiviteterBoutgifter(
+    aktivitetType: AktivitetType,
+    faktaOgSvar: FaktaOgSvarAktivitetBoutgifterDto,
+): AktivitetBoutgifter =
+    when (aktivitetType) {
+        AktivitetType.TILTAK -> {
+            TiltakBoutgifter(
+                fakta = FaktaAktivitetBoutgifter(aktivitetsdager = faktaOgSvar.aktivitetsdager!!),
+                vurderinger = VurderingTiltakBoutgifter(lønnet = VurderingLønnet(faktaOgSvar.svarLønnet)),
+            )
+        }
+
+        AktivitetType.UTDANNING ->
+            UtdanningBoutgifter(
+                fakta = FaktaAktivitetBoutgifter(aktivitetsdager = faktaOgSvar.aktivitetsdager!!),
+            )
+
+        AktivitetType.INGEN_AKTIVITET -> {
+            feilHvis(faktaOgSvar.aktivitetsdager != null) {
+                "Kan ikke registrere aktivitetsdager på ingen aktivitet"
+            }
+            IngenAktivitetBoutgifter
+        }
+
+        AktivitetType.REELL_ARBEIDSSØKER -> brukerfeil("Reell arbeidssøker er ikke en gyldig aktivitet for boutgifter")
     }
 
 private fun mapMålgruppeBarnetilsyn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AAPLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AAPTilsynBarn
@@ -181,7 +181,7 @@ fun mapAktiviteterLæremidler(
 
         AktivitetType.INGEN_AKTIVITET -> IngenAktivitetLæremidler
 
-        AktivitetType.REELL_ARBEIDSSØKER -> brukerfeil("Reell arbeidssøker er ikke en gyldig aktivitet for læremidler")
+        AktivitetType.REELL_ARBEIDSSØKER -> feil("Reell arbeidssøker er ikke en gyldig aktivitet for læremidler")
     }
 
 private fun mapAktiviteterBoutgifter(
@@ -208,7 +208,7 @@ private fun mapAktiviteterBoutgifter(
             IngenAktivitetBoutgifter
         }
 
-        AktivitetType.REELL_ARBEIDSSØKER -> brukerfeil("Reell arbeidssøker er ikke en gyldig aktivitet for boutgifter")
+        AktivitetType.REELL_ARBEIDSSØKER -> feil("Reell arbeidssøker er ikke en gyldig aktivitet for boutgifter")
     }
 
 private fun mapMålgruppeBarnetilsyn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingJson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingJson.kt
@@ -36,6 +36,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
     JsonSubTypes.Type(UføretrygdLæremidler::class, name = "UFØRETRYGD_LÆREMIDLER"),
     JsonSubTypes.Type(SykepengerLæremidler::class, name = "SYKEPENGER_100_PROSENT_LÆREMIDLER"),
     JsonSubTypes.Type(IngenMålgruppeLæremidler::class, name = "INGEN_MÅLGRUPPE_LÆREMIDLER"),
+    JsonSubTypes.Type(UtdanningBoutgifter::class, name = "UTDANNING_BOUTGIFTER"),
+    JsonSubTypes.Type(TiltakBoutgifter::class, name = "TILTAK_BOUTGIFTER"),
+    JsonSubTypes.Type(IngenAktivitetBoutgifter::class, name = "INGEN_AKTIVITET_BOUTGIFTER"),
     failOnRepeatedNames = true,
 )
 sealed interface FaktaOgVurderingJson

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadBoutgifterFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadBoutgifterFaktaOgVurdering.kt
@@ -1,0 +1,125 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
+
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+
+sealed interface FaktaOgVurderingBoutgifter : FaktaOgVurdering {
+    override val type: TypeFaktaOgVurderingBoutgifter
+}
+
+// TODO disse er kopiert inn fra Tilsyn Barn. Kommenter inn når implemterer målgruppe for boutgifter
+// sealed interface MålgruppeBoutgifter :
+//    MålgruppeFaktaOgVurdering,
+//    FaktaOgVurderingBoutgifter {
+//    override val type: MålgruppeBoutgifterType
+// }
+
+sealed interface AktivitetBoutgifter :
+    AktivitetFaktaOgVurdering,
+    FaktaOgVurderingBoutgifter {
+    override val type: AktivitetBoutgifterType
+}
+
+// TODO disse er kopiert inn fra Tilsyn Barn. Kommenter inn når implemterer målgruppe for boutgifter
+// data class AAPBoutgifter(
+//    override val vurderinger: VurderingAAP,
+// ) : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.AAP_TILSYN_BARN
+//    override val fakta: IngenFakta = IngenFakta
+// }
+//
+// data class UføretrygdBoutgifter(
+//    override val vurderinger: VurderingUføretrygd,
+// ) : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.UFØRETRYGD_TILSYN_BARN
+//    override val fakta: IngenFakta = IngenFakta
+// }
+//
+// data class NedsattArbeidsevneBoutgifter(
+//    override val vurderinger: VurderingNedsattArbeidsevne,
+// ) : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.NEDSATT_ARBEIDSEVNE_TILSYN_BARN
+//    override val fakta: IngenFakta = IngenFakta
+// }
+//
+// data class OmstillingsstønadBoutgifter(
+//    override val vurderinger: VurderingOmstillingsstønad,
+// ) : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.OMSTILLINGSSTØNAD_TILSYN_BARN
+//    override val fakta: IngenFakta = IngenFakta
+// }
+//
+// data object OvergangssstønadBoutgifter : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.OVERGANGSSTØNAD_TILSYN_BARN
+//    override val vurderinger: VurderingOvergangsstønad = VurderingOvergangsstønad
+//    override val fakta: IngenFakta = IngenFakta
+// }
+//
+// data object IngenMålgruppeBoutgifter : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.INGEN_MÅLGRUPPE_TILSYN_BARN
+//    override val vurderinger: IngenVurderinger = IngenVurderinger
+//    override val fakta: IngenFakta = IngenFakta
+// }
+//
+// data object SykepengerBoutgifter : MålgruppeBoutgifter {
+//    override val type: MålgruppeBoutgifterType = MålgruppeBoutgifterType.SYKEPENGER_100_PROSENT_TILSYN_BARN
+//    override val vurderinger: IngenVurderinger = IngenVurderinger
+//    override val fakta: IngenFakta = IngenFakta
+// }
+
+data class TiltakBoutgifter(
+    override val fakta: FaktaAktivitetBoutgifter,
+    override val vurderinger: VurderingTiltakBoutgifter,
+) : AktivitetBoutgifter {
+    override val type: AktivitetBoutgifterType = AktivitetBoutgifterType.TILTAK_BOUTGIFTER
+}
+
+data class UtdanningBoutgifter(
+    override val fakta: FaktaAktivitetBoutgifter,
+) : AktivitetBoutgifter {
+    override val type: AktivitetBoutgifterType = AktivitetBoutgifterType.UTDANNING_BOUTGIFTER
+    override val vurderinger: IngenVurderinger = IngenVurderinger
+}
+
+data object IngenAktivitetBoutgifter : AktivitetBoutgifter {
+    override val type: AktivitetBoutgifterType = AktivitetBoutgifterType.INGEN_AKTIVITET_BOUTGIFTER
+    override val fakta: Fakta = IngenFakta
+    override val vurderinger: Vurderinger = IngenVurderinger
+}
+
+data class VurderingTiltakBoutgifter(
+    override val lønnet: VurderingLønnet,
+) : LønnetVurdering
+
+data class FaktaAktivitetBoutgifter(
+    override val aktivitetsdager: Int,
+) : Fakta,
+    FaktaAktivitetsdager {
+    init {
+        require(aktivitetsdager in 1..5) { "Aktivitetsdager må være mellom 1 og 5" }
+    }
+}
+
+sealed interface TypeFaktaOgVurderingBoutgifter : TypeFaktaOgVurdering
+
+enum class AktivitetBoutgifterType(
+    override val vilkårperiodeType: AktivitetType,
+) : TypeAktivitetOgVurdering,
+    TypeFaktaOgVurderingBoutgifter {
+    UTDANNING_BOUTGIFTER(AktivitetType.UTDANNING),
+    TILTAK_BOUTGIFTER(AktivitetType.TILTAK),
+    INGEN_AKTIVITET_BOUTGIFTER(AktivitetType.INGEN_AKTIVITET),
+}
+
+// TODO disse er kopiert inn fra Tilsyn Barn. Kommenter inn når implemterer målgruppe for boutgifter
+// enum class MålgruppeBoutgifterType(
+//    override val vilkårperiodeType: MålgruppeType,
+// ) : TypeMålgruppeOgVurdering,
+//    TypeFaktaOgVurderingBoutgifter {
+//    AAP_TILSYN_BARN(MålgruppeType.AAP),
+//    OMSTILLINGSSTØNAD_TILSYN_BARN(MålgruppeType.OMSTILLINGSSTØNAD),
+//    OVERGANGSSTØNAD_TILSYN_BARN(MålgruppeType.OVERGANGSSTØNAD),
+//    NEDSATT_ARBEIDSEVNE_TILSYN_BARN(MålgruppeType.NEDSATT_ARBEIDSEVNE),
+//    UFØRETRYGD_TILSYN_BARN(MålgruppeType.UFØRETRYGD),
+//    SYKEPENGER_100_PROSENT_TILSYN_BARN(MålgruppeType.SYKEPENGER_100_PROSENT),
+//    INGEN_MÅLGRUPPE_TILSYN_BARN(MålgruppeType.INGEN_MÅLGRUPPE),
+// }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
@@ -23,6 +23,7 @@ data class LagreVilkårperiode(
     JsonSubTypes.Type(FaktaOgSvarMålgruppeDto::class, name = "MÅLGRUPPE"),
     JsonSubTypes.Type(FaktaOgSvarAktivitetBarnetilsynDto::class, name = "AKTIVITET_BARNETILSYN"),
     JsonSubTypes.Type(FaktaOgSvarAktivitetLæremidlerDto::class, name = "AKTIVITET_LÆREMIDLER"),
+    JsonSubTypes.Type(FaktaOgSvarAktivitetBoutgifterDto::class, name = "AKTIVITET_BOUTGIFTER"),
 )
 sealed class FaktaOgSvarDto
 
@@ -41,4 +42,9 @@ data class FaktaOgSvarAktivitetLæremidlerDto(
     val studienivå: Studienivå? = null,
     val svarHarUtgifter: SvarJaNei? = null,
     val svarHarRettTilUtstyrsstipend: SvarJaNei? = null,
+) : FaktaOgSvarDto()
+
+data class FaktaOgSvarAktivitetBoutgifterDto(
+    val aktivitetsdager: Int? = null,
+    val svarLønnet: SvarJaNei? = null,
 ) : FaktaOgSvarDto()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.DekketAvAnnetRegelverkVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetsdager
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfFakta
@@ -87,6 +88,7 @@ fun Vurdering.tilDto() =
     JsonSubTypes.Type(MålgruppeFaktaOgVurderingerDto::class, name = "MÅLGRUPPE"),
     JsonSubTypes.Type(AktivitetBarnetilsynFaktaOgVurderingerDto::class, name = "AKTIVITET_BARNETILSYN"),
     JsonSubTypes.Type(AktivitetLæremidlerFaktaOgVurderingerDto::class, name = "AKTIVITET_LÆREMIDLER"),
+    JsonSubTypes.Type(AktivitetBoutgifterFaktaOgVurderingerDto::class, name = "AKTIVITET_BOUTGIFTER"),
 )
 sealed class FaktaOgVurderingerDto
 
@@ -105,6 +107,11 @@ data class AktivitetLæremidlerFaktaOgVurderingerDto(
     val studienivå: Studienivå? = null,
     val harUtgifter: VurderingDto? = null,
     val harRettTilUtstyrsstipend: VurderingDto? = null,
+) : FaktaOgVurderingerDto()
+
+data class AktivitetBoutgifterFaktaOgVurderingerDto(
+    val aktivitetsdager: Int? = null,
+    val lønnet: VurderingDto? = null,
 ) : FaktaOgVurderingerDto()
 
 fun FaktaOgVurdering.tilFaktaOgVurderingDto(): FaktaOgVurderingerDto =
@@ -137,6 +144,11 @@ fun FaktaOgVurdering.tilFaktaOgVurderingDto(): FaktaOgVurderingerDto =
                                 .takeIfVurderinger<HarRettTilUtstyrsstipendVurdering>()
                                 ?.harRettTilUtstyrsstipend
                                 ?.tilDto(),
+                    )
+                is FaktaOgVurderingBoutgifter ->
+                    AktivitetBoutgifterFaktaOgVurderingerDto(
+                        aktivitetsdager = fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
+                        lønnet = vurderinger.takeIfVurderinger<LønnetVurdering>()?.lønnet?.tilDto(),
                     )
             }
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingBoutgifterTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingBoutgifterTest.kt
@@ -1,0 +1,101 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
+
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FaktaOgVurderingBoutgifterTest {
+    @Nested
+    inner class ResultatForTypeInngangsvilkår {
+        // TODO kopiert fra tilsyn barn. Kommenter inn når implementerer målgruppe for boutgifter
+//        @Test
+//        fun `resultatet skal ikke være oppfylt hvis ikke typen målgruppen gir rett på stønaden`() {
+//            listOf(IngenMålgruppeTilsynBarn, SykepengerTilsynBarn).forEach { faktaOgVurdering ->
+//                assertThat(faktaOgVurdering.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+//            }
+//        }
+
+        @Test
+        fun `resultatet skal ikke være oppfylt hvis ikke typen aktivitet gir rett på stønaden`() {
+            listOf(IngenAktivitetBoutgifter).forEach { faktaOgVurdering ->
+                assertThat(faktaOgVurdering.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+            }
+        }
+    }
+
+    // TODO kopiert fra tilsyn barn. Kommenter inn når implementerer målgruppe for boutgifter
+//    @Nested
+//    inner class ResultatForInngangsvilkårMedVurderinger {
+//        val medlemskapIkkeVurdert = vurderingMedlemskap(svar = null)
+//        val medlemskapIkkeOppfylt = vurderingMedlemskap(svar = SvarJaNei.NEI)
+//        val medlemskapOppfylt = vurderingMedlemskap()
+//
+//        val dekketAvAnnetRegelverkIkkeVurdert = vurderingDekketAvAnnetRegelverk(svar = null)
+//        val dekketAvAnnetRegelverkIkkeOppfylt = vurderingDekketAvAnnetRegelverk(svar = SvarJaNei.JA)
+//        val dekketAvAnnetRegelverkOppfylt = vurderingDekketAvAnnetRegelverk()
+//
+//        @Test
+//        fun `resultat er IKKE_VURDERT hvis en vurdering ikke er vurdert og en er oppfylt`() {
+//            val inngangsvilkår =
+//                NedsattArbeidsevneTilsynBarn(
+//                    vurderinger =
+//                        VurderingNedsattArbeidsevne(
+//                            medlemskap = medlemskapIkkeVurdert,
+//                            dekketAvAnnetRegelverk = dekketAvAnnetRegelverkOppfylt,
+//                        ),
+//                )
+//
+//            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
+//        }
+//
+//        @Test
+//        fun `resultat er IKKE_VURDERT hvis en vurdering ikke er vurdert og en er ikke oppfylt`() {
+//            val inngangsvilkår =
+//                NedsattArbeidsevneTilsynBarn(
+//                    vurderinger =
+//                        VurderingNedsattArbeidsevne(
+//                            medlemskap = medlemskapIkkeOppfylt,
+//                            dekketAvAnnetRegelverk = dekketAvAnnetRegelverkIkkeVurdert,
+//                        ),
+//                )
+//
+//            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_VURDERT)
+//        }
+//
+//        @Test
+//        fun `resultat er IKKE_OPPFYKT hvis en vurdering er oppfylt og en er ikke oppfylt`() {
+//            val inngangsvilkår =
+//                NedsattArbeidsevneTilsynBarn(
+//                    vurderinger =
+//                        VurderingNedsattArbeidsevne(
+//                            medlemskap = medlemskapOppfylt,
+//                            dekketAvAnnetRegelverk = dekketAvAnnetRegelverkIkkeOppfylt,
+//                        ),
+//                )
+//
+//            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.IKKE_OPPFYLT)
+//        }
+//
+//        @Test
+//        fun `resultat er OPPFYLT hvis alle vurderinger har resultat oppfylt`() {
+//            val inngangsvilkår =
+//                NedsattArbeidsevneTilsynBarn(
+//                    vurderinger =
+//                        VurderingNedsattArbeidsevne(
+//                            medlemskap = medlemskapOppfylt,
+//                            dekketAvAnnetRegelverk = dekketAvAnnetRegelverkOppfylt,
+//                        ),
+//                )
+//
+//            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.OPPFYLT)
+//        }
+//
+//        @Test
+//        fun `resultat er OPPFYLT hvis det ikke finnes noen vurderinger som trengs`() {
+//            val inngangsvilkår = OvergangssstønadTilsynBarn
+//
+//            assertThat(inngangsvilkår.utledResultat()).isEqualTo(ResultatVilkårperiode.OPPFYLT)
+//        }
+//    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/TypeFaktaOgVurderingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/TypeFaktaOgVurderingTest.kt
@@ -16,6 +16,7 @@ val alleEnumTyperFaktaOgVurdering: List<Pair<Stønadstype, TypeFaktaOgVurdering>
         Stønadstype.BARNETILSYN to MålgruppeTilsynBarnType.entries,
         Stønadstype.LÆREMIDLER to AktivitetLæremidlerType.entries,
         Stønadstype.LÆREMIDLER to MålgruppeLæremidlerType.entries,
+        Stønadstype.BOUTGIFTER to AktivitetBoutgifterType.entries,
     ).flatMap { (stønadstype, enums) -> enums.map { stønadstype to it } }
 
 class TypeFaktaOgVurderingTest {
@@ -28,6 +29,7 @@ class TypeFaktaOgVurderingTest {
             when (type) {
                 is TypeFaktaOgVurderingTilsynBarn -> type.assertHarRiktigNavn(stønadstype)
                 is TypeFaktaOgVurderingLæremidler -> type.assertHarRiktigNavn(stønadstype)
+                is TypeFaktaOgVurderingBoutgifter -> type.assertHarRiktigNavn(stønadstype)
             }
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
@@ -145,6 +145,8 @@ class VilkårperiodeRepositoryJsonTest : IntegrationTest() {
             return forventetTypeTilsynBarn(type)
         } else if (type is TypeFaktaOgVurderingLæremidler) {
             return forventetTypeLæremidler(type)
+        } else if (type is TypeFaktaOgVurderingBoutgifter) {
+            return forventetTypeBoutgifter(type)
         }
         error("Ukjent type")
     }
@@ -192,6 +194,30 @@ class VilkårperiodeRepositoryJsonTest : IntegrationTest() {
                     AktivitetLæremidlerType.UTDANNING_LÆREMIDLER -> UtdanningLæremidler::class
                     AktivitetLæremidlerType.TILTAK_LÆREMIDLER -> TiltakLæremidler::class
                     AktivitetLæremidlerType.INGEN_AKTIVITET_LÆREMIDLER -> IngenAktivitetLæremidler::class
+                }
+            }
+        }.java
+
+    private fun forventetTypeBoutgifter(type: TypeFaktaOgVurderingBoutgifter): Class<out FaktaOgVurderingBoutgifter> =
+        when (type) {
+            // TODO kommenter inn når implementerer målgruppe for boutgifter
+//            is MålgruppeLæremidlerType -> {
+//                when (type) {
+//                    MålgruppeLæremidlerType.AAP_LÆREMIDLER -> AAPLæremidler::class
+//                    MålgruppeLæremidlerType.UFØRETRYGD_LÆREMIDLER -> UføretrygdLæremidler::class
+//                    MålgruppeLæremidlerType.NEDSATT_ARBEIDSEVNE_LÆREMIDLER -> NedsattArbeidsevneLæremidler::class
+//                    MålgruppeLæremidlerType.OMSTILLINGSSTØNAD_LÆREMIDLER -> OmstillingsstønadLæremidler::class
+//                    MålgruppeLæremidlerType.OVERGANGSSTØNAD_LÆREMIDLER -> OvergangssstønadLæremidler::class
+//                    MålgruppeLæremidlerType.INGEN_MÅLGRUPPE_LÆREMIDLER -> IngenMålgruppeLæremidler::class
+//                    MålgruppeLæremidlerType.SYKEPENGER_100_PROSENT_LÆREMIDLER -> SykepengerLæremidler::class
+//                }
+//            }
+
+            is AktivitetBoutgifterType -> {
+                when (type) {
+                    AktivitetBoutgifterType.TILTAK_BOUTGIFTER -> TiltakBoutgifter::class
+                    AktivitetBoutgifterType.UTDANNING_BOUTGIFTER -> UtdanningBoutgifter::class
+                    AktivitetBoutgifterType.INGEN_AKTIVITET_BOUTGIFTER -> IngenAktivitetBoutgifter::class
                 }
             }
         }.java

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/FaktaOgSvarDtoMapper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/FaktaOgSvarDtoMapper.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.DekketAvAnnetRegelverkVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetsdager
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfFakta
@@ -44,6 +45,11 @@ fun FaktaOgVurdering.tilFaktaOgSvarDto(): FaktaOgSvarDto =
                                 .takeIfVurderinger<HarRettTilUtstyrsstipendVurdering>()
                                 ?.harRettTilUtstyrsstipend
                                 ?.svar,
+                    )
+                is FaktaOgVurderingBoutgifter ->
+                    FaktaOgSvarAktivitetBoutgifterDto(
+                        aktivitetsdager = fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
+                        svarLønnet = vurderinger.takeIfVurderinger<LønnetVurdering>()?.lønnet?.svar,
                     )
             }
         }

--- a/src/test/resources/vilkår/vilkårperiode/BOUTGIFTER/INGEN_AKTIVITET_BOUTGIFTER.json
+++ b/src/test/resources/vilkår/vilkårperiode/BOUTGIFTER/INGEN_AKTIVITET_BOUTGIFTER.json
@@ -1,0 +1,5 @@
+{
+  "type": "INGEN_AKTIVITET_BOUTGIFTER",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/BOUTGIFTER/TILTAK_BOUTGIFTER.json
+++ b/src/test/resources/vilkår/vilkårperiode/BOUTGIFTER/TILTAK_BOUTGIFTER.json
@@ -1,0 +1,12 @@
+{
+  "type": "TILTAK_BOUTGIFTER",
+  "fakta": {
+    "aktivitetsdager": 3
+  },
+  "vurderinger": {
+    "lønnet": {
+      "svar": "NEI",
+      "resultat": "OPPFYLT"
+    }
+  }
+}

--- a/src/test/resources/vilkår/vilkårperiode/BOUTGIFTER/UTDANNING_BOUTGIFTER.json
+++ b/src/test/resources/vilkår/vilkårperiode/BOUTGIFTER/UTDANNING_BOUTGIFTER.json
@@ -1,0 +1,7 @@
+{
+  "type": "UTDANNING_BOUTGIFTER",
+  "fakta": {
+    "aktivitetsdager": 5
+  },
+  "vurderinger": {}
+}


### PR DESCRIPTION
Nesten en blåkopi av tilsyn barn.

- Har fjernet "reel arbeidssøker" som mulig aktivitet.
- Beholder "aktivitetsdager" da det ikke er landet om dette skal med
- Kunne laget mere generelle kode som går på tvers av tilsyn barn og boutgifter, men velger å kopiere for å gjøre oss mere fleksible på endringer i den ene stønaden uten at det trenger å påvirke den andre