### PR TITLE
Kafka journalhendelser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,9 @@ val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20241112093526_694e258"
 val tilleggsstønaderLibsVersion = "2025.03.14-14.38.d650c79601e9"
 val tilleggsstønaderKontrakterVersion = "2025.03.14-14.41.da22448d0489"
+val avroVersion = "1.12.0"
+val confluentVersion = "7.9.0"
+val joarkHendelseVersion = "1.1.6"
 val tokenSupportVersion = "5.0.11"
 val wiremockVersion = "3.9.2"
 val mockkVersion = "1.13.12"
@@ -26,6 +29,8 @@ plugins {
     id("io.spring.dependency-management") version "1.1.6"
     kotlin("plugin.spring") version "2.0.21"
 
+    id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
+
     id("org.cyclonedx.bom") version "1.10.0"
 }
 
@@ -33,9 +38,8 @@ repositories {
     mavenCentral()
     mavenLocal()
 
-    maven {
-        url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
-    }
+    maven(url = "https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
+    maven(url = "https://packages.confluent.io/maven/")
 }
 
 apply(plugin = "com.diffplug.spotless")
@@ -65,6 +69,12 @@ dependencies {
     implementation("org.postgresql:postgresql")
     implementation("org.flywaydb:flyway-database-postgresql")
 
+    // Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+    implementation("org.apache.avro:avro:$avroVersion")
+    implementation("io.confluent:kafka-avro-serializer:$confluentVersion")
+    implementation("no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas:$joarkHendelseVersion")
+
     // Logging
     implementation("net.logstash.logback:logstash-logback-encoder:8.0")
 
@@ -78,14 +88,12 @@ dependencies {
     implementation("no.nav.tilleggsstonader-libs:http-client:$tilleggsstønaderLibsVersion")
     implementation("no.nav.tilleggsstonader-libs:sikkerhet:$tilleggsstønaderLibsVersion")
     implementation("no.nav.tilleggsstonader-libs:unleash:$tilleggsstønaderLibsVersion")
+    implementation("no.nav.tilleggsstonader-libs:kafka:$tilleggsstønaderLibsVersion")
 
     implementation("no.nav.tilleggsstonader.kontrakter:tilleggsstonader-kontrakter:$tilleggsstønaderKontrakterVersion")
 
     // For auditlogger. August, 2014, men det er den som blir brukt på NAV
     implementation("com.papertrailapp:logback-syslog4j:1.0.0")
-
-    // Kafka
-    implementation("org.springframework.kafka:spring-kafka")
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test") {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterSøknadService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterSøknadService.kt
@@ -39,6 +39,15 @@ class HåndterSøknadService(
         håndterSøknad(personIdent = personIdent, stønadstype = stønadstype, journalpost = journalpost)
     }
 
+    @Transactional
+    fun håndterSøknad(
+        journalpost: Journalpost,
+        stønadstype: Stønadstype,
+    ) {
+        val personIdent = journalpostService.hentIdentFraJournalpost(journalpost)
+        håndterSøknad(personIdent = personIdent, stønadstype = stønadstype, journalpost = journalpost)
+    }
+
     private fun håndterSøknad(
         personIdent: String,
         stønadstype: Stønadstype,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/HendelseRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/HendelseRepository.kt
@@ -1,0 +1,50 @@
+package no.nav.tilleggsstonader.sak.hendelser
+
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.sak.infrastruktur.database.JsonWrapper
+import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.data.annotation.Id
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+/**
+ * Lagrer ned hendelser som er håndtert i tilfelle offset skulle bli resatt ved en uhell
+ * og man prøver å lese samme hendelse på nytt
+ *
+ * Familie-enslig forsørger hadde et tilfelle der de ved en oppdatering av en avhengighet
+ * resatte offset og leste alle hendelser på nytt
+ */
+@Repository
+interface HendelseRepository :
+    RepositoryInterface<Hendelse, String>,
+    InsertUpdateRepository<Hendelse> {
+    fun existsByTypeAndId(
+        type: TypeHendelse,
+        id: String,
+    ): Boolean
+}
+
+/**
+ * Primary key er [id] og [type] sammen, men spring-jdbc håndterer ikke composite key
+ * Samtidig trenger man annotere et felt med [@Id]
+ */
+data class Hendelse(
+    val type: TypeHendelse,
+    @Id
+    val id: String,
+    val metadata: JsonWrapper? = null,
+    val opprettetTid: LocalDateTime = SporbarUtils.now(),
+) {
+    constructor(type: TypeHendelse, id: String, metadata: Map<String, Any>? = null) :
+        this(
+            type = type,
+            id = id,
+            metadata = metadata?.let { JsonWrapper(objectMapper.writeValueAsString(it)) },
+        )
+}
+
+enum class TypeHendelse {
+    JOURNALPOST,
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaHåndterer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaHåndterer.kt
@@ -1,0 +1,46 @@
+package no.nav.tilleggsstonader.sak.hendelser.journalføring
+
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import no.nav.tilleggsstonader.sak.journalføring.brevkode
+import no.nav.tilleggsstonader.sak.journalføring.erInnkommende
+import no.nav.tilleggsstonader.sak.journalføring.gjelderKanalSkanningEllerNavNo
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class JournalhendelseKafkaHåndterer(
+    private val journalpostService: JournalpostService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun behandleJournalpost(hendelseRecord: JournalfoeringHendelseRecord) {
+        val journalpost = journalpostService.hentJournalpost(hendelseRecord.journalpostId.toString())
+        val kanBehandles = journalpost.kanBehandles()
+
+        logSkalBehandles(journalpost, kanBehandles = kanBehandles) // TODO erstatt med håndterSøknad
+    }
+
+    private fun Journalpost.kanBehandles() =
+        Tema.gjelderTemaTilleggsstønader(this.tema) &&
+            this.erInnkommende() &&
+            this.gjelderKanalSkanningEllerNavNo()
+
+    private fun logSkalBehandles(
+        journalpost: Journalpost,
+        kanBehandles: Boolean,
+    ) {
+        logger.info(
+            "BehandleJournalpost " +
+                "kanBehandles=$kanBehandles " +
+                "journalpost=${journalpost.journalpostId} " +
+                "tema=${journalpost.tema} " +
+                "status=${journalpost.journalstatus} " +
+                "type=${journalpost.journalposttype} " +
+                "kanal=${journalpost.kanal} " +
+                "brevkode=${journalpost.brevkode()}",
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaHåndterer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaHåndterer.kt
@@ -29,9 +29,10 @@ class JournalhendelseKafkaHåndterer(
             val stønadstype = brevkode.stønadstype
             logSkalBehandles(journalpost, kanBehandles = true)
             håndterSøknadService.håndterSøknad(journalpost, stønadstype)
-        } else {
+        } else if (journalpost.erInnkommende()) {
             logSkalBehandles(journalpost, kanBehandles = false)
         }
+        // Trenger ikke å logge andre journalposter av typen utgående eller notat
     }
 
     private fun Journalpost.kanBehandles() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaListener.kt
@@ -1,0 +1,85 @@
+package no.nav.tilleggsstonader.sak.hendelser.journalføring
+
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.libs.log.IdUtils
+import no.nav.tilleggsstonader.libs.log.mdc.MDCConstants
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+
+/**
+ * Lytting på journalhendelser fra dokarkiv
+ * https://github.com/navikt/teamdokumenthandtering-avro-schemas
+ * https://confluence.adeo.no/pages/viewpage.action?pageId=432217859
+ * https://confluence.adeo.no/display/BOA/Joarkhendelser
+ */
+@Service
+@Profile("!local & !integrasjonstest")
+class JournalhendelseKafkaListener(
+    private val transactionHandler: TransactionHandler,
+    private val journalhendelseKafkaHåndterer: JournalhendelseKafkaHåndterer,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @KafkaListener(
+        id = "tilleggsstonader-sak",
+        topics = ["\${topics.journalhendelser}"],
+        containerFactory = "journalhendelserListenerContainerFactory",
+    )
+    fun listen(
+        consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>,
+        ack: Acknowledgment,
+    ) {
+        try {
+            val hendelseRecord = consumerRecord.value()
+            MDC.put(MDCConstants.MDC_CALL_ID, getCallId(hendelseRecord))
+            prosesserHendelse(hendelseRecord)
+            ack.acknowledge()
+        } catch (e: Exception) {
+            logger.error("Feil ved prosessering av journalhendelser ", e)
+            throw e
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    private fun prosesserHendelse(hendelseRecord: JournalfoeringHendelseRecord) {
+        if (!hendelseRecord.skalProsesseres()) {
+            return
+        }
+        val hendelseId = hendelseRecord.hendelsesId.takeIf { it.isNotBlank() } ?: error("Mangler hendelseId")
+        // if (!hendelseRepository.existsByTypeAndId(TypeHendelse.JOURNALPOST, hendelseId)) {
+        transactionHandler.runInNewTransaction {
+            journalhendelseKafkaHåndterer.behandleJournalpost(hendelseRecord)
+            // val hendelse = Hendelse(TypeHendelse.JOURNALPOST, id = hendelseId)
+            //        hendelseRepository.insert(hendelse)
+            //   }
+        }
+    }
+
+    private fun JournalfoeringHendelseRecord.skalProsesseres(): Boolean =
+        Tema.gjelderTemaTilleggsstønader(temaNytt) && erHendelsetypeGyldig()
+
+    fun JournalfoeringHendelseRecord.erHendelsetypeGyldig(): Boolean =
+        JournalpostHendelseType.valueOf(hendelsesType) == JournalpostHendelseType.JournalpostMottatt
+
+    private fun getCallId(hendelseRecord: JournalfoeringHendelseRecord) =
+        hendelseRecord.kanalReferanseId?.takeIf { it.isNotBlank() } ?: IdUtils.generateId()
+}
+
+private enum class JournalpostHendelseType {
+    JournalpostMottatt,
+    TemaEndret,
+    EndeligJournalført,
+    JournalpostUtgått,
+}
+
+fun main() {
+    println(JournalfoeringHendelseRecord())
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelserListenerContainerFactoryConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelserListenerContainerFactoryConfig.kt
@@ -1,0 +1,46 @@
+package no.nav.tilleggsstonader.sak.hendelser.journalføring
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import no.nav.tilleggsstonader.libs.kafka.KafkaErrorHandler
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.boot.ssl.SslBundles
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.listener.ContainerProperties
+import java.time.Duration
+
+@Configuration
+@Profile("!local & !integrasjonstest")
+class JournalhendelserListenerContainerFactoryConfig {
+    @Bean
+    fun journalhendelserListenerContainerFactory(
+        properties: KafkaProperties,
+        kafkaErrorHandler: KafkaErrorHandler,
+        sslBundles: ObjectProvider<SslBundles>,
+    ): ConcurrentKafkaListenerContainerFactory<Long, JournalfoeringHendelseRecord> {
+        val consumerProperties =
+            properties.buildConsumerProperties(sslBundles.getIfAvailable()).apply {
+                this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = 1
+                this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+                this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
+                this[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = true
+                this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+                this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = KafkaAvroDeserializer::class.java
+            }
+
+        return ConcurrentKafkaListenerContainerFactory<Long, JournalfoeringHendelseRecord>().apply {
+            containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
+            containerProperties.setAuthExceptionRetryInterval(Duration.ofSeconds(2))
+            setCommonErrorHandler(kafkaErrorHandler)
+            consumerFactory = DefaultKafkaConsumerFactory(consumerProperties)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/KafkaConfig.kt
@@ -1,12 +1,17 @@
 package no.nav.tilleggsstonader.sak.infrastruktur.config
 
+import no.nav.tilleggsstonader.libs.kafka.KafkaErrorHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.support.LoggingProducerListener
 
 @EnableKafka
 @Configuration
+@Import(
+    KafkaErrorHandler::class,
+)
 class KafkaConfig {
     @Bean
     fun loggingProducerListener() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalføringService.kt
@@ -243,6 +243,10 @@ class JournalføringService(
         behandling: Behandling,
         stønadstype: Stønadstype,
     ) {
+        if (stønadstype == Stønadstype.BOUTGIFTER) {
+            logger.info("Oppretter ikke søknad for journalpost=${journalpost.journalpostId}")
+            return
+        }
         lagreSøknad(journalpost, behandling.id, stønadstype)
         if (stønadstype.gjelderBarn()) {
             lagreBarn(behandling)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostUtil.kt
@@ -5,6 +5,20 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
 import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
+import no.nav.tilleggsstonader.libs.utils.CollectionUtil.singleOrNullOrError
+
+fun Journalpost.erInnkommende(): Boolean = journalposttype == Journalposttype.I
+
+/**
+ * Finner brevkode for orginaldokument
+ */
+fun Journalpost.brevkode(): String? =
+    dokumenter
+        ?.filter { it.harOriginaldokument() }
+        ?.map { it.brevkode }
+        ?.singleOrNullOrError()
+
+fun Journalpost.gjelderKanalSkanningEllerNavNo(): Boolean = this.kanal?.substring(0, 5) == "SKAN_" || this.kanal == "NAV_NO"
 
 fun Journalpost.harStrukturertSøknad(): Boolean =
     this.dokumenter?.any {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostUtil.kt
@@ -12,11 +12,13 @@ fun Journalpost.erInnkommende(): Boolean = journalposttype == Journalposttype.I
 /**
  * Finner brevkode for orginaldokument
  */
-fun Journalpost.brevkode(): String? =
+fun Journalpost.dokumentBrevkode(): DokumentBrevkode? =
     dokumenter
-        ?.filter { it.harOriginaldokument() }
-        ?.map { it.brevkode }
+        ?.mapNotNull { it.brevkode }
+        ?.mapNotNull { DokumentBrevkode.fraBrevkode(it) }
         ?.singleOrNullOrError()
+
+fun Journalpost.brevkoder(): List<String> = dokumenter?.mapNotNull { it.brevkode } ?: emptyList()
 
 fun Journalpost.gjelderKanalSkanningEllerNavNo(): Boolean = this.kanal?.substring(0, 5) == "SKAN_" || this.kanal == "NAV_NO"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -227,3 +227,6 @@ clients:
   ereg:
     uri: https://ereg-services.${CLIENT_ENV}-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.arbeidsforhold.ereg-services/.default
+
+topics:
+  journalhendelser: teamdokumenthandtering.aapen-dok-journalfoering

--- a/src/main/resources/db/migration/V71__hendelser.sql
+++ b/src/main/resources/db/migration/V71__hendelser.sql
@@ -1,0 +1,8 @@
+CREATE TABLE hendelse
+(
+    id            TEXT         NOT NULL,
+    type          TEXT         NOT NULL,
+    opprettet_tid TIMESTAMP(3) NOT NULL,
+    metadata      JSONB,
+    PRIMARY KEY (id, type)
+)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -21,6 +21,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakDomain
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPerson
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
+import no.nav.tilleggsstonader.sak.hendelser.Hendelse
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.RolleConfig
 import no.nav.tilleggsstonader.sak.migrering.routing.SøknadRouting
 import no.nav.tilleggsstonader.sak.oppfølging.Oppfølging
@@ -128,6 +129,7 @@ abstract class IntegrationTest {
 
     private fun resetDatabase() {
         listOf(
+            Hendelse::class,
             TaskLogg::class,
             Task::class,
             SøknadRouting::class,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/hendelser/ConsumerRecordUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/hendelser/ConsumerRecordUtil.kt
@@ -1,0 +1,18 @@
+package no.nav.tilleggsstonader.sak.hendelser
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+object ConsumerRecordUtil {
+    fun <KEY, VALUE> lagConsumerRecord(
+        key: KEY,
+        value: VALUE,
+        offset: Long = 1,
+    ): ConsumerRecord<KEY, VALUE> =
+        ConsumerRecord(
+            "topic",
+            1,
+            offset,
+            key,
+            value,
+        )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/hendelser/HendelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/hendelser/HendelseRepositoryTest.kt
@@ -1,0 +1,51 @@
+package no.nav.tilleggsstonader.sak.hendelser
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+
+class HendelseRepositoryTest : IntegrationTest() {
+    @Autowired
+    lateinit var hendelseRepository: HendelseRepository
+
+    @Test
+    fun `skal kunne lagre og hente hendelse`() {
+        val id = UUID.randomUUID().toString()
+        val hendelse = Hendelse(TypeHendelse.JOURNALPOST, id = id)
+        hendelseRepository.insert(hendelse)
+
+        assertThat(hendelseRepository.findAll().single()).isEqualTo(hendelse)
+    }
+
+    @Test
+    fun `skal kunne lagre og hente hendelse med metadata`() {
+        val id = UUID.randomUUID().toString()
+        val hendelse = Hendelse(TypeHendelse.JOURNALPOST, id = id, metadata = mapOf("journalpostId" to "123"))
+        hendelseRepository.insert(hendelse)
+
+        assertThat(
+            hendelseRepository
+                .findAll()
+                .single()
+                .metadata
+                ?.json,
+        ).isEqualTo("""{"journalpostId": "123"}""")
+    }
+
+    @Nested
+    inner class ExistsByTypeAndId {
+        @Test
+        fun `skal finne hendelse på type og id`() {
+            val id = UUID.randomUUID().toString()
+            val type = TypeHendelse.JOURNALPOST
+            val hendelse = Hendelse(type, id = id)
+            hendelseRepository.insert(hendelse)
+
+            assertThat(hendelseRepository.existsByTypeAndId(type, id = id)).isTrue()
+            assertThat(hendelseRepository.existsByTypeAndId(type, id = UUID.randomUUID().toString())).isFalse()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaListenerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaListenerTest.kt
@@ -1,0 +1,86 @@
+package no.nav.tilleggsstonader.sak.hendelser.journalføring
+
+import io.mockk.clearMocks
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.sak.hendelser.ConsumerRecordUtil.lagConsumerRecord
+import no.nav.tilleggsstonader.sak.hendelser.Hendelse
+import no.nav.tilleggsstonader.sak.hendelser.TypeHendelse
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.HendelseRepositoryFake
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.support.Acknowledgment
+
+class JournalhendelseKafkaListenerTest {
+    val hendelseRepository = spyk(HendelseRepositoryFake())
+    val journalhendelseKafkaHåndterer: JournalhendelseKafkaHåndterer = mockk(relaxed = true)
+
+    val listener =
+        JournalhendelseKafkaListener(
+            hendelseRepository = hendelseRepository,
+            transactionHandler = TransactionHandler(),
+            journalhendelseKafkaHåndterer = journalhendelseKafkaHåndterer,
+        )
+
+    val ack = mockk<Acknowledgment>(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        hendelseRepository.deleteAll()
+    }
+
+    @Test
+    fun `skal behandle innkommende journalposter`() {
+        listener.listen(lagConsumerRecord("key", record()), ack)
+
+        with(hendelseRepository.findAll().single()) {
+            assertThat(id).isEqualTo("hendelseId")
+            assertThat(type).isEqualTo(TypeHendelse.JOURNALPOST)
+        }
+        verify(exactly = 1) { hendelseRepository.existsByTypeAndId(TypeHendelse.JOURNALPOST, "hendelseId") }
+        verify(exactly = 1) { journalhendelseKafkaHåndterer.behandleJournalpost(any()) }
+        verify(exactly = 1) { hendelseRepository.insert(any()) }
+        verify(exactly = 1) { ack.acknowledge() }
+    }
+
+    @Test
+    fun `skal ikke behandle hendelse hvis den allerede er behandlet`() {
+        hendelseRepository.insert(Hendelse(TypeHendelse.JOURNALPOST, "hendelseId"))
+        clearMocks(hendelseRepository, answers = false, recordedCalls = true) //
+
+        listener.listen(lagConsumerRecord("key", record()), ack)
+
+        verify(exactly = 1) { hendelseRepository.existsByTypeAndId(any(), any()) }
+        verify(exactly = 0) { journalhendelseKafkaHåndterer.behandleJournalpost(any()) }
+        verify(exactly = 0) { hendelseRepository.insert(any()) }
+        verify(exactly = 1) { ack.acknowledge() }
+    }
+
+    @Test
+    fun `skal ikke behandle annet tema enn tilleggsstønader`() {
+        listener.listen(lagConsumerRecord("key", record(tema = "ENF")), ack)
+
+        verify(exactly = 0) { hendelseRepository.existsByTypeAndId(any(), any()) }
+        verify(exactly = 0) { journalhendelseKafkaHåndterer.behandleJournalpost(any()) }
+        verify(exactly = 0) { hendelseRepository.insert(any()) }
+        verify(exactly = 1) { ack.acknowledge() }
+    }
+
+    private fun record(
+        tema: String? = Tema.TSO.name,
+        hendelseId: String? = "hendelseId",
+        hendelseType: String? = "JournalpostMottatt",
+        journalpostId: Long = 1,
+    ): JournalfoeringHendelseRecord =
+        JournalfoeringHendelseRecord().apply {
+            temaNytt = tema
+            hendelsesId = hendelseId
+            hendelsesType = hendelseType
+            this.journalpostId = journalpostId
+        }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/HendelseRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/HendelseRepositoryFake.kt
@@ -1,0 +1,14 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.database.repository
+
+import no.nav.tilleggsstonader.sak.hendelser.Hendelse
+import no.nav.tilleggsstonader.sak.hendelser.HendelseRepository
+import no.nav.tilleggsstonader.sak.hendelser.TypeHendelse
+
+class HendelseRepositoryFake :
+    DummyRepository<Hendelse, String>({ it.id }),
+    HendelseRepository {
+    override fun existsByTypeAndId(
+        type: TypeHendelse,
+        id: String,
+    ): Boolean = findAll().any { it.type == type && it.id == id }
+}


### PR DESCRIPTION
Endret ordningen på commits og måtte lage ny pr. Ønsket å teste at selve lyttingen gikk fint 
Forrige PR
* https://github.com/navikt/tilleggsstonader-sak/pull/638

### Hvorfor er denne endringen nødvendig? ✨

Då vi går over til å bruke fyllUt/send-inn søknaden så er det de som arkiverer søknaden i stedet for oss.
Då har vi behov for å opprette journalføringsoppgave/opprette behandling basert på hendelser fra journalføring.

Inspirasjon tatt fra https://github.com/navikt/familie-ef-mottak/blob/main/src/main/kotlin/no/nav/familie/ef/mottak/hendelse/JournalhendelseKafkaH%C3%A5ndterer.kt#L16

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24279

https://github.com/navikt/teamdokumenthandtering-avro-schemas
https://confluence.adeo.no/pages/viewpage.action?pageId=432217859
https://confluence.adeo.no/display/BOA/Joarkhendelser