### PR TITLE
Skriver om "UtgiftBeregning" til å bruke "LocalDate"

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/HarUtgifterHeleVedtaksperiodenValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/HarUtgifterHeleVedtaksperiodenValidering.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning
 
-import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
@@ -29,11 +28,7 @@ private fun erUtgiftperiodeSomInneholderVedtaksperiode(
     utgifter: Map<BarnId, List<UtgiftBeregning>>,
 ): Boolean {
     val sammenslåtteUtgiftPerioder =
-        utgifter.values
-            .flatMap {
-                it.map { Datoperiode(fom = it.fom.atDay(1), tom = it.tom.atEndOfMonth()) }
-            }.sorted()
-            .mergeSammenhengende { p1, p2 -> p1.overlapperEllerPåfølgesAv(p2) }
+        utgifter.values.flatten().mergeSammenhengende { p1, p2 -> p1.overlapperEllerPåfølgesAv(p2) }
 
     return vedtaksperioder.any { vedtaksperiode ->
         sammenslåtteUtgiftPerioder.any { utgiftPeriode -> utgiftPeriode.inneholder(vedtaksperiode) }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnUtgiftService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnUtgiftService.kt
@@ -9,7 +9,6 @@ import no.nav.tilleggsstonader.sak.util.erSisteDagIMåneden
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import org.springframework.stereotype.Service
-import java.time.YearMonth
 
 @Service
 class TilsynBarnUtgiftService(
@@ -35,8 +34,8 @@ class TilsynBarnUtgiftService(
             "Noe er feil. Tom skal være satt til siste dagen i måneden"
         }
         return UtgiftBeregning(
-            fom = YearMonth.from(fom),
-            tom = YearMonth.from(tom),
+            fom = fom,
+            tom = tom,
             utgift = utgift,
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnUtgiftService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBarnUtgiftService.kt
@@ -18,14 +18,11 @@ class TilsynBarnUtgiftService(
         vilkårService
             .hentOppfyltePassBarnVilkår(behandlingId)
             .groupBy { it.barnId ?: error("Vilkår=${it.id} type=${it.type} for tilsyn barn mangler barnId") }
-            .mapValues { (_, values) -> values.map { mapUtgiftBeregning(it) } }
+            .mapValues { (_, values) -> values.map { it.tilUtgiftBeregning() } }
 
-    private fun mapUtgiftBeregning(it: Vilkår): UtgiftBeregning {
-        val fom = it.fom
-        val tom = it.tom
-        val utgift = it.utgift
+    private fun Vilkår.tilUtgiftBeregning(): UtgiftBeregning {
         feilHvis(fom == null || tom == null || utgift == null) {
-            "Forventer at fra-dato, til-dato og utgift er satt. Gå tilbake til Pass barn-fanen, og legg til datoer og utgifter der. For utviklerteamet: dette gjelder vilkår=${it.id}."
+            "Forventer at fra-dato, til-dato og utgift er satt. Gå tilbake til Pass barn-fanen, og legg til datoer og utgifter der. For utviklerteamet: dette gjelder vilkår=$id."
         }
         feilHvisIkke(fom.erFørsteDagIMåneden()) {
             "Noe er feil. Fom skal være satt til første dagen i måneden"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/UtgiftBeregning.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/UtgiftBeregning.kt
@@ -1,14 +1,19 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning
 
+import no.nav.tilleggsstonader.kontrakter.felles.Mergeable
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
-import java.time.YearMonth
+import java.time.LocalDate
 
 data class UtgiftBeregning(
-    override val fom: YearMonth,
-    override val tom: YearMonth,
+    override val fom: LocalDate,
+    override val tom: LocalDate,
     val utgift: Int,
-) : Periode<YearMonth> {
+) : Periode<LocalDate>,
+    Mergeable<LocalDate, UtgiftBeregning> {
     init {
         validatePeriode()
     }
+
+    override fun merge(other: UtgiftBeregning): UtgiftBeregning =
+        this.copy(fom = minOf(this.fom, other.fom), tom = maxOf(this.tom, other.tom))
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsFaktiskMålgruppeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsFaktiskMålgruppeTest.kt
@@ -52,8 +52,8 @@ class VedtaksperiodeValideringUtilsFaktiskMålgruppeTest {
             BarnId.random() to
                 listOf(
                     UtgiftBeregning(
-                        fom = YearMonth.of(2025, 1),
-                        tom = YearMonth.of(2025, 2),
+                        fom = LocalDate.of(2025, 1, 1),
+                        tom = LocalDate.of(2025, 2, 28),
                         utgift = 1000,
                     ),
                 ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValideringUtilsTest.kt
@@ -59,8 +59,8 @@ class VedtaksperiodeValideringUtilsTest {
             BarnId.random() to
                 listOf(
                     UtgiftBeregning(
-                        fom = YearMonth.of(2025, 1),
-                        tom = YearMonth.of(2025, 2),
+                        fom = LocalDate.of(2025, 1, 1),
+                        tom = LocalDate.of(2025, 2, 28),
                         utgift = 1000,
                     ),
                 ),
@@ -334,8 +334,8 @@ class VedtaksperiodeValideringUtilsTest {
                     BarnId.random() to
                         listOf(
                             UtgiftBeregning(
-                                fom = YearMonth.of(2025, 1),
-                                tom = YearMonth.of(2025, 1),
+                                fom = LocalDate.of(2025, 1, 1),
+                                tom = LocalDate.of(2025, 1, 31),
                                 utgift = 1000,
                             ),
                         ),
@@ -370,13 +370,13 @@ class VedtaksperiodeValideringUtilsTest {
                         BarnId.random() to
                             listOf(
                                 UtgiftBeregning(
-                                    fom = YearMonth.of(2025, 1),
-                                    tom = YearMonth.of(2025, 1),
+                                    fom = LocalDate.of(2025, 1, 1),
+                                    tom = LocalDate.of(2025, 1, 31),
                                     utgift = 1000,
                                 ),
                                 UtgiftBeregning(
-                                    fom = YearMonth.of(2025, 2),
-                                    tom = YearMonth.of(2025, 2),
+                                    fom = LocalDate.of(2025, 2, 1),
+                                    tom = LocalDate.of(2025, 2, 28),
                                     utgift = 1000,
                                 ),
                             ),
@@ -397,16 +397,16 @@ class VedtaksperiodeValideringUtilsTest {
                         BarnId.random() to
                             listOf(
                                 UtgiftBeregning(
-                                    fom = YearMonth.of(2025, 1),
-                                    tom = YearMonth.of(2025, 1),
+                                    fom = LocalDate.of(2025, 1, 1),
+                                    tom = LocalDate.of(2025, 1, 31),
                                     utgift = 1000,
                                 ),
                             ),
                         BarnId.random() to
                             listOf(
                                 UtgiftBeregning(
-                                    fom = YearMonth.of(2025, 2),
-                                    tom = YearMonth.of(2025, 2),
+                                    fom = LocalDate.of(2025, 2, 1),
+                                    tom = LocalDate.of(2025, 2, 28),
                                     utgift = 1000,
                                 ),
                             ),
@@ -427,13 +427,13 @@ class VedtaksperiodeValideringUtilsTest {
                         BarnId.random() to
                             listOf(
                                 UtgiftBeregning(
-                                    fom = YearMonth.of(2025, 1),
-                                    tom = YearMonth.of(2025, 1),
+                                    fom = LocalDate.of(2025, 1, 1),
+                                    tom = LocalDate.of(2025, 1, 31),
                                     utgift = 1000,
                                 ),
                                 UtgiftBeregning(
-                                    fom = YearMonth.of(2025, 3),
-                                    tom = YearMonth.of(2025, 3),
+                                    fom = LocalDate.of(2025, 3, 1),
+                                    tom = LocalDate.of(2025, 3, 31),
                                     utgift = 1000,
                                 ),
                             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValidingerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtaksperiodeValidingerServiceTest.kt
@@ -21,7 +21,6 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.YearMonth
 import java.util.UUID
 
 class VedtaksperiodeValidingerServiceTest {
@@ -58,8 +57,8 @@ class VedtaksperiodeValidingerServiceTest {
             BarnId.Companion.random() to
                 listOf(
                     UtgiftBeregning(
-                        fom = YearMonth.of(2025, 1),
-                        tom = YearMonth.of(2025, 2),
+                        fom = LocalDate.of(2025, 1, 1),
+                        tom = LocalDate.of(2025, 2, 28),
                         utgift = 1000,
                     ),
                 ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -84,7 +84,7 @@ class TilsynBarnBeregnYtelseStegTest {
         every { repository.insert(any()) } answers { firstArg() }
         mockVilkårperioder(fom, tom, saksbehandling.id)
         every { tilsynBarnUtgiftService.hentUtgifterTilBeregning(any()) } returns
-            mapOf(barn.id to listOf(UtgiftBeregning(YearMonth.of(2023, 1), YearMonth.of(2023, 1), 1)))
+            mapOf(barn.id to listOf(UtgiftBeregning(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31), 1)))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/StepDefinitions.kt
@@ -98,8 +98,8 @@ class StepDefinitions {
         utgifter[barnUuid] =
             dataTable.mapRad { rad ->
                 UtgiftBeregning(
-                    fom = parseÅrMåned(DomenenøkkelFelles.FOM, rad),
-                    tom = parseÅrMåned(DomenenøkkelFelles.TOM, rad),
+                    fom = parseDato(DomenenøkkelFelles.FOM, rad),
+                    tom = parseDato(DomenenøkkelFelles.TOM, rad),
                     utgift = parseInt(BeregningNøkler.UTGIFT, rad),
                 )
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBeregningUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/TilsynBeregningUtilTest.kt
@@ -151,20 +151,20 @@ class TilsynBeregningUtilTest {
 
         val utgiftJanuar =
             UtgiftBeregning(
-                fom = YearMonth.of(2025, 1),
-                tom = YearMonth.of(2025, 1),
+                fom = LocalDate.of(2025, 1, 1),
+                tom = LocalDate.of(2025, 1, 31),
                 utgift = 1000,
             )
         val utgiftFebruar =
             UtgiftBeregning(
-                fom = YearMonth.of(2025, 2),
-                tom = YearMonth.of(2025, 2),
+                fom = LocalDate.of(2025, 2, 1),
+                tom = LocalDate.of(2025, 2, 28),
                 utgift = 1000,
             )
         val utgiftJanuarTilFebruar =
             UtgiftBeregning(
-                fom = YearMonth.of(2025, 1),
-                tom = YearMonth.of(2025, 2),
+                fom = LocalDate.of(2025, 1, 31),
+                tom = LocalDate.of(2025, 2, 28),
                 utgift = 1000,
             )
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_helgdager.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_helgdager.feature
@@ -13,8 +13,8 @@ Egenskap: Beregning - Håndtering av helgdager
       | 01.01.2023 | 31.01.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -42,7 +42,7 @@ Egenskap: Beregning - Håndtering av helgdager
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 04.2023 | 04.2023 | 1000   |
+      | 01.04.2023 | 30.04.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_makssats.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_makssats.feature
@@ -15,8 +15,8 @@ Egenskap: Verifisering av makssats
       | 01.01.2023 | 30.07.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Når beregner
 
@@ -37,12 +37,12 @@ Egenskap: Verifisering av makssats
       | 01.01.2023 | 30.07.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Gitt følgende utgifter for barn med id: 2
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Når beregner
 
@@ -63,16 +63,16 @@ Egenskap: Verifisering av makssats
       | 01.01.2023 | 30.07.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Gitt følgende utgifter for barn med id: 2
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Gitt følgende utgifter for barn med id: 3
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Når beregner
 
@@ -93,20 +93,20 @@ Egenskap: Verifisering av makssats
       | 01.01.2023 | 30.07.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Gitt følgende utgifter for barn med id: 2
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Gitt følgende utgifter for barn med id: 3
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Gitt følgende utgifter for barn med id: 4
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 12.2023 | 10000  |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.12.2023 | 10000  |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_samme_data_uppsplittede_stønadsperioder.feature
@@ -13,8 +13,8 @@ Egenskap: Beregning med vedtaksperioder for februar med 3 aktivitetsdager. Hele 
       | 01.02.2024 | 29.02.2024 | TILTAK    | 3               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner
 
@@ -33,8 +33,8 @@ Egenskap: Beregning med vedtaksperioder for februar med 3 aktivitetsdager. Hele 
       | 01.02.2024 | 29.02.2024 | TILTAK    | 3               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner
 
@@ -54,8 +54,8 @@ Egenskap: Beregning med vedtaksperioder for februar med 3 aktivitetsdager. Hele 
       | 07.02.2024 | 08.02.2024 | TILTAK    | 3               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_utgifter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/beregning_utgifter.feature
@@ -4,7 +4,6 @@
 Egenskap: Beregning - Utgifter
 
 
-
   Scenario: Beregning skal ikke ta med utgifter utenfor vedtaksperiode
     # Mål: Beregningen skal ikke gi resultat for februar fordi det ikke er utgifter i denne perioden
 
@@ -17,8 +16,8 @@ Egenskap: Beregning - Utgifter
       | 01.02.2023 | 28.02.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 03.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.03.2023 | 1000   |
 
     Når beregner
 
@@ -38,12 +37,12 @@ Egenskap: Beregning - Utgifter
       | 01.01.2023 | 28.02.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Gitt følgende utgifter for barn med id: 2
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 02.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 28.02.2023 | 1000   |
 
     Når beregner
 
@@ -73,10 +72,10 @@ Egenskap: Beregning - Utgifter
       | 01.01.2023 | 07.03.2023 | TILTAK | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 144    |
-      | 02.2023 | 02.2023 | 136    |
-      | 03.2023 | 03.2023 | 131    |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 144    |
+      | 01.02.2023 | 28.02.2023 | 136    |
+      | 01.03.2023 | 31.03.2023 | 131    |
 
     Når beregner
 
@@ -99,8 +98,8 @@ Egenskap: Beregning - Utgifter
       | 01.01.2023 | 28.02.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 0      |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 0      |
 
     Når beregner
 
@@ -119,8 +118,8 @@ Egenskap: Beregning - Utgifter
       | 01.01.2023 | 28.02.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/feilhåndtering.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/feilhåndtering.feature
@@ -17,7 +17,7 @@ Egenskap: Feilhåndtering i beregning
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -34,7 +34,7 @@ Egenskap: Feilhåndtering i beregning
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 02.2023 | 1000   |
+      | 01.01.2023 | 28.02.2023 | 1000   |
 
     Når beregner
 
@@ -51,7 +51,7 @@ Egenskap: Feilhåndtering i beregning
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -68,7 +68,7 @@ Egenskap: Feilhåndtering i beregning
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/fullAktivitet/en_vedtaksperiode.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/fullAktivitet/en_vedtaksperiode.feature
@@ -13,8 +13,8 @@ Egenskap: Beregning - En vedtaksperiode med full aktivitet
       | 01.01.2023 | 31.01.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -33,8 +33,8 @@ Egenskap: Beregning - En vedtaksperiode med full aktivitet
       | 02.01.2023 | 11.01.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -58,8 +58,8 @@ Egenskap: Beregning - En vedtaksperiode med full aktivitet
       | 10.04.2023 | 26.05.2023 | UTDANNING | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 06.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 30.06.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/fullAktivitet/flere_vedtaksperioder.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/fullAktivitet/flere_vedtaksperioder.feature
@@ -15,7 +15,7 @@ Egenskap: Beregning - Flere vedtaksperioder med full aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -49,7 +49,7 @@ Egenskap: Beregning - Flere vedtaksperioder med full aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFra.feature
@@ -14,7 +14,7 @@ Egenskap: Beregning - med revurderFra
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2024 | 02.2024 | 1000   |
+      | 01.01.2024 | 28.02.2024 | 1000   |
 
     Når beregner med revurderFra=2024-02-15
 
@@ -33,7 +33,7 @@ Egenskap: Beregning - med revurderFra
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2024 | 01.2024 | 1000   |
+      | 01.01.2024 | 31.01.2024 | 1000   |
 
     Når beregner med revurderFra=2023-12-15
 
@@ -52,7 +52,7 @@ Egenskap: Beregning - med revurderFra
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2024 | 03.2024 | 1000   |
+      | 01.01.2024 | 31.03.2024 | 1000   |
 
     Når beregner
 
@@ -98,7 +98,7 @@ Egenskap: Beregning - med revurderFra
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2024 | 01.2024 | 1000   |
+      | 01.01.2024 | 31.01.2024 | 1000   |
 
     Når beregner med revurderFra=2024-01-15
 
@@ -119,7 +119,7 @@ Egenskap: Beregning - med revurderFra
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2024 | 01.2024 | 1000   |
+      | 01.01.2024 | 31.01.2024 | 1000   |
 
     Når beregner med revurderFra=2024-01-15
 
@@ -145,7 +145,7 @@ Egenskap: Beregning - med revurderFra
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2024 | 01.2024 | 1000   |
+      | 01.01.2024 | 31.01.2024 | 1000   |
 
     Når beregner med revurderFra=2024-01-15
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFraBeholdPeriodeFraForrigeBehandling.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/revurderFra/revurderFraBeholdPeriodeFraForrigeBehandling.feature
@@ -21,7 +21,7 @@ Egenskap: Beregning - med revurderFra - behold perioder fra forrige behandling
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner med revurderFra=2024-02-05
 
@@ -49,7 +49,7 @@ Egenskap: Beregning - med revurderFra - behold perioder fra forrige behandling
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner med revurderFra=2024-02-05
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/en_aktivitet.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/en_aktivitet.feature
@@ -15,8 +15,8 @@ Egenskap: Beregning - En aktivitet med delvisaktivitet
       | 02.01.2023 | 21.01.2023 | TILTAK    | 3               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -35,8 +35,8 @@ Egenskap: Beregning - En aktivitet med delvisaktivitet
       | 02.01.2023 | 04.01.2023 | TILTAK    | 4               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/flere_aktiviteter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/flere_aktiviteter.feature
@@ -17,7 +17,7 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -39,7 +39,7 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -61,7 +61,7 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 01.2023 | 1000   |
+      | 01.01.2023 | 31.01.2023 | 1000   |
 
     Når beregner
 
@@ -83,7 +83,7 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 01.2023 | 02.2023 | 1000   |
+      | 01.01.2023 | 28.02.2023 | 1000   |
 
     Når beregner
 
@@ -107,7 +107,7 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner
 
@@ -128,7 +128,7 @@ Egenskap: Beregning - Flere aktiviteter med delvis aktivitet
 
     Gitt følgende utgifter for barn med id: 1
       | Fom     | Tom     | Utgift |
-      | 02.2024 | 02.2024 | 1000   |
+      | 01.02.2024 | 29.02.2024 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/komplisert_case.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/beregning/varierendeAktivitetsdager/komplisert_case.feature
@@ -21,12 +21,12 @@ Egenskap: Beregning - Komplisert scenario
       | 19.06.2023 | 30.06.2023 | TILTAK    | 2               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 06.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 30.06.2023 | 1000   |
 
     Gitt følgende utgifter for barn med id: 2
-      | Fom     | Tom     | Utgift |
-      | 04.2023 | 06.2023 | 1000   |
+      | Fom        | Tom        | Utgift |
+      | 01.04.2023 | 30.06.2023 | 1000   |
 
     Når beregner
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/validering_utgifter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/validering_utgifter.feature
@@ -31,9 +31,9 @@ Egenskap: Beregning barnetilsyn - validering av utgifter
       | 01.2023 | 03.2023 | TILTAK    | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 02.2023 | 100    |
-      | 02.2023 | 03.2023 | 100    |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 29.02.2023 | 100    |
+      | 01.02.2023 | 31.03.2023 | 100    |
 
     Når beregner
 
@@ -50,8 +50,8 @@ Egenskap: Beregning barnetilsyn - validering av utgifter
       | 01.2023 | 03.2023 | TILTAK    | 5               |
 
     Gitt følgende utgifter for barn med id: 1
-      | Fom     | Tom     | Utgift |
-      | 01.2023 | 03.2023 | -100   |
+      | Fom        | Tom        | Utgift |
+      | 01.01.2023 | 31.03.2023 | -100   |
 
     Når beregner
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å slå sammen `UtgiftBeregning` og `UtgiftBeregningBoutgifter` for å kunne gjenbruke validering, utils og tester. For å kunne gjøre dette må må både `UtgiftBeregning` og `UtgiftBeregningBoutgifter` bruke `LocalDate`. 

Denne PRen gjør skriver om `UtgiftBeregning` til å bruke `LocalDate`. Neste steg blir å slå sammen `UtgiftBeregning` og `UtgiftBeregningBoutgifter` og høste fordelene av det.