### PR TITLE
Ny vurdering av sykepenger - håndtering av gammel data

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValidering.kt
@@ -60,6 +60,15 @@ object VilkårperiodeRevurderFraValidering {
         }
     }
 
+    fun validerAtVilkårperiodeKanOppdateresIRevurdering(
+        eksisterendePeriode: Vilkårperiode,
+        revurderFra: LocalDate,
+    ) {
+        feilHvis(eksisterendePeriode.tom < revurderFra) {
+            "Kan ikke endre vilkårperiode som er ferdig før revurderingsdato. Kontakt utviklingsteamet."
+        }
+    }
+
     private fun logEndring(
         eksisterendePeriode: Vilkårperiode,
         oppdatertPeriode: LagreVilkårperiode,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValidering.kt
@@ -7,18 +7,8 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.util.norskFormat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AldersvilkårVurdering
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfVurderingOrThrow
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MedlemskapVurdering
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SvarJaNei
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAAP
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAAPLæremidler
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingNedsattArbeidsevne
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingNedsattArbeidsevneLæremidler
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingOmstillingsstønad
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUføretrygd
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUføretrygdLæremidler
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.Vurderinger
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilFaktaOgSvarDto
 import java.time.LocalDate
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -48,26 +38,15 @@ object VilkårperiodeRevurderFraValidering {
         }
     }
 
