### PR TITLE
🗃️ Migrer vedtaksstatistikken med aktivitet på læremidler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/VedtaksstatistikkV2MigreringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/VedtaksstatistikkV2MigreringController.kt
@@ -1,0 +1,63 @@
+import no.nav.familie.prosessering.util.MDCConstants
+import no.nav.security.token.support.core.api.Unprotected
+import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sortertEtterVedtakstidspunkt
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.statistikk.vedtak.VedtaksstatistikkRepositoryV2
+import no.nav.tilleggsstonader.sak.statistikk.vedtak.VedtaksstatistikkService
+import org.jboss.logging.MDC
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.Executors
+
+@RestController
+@RequestMapping("/admin/statistikk/migrering")
+@Unprotected
+class VedtaksstatistikkV2MigreringController(
+    private val behandlingRepository: BehandlingRepository,
+    private val vedtaksstatistikkRepositoryV2: VedtaksstatistikkRepositoryV2,
+    private val vedtaksstatistikkService: VedtaksstatistikkService,
+    private val transactionHandler: TransactionHandler,
+) {
+    val logger: Logger = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping
+    fun migrering() {
+        logger.info("Starter migrasjon av aktivitet læremidler i vedtaksstatistikk v2")
+
+        val callId = MDC.get(MDCConstants.MDC_CALL_ID)
+        Executors.newVirtualThreadPerTaskExecutor().submit {
+            MDC.put(MDCConstants.MDC_CALL_ID, callId)
+            try {
+                transactionHandler.runInNewTransaction {
+                    migrerStatistikkData()
+                }
+            } catch (e: Exception) {
+                secureLogger.error("Feilet jobb", e)
+            } finally {
+                MDC.remove(MDCConstants.MDC_CALL_ID)
+            }
+        }
+    }
+
+    fun migrerStatistikkData() {
+        vedtaksstatistikkRepositoryV2.deleteAll()
+
+        behandlingRepository
+            .findAll()
+            .filter { it.status == BehandlingStatus.FERDIGSTILT }
+            .filter { it.resultat != BehandlingResultat.HENLAGT }
+            .sortertEtterVedtakstidspunkt()
+            .forEach { behandling ->
+                vedtaksstatistikkService.lagreVedtaksstatistikkV2(behandling.id, behandling.fagsakId)
+            }
+
+        logger.info("vedtaksstatistikk-migrasjon ferdig 🚀")
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/VedtaksstatistikkV2MigreringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/VedtaksstatistikkV2MigreringController.kt
@@ -1,5 +1,5 @@
 import no.nav.familie.prosessering.util.MDCConstants
-import no.nav.security.token.support.core.api.Unprotected
+import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sortertEtterVedtakstidspunkt
@@ -20,7 +20,7 @@ import java.util.concurrent.Executors
 
 @RestController
 @RequestMapping("/admin/statistikk/migrering")
-@Unprotected
+@ProtectedWithClaims("azuread")
 class VedtaksstatistikkV2MigreringController(
     private val behandlingRepository: BehandlingRepository,
     private val vedtaksstatistikkRepositoryV2: VedtaksstatistikkRepositoryV2,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2MigreringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2MigreringController.kt
@@ -1,6 +1,8 @@
+package no.nav.tilleggsstonader.sak.statistikk.vedtak
+
 import no.nav.familie.prosessering.util.MDCConstants
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
+import no.nav.tilleggsstonader.libs.log.SecureLogger
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sortertEtterVedtakstidspunkt
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
@@ -8,11 +10,10 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
-import no.nav.tilleggsstonader.sak.statistikk.vedtak.VedtaksstatistikkRepositoryV2
-import no.nav.tilleggsstonader.sak.statistikk.vedtak.VedtaksstatistikkService
 import org.jboss.logging.MDC
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -32,7 +33,7 @@ class VedtaksstatistikkV2MigreringController(
     val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     @GetMapping
-    fun migrering() {
+    fun migrering(): ResponseEntity<String> {
         logger.info("Starter migrasjon av aktivitet læremidler i vedtaksstatistikk v2")
 
         val callId = MDC.get(MDCConstants.MDC_CALL_ID)
@@ -43,16 +44,15 @@ class VedtaksstatistikkV2MigreringController(
                     migrerStatistikkData()
                 }
             } catch (e: Exception) {
-                secureLogger.error("Feilet jobb", e)
+                SecureLogger.secureLogger.error("Feilet jobb", e)
             } finally {
                 MDC.remove(MDCConstants.MDC_CALL_ID)
             }
         }
+        return ResponseEntity.ok("Migrering kjører!")
     }
 
     fun migrerStatistikkData() {
-        vedtaksstatistikkRepositoryV2.deleteAll()
-
         val behandinger =
             behandlingRepository
                 .findAll()
@@ -64,6 +64,8 @@ class VedtaksstatistikkV2MigreringController(
             .hentPersonKortBolk(
                 behandinger.map { behandlingService.hentAktivIdent(it.id) },
             )
+
+        vedtaksstatistikkRepositoryV2.deleteAll()
 
         behandinger
             .sortertEtterVedtakstidspunkt()


### PR DESCRIPTION
Legger til et endepunkt som nuker den gamle vedtaksstatistikken og regner ut alt på nytt. 

Det er litt overkill, men lar oss gjenbruke scriptet fra v2-migreringen. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24488