### PR TITLE
Vedtaksperioder for boutgifter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
@@ -5,9 +5,9 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.BeregningsresultatBoutgifterDto
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.VedtaksperiodeBoutgifterDto
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.tilDomene
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.tilDto
+import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
+import no.nav.tilleggsstonader.sak.vedtak.dto.tilDomene
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -60,7 +60,7 @@ class BoutgifterVedtakController(
     @PostMapping("{behandlingId}/beregn")
     fun beregn(
         @PathVariable behandlingId: BehandlingId,
-        @RequestBody vedtaksperioder: List<VedtaksperiodeBoutgifterDto>,
+        @RequestBody vedtaksperioder: List<VedtaksperiodeDto>,
     ): BeregningsresultatBoutgifterDto {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         return beregningService

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregnBeløpUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregnBeløpUtil.kt
@@ -4,16 +4,13 @@ object BoutgifterBeregnBeløpUtil {
 //    private val PROSENT_50 = BigDecimal(0.5)
 //    private val PROSENTGRENSE_HALV_SATS = 50
 
-    fun beregnBeløp(
-//        sats: Int,
-//        studieprosent: Int,
-    ): Int {
+    fun beregnBeløp(utgifter: Map<Unit, List<UtgiftBeregning>>): Int {
 //        if (studieprosent <= PROSENTGRENSE_HALV_SATS) {
 //            return BigDecimal(sats)
 //                .multiply(PROSENT_50)
 //                .setScale(0, RoundingMode.HALF_UP)
 //                .toInt()
 //        }
-        return TODO("Makssats for boutgifter er ikke implementert enda")
+        return TODO("Beregning av beløp med utgifter og makssats for boutgifter er ikke implementert enda")
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregnUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregnUtil.kt
@@ -5,7 +5,7 @@ import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøn
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterVedtaksperiodeUtil.sisteDagenILøpendeMåned
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterVedtaksperiodeUtil.splitPerLøpendeMåneder
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterVedtaksperiodeUtil.splitVedtaksperiodePerÅr
-import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeBeregning
 import kotlin.collections.plus
 
 object BoutgifterBeregnUtil {
@@ -13,7 +13,7 @@ object BoutgifterBeregnUtil {
      * Grupperer vedtaksperioder innenfor en løpende måned
      * Hvis en vedtaksperiode løper lengre enn første måned vil det bli en ny periode, med nytt utbetalingsdatum
      */
-    fun List<Vedtaksperiode>.grupperVedtaksperioderPerLøpendeMåned(): List<LøpendeMåned> =
+    fun List<VedtaksperiodeBeregning>.grupperVedtaksperioderPerLøpendeMåned(): List<LøpendeMåned> =
         this
             .sorted()
             .splitVedtaksperiodePerÅr()
@@ -44,6 +44,8 @@ object BoutgifterBeregnUtil {
                 VedtaksperiodeInnenforLøpendeMåned(
                     fom = vedtaksperiode.fom,
                     tom = minOf(this.tom, vedtaksperiode.tom),
+                    målgruppe = vedtaksperiode.målgruppe,
+                    aktivitet = vedtaksperiode.aktivitet,
                 )
             this.medVedtaksperiode(overlappendeVedtaksperiode)
         }
@@ -79,7 +81,14 @@ object BoutgifterBeregnUtil {
                 fom = fom,
                 tom = minOf(fom.sisteDagenILøpendeMåned(), this.tom.sisteDagIÅret()),
                 utbetalingsdato = this.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
-            ).medVedtaksperiode(VedtaksperiodeInnenforLøpendeMåned(fom = fom, tom = tom))
+            ).medVedtaksperiode(
+                VedtaksperiodeInnenforLøpendeMåned(
+                    fom = fom,
+                    tom = tom,
+                    målgruppe = this.målgruppe,
+                    aktivitet = this.aktivitet,
+                ),
+            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterUtgiftService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterUtgiftService.kt
@@ -1,0 +1,41 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+
+@Service
+class BoutgifterUtgiftService(
+    private val vilkårService: VilkårService,
+) {
+    // TODO: Lag en map over type utgift i stedet for over Unit
+    fun hentUtgifterTilBeregning(behandlingId: BehandlingId): Map<Unit, List<UtgiftBeregning>> =
+        vilkårService
+            .hentOppfylteBoutgiftVilkår(behandlingId)
+//            .groupBy { it.barnId ?: error("Vilkår=${it.id} type=${it.type} for tilsyn barn mangler barnId") }
+            .groupBy { } // TODO: Splitt på FASTE_UTGIFTER og MIDLERTIDIG_OVERNATTING
+            .mapValues { (_, values) -> values.map { mapUtgiftBeregning(it) } }
+
+    private fun mapUtgiftBeregning(it: Vilkår): UtgiftBeregning {
+        val fom = it.fom
+        val tom = it.tom
+        val utgift = it.utgift
+        feilHvis(fom == null || tom == null || utgift == null) {
+            "Forventer at fra-dato, til-dato og utgift er satt. Gå tilbake til Pass barn-fanen, og legg til datoer og utgifter der. For utviklerteamet: dette gjelder vilkår=${it.id}."
+        }
+//        feilHvisIkke(fom.erFørsteDagIMåneden()) {
+//            "Noe er feil. Fom skal være satt til første dagen i måneden"
+//        }
+//        feilHvisIkke(tom.erSisteDagIMåneden()) {
+//            "Noe er feil. Tom skal være satt til siste dagen i måneden"
+//        }
+        return UtgiftBeregning(
+            fom = YearMonth.from(fom),
+            tom = YearMonth.from(tom),
+            utgift = utgift,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterVedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterVedtaksperiodeUtil.kt
@@ -5,7 +5,9 @@ import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.kontrakter.felles.splitPerÅr
 import no.nav.tilleggsstonader.sak.util.lørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterVedtaksperiodeUtil.sisteDagenILøpendeMåned
-import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeBeregning
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
 
 object BoutgifterVedtaksperiodeUtil {
@@ -13,10 +15,18 @@ object BoutgifterVedtaksperiodeUtil {
      * Vedtaksperiode deles i ulike år då nytt år betyr ny termine og ikke skal utbetales direkte
      * For å innvilge høst og vår i 2 ulike perioder og der vårterminen får en ny sats
      */
-    fun List<Vedtaksperiode>.splitVedtaksperiodePerÅr(): List<VedtaksperiodeInnenforÅr> =
+    fun List<VedtaksperiodeBeregning>.splitVedtaksperiodePerÅr(): List<VedtaksperiodeInnenforÅr> =
         this
-            .map { it.splitPerÅr { fom, tom -> VedtaksperiodeInnenforÅr(fom, tom) } }
-            .flatten()
+            .map {
+                it.splitPerÅr { fom, tom ->
+                    VedtaksperiodeInnenforÅr(
+                        fom = fom,
+                        tom = tom,
+                        målgruppe = it.målgruppe,
+                        aktivitet = it.aktivitet,
+                    )
+                }
+            }.flatten()
 
     /**
      * Splitter en periode i løpende måneder. Løpende måned er fra dagens dato og en måned frem i tiden.
@@ -51,6 +61,8 @@ object BoutgifterVedtaksperiodeUtil {
 data class VedtaksperiodeInnenforÅr(
     override val fom: LocalDate,
     override val tom: LocalDate,
+    val målgruppe: MålgruppeType,
+    val aktivitet: AktivitetType,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
@@ -66,6 +78,8 @@ data class VedtaksperiodeInnenforÅr(
 data class VedtaksperiodeInnenforLøpendeMåned(
     override val fom: LocalDate,
     override val tom: LocalDate,
+    val målgruppe: MålgruppeType,
+    val aktivitet: AktivitetType,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
@@ -61,7 +61,8 @@ data class UtbetalingPeriode(
     ) : this(
         fom = løpendeMåned.fom,
         tom = løpendeMåned.vedtaksperioder.maxOf { it.tom },
-        målgruppe = løpendeMåned.vedtaksperioder.first().målgruppe, // TODO: Prioriter hvilken målgruppe som skal være gjeldende til økonomi hvis ulike målgrupper havner innenfor samme løpende måned
+        // TODO: Prioriter hvilken målgruppe som skal være gjeldende til økonomi hvis ulike målgrupper havner innenfor samme løpende måned
+        målgruppe = løpendeMåned.vedtaksperioder.first().målgruppe,
         aktivitet = løpendeMåned.vedtaksperioder.first().aktivitet,
 //        studienivå = målgruppeOgAktivitet.aktivitet.studienivå,
 //        prosent = målgruppeOgAktivitet.aktivitet.prosent,
@@ -180,7 +181,7 @@ data class MålgruppeOgAktivitet(
     override fun compareTo(other: MålgruppeOgAktivitet): Int = COMPARE_BY.compare(this, other)
 
     companion object {
-//        val COMPARE_BY =
+        //        val COMPARE_BY =
 //            compareBy<MålgruppeOgAktivitet> { it.aktivitet.studienivå.prioritet }
 //                .thenByDescending { it.aktivitet.prosent }
 //                .thenBy { it.målgruppe.prioritet() }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.kontrakter.felles.overlapper
 import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
+import no.nav.tilleggsstonader.sak.behandling.dto.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
@@ -54,6 +55,18 @@ data class UtbetalingPeriode(
 //        prosent = målgruppeOgAktivitet.aktivitet.prosent,
         utbetalingsdato = løpendeMåned.utbetalingsdato,
     )
+
+    constructor(
+        løpendeMåned: LøpendeMåned,
+    ) : this(
+        fom = løpendeMåned.fom,
+        tom = løpendeMåned.vedtaksperioder.maxOf { it.tom },
+        målgruppe = løpendeMåned.vedtaksperioder.first().målgruppe, // TODO: Prioriter hvilken målgruppe som skal være gjeldende til økonomi hvis ulike målgrupper havner innenfor samme løpende måned
+        aktivitet = løpendeMåned.vedtaksperioder.first().aktivitet,
+//        studienivå = målgruppeOgAktivitet.aktivitet.studienivå,
+//        prosent = målgruppeOgAktivitet.aktivitet.prosent,
+        utbetalingsdato = løpendeMåned.utbetalingsdato,
+    )
 }
 
 data class LøpendeMåned(
@@ -89,6 +102,7 @@ data class LøpendeMåned(
      * Finner hvilken stønadsperiode og aktivitet som skal brukes for den aktuelle utbetalingsperioden
      */
     fun tilUtbetalingPeriode(
+        vedtaksperiode: List<Vedtaksperiode>,
         stønadsperioder: List<StønadsperiodeBeregningsgrunnlag>,
         aktiviteter: List<AktivitetBoutgifterBeregningGrunnlag>,
     ): UtbetalingPeriode {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtgiftBeregning.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtgiftBeregning.kt
@@ -1,0 +1,35 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
+
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import java.time.YearMonth
+
+// TODO: Denne er kopiert fra tilsyn barn, og der forventes det utgifter for en hel kalendermåned.
+//  I boutgifter trenger vi å forholde oss til spesifikke datoer.
+data class UtgiftBeregning(
+    override val fom: YearMonth,
+    override val tom: YearMonth,
+    val utgift: Int,
+) : Periode<YearMonth> {
+    init {
+        validatePeriode()
+    }
+}
+
+// /**
+// * Dersom man har en lang utgiftsperiode for 1.1 - 31.1 så skal den splittes opp fra revurderFra sånn at man får 2 perioder
+// * Eks for revurderFra=15.1 så får man 1.1 - 14.1 og 15.1 - 31.1
+// * Dette for å kunne filtrere vekk perioder som begynner før revurderFra og beregne beløp som skal utbetales i gitt måned
+// */
+// fun List<UtgiftBeregning>.splitFraRevurderFra(revurderFra: LocalDate?): List<UtgiftBeregning> {
+//    val revurderFraMåned = revurderFra?.toYearMonth() ?: return this
+//    return this.flatMap {
+//        if (it.fom < revurderFraMåned && revurderFraMåned <= it.tom) {
+//            listOf(
+//                it.copy(tom = revurderFraMåned.minusMonths(1)),
+//                it.copy(fom = revurderFraMåned),
+//            )
+//        } else {
+//            listOf(it)
+//        }
+//    }
+// }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/InnvilgelseBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/InnvilgelseBoutgifterDto.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto
 
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 import java.time.LocalDate
 
 /**
@@ -10,7 +11,7 @@ import java.time.LocalDate
  * @param gjelderFraOgMed gjelder fra og med revurder-fra-dato, brukes til brevet for å vise fra når vedtaket gjelder fra
  */
 data class InnvilgelseBoutgifterResponse(
-    val vedtaksperioder: List<VedtaksperiodeBoutgifterDto>,
+    val vedtaksperioder: List<VedtaksperiodeDto>,
     val beregningsresultat: BeregningsresultatBoutgifterDto,
     val gjelderFraOgMed: LocalDate,
     val gjelderTilOgMed: LocalDate,
@@ -19,7 +20,7 @@ data class InnvilgelseBoutgifterResponse(
     VedtakBoutgifterResponse
 
 data class InnvilgelseBoutgifterRequest(
-    val vedtaksperioder: List<VedtaksperiodeBoutgifterDto>,
+    val vedtaksperioder: List<VedtaksperiodeDto>,
     val begrunnelse: String? = null,
 ) : VedtakBoutgifterDto(TypeVedtak.INNVILGELSE),
     VedtakBoutgifterRequest

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -266,4 +266,13 @@ class VilkårService(
         vilkårRepository
             .findByBehandlingId(behandlingId)
             .filter { it.type == VilkårType.PASS_BARN }
+
+    fun hentOppfylteBoutgiftVilkår(behandlingId: BehandlingId): List<Vilkår> =
+        hentBoutgiftVilkår(behandlingId)
+            .filter { it.resultat == Vilkårsresultat.OPPFYLT }
+
+    fun hentBoutgiftVilkår(behandlingId: BehandlingId): List<Vilkår> =
+        vilkårRepository
+            .findByBehandlingId(behandlingId)
+            .filter { it.type == VilkårType.MIDLERTIDIG_OVERNATTING } // TODO: Skal også hente faste utgifter
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Boutgifter har aktivitet og målgruppe i vedtaksperiodene, så vi trenger ikke overlappsperiode/stønadsperiode i beregningen. 

Jeg ønsker å vite om jeg er på riktig spor ☺️

Hovedendringer fra læremidler: 
- Tar inn målgruppe og aktivitet i `LøpendeMåned`, `VedtaksperiodeInnenforÅr`, `VedtaksperiodeInnenforLøpendeMåned` og `VedtaksperiodeBeregning`. Den informasjonen er lett tilgjengelig i vedtaksperiodene våre i boutgifter, i motsetning til for læremidler, der målgruppe og aktivitet måtte hentes fra stønadsperiodene. 
- Oppretter `BoutgifterUtgiftService` som henter utgifter fra de oppfylte vilkårene, med inspirasjon fra tilsyn barn

Gjenstår for å beregne enkel case: 
- Faktiske bruke utgiftene i beregningen
- Implementere makssatsen

Til info: Endringene kommer oppå [disse endringene](https://github.com/navikt/tilleggsstonader-sak/compare/514a42a7fa47...e679a2855cd8). Jeg splittet ut rene refaktorerings-ting så ikke PR-en skulle bli så stor og stygg.