-    fun validerEndrePeriodeRevurdering(
-        behandling: Saksbehandling,
+    /**
+     * Valider at det ikke er gjort noen endringer på vilkårperiode
+     * Antar at resultatet ikke er endret dersom ingen svar er endret
+     */
+    fun validerAtKunTomErEndret(
         eksisterendePeriode: Vilkårperiode,
-        oppdatertPeriode: Vilkårperiode,
+        oppdatertPeriode: LagreVilkårperiode,
+        revurderFra: LocalDate,
     ) {
-        if (behandling.type != BehandlingType.REVURDERING) {
-            return
-        }
-
-        val revurderFra = behandling.revurderFra
-
-        validerRevurderFraErSatt(revurderFra)
-
-        if (eksisterendePeriode.fom >= revurderFra) {
-            feilHvis(oppdatertPeriode.fom < revurderFra) {
-                "Kan ikke sette fom før revurder-fra(${revurderFra.norskFormat()})"
-            }
-            return
-        }
-
         feilHvis(eksisterendePeriode.fom != oppdatertPeriode.fom) {
             "Kan ikke endre fom til ${oppdatertPeriode.fom.norskFormat()} fordi " +
                 "revurder fra(${revurderFra.norskFormat()}) er før. Kontakt utviklingsteamet"
@@ -75,28 +54,15 @@ object VilkårperiodeRevurderFraValidering {
         feilHvis(oppdatertPeriode.tom < revurderFra.minusDays(1)) {
             "Kan ikke sette tom tidligere enn dagen før revurder-fra(${revurderFra.norskFormat()})"
         }
-        feilHvis(eksisterendePeriode.faktaOgVurdering.type != oppdatertPeriode.faktaOgVurdering.type) {
+        feilHvis(eksisterendePeriode.faktaOgVurdering.tilFaktaOgSvarDto() != oppdatertPeriode.faktaOgSvar) {
             logEndring(eksisterendePeriode, oppdatertPeriode)
-            "Kan ikke endre type på perioden. Kontakt utviklingsteamet"
-        }
-        feilHvis(eksisterendePeriode.faktaOgVurdering.fakta != oppdatertPeriode.faktaOgVurdering.fakta) {
-            logEndring(eksisterendePeriode, oppdatertPeriode)
-            "Kan ikke endre fakta på perioden. Kontakt utviklingsteamet"
-        }
-        val eksisterendeVurderinger = eksisterendeVurderinger(eksisterendePeriode, oppdatertPeriode)
-        feilHvis(eksisterendeVurderinger != oppdatertPeriode.faktaOgVurdering.vurderinger) {
-            logEndring(eksisterendePeriode, oppdatertPeriode)
-            "Kan ikke endre vurderinger på perioden. Kontakt utviklingsteamet"
-        }
-        feilHvis(eksisterendePeriode.resultat != oppdatertPeriode.resultat) {
-            logEndring(eksisterendePeriode, oppdatertPeriode)
-            "Resultat kan ikke endre seg. Kontakt utviklingsteamet"
+            "Kan ikke endre vurderinger eller fakta på perioden. Kontakt utviklingsteamet"
         }
     }
 
     private fun logEndring(
         eksisterendePeriode: Vilkårperiode,
-        oppdatertPeriode: Vilkårperiode,
+        oppdatertPeriode: LagreVilkårperiode,
     ) {
         secureLogger.info(
             "Ugyldig endring på vilkårperiode " +
@@ -104,43 +70,8 @@ object VilkårperiodeRevurderFraValidering {
         )
     }
 
-    private fun eksisterendeVurderinger(
-        eksisterendePeriode: Vilkårperiode,
-        oppdatertPeriode: Vilkårperiode,
-    ): Vurderinger =
-        eksisterendePeriode.faktaOgVurdering.vurderinger.let { vurderinger ->
-            if (vurderinger is AldersvilkårVurdering) {
-                brukNyttAldersvilkår(vurderinger, oppdatertPeriode)
-            } else {
-                vurderinger
-            }
-        }
-
-    /**
-     * Overskriver aldersvilkår med oppdatert informasjon då aldervilkåret automatisk vurderes og skal kunne gå fra
-     * [SvarJaNei.GAMMEL_MANGLER_DATA] til [SvarJaNei.JA] uten at man kaster feil
-     */
-    private fun brukNyttAldersvilkår(
-        vurdering: AldersvilkårVurdering,
-        oppdatertPeriode: Vilkårperiode,
-    ): MedlemskapVurdering {
-        val oppdatertAldersvilkår =
-            oppdatertPeriode.faktaOgVurdering.vurderinger
-                .takeIfVurderingOrThrow<AldersvilkårVurdering>()
-                .aldersvilkår
-        return when (vurdering) {
-            is VurderingAAP -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-            is VurderingNedsattArbeidsevne -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-            is VurderingOmstillingsstønad -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-            is VurderingUføretrygd -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-            is VurderingAAPLæremidler -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-            is VurderingUføretrygdLæremidler -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-            is VurderingNedsattArbeidsevneLæremidler -> vurdering.copy(aldersvilkår = oppdatertAldersvilkår)
-        }
-    }
-
     @OptIn(ExperimentalContracts::class)
-    private fun validerRevurderFraErSatt(revurderFra: LocalDate?) {
+    fun validerRevurderFraErSatt(revurderFra: LocalDate?) {
         contract {
             returns() implies (revurderFra != null)
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValidering.kt
@@ -5,7 +5,10 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.Grunnlagsdata
 import no.nav.tilleggsstonader.sak.util.norskFormat
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.AldersvilkårVurdering.vurderAldersvilkår
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilFaktaOgSvarDto
@@ -57,6 +60,24 @@ object VilkårperiodeRevurderFraValidering {
         feilHvis(eksisterendePeriode.faktaOgVurdering.tilFaktaOgSvarDto() != oppdatertPeriode.faktaOgSvar) {
             logEndring(eksisterendePeriode, oppdatertPeriode)
             "Kan ikke endre vurderinger eller fakta på perioden. Kontakt utviklingsteamet"
+        }
+    }
+
+    /**
+     * Brukes for å validere at målgruppen fortsatt har gyldig aldersvilkår dersom kun tom-utvides.
+     * Vil kun kaste feil dersom man i løpet av perioden krysser enten øvre eller nedre aldersbegrensning.
+     *
+     * Begrensning/mangler:
+     * Vil ikke varsle saksbehandler om at aldersvilkår ikke er oppfylt dersom tidligere vilkår inneholder GAMMEL_MANGLER_DATA
+     * Lagres ikke ned i internt vedtak at vi faktisk sjekker alderen i disse tilfellene
+     */
+    fun validerAtAldersvilkårErGyldig(
+        eksisterendePeriode: Vilkårperiode,
+        oppdatertPeriode: LagreVilkårperiode,
+        grunnlagsdata: Grunnlagsdata,
+    ) {
+        if (eksisterendePeriode.type is MålgruppeType) {
+            vurderAldersvilkår(oppdatertPeriode, grunnlagsdata)
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -189,8 +189,8 @@ class VilkårperiodeService(
         revurderFra: LocalDate,
         grunnlagsdata: Grunnlagsdata,
     ): Vilkårperiode {
-        val vurderingerMedGammelManglerData = eksisterendeVilkårperiode.faktaOgVurdering.vurderinger.inneholderGammelManglerData()
-        val finnesGammelDataUtenomAldersVilkår = vurderingerMedGammelManglerData.filterNot { it is VurderingAldersVilkår }.isNotEmpty()
+        val vurderingerMedGammelManglerData = eksisterendeVilkårperiode.faktaOgVurdering.vurderinger.vurderingerMedSvarGammelManglerData()
+        val finnesGammelDataUtenomAldersVilkår = vurderingerMedGammelManglerData.any { it !is VurderingAldersVilkår }
 
         if (finnesGammelDataUtenomAldersVilkår) {
             brukerfeilHvis(vilkårperiode.tom > eksisterendeVilkårperiode.tom) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.domain.Stønadsperiod
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.dto.tilSortertDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.MålgruppeValidering.validerKanLeggeTilMålgruppeManuelt
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerAtKunTomErEndret
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerAtVilkårperiodeKanOppdateresIRevurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerNyPeriodeRevurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerRevurderFraErSatt
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerSlettPeriodeRevurdering
@@ -156,6 +157,7 @@ class VilkårperiodeService(
     ): Vilkårperiode {
         val revurderFra = behandling.revurderFra
         validerRevurderFraErSatt(revurderFra)
+        validerAtVilkårperiodeKanOppdateresIRevurdering(eksisterendeVilkårperiode, revurderFra)
 
         // Håndter vilkårsperioder hvor alle felter kan oppdateres
         if (eksisterendeVilkårperiode.fom >= revurderFra) {
@@ -178,11 +180,11 @@ class VilkårperiodeService(
         eksisterendeVilkårperiode: Vilkårperiode,
         revurderFra: LocalDate,
     ): Vilkårperiode {
-        val finnesGammelData = vilkårperiode.faktaOgSvar?.inneholderGammelManglerData() ?: false
+        val finnesGammelData = eksisterendeVilkårperiode.faktaOgVurdering.vurderinger.inneholderGammelManglerData() ?: false
 
         if (finnesGammelData) {
             brukerfeilHvis(vilkårperiode.tom > eksisterendeVilkårperiode.tom) {
-                "Det har kommet nye vilkår som må vurderes, og denne perioden er ikke lenger mulig å gjøre endringer på.Det er ikke mulig å gjøre noe annet enn å korte ned tom på denne perioden fordi det har kommet nye vilkår som må vurderes."
+                "Det har kommet nye vilkår som må vurderes, og denne perioden er derfor ikke mulig å forlenge. Hvis du ønsker å forlenge perioden må du legge til en ny periode."
             }
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
@@ -62,10 +62,7 @@ sealed interface Vurderinger {
         return utledResultat(resultater)
     }
 
-    fun inneholderGammelManglerData(): Boolean {
-        val svar = finnVurderinger().map { it.svar }
-        return svar.contains(SvarJaNei.GAMMEL_MANGLER_DATA)
-    }
+    fun inneholderGammelManglerData(): List<Vurdering> = finnVurderinger().filter { it.svar == SvarJaNei.GAMMEL_MANGLER_DATA }
 
     private fun finnVurderinger(): MutableList<Vurdering> {
         val vurderinger = mutableListOf<Vurdering>()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
@@ -58,34 +58,39 @@ data object IngenFakta : Fakta
  */
 sealed interface Vurderinger {
     fun resultatVurderinger(): ResultatVilkårperiode {
-        val resultater = finnResultatetFraVurderinger()
+        val resultater = finnVurderinger().map { it.resultat }
         return utledResultat(resultater)
     }
 
-    private fun finnResultatetFraVurderinger(): MutableList<ResultatDelvilkårperiode> {
-        val resultater = mutableListOf<ResultatDelvilkårperiode>()
+    fun inneholderGammelManglerData(): Boolean {
+        val svar = finnVurderinger().map { it.svar }
+        return svar.contains(SvarJaNei.GAMMEL_MANGLER_DATA)
+    }
+
+    private fun finnVurderinger(): MutableList<Vurdering> {
+        val vurderinger = mutableListOf<Vurdering>()
         if (this is LønnetVurdering) {
-            resultater.add(lønnet.resultat)
+            vurderinger.add(lønnet)
         }
         if (this is MedlemskapVurdering) {
-            resultater.add(medlemskap.resultat)
+            vurderinger.add(medlemskap)
         }
         if (this is DekketAvAnnetRegelverkVurdering) {
-            resultater.add(dekketAvAnnetRegelverk.resultat)
+            vurderinger.add(dekketAvAnnetRegelverk)
         }
         if (this is HarUtgifterVurdering) {
-            resultater.add(harUtgifter.resultat)
+            vurderinger.add(harUtgifter)
         }
         if (this is HarRettTilUtstyrsstipendVurdering) {
-            resultater.add(harRettTilUtstyrsstipend.resultat)
+            vurderinger.add(harRettTilUtstyrsstipend)
         }
         if (this is AldersvilkårVurdering) {
-            resultater.add(aldersvilkår.resultat)
+            vurderinger.add(aldersvilkår)
         }
         if (this is MottarSykepengerForFulltidsstillingVurdering) {
-            resultater.add(mottarSykepengerForFulltidsstilling.resultat)
+            vurderinger.add(mottarSykepengerForFulltidsstilling)
         }
-        return resultater
+        return vurderinger
     }
 
     private fun utledResultat(resultater: List<ResultatDelvilkårperiode>) =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurdering.kt
@@ -62,7 +62,7 @@ sealed interface Vurderinger {
         return utledResultat(resultater)
     }
 
-    fun inneholderGammelManglerData(): List<Vurdering> = finnVurderinger().filter { it.svar == SvarJaNei.GAMMEL_MANGLER_DATA }
+    fun vurderingerMedSvarGammelManglerData(): List<Vurdering> = finnVurderinger().filter { it.svar == SvarJaNei.GAMMEL_MANGLER_DATA }
 
     private fun finnVurderinger(): MutableList<Vurdering> {
         val vurderinger = mutableListOf<Vurdering>()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/Vurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/Vurdering.kt
@@ -167,7 +167,7 @@ data class VurderingAldersVilkår(
     }
 }
 
-data class VurderingMottarSykepengerForFulltidsstilling private constructor(
+data class VurderingMottarSykepengerForFulltidsstilling constructor(
     override val svar: SvarJaNei?,
     override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/Vurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/Vurdering.kt
@@ -183,7 +183,7 @@ data class VurderingMottarSykepengerForFulltidsstilling private constructor(
                 SvarJaNei.JA_IMPLISITT -> error("$svar er ugyldig for ${VurderingMottarSykepengerForFulltidsstilling::class.simpleName}")
                 SvarJaNei.GAMMEL_MANGLER_DATA ->
                     error(
-                        "$svar er ugyldig for nye eller oppdaterte vurderinger av typen: ${VurderingAldersVilkår::class.simpleName}",
+                        "$svar er ugyldig for nye eller oppdaterte vurderinger av typen: ${VurderingMottarSykepengerForFulltidsstilling::class.simpleName}",
                     )
             }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
@@ -5,6 +5,22 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.Studienivå
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetBoutgifter
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetLæremidler
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetTilsynBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.DekketAvAnnetRegelverkVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetsdager
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfFakta
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfVurderinger
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaProsent
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaStudienivå
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.HarRettTilUtstyrsstipendVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.HarUtgifterVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.LønnetVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MedlemskapVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MottarSykepengerForFulltidsstillingVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SvarJaNei
 import java.time.LocalDate
 
@@ -25,13 +41,17 @@ data class LagreVilkårperiode(
     JsonSubTypes.Type(FaktaOgSvarAktivitetLæremidlerDto::class, name = "AKTIVITET_LÆREMIDLER"),
     JsonSubTypes.Type(FaktaOgSvarAktivitetBoutgifterDto::class, name = "AKTIVITET_BOUTGIFTER"),
 )
-sealed class FaktaOgSvarDto
+sealed class FaktaOgSvarDto {
+    open fun inneholderGammelManglerData(): Boolean = false
+}
 
 data class FaktaOgSvarMålgruppeDto(
     val svarMedlemskap: SvarJaNei? = null,
     val svarUtgifterDekketAvAnnetRegelverk: SvarJaNei? = null,
     val svarMottarSykepengerForFulltidsstilling: SvarJaNei? = null,
-) : FaktaOgSvarDto()
+) : FaktaOgSvarDto() {
+    override fun inneholderGammelManglerData(): Boolean = svarMottarSykepengerForFulltidsstilling == SvarJaNei.GAMMEL_MANGLER_DATA
+}
 
 data class FaktaOgSvarAktivitetBarnetilsynDto(
     val aktivitetsdager: Int? = null,
@@ -48,3 +68,60 @@ data class FaktaOgSvarAktivitetLæremidlerDto(
 data class FaktaOgSvarAktivitetBoutgifterDto(
     val svarLønnet: SvarJaNei? = null,
 ) : FaktaOgSvarDto()
+
+fun FaktaOgVurdering.tilFaktaOgSvarDto(): FaktaOgSvarDto =
+    when (this) {
+        is MålgruppeFaktaOgVurdering ->
+            FaktaOgSvarMålgruppeDto(
+                svarMedlemskap =
+                    this.vurderinger
+                        .takeIfVurderinger<MedlemskapVurdering>()
+                        ?.medlemskap
+                        ?.svar,
+                svarUtgifterDekketAvAnnetRegelverk =
+                    this.vurderinger
+                        .takeIfVurderinger<DekketAvAnnetRegelverkVurdering>()
+                        ?.dekketAvAnnetRegelverk
+                        ?.svar,
+                svarMottarSykepengerForFulltidsstilling =
+                    this.vurderinger
+                        .takeIfVurderinger<MottarSykepengerForFulltidsstillingVurdering>()
+                        ?.mottarSykepengerForFulltidsstilling
+                        ?.svar,
+            )
+
+        is AktivitetTilsynBarn ->
+            FaktaOgSvarAktivitetBarnetilsynDto(
+                aktivitetsdager = this.fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
+                svarLønnet =
+                    this.vurderinger
+                        .takeIfVurderinger<LønnetVurdering>()
+                        ?.lønnet
+                        ?.svar,
+            )
+
+        is AktivitetLæremidler ->
+            FaktaOgSvarAktivitetLæremidlerDto(
+                svarHarRettTilUtstyrsstipend =
+                    this.vurderinger
+                        .takeIfVurderinger<HarRettTilUtstyrsstipendVurdering>()
+                        ?.harRettTilUtstyrsstipend
+                        ?.svar,
+                svarHarUtgifter =
+                    this.vurderinger
+                        .takeIfVurderinger<HarUtgifterVurdering>()
+                        ?.harUtgifter
+                        ?.svar,
+                prosent = this.fakta.takeIfFakta<FaktaProsent>()?.prosent,
+                studienivå = this.fakta.takeIfFakta<FaktaStudienivå>()?.studienivå,
+            )
+
+        is AktivitetBoutgifter ->
+            FaktaOgSvarAktivitetBoutgifterDto(
+                svarLønnet =
+                    this.vurderinger
+                        .takeIfVurderinger<LønnetVurdering>()
+                        ?.lønnet
+                        ?.svar,
+            )
+    }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
@@ -41,17 +41,13 @@ data class LagreVilkårperiode(
     JsonSubTypes.Type(FaktaOgSvarAktivitetLæremidlerDto::class, name = "AKTIVITET_LÆREMIDLER"),
     JsonSubTypes.Type(FaktaOgSvarAktivitetBoutgifterDto::class, name = "AKTIVITET_BOUTGIFTER"),
 )
-sealed class FaktaOgSvarDto {
-    open fun inneholderGammelManglerData(): Boolean = false
-}
+sealed class FaktaOgSvarDto
 
 data class FaktaOgSvarMålgruppeDto(
     val svarMedlemskap: SvarJaNei? = null,
     val svarUtgifterDekketAvAnnetRegelverk: SvarJaNei? = null,
     val svarMottarSykepengerForFulltidsstilling: SvarJaNei? = null,
-) : FaktaOgSvarDto() {
-    override fun inneholderGammelManglerData(): Boolean = svarMottarSykepengerForFulltidsstilling == SvarJaNei.GAMMEL_MANGLER_DATA
-}
+) : FaktaOgSvarDto()
 
 data class FaktaOgSvarAktivitetBarnetilsynDto(
     val aktivitetsdager: Int? = null,

--- a/src/main/resources/db/migration/V75__sykepengevilkår_målgruppe.sql
+++ b/src/main/resources/db/migration/V75__sykepengevilkår_målgruppe.sql
@@ -1,0 +1,23 @@
+UPDATE vilkar_periode
+SET fakta_og_vurdering = jsonb_set(fakta_og_vurdering, '{vurderinger, mottarSykepengerForFulltidsstilling}', '{
+  "svar": "GAMMEL_MANGLER_DATA",
+  "resultat": "IKKE_VURDERT"
+}'::jsonb)
+WHERE type IN ('NEDSATT_ARBEIDSEVNE')
+  and behandling_id in
+      (select b.id
+       from behandling b
+                join fagsak f on b.fagsak_id = f.id
+       where f.stonadstype != 'LÆREMIDLER');
+
+UPDATE vilkar_periode
+SET fakta_og_vurdering = jsonb_set(fakta_og_vurdering, '{vurderinger, mottarSykepengerForFulltidsstilling}', '{
+  "svar": "NEI_IMPLISITT",
+  "resultat": "OPPFYLT"
+}'::jsonb)
+WHERE type IN ('AAP', 'UFØRETRYGD')
+  and behandling_id in
+      (select b.id
+       from behandling b
+                join fagsak f on b.fagsak_id = f.id
+       where f.stonadstype != 'LÆREMIDLER');

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
@@ -40,8 +40,8 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppe
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.vurderingAldersVilkår
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppeLæremidler
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.vurderingAldersVilkår
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.vurderingDekketAvAnnetRegelverk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.vurderingHarRettTilUtstyrsstipend
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.vurderingLønnet

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
@@ -151,7 +151,7 @@ class TestoppsettService(
             ),
         )
 
-    fun lagBehandlingOgRevurdering(): Behandling {
+    fun lagBehandlingOgRevurdering(revurderFra: LocalDate = now()): Behandling {
         val fagsak = fagsak()
         lagreFagsak(fagsak)
         val førsteBehandling =
@@ -161,7 +161,7 @@ class TestoppsettService(
                 fagsak = fagsak,
                 forrigeIverksatteBehandlingId = førsteBehandling.id,
                 type = BehandlingType.REVURDERING,
-                revurderFra = now(),
+                revurderFra = revurderFra,
             )
         return lagre(revurdering)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeAktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeAktivitetServiceTest.kt
@@ -476,7 +476,7 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
         }
 
         @Test
-        fun `kan ikke oppdatere periode hvis periode begynner før revurderFra`() {
+        fun `kan ikke oppdatere fakta hvis periode begynner før revurderFra`() {
             val behandling =
                 testoppsettService.oppdater(
                     testoppsettService.lagBehandlingOgRevurdering().copy(revurderFra = now()),
@@ -494,7 +494,7 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                     id = aktivitet.id,
                     vilkårperiode = aktivitet.tilOppdatering(aktivitetsdager = 3),
                 )
-            }.hasMessageContaining("Kan ikke endre fakta på perioden")
+            }.hasMessageContaining("Kan ikke endre vurderinger eller fakta på perioden")
         }
     }
 
@@ -526,4 +526,3 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
         )
     }
 }
-

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeAktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeAktivitetServiceTest.kt
@@ -332,7 +332,7 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
     }
 
     @Nested
-    inner class OppdaterAktivitet {
+    inner class OppdaterAktivitetFørstegangsbehandling {
         @Test
         fun `skal oppdatere alle felter på aktivitet`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
@@ -377,27 +377,6 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
         }
 
         @Test
-        fun `endring av ativiteter opprettet fra tidligere behandling skal få status ENDRET`() {
-            val revurdering = testoppsettService.lagBehandlingOgRevurdering()
-            val opprinneligAktivitet =
-                vilkårperiodeRepository.insert(
-                    aktivitet(
-                        behandlingId = revurdering.forrigeIverksatteBehandlingId!!,
-                    ),
-                )
-            vilkårperiodeService.gjenbrukVilkårperioder(revurdering.forrigeIverksatteBehandlingId!!, revurdering.id)
-            val vilkårperiode = vilkårperiodeRepository.findByBehandlingId(revurdering.id).single()
-            val oppdatertPeriode =
-                aktivitetService.oppdaterVilkårperiode(
-                    id = vilkårperiode.id,
-                    vilkårperiode = vilkårperiode.tilOppdatering(),
-                )
-            assertThat(opprinneligAktivitet.status).isEqualTo(Vilkårstatus.NY)
-            assertThat(vilkårperiode.status).isEqualTo(Vilkårstatus.UENDRET)
-            assertThat(oppdatertPeriode.status).isEqualTo(Vilkårstatus.ENDRET)
-        }
-
-        @Test
         fun `skal feile dersom manglende begrunnelse når lønnet endres til ja`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
             val tiltak =
@@ -435,6 +414,30 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                 )
             }.hasMessageContaining("Kan ikke gjøre endringer på denne behandlingen fordi den er ferdigstilt.")
         }
+    }
+
+    @Nested
+    inner class OppdaterAktivitetRevurdering {
+        @Test
+        fun `endring av ativiteter opprettet fra tidligere behandling skal få status ENDRET`() {
+            val revurdering = testoppsettService.lagBehandlingOgRevurdering()
+            val opprinneligAktivitet =
+                vilkårperiodeRepository.insert(
+                    aktivitet(
+                        behandlingId = revurdering.forrigeIverksatteBehandlingId!!,
+                    ),
+                )
+            vilkårperiodeService.gjenbrukVilkårperioder(revurdering.forrigeIverksatteBehandlingId!!, revurdering.id)
+            val vilkårperiode = vilkårperiodeRepository.findByBehandlingId(revurdering.id).single()
+            val oppdatertPeriode =
+                aktivitetService.oppdaterVilkårperiode(
+                    id = vilkårperiode.id,
+                    vilkårperiode = vilkårperiode.tilOppdatering(),
+                )
+            assertThat(opprinneligAktivitet.status).isEqualTo(Vilkårstatus.NY)
+            assertThat(vilkårperiode.status).isEqualTo(Vilkårstatus.UENDRET)
+            assertThat(oppdatertPeriode.status).isEqualTo(Vilkårstatus.ENDRET)
+        }
 
         @Test
         fun `skal ikke kunne oppdatere aktivitetstypen`() {
@@ -449,7 +452,7 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                     id = aktivitet.id,
                     vilkårperiode = aktivitet.tilOppdatering().copy(type = AktivitetType.REELL_ARBEIDSSØKER),
                 )
-            }.hasMessageContaining("Ugyldig kombinasjon")
+            }.hasMessageContaining("Kan ikke endre type på en eksisterende periode.")
         }
 
         @Test
@@ -493,33 +496,34 @@ class VilkårperiodeAktivitetServiceTest : IntegrationTest() {
                 )
             }.hasMessageContaining("Kan ikke endre fakta på perioden")
         }
+    }
 
-        private fun Vilkårperiode.tilOppdatering(
-            nyFom: LocalDate? = null,
-            nyTom: LocalDate? = null,
-            aktivitetsdager: Int? = null,
-            svarLønnet: SvarJaNei? = null,
-            nyBegrunnelse: String? = null,
-        ): LagreVilkårperiode {
-            val faktaOgSvarTilsynBarnDto =
-                FaktaOgSvarAktivitetBarnetilsynDto(
-                    svarLønnet =
-                        svarLønnet ?: faktaOgVurdering.vurderinger
-                            .takeIfVurderinger<LønnetVurdering>()
-                            ?.lønnet
-                            ?.svar,
-                    aktivitetsdager =
-                        aktivitetsdager
-                            ?: faktaOgVurdering.fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
-                )
-            return dummyVilkårperiodeAktivitet(
-                behandlingId = behandlingId,
-                type = type as AktivitetType,
-                fom = nyFom ?: fom,
-                tom = nyTom ?: tom,
-                faktaOgSvar = faktaOgSvarTilsynBarnDto,
-                begrunnelse = nyBegrunnelse ?: begrunnelse,
+    private fun Vilkårperiode.tilOppdatering(
+        nyFom: LocalDate? = null,
+        nyTom: LocalDate? = null,
+        aktivitetsdager: Int? = null,
+        svarLønnet: SvarJaNei? = null,
+        nyBegrunnelse: String? = null,
+    ): LagreVilkårperiode {
+        val faktaOgSvarTilsynBarnDto =
+            FaktaOgSvarAktivitetBarnetilsynDto(
+                svarLønnet =
+                    svarLønnet ?: faktaOgVurdering.vurderinger
+                        .takeIfVurderinger<LønnetVurdering>()
+                        ?.lønnet
+                        ?.svar,
+                aktivitetsdager =
+                    aktivitetsdager
+                        ?: faktaOgVurdering.fakta.takeIfFakta<FaktaAktivitetsdager>()?.aktivitetsdager,
             )
-        }
+        return dummyVilkårperiodeAktivitet(
+            behandlingId = behandlingId,
+            type = type as AktivitetType,
+            fom = nyFom ?: fom,
+            tom = nyTom ?: tom,
+            faktaOgSvar = faktaOgSvarTilsynBarnDto,
+            begrunnelse = nyBegrunnelse ?: begrunnelse,
+        )
     }
 }
+

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeMålgruppeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeMålgruppeServiceTest.kt
@@ -403,6 +403,26 @@ class VilkårperiodeMålgruppeServiceTest : IntegrationTest() {
         }
     }
 
+        @Test
+        fun `kan ikke endre målgruppe dersom hele perioden er før revurderFra`() {
+            val originalMålgruppe =
+                målgruppe(
+                    fom = now().minusMonths(2),
+                    tom = now().minusMonths(1),
+                )
+            val behandling = lagRevurderingMedKopiertMålgruppe(originalMålgruppe, revurderFra = now())
+            val målgruppeFørOppdatering = vilkårperiodeRepository.findByBehandlingId(behandling.id).single()
+
+            assertThatThrownBy {
+                vilkårperiodeService.oppdaterVilkårperiode(
+                    målgruppeFørOppdatering.id,
+                    målgruppeFørOppdatering
+                        .tilOppdatering()
+                        .copy(tom = målgruppeFørOppdatering.tom.plusMonths(1)),
+                )
+            }.hasMessageContaining("Kan ikke endre vilkårperiode som er ferdig før revurderingsdato.")
+        }
+    }
 
     private fun Vilkårperiode.tilOppdatering() =
         LagreVilkårperiode(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValideringTest.kt
@@ -103,25 +103,7 @@ class VilkårperiodeRevurderFraValideringTest {
     }
 
     @Nested
-    inner class OppdateringAvPeriode {
-        @Test
-        fun `kan oppdatere periode hvis revurder-fra er satt`() {
-            assertDoesNotThrow {
-                val eksisterendeVilkårperiode =
-                    aktivitet(
-                        fom = revurderFra.plusDays(1),
-                        faktaOgVurdering =
-                            faktaOgVurderingAktivitetTilsynBarn(
-                                aktivitetsdager = 1,
-                            ),
-                    )
-                endringMedRevurderFra(
-                    eksisterendeVilkårperiode,
-                    eksisterendeVilkårperiode.medAktivitetsdager(aktivitetsdager = 2),
-                )
-            }
-        }
-
+    inner class OppdateringAvPeriodeHvorKunTomKanEndres {
         @Test
         fun `kan oppdatere periodens tom-dato til og med dagen før revurder fra`() {
             val eksisterendeVilkårperiode =
@@ -131,7 +113,7 @@ class VilkårperiodeRevurderFraValideringTest {
                 )
             assertDoesNotThrow {
                 listOf(revurderFra.minusDays(1), revurderFra, revurderFra.plusDays(1)).forEach { nyttTom ->
-                    endringMedRevurderFra(
+                    validerEndringKunTomKanOppdates(
                         eksisterendeVilkårperiode,
                         eksisterendeVilkårperiode.copy(tom = nyttTom),
                     )
@@ -147,7 +129,7 @@ class VilkårperiodeRevurderFraValideringTest {
                     tom = revurderFra.plusMonths(1),
                 )
             assertThatThrownBy {
-                endringMedRevurderFra(
+                validerEndringKunTomKanOppdates(
                     eksisterendeVilkårperiode,
                     eksisterendeVilkårperiode.copy(tom = revurderFra.minusDays(2)),
                 )
@@ -162,11 +144,11 @@ class VilkårperiodeRevurderFraValideringTest {
                     tom = revurderFra.plusMonths(1),
                 )
             assertThatThrownBy {
-                endringMedRevurderFra(
+                validerEndringKunTomKanOppdates(
                     eksisterendeVilkårperiode,
                     eksisterendeVilkårperiode.copy(fom = revurderFra.minusDays(2)),
                 )
-            }.hasMessageContaining("Kan ikke sette fom før revurder-fra")
+            }.message().contains("Kan ikke endre fom til", "fordi revurder fra", "er før")
         }
 
         @Test
@@ -178,27 +160,11 @@ class VilkårperiodeRevurderFraValideringTest {
                 )
 
             assertDoesNotThrow {
-                endringMedRevurderFra(
+                validerEndringKunTomKanOppdates(
                     eksisterendeVilkårperiode,
                     eksisterendeVilkårperiode.copy(begrunnelse = "en begrunnelse"),
                 )
             }
-        }
-
-        @Test
-        fun `skal ikke kunne oppdatere resultat`() {
-            val eksisterendeVilkårperiode =
-                aktivitet(
-                    fom = revurderFra.minusMonths(1),
-                    tom = revurderFra.plusMonths(1),
-                    resultat = ResultatVilkårperiode.OPPFYLT,
-                )
-            assertThatThrownBy {
-                endringMedRevurderFra(
-                    eksisterendeVilkårperiode,
-                    eksisterendeVilkårperiode.copy(resultat = ResultatVilkårperiode.IKKE_OPPFYLT),
-                )
-            }.hasMessageContaining("Resultat kan ikke endre seg")
         }
 
         @Test
@@ -215,11 +181,11 @@ class VilkårperiodeRevurderFraValideringTest {
                     resultat = ResultatVilkårperiode.OPPFYLT,
                 )
             assertThatThrownBy {
-                endringMedRevurderFra(
+                validerEndringKunTomKanOppdates(
                     eksisterendeVilkårperiode,
                     eksisterendeVilkårperiode.medAktivitetsdager(5),
                 )
-            }.hasMessageContaining("Kan ikke endre fakta på perioden")
+            }.hasMessageContaining("Kan ikke endre vurderinger eller fakta på perioden")
         }
 
         @Test
@@ -244,11 +210,11 @@ class VilkårperiodeRevurderFraValideringTest {
                     it.copy(faktaOgVurdering = it.faktaOgVurdering.copy(vurderinger = oppdaterteVurderinger))
                 }
             assertThatThrownBy {
-                endringMedRevurderFra(
+                validerEndringKunTomKanOppdates(
                     eksisterendeVilkårperiode,
                     oppdatert,
                 )
-            }.hasMessageContaining("Kan ikke endre vurderinger på perioden")
+            }.hasMessageContaining("Kan ikke endre vurderinger eller fakta på perioden")
         }
 
         @Test
@@ -274,14 +240,14 @@ class VilkårperiodeRevurderFraValideringTest {
                     it.copy(faktaOgVurdering = it.faktaOgVurdering.copy(vurderinger = oppdaterteVurderinger))
                 }
             assertDoesNotThrow {
-                endringMedRevurderFra(
+                validerEndringKunTomKanOppdates(
                     eksisterendeVilkårperiode,
                     oppdatert,
                 )
             }
         }
 
-        private fun endringMedRevurderFra(
+        private fun validerEndringKunTomKanOppdates(
             eksisterendeVilkårperiode: Vilkårperiode,
             oppdatertVilkårperiode: Vilkårperiode,
         ) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeRevurderFraValideringTest.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode
 
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.util.saksbehandling
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerEndrePeriodeRevurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerAtKunTomErEndret
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerNyPeriodeRevurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeRevurderFraValidering.validerSlettPeriodeRevurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
@@ -20,6 +20,8 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.ResultatDelvilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.SvarJaNei
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAldersVilkår
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilFaktaOgSvarDto
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -283,10 +285,16 @@ class VilkårperiodeRevurderFraValideringTest {
             eksisterendeVilkårperiode: Vilkårperiode,
             oppdatertVilkårperiode: Vilkårperiode,
         ) {
-            validerEndrePeriodeRevurdering(
-                behandlingMedRevurderFra,
+            validerAtKunTomErEndret(
                 eksisterendeVilkårperiode,
-                oppdatertVilkårperiode,
+                LagreVilkårperiode(
+                    behandlingId = oppdatertVilkårperiode.behandlingId,
+                    type = oppdatertVilkårperiode.type,
+                    fom = oppdatertVilkårperiode.fom,
+                    tom = oppdatertVilkårperiode.tom,
+                    faktaOgSvar = oppdatertVilkårperiode.faktaOgVurdering.tilFaktaOgSvarDto(),
+                ),
+                behandlingMedRevurderFra.revurderFra!!,
             )
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -168,7 +168,7 @@ object VilkårperiodeTestUtil {
             MålgruppeType.OVERGANGSSTØNAD -> OvergangssstønadLæremidler
             MålgruppeType.AAP ->
                 AAPLæremidler(
-                    vurderinger = VurderingAAPLæremidler(dekketAvAnnetRegelverk = dekketAvAnnetRegelverk, aldersvilkår = aldersvilkår,),
+                    vurderinger = VurderingAAPLæremidler(dekketAvAnnetRegelverk = dekketAvAnnetRegelverk, aldersvilkår = aldersvilkår),
                 )
 
             MålgruppeType.UFØRETRYGD ->
@@ -308,6 +308,7 @@ object VilkårperiodeTestUtil {
         tom: LocalDate = osloDateNow(),
         medlemskap: SvarJaNei? = null,
         dekkesAvAnnetRegelverk: SvarJaNei? = null,
+        mottarSykepengerForFulltidsstilling: SvarJaNei? = null,
         begrunnelse: String? = null,
         behandlingId: BehandlingId = BehandlingId.random(),
     ) = LagreVilkårperiode(
@@ -318,6 +319,7 @@ object VilkårperiodeTestUtil {
             FaktaOgSvarMålgruppeDto(
                 svarMedlemskap = medlemskap,
                 svarUtgifterDekketAvAnnetRegelverk = dekkesAvAnnetRegelverk,
+                svarMottarSykepengerForFulltidsstilling = mottarSykepengerForFulltidsstilling,
             ),
         begrunnelse = begrunnelse,
         behandlingId = behandlingId,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeTestUtil.kt
@@ -57,6 +57,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivit
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.tilFaktaOgSvarDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import java.time.LocalDate
 import java.util.UUID
@@ -385,4 +386,14 @@ object VilkårperiodeTestUtil {
             else -> error("Har ikke mappet ${faktaOgVurdering1::class.simpleName}")
         }
     }
+
+    fun Vilkårperiode.tilOppdatering() =
+        LagreVilkårperiode(
+            behandlingId = behandlingId,
+            fom = fom,
+            tom = tom,
+            faktaOgSvar = faktaOgVurdering.tilFaktaOgSvarDto(),
+            begrunnelse = begrunnelse,
+            type = type,
+        )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VurderingMottarSykepengerForFulltidsstillingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VurderingMottarSykepengerForFulltidsstillingTest.kt
@@ -44,4 +44,11 @@ class VurderingMottarSykepengerForFulltidsstillingTest {
             vurderingMottarSykepengerForFulltidsstilling(SvarJaNei.JA_IMPLISITT)
         }.hasMessageContaining("ugyldig")
     }
+
+    @Test
+    fun `hvis svar=GAMMEL_MANGLER_DATA så skal det kastes feil`() {
+        assertThatThrownBy {
+            vurderingMottarSykepengerForFulltidsstilling(SvarJaNei.GAMMEL_MANGLER_DATA)
+        }.hasMessageContaining("GAMMEL_MANGLER_DATA er ugyldig for nye eller oppdaterte vurderinger")
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/FaktaOgSvarDtoMapper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/FaktaOgSvarDtoMapper.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.HarUtgifterVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.LønnetVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MedlemskapVurdering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MottarSykepengerForFulltidsstillingVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
 
 fun FaktaOgVurdering.tilFaktaOgSvarDto(): FaktaOgSvarDto =
@@ -25,6 +26,11 @@ fun FaktaOgVurdering.tilFaktaOgSvarDto(): FaktaOgSvarDto =
                     vurderinger
                         .takeIfVurderinger<DekketAvAnnetRegelverkVurdering>()
                         ?.dekketAvAnnetRegelverk
+                        ?.svar,
+                svarMottarSykepengerForFulltidsstilling =
+                    vurderinger
+                        .takeIfVurderinger<MottarSykepengerForFulltidsstillingVurdering>()
+                        ?.mottarSykepengerForFulltidsstilling
                         ?.svar,
             )
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når det legges til nye vurderinger så må vi håndtere at eksisterende perioder mangler data. Dette gjøres ved bruk av GAMMEL_MANGLER_DATA for perioder med nedsatt arbeidsevne. Dette skal kun være et gyldig svar på eksisterende perioder, og skal kun tas med videre hvis en eksisterende periode kortes ned eller ikke røres.

Hvordan ulike type perioder skal håndteres:
- Legge til ny periode: ikke lov med GAMMEL_MANGLER_DATA (feil kastes)
- Oppdatere:
     - Hele perioden før revurder fra - ikke lov å oppdatere at all (dette håndterte vi ikke før, ble kun stoppet i frontend)
     - Hele periode er etter revurder fra - alt kan oppdateres og GAMMEL_MANGLER_DATA kaster feil. Frontend håndterer at denne byttes ut med `null` slik at hele perioden blir "ikke vurdert" om man oppdaterer den uten å velge svar
     - Perioden krysser revurder fra - kun tom-dato kan oppdateres
           - Hvis den inneholder svar med GAMMEL_MANGLER_DATA så får man beskjed om at denne perioden ikke kan utvides fordi den mangler vurderinger.

**⚠️ Aldersvilkår**

Ved å endre oppdateringsfunksjonen til å kun oppdatere tom-feltet så får man ikke gjort en kjøring av aldersvilkåret. Dette er håndtert ved å sjekke at perioden hvertfall ikke endres slik at den strekker seg over noen av grensene. Dvs. at så lenge hele perioden er oppfylt eller ikke oppfylt får man lov å lagre ned. 

Hvis noen har `GAMMEL_MANGLER_DATA` fra før så vil ikke saksbehandler få beskjed dersom hele perioden faktisk ikke er oppfylt. Tror dog det er veldig sjeldent at noen er nærme disse grensene.

Laget [favrokort](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24863) for oppfølging
