### PR TITLE
Rekjører task i et halvt år hvis brevmottaker er død 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/domain/BrevmottakerVedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/domain/BrevmottakerVedtaksbrev.kt
@@ -18,4 +18,6 @@ data class BrevmottakerVedtaksbrev(
     val bestillingId: String? = null,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
-)
+) {
+    fun harIkkeFåttBrevet() = bestillingId == null
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.brev.vedtaksbrev
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
 import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
@@ -10,10 +11,15 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.util.rekjørTaskSenere
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import java.util.Properties
 
 @Service
@@ -30,43 +36,67 @@ class DistribuerVedtaksbrevTask(
     private val stegService: StegService,
     private val brevSteg: BrevSteg,
     private val transactionHandler: TransactionHandler,
+    private val taskService: TaskService,
 ) : AsyncTaskStep {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
     override fun doTask(task: Task) {
         val behandlingId = BehandlingId.fromString(task.payload)
 
-        val brevmottakere = brevmottakerVedtaksbrevRepository.findByBehandlingId(behandlingId)
-
-        validerHarBrevmottakere(brevmottakere)
-
-        brevmottakere
-            .filter { it.bestillingId == null }
-            .forEach { brevmottaker ->
-                val bestillingId = distribuerTilBrevmottaker(brevmottaker)
-
-                transactionHandler.runInNewTransaction {
-                    brevmottakerVedtaksbrevRepository.update(brevmottaker.copy(bestillingId = bestillingId))
-                }
-            }
+        brevmottakerVedtaksbrevRepository
+            .findByBehandlingId(behandlingId)
+            .ifEmpty { throw Feil("Ingen brevmottakere funnet") }
+            .filter { it.harIkkeFåttBrevet() }
+            .map { distribuerBrevet(mottaker = it) }
+            .håndterRekjøringSenereHvisMottakerErDød(task)
 
         stegService.håndterSteg(behandlingId, brevSteg)
     }
 
-    private fun distribuerTilBrevmottaker(it: BrevmottakerVedtaksbrev) =
+    private sealed interface ResultatBrevutsendelse {
+        data object BrevDistribuert : ResultatBrevutsendelse
+
+        data class FeiletFordiMottakerErDød(
+            val feilmelding: String?,
+        ) : ResultatBrevutsendelse
+    }
+
+    private fun distribuerBrevet(mottaker: BrevmottakerVedtaksbrev): ResultatBrevutsendelse {
+        feilHvis(mottaker.journalpostId == null) { "Ugyldig tilstand. Mangler journalpostId for brev som skal distribueres" }
+
+        try {
+            val bestillingId = distribuerVedtaksbrev(mottaker.journalpostId)
+            mottaker.lagreDistribusjonGjennomført(bestillingId)
+            return ResultatBrevutsendelse.BrevDistribuert
+        } catch (ex: HttpClientErrorException.Gone) {
+            logger.warn("Distribusjon av vedtaksbrev for journalpost ${mottaker.journalpostId} feilet: ${ex.message}")
+            return ResultatBrevutsendelse.FeiletFordiMottakerErDød(ex.message)
+        }
+    }
+
+    private fun BrevmottakerVedtaksbrev.lagreDistribusjonGjennomført(bestillingId: String) {
+        transactionHandler.runInNewTransaction {
+            brevmottakerVedtaksbrevRepository.update(this.copy(bestillingId = bestillingId))
+        }
+        logger.info(
+            "Distribuert vedtaksbrev (journalpost=$journalpostId) med bestillingId=$bestillingId",
+        )
+    }
+
+    private fun distribuerVedtaksbrev(journalpostId: String): String =
         journalpostClient.distribuerJournalpost(
             DistribuerJournalpostRequest(
-                journalpostId =
-                    it.journalpostId
-                        ?: error("Ugyldig tilstand. Mangler journalpostId for brev som skal distribueres"),
+                journalpostId = journalpostId,
                 bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
                 dokumentProdApp = "TILLEGGSSTONADER-SAK",
                 distribusjonstype = Distribusjonstype.VEDTAK,
             ),
         )
 
-    private fun validerHarBrevmottakere(brevmottakere: List<BrevmottakerVedtaksbrev>) {
-        feilHvis(brevmottakere.isEmpty()) {
-            "Ingen brevmottakere"
-        }
+    private fun List<ResultatBrevutsendelse>.håndterRekjøringSenereHvisMottakerErDød(task: Task) {
+        filterIsInstance<ResultatBrevutsendelse.FeiletFordiMottakerErDød>()
+            .firstOrNull()
+            ?.let { taskService.rekjørTaskSenere(task, årsak = "Mottaker er død: ${it.feilmelding}") }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/util/ProsesseringExtensions.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/util/ProsesseringExtensions.kt
@@ -2,12 +2,14 @@ package no.nav.tilleggsstonader.sak.util
 
 import no.nav.familie.prosessering.domene.Loggtype
 import no.nav.familie.prosessering.domene.Task
-import no.nav.familie.prosessering.error.MaxAntallRekjøringerException
 import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.libs.utils.osloNow
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+
+val logger: Logger = LoggerFactory.getLogger(TaskService::class.java)
 
 /**
  * Avbryter opprinnelig task, og setter opp ny kjøring etter et spesifisert antall dager.
@@ -23,22 +25,22 @@ fun TaskService.rekjørTaskSenere(
     antallDagerTilNesteRekjøring: Long = 7L,
     totaltAntallRekjøringerFørFeiling: Int = 26,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(this::class.java)
-
     val antallRekjøringer =
         findTaskLoggByTaskId(task.id)
             .count { it.type == Loggtype.KLAR_TIL_PLUKK && it.melding?.startsWith(årsak) == true }
     if (antallRekjøringer < totaltAntallRekjøringerFørFeiling) {
         logger.info(
-            "Rekjøring nummer $antallRekjøringer/$totaltAntallRekjøringerFørFeiling av task. " +
-                "Årsak til rekjøring: $årsak. " +
-                "Prøver å kjøre task på nytt om $antallDagerTilNesteRekjøring dager",
+            """
+            Setter opp rekjøring nummer $antallRekjøringer/$totaltAntallRekjøringerFørFeiling av task "${task.type}". 
+            Årsak til rekjøring: "$årsak." 
+            Prøver å kjøre task på nytt om $antallDagerTilNesteRekjøring dager
+            """.trimIndent(),
         )
         throw RekjørSenereException(
             årsak = årsak,
             triggerTid = osloNow().plusDays(antallDagerTilNesteRekjøring),
         )
     } else {
-        throw MaxAntallRekjøringerException(maxAntallRekjøring = totaltAntallRekjøringerFørFeiling)
+        throw TaskExceptionUtenStackTrace("Nådd max antall rekjøringer - $totaltAntallRekjøringerFørFeiling")
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/util/ProsesseringExtensions.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/util/ProsesseringExtensions.kt
@@ -1,0 +1,44 @@
+package no.nav.tilleggsstonader.sak.util
+
+import no.nav.familie.prosessering.domene.Loggtype
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.MaxAntallRekjøringerException
+import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.libs.utils.osloNow
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Avbryter opprinnelig task, og setter opp ny kjøring etter et spesifisert antall dager.
+ *
+ * Etter at maks antall tillatte forsøk har blitt brukt opp, blir tasken satt til feilet.
+ *
+ * @param årsak brukes til å telle antall rekjøringer, så det er fint om verdien ikke endrer seg
+ * mellom hver kjøring.
+ */
+fun TaskService.rekjørTaskSenere(
+    task: Task,
+    årsak: String,
+    antallDagerTilNesteRekjøring: Long = 7L,
+    totaltAntallRekjøringerFørFeiling: Int = 26,
+) {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    val antallRekjøringer =
+        findTaskLoggByTaskId(task.id)
+            .count { it.type == Loggtype.KLAR_TIL_PLUKK && it.melding?.startsWith(årsak) == true }
+    if (antallRekjøringer < totaltAntallRekjøringerFørFeiling) {
+        logger.info(
+            "Rekjøring nummer $antallRekjøringer/$totaltAntallRekjøringerFørFeiling av task. " +
+                "Årsak til rekjøring: $årsak. " +
+                "Prøver å kjøre task på nytt om $antallDagerTilNesteRekjøring dager",
+        )
+        throw RekjørSenereException(
+            årsak = årsak,
+            triggerTid = osloNow().plusDays(antallDagerTilNesteRekjøring),
+        )
+    } else {
+        throw MaxAntallRekjøringerException(maxAntallRekjøring = totaltAntallRekjøringerFørFeiling)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
@@ -6,8 +6,8 @@ import io.mockk.verify
 import no.nav.familie.prosessering.domene.Loggtype
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskLogg
-import no.nav.familie.prosessering.error.MaxAntallRekjøringerException
 import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
@@ -204,8 +204,8 @@ class DistribuerVedtaksbrevTaskTest {
             every { taskService.findTaskLoggByTaskId(any()) } returns taskLogg
 
             val throwable = catchThrowable { distribuerVedtaksbrevTask.doTask(task) }
-            assertThat(throwable).isInstanceOf(MaxAntallRekjøringerException::class.java)
-            assertThat(throwable).hasMessageStartingWith("Nådd max antall rekjøring - 26")
+            assertThat(throwable).isInstanceOf(TaskExceptionUtenStackTrace::class.java)
+            assertThat(throwable).hasMessageStartingWith("Nådd max antall rekjøringer - 26")
 
             verify(exactly = 1) { journalpostClient.distribuerJournalpost(any(), any()) }
             verify(exactly = 0) { brevmottakerVedtaksbrevRepository.update(any()) }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når en person dør så fjernes adressen og vi får ikke distribuert brevet før personen fått et dødsbo. 

Det skaper støy for oss, ettersom [vi har en slik sak i prod nå](https://tilleggsstonader-prosessering.intern.nav.no/service/tilleggsstonader-sak/task/84746). 

Løsningen her blir å rekjøre tasken ukentlig i et halvt år, før vi til slutt sier "🤷‍♂️" og gir opp.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24538