### PR TITLE
Legger til behandlingsdetaljer på MDC på alle requester knyttet til b…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
@@ -45,6 +45,7 @@ class BehandlingController(
     fun hentBehandling(
         @PathVariable behandlingId: BehandlingId,
     ): BehandlingDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val saksbehandling: Saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         if (saksbehandling.status == BehandlingStatus.OPPRETTET) {
@@ -101,6 +102,7 @@ class BehandlingController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody henlagt: HenlagtDto,
     ): BehandlingDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
         val henlagtBehandling = henleggService.henleggBehandling(behandlingId, henlagt)
@@ -122,6 +124,7 @@ class BehandlingController(
         @PathVariable behandlingId: BehandlingId,
         @PathVariable revurderFra: LocalDate,
     ): BehandlingDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         return revurderFraService.oppdaterRevurderFra(behandlingId, revurderFra).tilDto()
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/fakta/BehandlingFaktaController.kt
@@ -20,6 +20,7 @@ class BehandlingFaktaController(
     fun hentBehandlingFakta(
         @PathVariable behandlingId: BehandlingId,
     ): BehandlingFaktaDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return behandlingFaktaService.hentFakta(behandlingId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkController.kt
@@ -23,6 +23,7 @@ class BehandlingshistorikkController(
     fun hentBehandlingshistorikk(
         @PathVariable behandlingId: BehandlingId,
     ): List<BehandlingshistorikkDto> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling.id, AuditLoggerEvent.ACCESS)
         val behandlingHistorikk = behandlingshistorikkService.finnHendelseshistorikk(saksbehandling)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentController.kt
@@ -24,6 +24,7 @@ class SettPåVentController(
     fun hentStatusSettPåVent(
         @PathVariable behandlingId: BehandlingId,
     ): StatusPåVentDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return settPåVentService.hentStatusSettPåVent(behandlingId)
     }
@@ -33,6 +34,7 @@ class SettPåVentController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody dto: SettPåVentDto,
     ): StatusPåVentDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
         return settPåVentService.settPåVent(behandlingId, dto)
@@ -43,6 +45,7 @@ class SettPåVentController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody dto: OppdaterSettPåVentDto,
     ): StatusPåVentDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
         return settPåVentService.oppdaterSettPåVent(behandlingId, dto)
@@ -53,6 +56,7 @@ class SettPåVentController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody taAvVentDto: TaAvVentDto,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
         settPåVentService.taAvVent(behandlingId, taAvVentDto)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegController.kt
@@ -22,6 +22,7 @@ class StegController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody request: FerdigstillStegRequest,
     ): BehandlingId {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -33,6 +34,7 @@ class StegController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody request: ResetStegRequest,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
@@ -24,6 +24,7 @@ class BrevmottakereController(
     fun hentBrevmottakere(
         @PathVariable behandlingId: BehandlingId,
     ): BrevmottakereDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 
         return brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId)
@@ -34,6 +35,7 @@ class BrevmottakereController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody brevmottakere: BrevmottakereDto,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
@@ -24,6 +24,7 @@ class BrevMellomlagerController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody mellomlagretBrev: MellomlagreBrevDto,
     ): BehandlingId {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -38,6 +39,7 @@ class BrevMellomlagerController(
     fun hentMellomlagretBrevverdier(
         @PathVariable behandlingId: BehandlingId,
     ): MellomlagreBrevDto? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 
         return mellomlagringBrevService.hentMellomlagretBrev(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/BrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/BrevController.kt
@@ -27,6 +27,7 @@ class BrevController(
         @RequestBody request: GenererPdfRequest,
         @PathVariable behandlingId: BehandlingId,
     ): ByteArray {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
 
         tilgangService.validerTilgangTilBehandling(saksbehandling.id, AuditLoggerEvent.UPDATE)
@@ -39,6 +40,7 @@ class BrevController(
     fun hentBrev(
         @PathVariable behandlingId: BehandlingId,
     ): ByteArray {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
 
         return Base64.getEncoder().encode(brevService.hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId))
@@ -48,6 +50,7 @@ class BrevController(
     fun forhåndsvisBeslutterbrev(
         @PathVariable behandlingId: BehandlingId,
     ): ByteArray {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling.id, AuditLoggerEvent.ACCESS)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/ApplicationConfig.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.libs.http.config.RestTemplateConfiguration
 import no.nav.tilleggsstonader.libs.log.filter.LogFilterConfiguration
 import no.nav.tilleggsstonader.libs.unleash.UnleashConfiguration
 import no.nav.tilleggsstonader.sak.infrastruktur.filter.NAVIdentFilter
+import no.nav.tilleggsstonader.sak.infrastruktur.logging.BehandlingLogFilter
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import org.slf4j.LoggerFactory
 import org.springframework.boot.SpringBootConfiguration
@@ -28,6 +29,14 @@ class ApplicationConfig {
 
     init {
         logger.info("Starter versjon=${Applikasjonsversjon.versjon}")
+    }
+
+    @Bean
+    fun behandlingLoggingFilter(): FilterRegistrationBean<BehandlingLogFilter> {
+        val filterRegistration = FilterRegistrationBean<BehandlingLogFilter>()
+        filterRegistration.filter = BehandlingLogFilter()
+        filterRegistration.order = 1 // Samme nivå som LogFilter sånn at navIdent blir med på RequestTimeFilter
+        return filterRegistration
     }
 
     @Bean

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/logging/BehandlingLogFilter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/logging/BehandlingLogFilter.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.logging
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpFilter
+import org.slf4j.MDC
+
+class BehandlingLogFilter : HttpFilter() {
+    override fun doFilter(
+        req: ServletRequest?,
+        res: ServletResponse?,
+        chain: FilterChain?,
+    ) {
+        try {
+            super.doFilter(req, res, chain)
+        } finally {
+            TypeBehandlingLogging.entries.forEach { MDC.remove(it.key) }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/logging/BehandlingLogService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/logging/BehandlingLogService.kt
@@ -1,0 +1,42 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.logging
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.spring.cache.getValue
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import org.slf4j.MDC
+import org.springframework.cache.CacheManager
+import org.springframework.stereotype.Service
+
+@Service
+class BehandlingLogService(
+    private val behandlingService: BehandlingService,
+    private val cacheManager: CacheManager,
+) {
+    fun settBehandlingsdetaljerForRequest(behandlingId: BehandlingId) {
+        val behandlingsinformasjon = hentBehandlingsinformasjon(behandlingId)
+        MDC.put(TypeBehandlingLogging.BEHANDLING_ID.key, behandlingsinformasjon.behandlingId.toString())
+        MDC.put(TypeBehandlingLogging.FAGSAK_ID.key, behandlingsinformasjon.fagsakId.toString())
+        MDC.put(TypeBehandlingLogging.STØNADSTYPE.key, behandlingsinformasjon.stønadstype.name)
+    }
+
+    private fun hentBehandlingsinformasjon(behandlingId: BehandlingId): Behandlingsinformasjon =
+        cacheManager.getValue("request_logging_behandlingsinfo", behandlingId, {
+            val behandling = behandlingService.hentSaksbehandling(behandlingId)
+            Behandlingsinformasjon(behandling)
+        })
+}
+
+private data class Behandlingsinformasjon(
+    val fagsakId: FagsakId,
+    val behandlingId: BehandlingId,
+    val stønadstype: Stønadstype,
+) {
+    constructor(behandling: Saksbehandling) : this(
+        fagsakId = behandling.fagsakId,
+        behandlingId = behandling.id,
+        stønadstype = behandling.stønadstype,
+    )
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/logging/TypeBehandlingLogging.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/logging/TypeBehandlingLogging.kt
@@ -1,0 +1,9 @@
+package no.nav.tilleggsstonader.sak.infrastruktur.logging
+
+enum class TypeBehandlingLogging(
+    val key: String,
+) {
+    BEHANDLING_ID("behandlingId"),
+    FAGSAK_ID("fagsakId"),
+    STØNADSTYPE("stonadstype"),
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningController.kt
@@ -22,6 +22,7 @@ class PersonopplysningController(
     fun hentPersonopplysninger(
         @PathVariable behandlingId: BehandlingId,
     ): PersonopplysningerDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return personopplysningerService.hentPersonopplysninger(behandlingId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/aktivitet/RegisterAktivitetController.kt
@@ -42,6 +42,7 @@ class RegisterAktivitetController(
     fun hentAktivitetForBehandling(
         @PathVariable behandlingId: BehandlingId,
     ): List<AktivitetArenaDto> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         return registerAktivitetService.hentAktiviteter(saksbehandling.fagsakPersonId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ManglerTilgang
+import no.nav.tilleggsstonader.sak.infrastruktur.logging.BehandlingLogService
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.RolleConfig
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
@@ -32,7 +33,12 @@ class TilgangService(
     private val rolleConfig: RolleConfig,
     private val cacheManager: CacheManager,
     private val auditLogger: AuditLogger,
+    private val behandlingLogService: BehandlingLogService,
 ) {
+    fun settBehandlingsdetaljerForRequest(behandlingId: BehandlingId) {
+        behandlingLogService.settBehandlingsdetaljerForRequest(behandlingId)
+    }
+
     /**
      * Kun ved tilgangskontroll for enkeltperson (eks når man skal søke etter brevmottaker)
      * Ellers bruk [validerTilgangTilPersonMedRelasjoner]

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringController.kt
@@ -25,6 +25,7 @@ class SimuleringController(
     fun simulerForBehandling(
         @PathVariable behandlingId: BehandlingId,
     ): SimuleringDto? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
 
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -63,6 +63,7 @@ class TilsynBarnVedtakController(
         behandlingId: BehandlingId,
         vedtak: VedtakTilsynBarnRequest,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
         vedtakService.håndterSteg(behandlingId, vedtak)
     }
@@ -72,6 +73,7 @@ class TilsynBarnVedtakController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseTilsynBarnRequest,
     ): BeregningsresultatTilsynBarnDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         return beregningService
             .beregn(
@@ -89,6 +91,7 @@ class TilsynBarnVedtakController(
     fun hentVedtak(
         @PathVariable behandlingId: BehandlingId,
     ): VedtakResponse? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val revurderFra = behandlingService.hentSaksbehandling(behandlingId).revurderFra
         val vedtak = vedtakService.hentVedtak(behandlingId) ?: return null
@@ -99,6 +102,7 @@ class TilsynBarnVedtakController(
     fun hentFullstendigVedtaksoversikt(
         @PathVariable behandlingId: BehandlingId,
     ): VedtakResponse? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val vedtak = vedtakService.hentVedtak(behandlingId) ?: return null
         return VedtakDtoMapper.toDto(vedtak, null)
@@ -108,6 +112,7 @@ class TilsynBarnVedtakController(
     fun foreslåVedtaksperioder(
         @PathVariable behandlingId: BehandlingId,
     ): List<VedtaksperiodeDto> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
@@ -66,6 +66,7 @@ class BoutgifterVedtakController(
         behandlingId: BehandlingId,
         vedtak: VedtakBoutgifterRequest,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
         stegService.håndterSteg(behandlingId, steg, vedtak)
     }
@@ -75,6 +76,7 @@ class BoutgifterVedtakController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseBoutgifterRequest,
     ): BeregningsresultatBoutgifterDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         return beregningService
             .beregn(
@@ -88,6 +90,7 @@ class BoutgifterVedtakController(
     fun hentVedtak(
         @PathVariable behandlingId: BehandlingId,
     ): VedtakResponse? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val revurderFra = behandlingService.hentSaksbehandling(behandlingId).revurderFra
         val vedtak = vedtakService.hentVedtak(behandlingId) ?: return null
@@ -107,6 +110,7 @@ class BoutgifterVedtakController(
     fun foreslåVedtaksperioder(
         @PathVariable behandlingId: BehandlingId,
     ): List<VedtaksperiodeDto> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
@@ -65,6 +65,7 @@ class LæremidlerVedtakController(
         behandlingId: BehandlingId,
         vedtak: VedtakLæremidlerRequest,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
         stegService.håndterSteg(behandlingId, steg, vedtak)
     }
@@ -74,6 +75,7 @@ class LæremidlerVedtakController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtaksperioder: List<VedtaksperiodeLæremidlerDto>,
     ): BeregningsresultatLæremidlerDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         return beregningService
             .beregn(
@@ -90,6 +92,7 @@ class LæremidlerVedtakController(
     fun hentVedtak(
         @PathVariable behandlingId: BehandlingId,
     ): VedtakResponse? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val revurderFra = behandlingService.hentSaksbehandling(behandlingId).revurderFra
         val vedtak = vedtakService.hentVedtak(behandlingId) ?: return null
@@ -100,6 +103,7 @@ class LæremidlerVedtakController(
     fun hentFullstendigVedtaksoversikt(
         @PathVariable behandlingId: BehandlingId,
     ): VedtakResponse? {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         val vedtak = vedtakService.hentVedtak(behandlingId) ?: return null
         return VedtakDtoMapper.toDto(vedtak, null)
@@ -109,6 +113,7 @@ class LæremidlerVedtakController(
     fun foreslåVedtaksperioder(
         @PathVariable behandlingId: BehandlingId,
     ): List<VedtaksperiodeLæremidlerDto> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
@@ -30,6 +30,7 @@ class TotrinnskontrollController(
     fun hentTotrinnskontroll(
         @PathVariable behandlingId: BehandlingId,
     ): StatusTotrinnskontrollDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
     }
@@ -39,6 +40,7 @@ class TotrinnskontrollController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody request: SendTilBeslutterRequest,
     ): StatusTotrinnskontrollDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         stegService.håndterSteg(behandlingId, sendTilBeslutterSteg, request)
         return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
@@ -49,6 +51,7 @@ class TotrinnskontrollController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody request: BeslutteVedtakDto,
     ): StatusTotrinnskontrollDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         stegService.håndterSteg(behandlingId, beslutteVedtakSteg, request)
         return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)
@@ -58,6 +61,7 @@ class TotrinnskontrollController(
     fun angreSendTilBeslutter(
         @PathVariable behandlingId: BehandlingId,
     ): StatusTotrinnskontrollDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårController.kt
@@ -39,6 +39,7 @@ class VilkårController(
     fun oppdaterVilkår(
         @RequestBody svarPåVilkårDto: SvarPåVilkårDto,
     ): VilkårDto {
+        tilgangService.settBehandlingsdetaljerForRequest(svarPåVilkårDto.behandlingId)
         tilgangService.validerTilgangTilBehandling(svarPåVilkårDto.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
         try {
@@ -58,6 +59,7 @@ class VilkårController(
     fun opprettVilkår(
         @RequestBody opprettVilkårDto: OpprettVilkårDto,
     ): VilkårDto {
+        tilgangService.settBehandlingsdetaljerForRequest(opprettVilkårDto.behandlingId)
         tilgangService.validerTilgangTilBehandling(opprettVilkårDto.behandlingId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -68,6 +70,7 @@ class VilkårController(
     fun slettVilkår(
         @RequestBody request: OppdaterVilkårDto,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(request.behandlingId)
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.DELETE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -78,6 +81,7 @@ class VilkårController(
     fun settVilkårTilSkalIkkeVurderes(
         @RequestBody request: OppdaterVilkårDto,
     ): VilkårDto {
+        tilgangService.settBehandlingsdetaljerForRequest(request.behandlingId)
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
         return vilkårService.settVilkårTilSkalIkkeVurderes(request)
@@ -87,6 +91,7 @@ class VilkårController(
     fun getVilkår(
         @PathVariable behandlingId: BehandlingId,
     ): VilkårsvurderingDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return VilkårsvurderingDto(vilkårService.hentVilkår(behandlingId).map { it.tilDto() })
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -33,6 +33,7 @@ class VilkårperiodeController(
     fun hentVilkårperioder(
         @PathVariable behandlingId: BehandlingId,
     ): VilkårperioderResponse {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 
         return vilkårperiodeService.hentVilkårperioderResponse(behandlingId)
@@ -43,6 +44,7 @@ class VilkårperiodeController(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody oppdaterGrunnlag: OppdaterGrunnlagDto?,
     ) {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -53,6 +55,7 @@ class VilkårperiodeController(
     fun opprettVilkårperiode(
         @RequestBody vilkårperiode: LagreVilkårperiode,
     ): LagreVilkårperiodeResponse {
+        tilgangService.settBehandlingsdetaljerForRequest(vilkårperiode.behandlingId)
         tilgangService.validerTilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -65,6 +68,7 @@ class VilkårperiodeController(
         @PathVariable("id") id: UUID,
         @RequestBody vilkårperiode: LagreVilkårperiode,
     ): LagreVilkårperiodeResponse {
+        tilgangService.settBehandlingsdetaljerForRequest(vilkårperiode.behandlingId)
         tilgangService.validerTilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
@@ -77,6 +81,7 @@ class VilkårperiodeController(
         @PathVariable("id") id: UUID,
         @RequestBody slettVikårperiode: SlettVikårperiode,
     ): LagreVilkårperiodeResponse {
+        tilgangService.settBehandlingsdetaljerForRequest(slettVikårperiode.behandlingId)
         tilgangService.validerTilgangTilBehandling(slettVikårperiode.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårsoppsummering/VilkårsoppsummeringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårsoppsummering/VilkårsoppsummeringController.kt
@@ -22,6 +22,7 @@ class VilkårsoppsummeringController(
     fun hentVilkårsoppsummering(
         @PathVariable behandlingId: BehandlingId,
     ): VilkårsoppsummeringDto {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
 
         return vilkårsoppsummeringService.hentVilkårsoppsummering(behandlingId)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangServiceTest.kt
@@ -50,6 +50,7 @@ internal class TilgangServiceTest {
             rolleConfig = rolleConfig,
             cacheManager = cacheManager,
             auditLogger = mockk(relaxed = true),
+            mockk(),
         )
     private val mocketPersonIdent = "12345"
 


### PR DESCRIPTION
…ehandling for å kunne vise informasjonen i kibana på hvert logginnslag

### Hvorfor er denne endringen nødvendig? ✨

Jeg mangler ofte litt context til loggmeldinger, eks behandlingId, fagsakId og stønadstype. Disse feltene kan gjøre det litt enklere for å skjønne hvilken behandling det gjelder, eller hvilken stønadstype.
MDC-felter blir automatisk til i loggingen, og kan vises i egen kolonne i eks kibana. (Se bilde)
Informasjonen kommer selvfølgelig også med i loki. 

![image](https://github.com/user-attachments/assets/1f7ffdce-98ec-4362-877d-c4b885cb1256)


https://logs.adeo.no/s/nav-logs-legacy/app/r/s/8XKtu

[grafana-loki](https://grafana.nav.cloud.nais.io/a/grafana-lokiexplore-app/explore/service_name/tilleggsstonader-sak/logs?from=2025-04-25T05:00:00.000Z&to=2025-04-25T08:00:00.000Z&var-ds=P7BE696147D279490&var-filters=service_name%7C%3D%7Ctilleggsstonader-sak&patterns=%5B%5D&var-fields=behandlingId%7C%3D%7C%7B%22value%22:%223e2800fe-135e-43fe-9e15-ccb9f92e5bba%22__gfc__%22parser%22:%22json%22%7D,3e2800fe-135e-43fe-9e15-ccb9f92e5bba&var-levels=&var-metadata=&var-patterns=&var-lineFilterV2=&var-lineFilters=caseInsensitive,0%7C__gfp__%3D%7C3e2800fe&urlColumns=%5B%22Time%22,%22Line%22%5D&visualizationType=%22logs%22&displayedFields=%5B%5D&var-labelBy=$__all&timezone=browser&var-all-fields=behandlingId%7C%3D%7C%7B%22value%22:%223e2800fe-135e-43fe-9e15-ccb9f92e5bba%22__gfc__%22parser%22:%22json%22%7D,3e2800fe-135e-43fe-9e15-ccb9f92e5bba&sortOrder=%22Descending%22&wrapLogMessage=false)
