### PR TITLE
Fjerne fødselsdato fra valider enkeltperiode

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtils.kt
@@ -61,7 +61,6 @@ object VedtaksperiodeValideringUtils {
         vedtaksperiode: Vedtaksperiode,
         målgruppePerioderPerType: Map<MålgruppeType, List<Datoperiode>>,
         aktivitetPerioderPerType: Map<AktivitetType, List<Datoperiode>>,
-        fødselsdato: LocalDate?,
     ) {
         brukerfeilHvisIkke(vedtaksperiode.målgruppe.gyldigeAktiviter.contains(vedtaksperiode.aktivitet)) {
             "Kombinasjonen av ${vedtaksperiode.målgruppe} og ${vedtaksperiode.aktivitet} er ikke gyldig"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerService.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning
 
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
-import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.VedtaksperiodeValideringUtils.validerAtVedtaksperioderIkkeOverlapperMedVilkårPeriodeUtenRett
@@ -23,7 +22,6 @@ import org.springframework.stereotype.Service
 @Service
 class TilsynBarnVedtaksperiodeValidingerService(
     private val vilkårperiodeService: VilkårperiodeService,
-    private val grunnlagsdataService: GrunnlagsdataService,
     private val vedtakRepository: VedtakRepository,
 ) {
     fun validerVedtaksperioder(
@@ -44,18 +42,11 @@ class TilsynBarnVedtaksperiodeValidingerService(
         val målgrupper = vilkårperioder.målgrupper.mergeSammenhengendeOppfylteMålgrupper()
         val aktiviteter = vilkårperioder.aktiviteter.mergeSammenhengendeOppfylteAktiviteter()
 
-        val fødselsdato =
-            grunnlagsdataService
-                .hentGrunnlagsdata(behandling.id)
-                .grunnlag.fødsel
-                ?.fødselsdatoEller1JanForFødselsår()
-
         vedtaksperioder.forEach {
             validerEnkeltperiode(
                 vedtaksperiode = it,
                 målgruppePerioderPerType = målgrupper,
                 aktivitetPerioderPerType = aktiviteter,
-                fødselsdato = fødselsdato,
             )
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterVedtaksperiodeValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterVedtaksperiodeValideringService.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.VedtaksperiodeValideringUtils.validerAtVedtaksperioderIkkeOverlapperMedVilkårPeriodeUtenRett
@@ -23,7 +22,6 @@ import org.springframework.stereotype.Service
 @Service
 class BoutgifterVedtaksperiodeValideringService(
     private val vilkårperiodeService: VilkårperiodeService,
-    private val grunnlagsdataService: GrunnlagsdataService,
     private val vedtakRepository: VedtakRepository,
 ) {
     fun validerVedtaksperioder(
@@ -44,18 +42,11 @@ class BoutgifterVedtaksperiodeValideringService(
         val målgrupper = vilkårperioder.målgrupper.mergeSammenhengendeOppfylteMålgrupper()
         val aktiviteter = vilkårperioder.aktiviteter.mergeSammenhengendeOppfylteAktiviteter()
 
-        val fødselsdato =
-            grunnlagsdataService
-                .hentGrunnlagsdata(behandling.id)
-                .grunnlag.fødsel
-                ?.fødselsdatoEller1JanForFødselsår()
-
         vedtaksperioder.forEach {
             validerEnkeltperiode(
                 vedtaksperiode = it,
                 målgruppePerioderPerType = målgrupper,
                 aktivitetPerioderPerType = aktiviteter,
-                fødselsdato = fødselsdato,
             )
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -25,7 +25,6 @@ class StønadsperiodeService(
     private val behandlingService: BehandlingService,
     private val stønadsperiodeRepository: StønadsperiodeRepository,
     private val vilkårperiodeService: VilkårperiodeService,
-    private val grunnlagsdataService: GrunnlagsdataService,
 ) {
     fun hentStønadsperioder(behandlingId: BehandlingId): List<StønadsperiodeDto> =
         stønadsperiodeRepository.findAllByBehandlingId(behandlingId).tilSortertDto()
@@ -153,13 +152,8 @@ class StønadsperiodeService(
         stønadsperioder: List<StønadsperiodeDto>,
     ) {
         val vilkårperioder = vilkårperiodeService.hentVilkårperioder(behandlingId)
-        val fødselsdato =
-            grunnlagsdataService
-                .hentGrunnlagsdata(behandlingId)
-                .grunnlag.fødsel
-                ?.fødselsdatoEller1JanForFødselsår()
 
-        StønadsperiodeValidering.valider(stønadsperioder, vilkårperioder, fødselsdato)
+        StønadsperiodeValidering.valider(stønadsperioder, vilkårperioder)
     }
 
     fun gjenbrukStønadsperioder(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeService.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GrunnlagsdataService
 import no.nav.tilleggsstonader.sak.vedtak.forslag.ForeslåVedtaksperiodeFraVilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeRevurderFraValidering.validerEndrePeriodeRevurdering
 import no.nav.tilleggsstonader.sak.vilkår.stønadsperiode.StønadsperiodeRevurderFraValidering.validerNyPeriodeRevurdering

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValidering.kt
@@ -15,7 +15,6 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkår
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
-import java.time.LocalDate
 
 object StønadsperiodeValidering {
     /**
@@ -25,7 +24,7 @@ object StønadsperiodeValidering {
     fun validerStønadsperioderVedEndringAvVilkårperiode(
         stønadsperioder: List<StønadsperiodeDto>,
         vilkårperioder: Vilkårperioder,
-    ) = valider(stønadsperioder, vilkårperioder, null)
+    ) = valider(stønadsperioder, vilkårperioder)
 
     /**
      * @param fødselsdato er nullable då alle behandlinger ikke har [fødselsdato] i grunnlagsdata fra før
@@ -33,14 +32,13 @@ object StønadsperiodeValidering {
     fun valider(
         stønadsperioder: List<StønadsperiodeDto>,
         vilkårperioder: Vilkårperioder,
-        fødselsdato: LocalDate?,
     ) {
         validerIkkeOverlappendeStønadsperioder(stønadsperioder)
         val målgrupper = vilkårperioder.målgrupper.mergeSammenhengendeOppfylteMålgrupper()
         val aktiviteter = vilkårperioder.aktiviteter.mergeSammenhengendeOppfylteAktiviteter()
 
         validerAtStønadsperioderIkkeOverlapperMedVilkårPeriodeUtenRett(vilkårperioder, stønadsperioder)
-        stønadsperioder.forEach { validerEnkeltperiode(it, målgrupper, aktiviteter, fødselsdato) }
+        stønadsperioder.forEach { validerEnkeltperiode(it, målgrupper, aktiviteter) }
     }
 
     private fun validerIkkeOverlappendeStønadsperioder(stønadsperioder: List<StønadsperiodeDto>) {
@@ -59,7 +57,6 @@ object StønadsperiodeValidering {
         stønadsperiode: StønadsperiodeDto,
         målgruppePerioderPerType: Map<MålgruppeType, List<Datoperiode>>,
         aktivitetPerioderPerType: Map<AktivitetType, List<Datoperiode>>,
-        fødselsdato: LocalDate?,
     ) {
         brukerfeilHvisIkke(stønadsperiode.målgruppe.gyldigeAktiviter.contains(stønadsperiode.aktivitet)) {
             "Kombinasjonen av ${stønadsperiode.målgruppe} og ${stønadsperiode.aktivitet} er ikke gyldig"

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsTest.kt
@@ -326,87 +326,6 @@ class VedtaksperiodeValideringUtilsTest {
         }
 
         @Nested
-        inner class ValideringAvFødselsdato {
-            val fom = LocalDate.of(2025, 1, 1)
-            val tom = LocalDate.of(2025, 1, 31)
-            val vedtaksperioder = lagVedtaksperiode()
-
-            val dato18årGammel = fom.minusYears(18)
-            val dato67årGammel = tom.minusYears(67)
-
-            @Test
-            fun `skal ikke kaste feil dersom nedsatt arbeidsevne og personen er over 18 år`() {
-                assertThatCode {
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
-                        aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                        dato18årGammel,
-                    )
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
-                        aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                        dato18årGammel.minusDays(1),
-                    )
-                }.doesNotThrowAnyException()
-            }
-
-            @Test
-            fun `skal ikke kaste feil dersom nedsatt arbeidsevne og personen er under 67 år`() {
-                assertThatCode {
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
-                        aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                        dato67årGammel.plusDays(1),
-                    )
-                }.doesNotThrowAnyException()
-            }
-
-            @Test
-            fun `skal ikke kaste feil dersom overgangsstønad og under 18 år eller over 67 år`() {
-                val vedtaksperioder =
-                    lagVedtaksperiode(
-                        målgruppe = MålgruppeType.OVERGANGSSTØNAD,
-                        aktivitet = AktivitetType.UTDANNING,
-                    )
-
-                val målgrupper =
-                    listOf(
-                        målgruppe(
-                            faktaOgVurdering = faktaOgVurderingMålgruppe(type = MålgruppeType.OVERGANGSSTØNAD),
-                            fom = LocalDate.of(2025, 1, 1),
-                            tom = LocalDate.of(2025, 2, 28),
-                        ),
-                    )
-                val aktiviteter =
-                    listOf(
-                        aktivitet(
-                            faktaOgVurdering = faktaOgVurderingAktivitetTilsynBarn(type = AktivitetType.UTDANNING),
-                            fom = LocalDate.of(2025, 1, 1),
-                            tom = LocalDate.of(2025, 2, 28),
-                        ),
-                    )
-
-                assertThatCode {
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
-                        aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                        dato18årGammel.minusYears(1),
-                    )
-                    validerEnkeltperiode(
-                        vedtaksperioder,
-                        målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
-                        aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                        dato67årGammel.plusYears(1),
-                    )
-                }.doesNotThrowAnyException()
-            }
-        }
-
-        @Nested
         inner class ValiderUtgifterHeleVedtaksperioden {
             val vedtaksperiode = lagVedtaksperiode()
 
@@ -543,7 +462,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.hasMessageContaining("Kombinasjonen av OVERGANGSSTØNAD og TILTAK er ikke gyldig")
         }
@@ -557,7 +475,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.hasMessageContaining("Finner ingen perioder hvor vilkår for NEDSATT_ARBEIDSEVNE er oppfylt")
         }
@@ -571,7 +488,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.hasMessageContaining("Finner ingen perioder hvor vilkår for UTDANNING er oppfylt")
         }
@@ -585,7 +501,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.hasMessageContaining(
                 "Finnes ingen periode med oppfylte vilkår for AAP i perioden 01.12.2024 - 31.01.2025",
@@ -610,7 +525,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.hasMessageContaining(
                 "Finnes ingen periode med oppfylte vilkår for TILTAK i perioden 01.01.2025 - 31.01.2025",
@@ -640,7 +554,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.doesNotThrowAnyException()
         }
@@ -667,7 +580,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.doesNotThrowAnyException()
         }
@@ -714,7 +626,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.doesNotThrowAnyException()
         }
@@ -729,7 +640,6 @@ class VedtaksperiodeValideringUtilsTest {
                     vedtaksperiode = vedtaksperiode,
                     målgruppePerioderPerType = målgrupper.mergeSammenhengendeOppfylteMålgrupper(),
                     aktivitetPerioderPerType = aktiviteter.mergeSammenhengendeOppfylteAktiviteter(),
-                    fødselsdato = null,
                 )
             }.hasMessageContaining(
                 "Finnes ingen periode med oppfylte vilkår for AAP i perioden 01.01.2025 - 21.01.2025",

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnVedtaksperiodeValidingerServiceTest.kt
@@ -34,7 +34,6 @@ class TilsynBarnVedtaksperiodeValidingerServiceTest {
     val tilsynBarnVedtaksperiodeValidingerService =
         TilsynBarnVedtaksperiodeValidingerService(
             vilkårperiodeService = vilkårperiodeService,
-            grunnlagsdataService = grunnlagsdataService,
             vedtakRepository = vedtakRepository,
         )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningServiceTest.kt
@@ -34,7 +34,6 @@ class BoutgifterBeregningServiceTest {
     val vedtaksperiodeValideringService =
         BoutgifterVedtaksperiodeValideringService(
             vilkårperiodeService = vilkårperiodeService,
-            grunnlagsdataService = grunnlagsdataService,
             vedtakRepository = vedtakRepository,
         )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsperiode/StønadsperiodeValideringTest.kt
@@ -198,69 +198,6 @@ internal class StønadsperiodeValideringTest {
     }
 
     @Nested
-    inner class ValideringAvFødselsdato {
-        val fom = LocalDate.of(2024, 1, 1)
-        val tom = LocalDate.of(2025, 12, 31)
-        val stønadsperioder =
-            listOf(
-                lagStønadsperiode(målgruppe = MålgruppeType.AAP, aktivitet = AktivitetType.TILTAK, fom = fom, tom = tom),
-            )
-        val målgrupper = listOf(målgruppe(fom = fom, tom = tom))
-        val aktiviteter = listOf(aktivitet1(fom = fom, tom = tom))
-        val vilkårperioder = Vilkårperioder(målgrupper, aktiviteter)
-
-        val dato18årGammel = fom.minusYears(18)
-        val dato67årGammel = tom.minusYears(67)
-
-        @Test
-        fun `skal ikke kaste feil dersom nedsatt arbeidsevne og personen er over 18 år`() {
-            assertThatCode {
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato18årGammel)
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato18årGammel.minusDays(1))
-            }.doesNotThrowAnyException()
-        }
-
-        @Test
-        fun `skal ikke kaste feil dersom nedsatt arbeidsevne og personen er under 67 år`() {
-            assertThatCode {
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato67årGammel.plusDays(1))
-            }.doesNotThrowAnyException()
-        }
-
-        @Test
-        fun `skal ikke kaste feil dersom overgangsstønad og under 18 år eller over 67 år`() {
-            val stønadsperioder =
-                stønadsperioder.map {
-                    it.copy(målgruppe = MålgruppeType.OVERGANGSSTØNAD, aktivitet = AktivitetType.UTDANNING)
-                }
-            val vilkårperioder =
-                vilkårperioder.copy(
-                    målgrupper =
-                        målgrupper.map {
-                            målgruppe(
-                                fom = it.fom,
-                                tom = it.tom,
-                                faktaOgVurdering = faktaOgVurderingMålgruppe(type = MålgruppeType.OVERGANGSSTØNAD),
-                            )
-                        },
-                    aktiviteter =
-                        aktiviteter.map {
-                            aktivitet1(
-                                fom = it.fom,
-                                tom = it.tom,
-                                faktaOgVurdering = faktaOgVurderingAktivitetTilsynBarn(type = AktivitetType.UTDANNING),
-                            )
-                        },
-                )
-
-            assertThatCode {
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato18årGammel.minusYears(1))
-                valider(stønadsperioder, vilkårperioder, fødselsdato = dato67årGammel.plusYears(1))
-            }.doesNotThrowAnyException()
-        }
-    }
-
-    @Nested
     inner class ValiderStønadsperioderOverlapper {
         val fom = LocalDate.of(2023, 1, 1)
         val tom = LocalDate.of(2023, 1, 7)
@@ -743,23 +680,19 @@ internal class StønadsperiodeValideringTest {
     fun valider(
         stønadsperioder: List<StønadsperiodeDto>,
         vilkårperioder: Vilkårperioder,
-        fødselsdato: LocalDate? = null,
     ) = StønadsperiodeValidering.valider(
         stønadsperioder = stønadsperioder,
         vilkårperioder = vilkårperioder,
-        fødselsdato = fødselsdato,
     )
 
     fun validerEnkeltperiode(
         stønadsperiode: StønadsperiodeDto,
         målgruppePerioderPerType: Map<MålgruppeType, List<Datoperiode>>,
         aktivitetPerioderPerType: Map<AktivitetType, List<Datoperiode>>,
-        fødselsdato: LocalDate? = null,
     ) = StønadsperiodeValidering.validerEnkeltperiode(
         stønadsperiode = stønadsperiode,
         målgruppePerioderPerType = målgruppePerioderPerType,
         aktivitetPerioderPerType = aktivitetPerioderPerType,
-        fødselsdato = fødselsdato,
     )
 
     private fun feilmeldingIkkeOverlappendePeriode(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Fjerne fødselsdato fra validerEnkeltperiode (fødselsdato var ikke brukt)
