### PR TITLE
Fjernet alder validering fra vedtaksperioder og stønadsperiode

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtils.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
-import no.nav.tilleggsstonader.sak.util.norskFormat
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
@@ -80,23 +79,5 @@ object VedtaksperiodeValideringUtils {
             ?: brukerfeil(
                 "Finnes ingen periode med oppfylte vilkår for ${vedtaksperiode.aktivitet} i perioden ${vedtaksperiode.formatertPeriodeNorskFormat()}",
             )
-
-        validerVedtaksperiodeErInnenfor18og67år(fødselsdato, vedtaksperiode)
-    }
-
-    private fun validerVedtaksperiodeErInnenfor18og67år(
-        fødselsdato: LocalDate?,
-        vedtaksperiode: Vedtaksperiode,
-    ) {
-        if (fødselsdato != null && vedtaksperiode.målgruppe.gjelderNedsattArbeidsevne()) {
-            val dato18år = fødselsdato.plusYears(18)
-            brukerfeilHvis(vedtaksperiode.fom < dato18år) {
-                "Periode kan ikke begynne før søker fyller 18 år (${dato18år.norskFormat()})"
-            }
-            val dato67år = fødselsdato.plusYears(67)
-            brukerfeilHvis(vedtaksperiode.tom >= dato67år) {
-                "Periode kan ikke slutte etter søker fylt 67 år (${dato67år.norskFormat()})"
-            }
-        }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValidering.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
-import no.nav.tilleggsstonader.sak.util.norskFormat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.StønadsperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
@@ -77,8 +76,6 @@ object StønadsperiodeValidering {
             ?: brukerfeil(
                 "Finnes ingen periode med oppfylte vilkår for ${stønadsperiode.aktivitet} i perioden ${stønadsperiode.formatertPeriodeNorskFormat()}",
             )
-
-        validerStønadsperiodeErInnenfor18og67år(fødselsdato, stønadsperiode)
     }
 
     /**
@@ -107,22 +104,6 @@ object StønadsperiodeValidering {
                         "med ${it.type}(${it.formatertPeriodeNorskFormat()}) som ikke gir rett på stønad",
                 )
             }
-    }
-
-    private fun validerStønadsperiodeErInnenfor18og67år(
-        fødselsdato: LocalDate?,
-        stønadsperiode: StønadsperiodeDto,
-    ) {
-        if (fødselsdato != null && stønadsperiode.målgruppe.gjelderNedsattArbeidsevne()) {
-            val dato18år = fødselsdato.plusYears(18)
-            brukerfeilHvis(stønadsperiode.fom < dato18år) {
-                "Periode kan ikke begynne før søker fyller 18 år (${dato18år.norskFormat()})"
-            }
-            val dato67år = fødselsdato.plusYears(67)
-            brukerfeilHvis(stønadsperiode.tom >= dato67år) {
-                "Periode kan ikke slutte etter søker fylt 67 år (${dato67år.norskFormat()})"
-            }
-        }
     }
 }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsTest.kt
@@ -352,36 +352,6 @@ class VedtaksperiodeValideringUtilsTest {
             }
 
             @Test
-            fun `skal kaste feil dersom nedsatt arbeidsevne og personen er under 18 år`() {
-                assertThatCode {
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteVilkårperioder(),
-                        aktiviteter.mergeSammenhengendeOppfylteVilkårperioder(),
-                        dato18årGammel.plusDays(1),
-                    )
-                }.hasMessageContaining("Periode kan ikke begynne før søker fyller 18 år")
-            }
-
-            @Test
-            fun `skal kaste feil dersom nedsatt arbeidsevne og personen er over 67 år`() {
-                assertThatThrownBy {
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteVilkårperioder(),
-                        aktiviteter.mergeSammenhengendeOppfylteVilkårperioder(),
-                        dato67årGammel,
-                    )
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteVilkårperioder(),
-                        aktiviteter.mergeSammenhengendeOppfylteVilkårperioder(),
-                        dato67årGammel.minusDays(1),
-                    )
-                }.hasMessageContaining("Periode kan ikke slutte etter søker fylt 67 år")
-            }
-
-            @Test
             fun `skal ikke kaste feil dersom nedsatt arbeidsevne og personen er under 67 år`() {
                 assertThatCode {
                     validerEnkeltperiode(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringTest.kt
@@ -213,28 +213,11 @@ internal class StønadsperiodeValideringTest {
         val dato67årGammel = tom.minusYears(67)
 
         @Test
-        fun `skal kaste feil dersom nedsatt arbeidsevne og personen er under 18 år`() {
-            assertThatThrownBy {
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato18årGammel.plusDays(1))
-            }.hasMessageContaining("Periode kan ikke begynne før søker fyller 18 år")
-        }
-
-        @Test
         fun `skal ikke kaste feil dersom nedsatt arbeidsevne og personen er over 18 år`() {
             assertThatCode {
                 valider(stønadsperioder, vilkårperioder, fødselsdato = dato18årGammel)
                 valider(stønadsperioder, vilkårperioder, fødselsdato = dato18årGammel.minusDays(1))
             }.doesNotThrowAnyException()
-        }
-
-        @Test
-        fun `skal kaste feil dersom nedsatt arbeidsevne og personen er over 67 år`() {
-            assertThatThrownBy {
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato67årGammel)
-            }.hasMessageContaining("Periode kan ikke slutte etter søker fylt 67 år")
-            assertThatThrownBy {
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato67årGammel.minusDays(1))
-            }.hasMessageContaining("Periode kan ikke slutte etter søker fylt 67 år")
         }
 
         @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Favro-  https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24358


Fjernet kode relatert til aldersvalidering fra vedtaksperiode og fra stønadsperiode agså fjernet test cases.