### PR TITLE
✨ Håndter faste utgifter for boutgifter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -7,7 +7,6 @@ import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.util.erFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.util.erSisteDagIMåneden
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType.entries
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
 import org.springframework.data.annotation.Id
@@ -64,7 +63,9 @@ data class Vilkår(
         tom: LocalDate,
     ) {
         when (type) {
-            VilkårType.PASS_BARN -> {
+            VilkårType.PASS_BARN,
+            VilkårType.FASTE_UTGIFTER,
+            -> {
                 validerFørsteOgSisteDagIValgtMåned(fom, tom)
                 validerPåkrevdBeløpHvisOppfylt()
             }
@@ -210,6 +211,7 @@ enum class VilkårType(
 
     // Boutgifter
     MIDLERTIDIG_OVERNATTING("Midlertidig overnatting", listOf(Stønadstype.BOUTGIFTER)),
+    FASTE_UTGIFTER("Faste utgifter", listOf(Stønadstype.BOUTGIFTER)),
     ;
 
     fun gjelderFlereBarn(): Boolean = this == PASS_BARN

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelId.kt
@@ -18,4 +18,5 @@ enum class RegelId(
 
     // BOUTGIFTER
     NØDVENDIGE_MERUTGIFTER("Har søker nødvendige merutgifter til bolig eller overnatting?"),
+    RETT_TIL_BOSTØTTE("Har søker rett til bostøtte"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregler.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.FasteUtgifterRegel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.MidlertidigOvernattingRegel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegel
 
@@ -29,6 +30,7 @@ fun vilkårsreglerForStønad(stønadstype: Stønadstype): List<Vilkårsregel> =
         Stønadstype.BOUTGIFTER ->
             listOf(
                 MidlertidigOvernattingRegel(),
+                FasteUtgifterRegel(),
             )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -53,7 +53,12 @@ object OppdaterVilkår {
         val resultat = vilkårsresultat.vilkår
         val fom = oppdatering.fom
         val tom = oppdatering.tom
-        val vilkårMedUtgift = listOf(VilkårType.PASS_BARN, VilkårType.MIDLERTIDIG_OVERNATTING)
+        val vilkårMedUtgift =
+            listOf(
+                VilkårType.PASS_BARN,
+                VilkårType.MIDLERTIDIG_OVERNATTING,
+                VilkårType.FASTE_UTGIFTER,
+            )
         brukerfeilHvis(fom == null || tom == null) {
             "Mangler fra og med/til og med på vilkår"
         }
@@ -100,7 +105,9 @@ object OppdaterVilkår {
     ): LocalDate? =
         oppdatering.fom?.let {
             when (vilkår.type) {
-                VilkårType.PASS_BARN -> {
+                VilkårType.PASS_BARN,
+                VilkårType.FASTE_UTGIFTER,
+                -> {
                     validerErFørsteDagIMåned(it)
                     it
                 }
@@ -118,7 +125,9 @@ object OppdaterVilkår {
     ): LocalDate? =
         oppdatering.tom?.let {
             when (vilkår.type) {
-                VilkårType.PASS_BARN -> {
+                VilkårType.PASS_BARN,
+                VilkårType.FASTE_UTGIFTER,
+                -> {
                     validerErSisteDagIMåned(it)
                     it
                 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/FasteUtgifterRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/FasteUtgifterRegel.kt
@@ -1,0 +1,42 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår
+
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelSteg
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.OPPFYLT_MED_VALGFRI_BEGRUNNELSE
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.Vilkårsregel
+
+class FasteUtgifterRegel :
+    Vilkårsregel(
+        vilkårType = VilkårType.FASTE_UTGIFTER,
+        regler =
+            setOf(
+                NØDVENDIGE_MERUTGIFTER,
+                RETT_TIL_BOSTØTTE,
+            ),
+    ) {
+    companion object {
+        private val NØDVENDIGE_MERUTGIFTER =
+            RegelSteg(
+                regelId = RegelId.NØDVENDIGE_MERUTGIFTER,
+                erHovedregel = true,
+                svarMapping =
+                    mapOf(
+                        SvarId.JA to OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                        SvarId.NEI to IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
+                    ),
+            )
+        private val RETT_TIL_BOSTØTTE =
+            RegelSteg(
+                regelId = RegelId.RETT_TIL_BOSTØTTE,
+                erHovedregel = true,
+                svarMapping =
+                    mapOf(
+                        SvarId.JA to IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
+                        SvarId.NEI to OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    ),
+            )
+    }
+}

--- a/src/test/resources/vilkår/regler/FASTE_UTGIFTER.json
+++ b/src/test/resources/vilkår/regler/FASTE_UTGIFTER.json
@@ -1,0 +1,33 @@
+{
+  "vilkårType" : "FASTE_UTGIFTER",
+  "regler" : {
+    "NØDVENDIGE_MERUTGIFTER" : {
+      "regelId" : "NØDVENDIGE_MERUTGIFTER",
+      "erHovedregel" : true,
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "PÅKREVD",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    },
+    "RETT_TIL_BOSTØTTE" : {
+      "regelId" : "RETT_TIL_BOSTØTTE",
+      "erHovedregel" : true,
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "PÅKREVD",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Trenger å håndtere faste utgifter for boutgifter.

Ser det er litt endringer og design som fortsatt pågår, så kan være vi må oppdatere dette senere. Målet nå er å samle inn inputen vi trenger til beregning.