### PR TITLE
Fremtidig utgift som blir gjort om til vanlig vilkår får status ny

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -21,6 +21,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårRevurderFraVal
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.LagreVilkårDto
@@ -109,7 +110,7 @@ class VilkårService(
         val behandlingId = vilkår.behandlingId
 
         // TODO burde slettemarkeres hvis opprettet i tidligere behandling?
-        feilHvis(vilkår.opphavsvilkår != null) {
+        feilHvis(vilkår.opphavsvilkår != null || vilkår.status != VilkårStatus.NY) {
             "Kan ikke slette vilkår opprettet i tidligere behandling"
         }
         validerBehandlingIdErLikIRequestOgIVilkåret(behandlingId, oppdaterVilkårDto.behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -132,7 +132,7 @@ object OppdaterVilkår {
             )
         return vilkår.copy(
             resultat = vilkårsresultat.vilkår,
-            status = utledStatus(vilkår),
+            status = utledStatus(vilkår, oppdatering),
             delvilkårwrapper = oppdaterteDelvilkår,
             fom = utledFom(vilkår, oppdatering),
             tom = utledTom(vilkår, oppdatering),
@@ -186,9 +186,13 @@ object OppdaterVilkår {
             }
         }
 
-    private fun utledStatus(eksisterendeVilkår: Vilkår): VilkårStatus? =
-        when (eksisterendeVilkår.status) {
-            VilkårStatus.UENDRET -> VilkårStatus.ENDRET
+    private fun utledStatus(
+        eksisterendeVilkår: Vilkår,
+        lagreVilkårDto: LagreVilkårDto,
+    ): VilkårStatus? =
+        when {
+            eksisterendeVilkår.erFremtidigUtgift && lagreVilkårDto.erFremtidigUtgift != true -> VilkårStatus.NY
+            eksisterendeVilkår.status == VilkårStatus.UENDRET -> VilkårStatus.ENDRET
             else -> eksisterendeVilkår.status
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -188,10 +188,10 @@ object OppdaterVilkår {
 
     private fun utledStatus(
         eksisterendeVilkår: Vilkår,
-        lagreVilkårDto: LagreVilkårDto,
+        oppdatering: LagreVilkårDto,
     ): VilkårStatus? =
         when {
-            eksisterendeVilkår.erFremtidigUtgift && lagreVilkårDto.erFremtidigUtgift != true -> VilkårStatus.NY
+            eksisterendeVilkår.erFremtidigUtgift && oppdatering.erFremtidigUtgift != true -> VilkårStatus.NY
             eksisterendeVilkår.status == VilkårStatus.UENDRET -> VilkårStatus.ENDRET
             else -> eksisterendeVilkår.status
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
@@ -30,6 +30,7 @@ import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Opphavsvilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat.IKKE_TATT_STILLING_TIL
@@ -246,6 +247,7 @@ internal class VilkårServiceTest {
                     behandlingId = behandlingId,
                     type = VilkårType.PASS_BARN,
                     opphavsvilkår = Opphavsvilkår(BehandlingId.random(), LocalDateTime.now()),
+                    status = VilkårStatus.UENDRET,
                 )
             every { vilkårRepository.findByIdOrNull(vilkår.id) } returns vilkår
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -350,6 +350,17 @@ internal class OppdaterVilkårTest {
             assertThat(oppdaterVilkår.status).isEqualTo(VilkårStatus.ENDRET)
         }
 
+        @Test
+        fun `Vilkår som er fremtidig utgift skal få status ny når de gjøres om til vanlig vilkår`() {
+            val vilkår = vilkår(behandling.id, type = VilkårType.PASS_BARN, status = VilkårStatus.UENDRET, erFremtidigUtgift = true)
+            val innsendtOppdatering = innsendtOppdatering(vilkår.copy(erFremtidigUtgift = false))
+
+            val oppdaterVilkår =
+                oppdaterVilkår(vilkår = vilkår, oppdatering = innsendtOppdatering, vilkårsresultat = regelResultat)
+
+            assertThat(oppdaterVilkår.status).isEqualTo(VilkårStatus.NY)
+        }
+
         private fun innsendtOppdatering(originaltVilkår: Vilkår) =
             SvarPåVilkårDto(
                 id = originaltVilkår.id,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fremtidig utgift som blir gjort om til vanlig vilkår får status ny og kan slettes. Dette er for at det skal være tydlig for saksbehandler at den tidligere fremtidige utgiften nå blir en del av vedtaket. Sletting gjør det mulig for saksbehandler å "rydde opp" dersom vilkåret ble tatt med ved en feil. 