### PR TITLE
✨ Utebetalingsperioden som krysser nyttår skal ikke avkuttes og bruke…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -240,7 +240,7 @@ class BoutgifterBeregningService(
         periode: UtbetalingPeriode,
         utgifter: Map<TypeBoutgift, List<UtgiftBeregningBoutgifter>>,
     ): Beregningsgrunnlag {
-        val sats = finnMakssatsForPeriode(periode)
+        val sats = finnMakssatsForPeriode(periode.fom)
 
         val utgifterIPerioden = finnUtgiftForUtbetalingsperiode(utgifter, periode)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -240,7 +240,7 @@ class BoutgifterBeregningService(
         periode: UtbetalingPeriode,
         utgifter: Map<TypeBoutgift, List<UtgiftBeregningBoutgifter>>,
     ): Beregningsgrunnlag {
-        val sats = finnMakssatsForPeriode(periode.fom)
+        val sats = finnMakssats(periode.fom)
 
         val utgifterIPerioden = finnUtgiftForUtbetalingsperiode(utgifter, periode)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterVedtaksperiodeUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterVedtaksperiodeUtil.kt
@@ -2,32 +2,13 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
-import no.nav.tilleggsstonader.kontrakter.felles.splitPerÅr
 import no.nav.tilleggsstonader.sak.util.lørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterVedtaksperiodeUtil.sisteDagenILøpendeMåned
-import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
 
 object BoutgifterVedtaksperiodeUtil {
-    /**
-     * Vedtaksperiode deles i ulike år då nytt år betyr ny termine og ikke skal utbetales direkte
-     * For å innvilge høst og vår i 2 ulike perioder og der vårterminen får en ny sats
-     */
-    fun List<VedtaksperiodeBeregning>.splitVedtaksperiodePerÅr(): List<VedtaksperiodeInnenforÅr> =
-        this
-            .map {
-                it.splitPerÅr { fom, tom ->
-                    VedtaksperiodeInnenforÅr(
-                        fom = fom,
-                        tom = tom,
-                        målgruppe = it.målgruppe,
-                        aktivitet = it.aktivitet,
-                    )
-                }
-            }.flatten()
-
     /**
      * Splitter en periode i løpende måneder. Løpende måned er fra dagens dato og en måned frem i tiden.
      * eks 05.01.2024-29.02.24 blir listOf( P(fom=05.01.2024,tom=04.02.2024), P(fom=05.02.2024,tom=29.02.2024) )
@@ -56,20 +37,6 @@ object BoutgifterVedtaksperiodeUtil {
         this
             .alleDatoer()
             .any { dato -> !dato.lørdagEllerSøndag() }
-}
-
-data class VedtaksperiodeInnenforÅr(
-    override val fom: LocalDate,
-    override val tom: LocalDate,
-    val målgruppe: MålgruppeType,
-    val aktivitet: AktivitetType,
-) : Periode<LocalDate> {
-    init {
-        validatePeriode()
-        require(fom.year == tom.year) {
-            "Kan ikke være 2 ulike år (${fom.year}, ${tom.year}})"
-        }
-    }
 }
 
 /**

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MakssatsBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MakssatsBoutgifter.kt
@@ -47,7 +47,7 @@ private val satser: List<MakssatsBoutgifter> =
         },
     ) + bekreftedeSatser
 
-fun finnMakssatsForPeriode(dato: LocalDate): MakssatsBoutgifter =
-    satser.find {
-        dato >= it.fom && dato <= it.tom
-    } ?: error("Finner ikke satser for $dato")
+fun finnMakssats(dato: LocalDate): MakssatsBoutgifter =
+    satser.find { makssats ->
+        dato >= makssats.fom && dato <= makssats.tom
+    } ?: error("Finner ikke makssats for $dato")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MakssatsBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MakssatsBoutgifter.kt
@@ -47,7 +47,7 @@ private val satser: List<MakssatsBoutgifter> =
         },
     ) + bekreftedeSatser
 
-fun finnMakssatsForPeriode(periode: Periode<LocalDate>): MakssatsBoutgifter =
+fun finnMakssatsForPeriode(dato: LocalDate): MakssatsBoutgifter =
     satser.find {
-        it.inneholder(periode)
-    } ?: error("Finner ikke satser for $periode")
+        dato >= it.fom && dato <= it.tom
+    } ?: error("Finner ikke satser for $dato")

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_faste_utgifter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_faste_utgifter.feature
@@ -33,21 +33,21 @@ Egenskap: Beregning av faste utgifter
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe | Aktivitet |
       | 01.01.2025 | 31.01.2025 | 1              | 1000         | 4953      | 01.01.2025      | AAP       | TILTAK    |
 
-#  Scenario: Vedtaksperiode krysser nyttår
-#    Gitt følgende vedtaksperioder for boutgifter
-#      | Fom        | Tom        | Aktivitet | Målgruppe |
-#      | 15.11.2024 | 15.02.2025 | TILTAK    | AAP       |
-#
-#    Gitt følgende utgifter for: FASTE_UTGIFTER_TO_BOLIGER
-#      | Fom        | Tom        | Utgift |
-#      | 15.11.2024 | 15.02.2025 | 9000   |
-#
-#    Når beregner stønad for boutgifter
-#
-#    Så skal stønaden for boutgifter være
-#      | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe | Aktivitet |
-#      | 15.11.2024 | 14.12.2024 | 1              | 4809         | 4809      | 15.11.2024      | AAP       | TILTAK    |
-#      | 15.12.2024 | 14.01.2025 | 1              | 4809         | 4809      | 15.12.2024      | AAP       | TILTAK    |
-#      | 15.01.2025 | 14.02.2025 | 1              | 4953         | 4953      | 15.01.2025      | AAP       | TILTAK    |
-#      | 15.02.2025 | 15.02.2025 | 1              | 4953         | 4953      | 15.02.2025      | AAP       | TILTAK    |
+  Scenario: Vedtaksperiode krysser nyttår
+    Gitt følgende vedtaksperioder for boutgifter
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 15.11.2024 | 18.02.2025 | TILTAK    | AAP       |
+
+    Gitt følgende utgifter for: LØPENDE_UTGIFTER_TO_BOLIGER
+      | Fom        | Tom        | Utgift |
+      | 15.11.2024 | 18.02.2025 | 9000   |
+
+    Når beregner stønad for boutgifter
+
+    Så skal stønaden for boutgifter være
+      | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe | Aktivitet |
+      | 15.11.2024 | 14.12.2024 | 1              | 4809         | 4809      | 15.11.2024      | AAP       | TILTAK    |
+      | 15.12.2024 | 14.01.2025 | 1              | 4809         | 4809      | 15.12.2024      | AAP       | TILTAK    |
+      | 15.01.2025 | 14.02.2025 | 1              | 4953         | 4953      | 15.01.2025      | AAP       | TILTAK    |
+      | 15.02.2025 | 18.02.2025 | 1              | 4953         | 4953      | 15.02.2025      | AAP       | TILTAK    |
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_midlertidig_overnatting.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_midlertidig_overnatting.feature
@@ -16,7 +16,22 @@ Egenskap: Beregning av midlertidig overnatting
 
     Så skal stønaden for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe | Aktivitet |
-      | 07.01.2025 | 09.01.2025 | 1              | 1000         | 4953      | 07.01.2025      | AAp       | TILTAK    |
+      | 07.01.2025 | 09.01.2025 | 1              | 1000         | 4953      | 07.01.2025      | AAP       | TILTAK    |
+
+  Scenario: Vedtaksperiode krysser nyttår
+    Gitt følgende vedtaksperioder for boutgifter
+      | Fom        | Tom        | Aktivitet | Målgruppe |
+      | 30.12.2024 | 02.01.2025 | TILTAK    | AAP       |
+
+    Gitt følgende utgifter for: UTGIFTER_OVERNATTING
+      | Fom        | Tom        | Utgift |
+      | 30.12.2024 | 02.01.2025 | 8000   |
+
+    Når beregner stønad for boutgifter
+
+    Så skal stønaden for boutgifter være
+      | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe | Aktivitet |
+      | 30.12.2024 | 02.01.2025 | 1              | 4809         | 4809      | 30.12.2024      | AAP       | TILTAK    |
 
 
 #  Scenario: Ingen utgift i vedtaksperiode


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Utebetalingsperioden som krysser nyttår skal ikke avkuttes og bruke gammel sats.
Avhengig av: https://github.com/navikt/tilleggsstonader-sak/pull/663