### PR TITLE
🐛 Ikke send aldersvilkår i dto hvis er gammel mangler data

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -125,7 +125,12 @@ fun FaktaOgVurdering.tilFaktaOgVurderingDto(): FaktaOgVurderingerDto =
                         .takeIfVurderinger<DekketAvAnnetRegelverkVurdering>()
                         ?.dekketAvAnnetRegelverk
                         ?.tilDto(),
-                aldersvilkår = vurderinger.takeIfVurderinger<AldersvilkårVurdering>()?.aldersvilkår?.tilDto(),
+                aldersvilkår =
+                    vurderinger
+                        .takeIfVurderinger<AldersvilkårVurdering>()
+                        ?.aldersvilkår
+                        ?.takeIf { it.svar != SvarJaNei.GAMMEL_MANGLER_DATA }
+                        ?.tilDto(),
             )
 
         is AktivitetFaktaOgVurdering -> {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ikke send aldervilkår i dto hvis gammel mangler data da dette ikke er relevant (og htmlify vet ikke hvordan parse det)