### PR TITLE
🚩 Fjern `sak.kan-bruke-vedtaksperioder-tilsyn-barn` feature toggle

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -13,6 +13,4 @@ enum class Toggle(
     HENT_BEHANDLINGER_FOR_OPPFØLGING("sak.hent-behandlinger-for-oppfoelging"),
 
     SØKNAD_ROUTING_LÆREMIDLER("sak.soknad-routing.laremidler"),
-
-    KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN("sak.kan-bruke-vedtaksperioder-tilsyn-barn"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårSteg.kt
@@ -1,6 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår
 
-import no.nav.tilleggsstonader.libs.unleash.UnleashService
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
@@ -8,7 +8,6 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
-import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeService
 import org.springframework.stereotype.Service
 
@@ -16,10 +15,9 @@ import org.springframework.stereotype.Service
 class InngangsvilkårSteg(
     private val behandlingService: BehandlingService,
     private val stønadsperiodeService: StønadsperiodeService,
-    private val unleashService: UnleashService,
 ) : BehandlingSteg<Void?> {
     override fun validerSteg(saksbehandling: Saksbehandling) {
-        if (!unleashService.isEnabled(Toggle.KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN)) {
+        if (saksbehandling.stønadstype == Stønadstype.LÆREMIDLER) {
             stønadsperiodeService.validerStønadsperioder(saksbehandling.id)
         }
         brukerfeilHvis(saksbehandling.type == BehandlingType.REVURDERING && saksbehandling.revurderFra == null) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.behandlingsflyt
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.mockk.every
 import no.nav.familie.prosessering.domene.Status
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -24,7 +23,6 @@ import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPe
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.BrevController
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveRepository
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
@@ -34,6 +32,7 @@ import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnVedtakController
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequestV2
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.TotrinnskontrollController
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.TotrinnskontrollService
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
@@ -50,9 +49,12 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBa
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.dummyVilkårperiodeAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.dummyVilkårperiodeMålgruppe
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgSvarTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SvarJaNei
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetLæremidlerDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -186,10 +188,16 @@ class BehandlingFlytTest(
 
     @Test
     fun `skal ikke kunne gå videre til vilkår-steg dersom inngangsvilkåren ikke validerer`() {
-        every { unleashService.isEnabled(Toggle.KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN) } returns false
         somSaksbehandler {
-            val behandlingId = opprettBehandling(personIdent)
-            vurderInngangsvilkår(behandlingId)
+            val behandlingId = opprettBehandling(personIdent = personIdent, stønadstype = Stønadstype.LÆREMIDLER)
+            val faktaOgSvarLæremidler =
+                FaktaOgSvarAktivitetLæremidlerDto(
+                    prosent = 100,
+                    studienivå = Studienivå.HØYERE_UTDANNING,
+                    svarHarUtgifter = SvarJaNei.JA,
+                    svarHarRettTilUtstyrsstipend = SvarJaNei.JA,
+                )
+            vurderInngangsvilkår(behandlingId = behandlingId, aktivitetFaktaOgSvar = faktaOgSvarLæremidler)
             stegService.resetSteg(behandlingId, StegType.INNGANGSVILKÅR)
             with(vilkårperiodeService.hentVilkårperioder(behandlingId)) {
                 val slettVikårperiode = SlettVikårperiode(behandlingId, "kommentar")
@@ -271,7 +279,10 @@ class BehandlingFlytTest(
         return behandlingId
     }
 
-    private fun vurderInngangsvilkår(behandlingId: BehandlingId) {
+    private fun vurderInngangsvilkår(
+        behandlingId: BehandlingId,
+        aktivitetFaktaOgSvar: FaktaOgSvarDto = faktaOgSvarTilsynBarnDto,
+    ) {
         val fom = LocalDate.of(2024, 1, 1)
         val tom = LocalDate.of(2024, 1, 31)
 
@@ -290,8 +301,7 @@ class BehandlingFlytTest(
                 fom = fom,
                 tom = tom,
                 type = AktivitetType.TILTAK,
-                svarLønnet = SvarJaNei.NEI,
-                aktivitetsdager = 5,
+                faktaOgSvar = aktivitetFaktaOgSvar,
             ),
         )
         stønadsperiodeService.lagreStønadsperioder(
@@ -325,12 +335,15 @@ class BehandlingFlytTest(
         stegService.håndterSteg(behandlingId, StegType.VILKÅR)
     }
 
-    private fun opprettBehandling(personIdent: String): BehandlingId {
+    private fun opprettBehandling(
+        personIdent: String,
+        stønadstype: Stønadstype = Stønadstype.BARNETILSYN,
+    ): BehandlingId {
         val behandlingId =
             opprettTestBehandlingController.opprettBehandling(
                 TestBehandlingRequest(
                     personIdent,
-                    stønadstype = Stønadstype.BARNETILSYN,
+                    stønadstype = stønadstype,
                 ),
             )
         testoppsettService.opprettGrunnlagsdata(behandlingId)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
-import io.mockk.every
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnRepository
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
@@ -9,7 +8,6 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
-import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.resetMock
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
@@ -243,7 +241,6 @@ class TilsynBarnBeregnYtelseStegIntegrationTest(
     inner class Opphør {
         @Test
         fun `skal lagre vedtak`() {
-            every { unleashService.isEnabled(Toggle.KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN) } returns true
             val beløpsperioderJanuar =
                 listOf(Beløpsperiode(dato = LocalDate.of(2023, 1, 2), beløp = 1000, målgruppe = MålgruppeType.AAP))
             val beløpsperiodeFebruar =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakControllerTest.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
-import io.mockk.every
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnRepository
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
@@ -9,7 +8,6 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
-import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.util.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
@@ -148,7 +146,6 @@ class TilsynBarnVedtakControllerTest(
 
     @Test
     fun `skal lagre og hente opphør med vedtaksperioder`() {
-        every { unleashService.isEnabled(Toggle.KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN) } returns true
         innvilgeVedtakV2(
             behandling = behandling,
             vedtak =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/InngangsvilkårStegTest.kt
@@ -4,7 +4,6 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.util.behandling
@@ -19,13 +18,11 @@ import org.junit.jupiter.api.Test
 class InngangsvilkårStegTest {
     val behandlingService = mockk<BehandlingService>()
     val stønadsperiodeService = mockk<StønadsperiodeService>()
-    val unleashService = mockk<UnleashService>()
 
     val steg =
         InngangsvilkårSteg(
             behandlingService = behandlingService,
             stønadsperiodeService = stønadsperiodeService,
-            unleashService = unleashService,
         )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeAktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeAktivitetServiceTest.kt
@@ -29,6 +29,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingLønnet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakBoutgifter
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBarnetilsynDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBoutgifterDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetLæremidlerDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
@@ -84,7 +85,6 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                 aktivitetService.opprettVilkårperiode(
                     dummyVilkårperiodeAktivitet(
                         behandlingId = behandling.id,
-                        svarLønnet = SvarJaNei.NEI,
                     ),
                 )
             with(opprettetAktivitet) {
@@ -143,14 +143,19 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
         @Test
         fun `skal kaste feil ved opprettelse av lønnet tiltak uten begrunnelse`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val faktaOgSvarTilsynBarnDto =
+                FaktaOgSvarAktivitetBarnetilsynDto(
+                    svarLønnet = SvarJaNei.JA,
+                    aktivitetsdager = 5,
+                )
 
             assertThatThrownBy {
                 aktivitetService.opprettVilkårperiode(
                     dummyVilkårperiodeAktivitet(
                         type = AktivitetType.TILTAK,
-                        svarLønnet = SvarJaNei.JA,
                         behandlingId = behandling.id,
                         begrunnelse = null,
+                        faktaOgSvar = faktaOgSvarTilsynBarnDto,
                     ),
                 )
             }.hasMessageContaining("Mangler begrunnelse for ikke oppfylt vurdering av lønnet arbeid")
@@ -159,6 +164,11 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
         @Test
         fun `skal kaste feil ved tom og null begrunnelse på ingen aktivitet`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
+            val faktaOgSvarTilsynBarnDto =
+                FaktaOgSvarAktivitetBarnetilsynDto(
+                    svarLønnet = SvarJaNei.JA,
+                    aktivitetsdager = null,
+                )
             listOf("", null).forEach {
                 assertThatThrownBy {
                     aktivitetService.opprettVilkårperiode(
@@ -166,7 +176,7 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                             type = AktivitetType.INGEN_AKTIVITET,
                             begrunnelse = it,
                             behandlingId = behandling.id,
-                            aktivitetsdager = null,
+                            faktaOgSvar = faktaOgSvarTilsynBarnDto,
                         ),
                     )
                 }.hasMessageContaining("Mangler begrunnelse for ingen relevant aktivitet")
@@ -182,7 +192,6 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                     dummyVilkårperiodeAktivitet(
                         behandlingId = behandling.id,
                         type = AktivitetType.INGEN_AKTIVITET,
-                        aktivitetsdager = 5,
                     ),
                 )
             }.hasMessageContaining("Kan ikke registrere aktivitetsdager på ingen aktivitet")
@@ -200,7 +209,6 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                     dummyVilkårperiodeAktivitet(
                         behandlingId = behandling.id,
                         fom = now().plusDays(1),
-                        aktivitetsdager = 5,
                     ),
                 )
             }.hasMessageContaining("Til-og-med før fra-og-med")
@@ -396,7 +404,6 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                 aktivitetService.opprettVilkårperiode(
                     dummyVilkårperiodeAktivitet(
                         behandlingId = behandling.id,
-                        svarLønnet = SvarJaNei.NEI,
                     ),
                 )
 
@@ -493,21 +500,26 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
             aktivitetsdager: Int? = null,
             svarLønnet: SvarJaNei? = null,
             nyBegrunnelse: String? = null,
-        ): LagreVilkårperiode =
-            dummyVilkårperiodeAktivitet(
+        ): LagreVilkårperiode {
+            val faktaOgSvarTilsynBarnDto =
+                FaktaOgSvarAktivitetBarnetilsynDto(
+                    svarLønnet =
+                        svarLønnet ?: faktaOgVurdering.vurderinger
+                            .takeIfVurderinger<LønnetVurdering>()
+                            ?.lønnet
+                            ?.svar,
+                    aktivitetsdager =
+                        aktivitetsdager
+                            ?: faktaOgVurdering.fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
+                )
+            return dummyVilkårperiodeAktivitet(
                 behandlingId = behandlingId,
                 type = type as AktivitetType,
                 fom = nyFom ?: fom,
                 tom = nyTom ?: tom,
-                aktivitetsdager =
-                    aktivitetsdager
-                        ?: faktaOgVurdering.fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
-                svarLønnet =
-                    svarLønnet ?: faktaOgVurdering.vurderinger
-                        .takeIfVurderinger<LønnetVurdering>()
-                        ?.lønnet
-                        ?.svar,
+                faktaOgSvar = faktaOgSvarTilsynBarnDto,
                 begrunnelse = nyBegrunnelse ?: begrunnelse,
             )
+        }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeServiceTest.kt
@@ -235,9 +235,7 @@ class VilkårperiodeServiceTest : IntegrationTest() {
                     type = AktivitetType.TILTAK,
                     fom = fom1,
                     tom = tom1,
-                    svarLønnet = SvarJaNei.NEI,
                     behandlingId = behandling.id,
-                    aktivitetsdager = 5,
                 )
             val opprettetTiltakPeriode = vilkårperiodeService.opprettVilkårperiode(ulønnetTiltak)
             assertThat(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -41,6 +41,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUføretrygd
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingerUtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBarnetilsynDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
@@ -239,24 +240,25 @@ object VilkårperiodeTestUtil {
         behandlingId = behandlingId,
     )
 
+    val faktaOgSvarTilsynBarnDto =
+        FaktaOgSvarAktivitetBarnetilsynDto(
+            svarLønnet = SvarJaNei.NEI,
+            aktivitetsdager = 5,
+        )
+
     fun dummyVilkårperiodeAktivitet(
         type: AktivitetType = AktivitetType.TILTAK,
         fom: LocalDate = osloDateNow(),
         tom: LocalDate = osloDateNow(),
-        svarLønnet: SvarJaNei? = null,
         begrunnelse: String? = null,
         behandlingId: BehandlingId = BehandlingId.random(),
-        aktivitetsdager: Int? = 5,
         kildeId: String? = null,
+        faktaOgSvar: FaktaOgSvarDto = faktaOgSvarTilsynBarnDto,
     ) = LagreVilkårperiode(
         type = type,
         fom = fom,
         tom = tom,
-        faktaOgSvar =
-            FaktaOgSvarAktivitetBarnetilsynDto(
-                svarLønnet = svarLønnet,
-                aktivitetsdager = aktivitetsdager,
-            ),
+        faktaOgSvar = faktaOgSvar,
         kildeId = kildeId,
         begrunnelse = begrunnelse,
         behandlingId = behandlingId,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Rydder opp og fjerner `sak.kan-bruke-vedtaksperioder-tilsyn-barn` feature toggle.

Nå valideres stønadsperioder kun dersom `saksbehandling.stønadstype == Stønadstype.LÆREMIDLER`