### PR TITLE
Kutt stønadsvilkår fra første i måneden om det er utgifter som legges inn med YearMonth 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårUtil.kt
@@ -5,7 +5,9 @@ import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.kontrakter.periode.avkortPerioderFør
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import java.time.LocalDate
 
 object VilkårUtil {
@@ -26,40 +28,50 @@ object VilkårUtil {
 
     fun List<Vilkår>.finnPerioderEtterRevurderFra(revurderFra: LocalDate?): List<Vilkår> =
         this
-            .map { VilkårHolder(it) }
-            .avkortPerioderFør(revurderFra)
-            .map { it.vilkår }
+            .map { VilkårHolder(it).avkortPerioderFør(revurderFraEllerFørsteIMåneden(it.type, revurderFra)) }
+            .mapNotNull { it?.vilkår }
 
-    /**
-     * Hjelpeklasse for å kunne bruke funksjonene som finnes på Periode<T>
-     */
-    private data class VilkårHolder(
-        val vilkår: Vilkår,
-    ) : Periode<LocalDate>,
-        KopierPeriode<VilkårHolder> {
-        override val fom: LocalDate
-            get() = vilkår.fom ?: error("Mangler tom")
-        override val tom: LocalDate
-            get() = vilkår.tom ?: error("Mangler tom")
+    private fun revurderFraEllerFørsteIMåneden(
+        vilkårType: VilkårType,
+        revurderFra: LocalDate?,
+    ): LocalDate? {
+        if (revurderFra == null || !vilkårType.kreverYearMonthDatoer()) {
+            return revurderFra
+        }
 
-        override fun medPeriode(
-            fom: LocalDate,
-            tom: LocalDate,
-        ): VilkårHolder = VilkårHolder(vilkår.copy(fom = fom, tom = tom))
-
-        fun slåSammen(other: VilkårHolder): VilkårHolder =
-            VilkårHolder(
-                vilkår.copy(
-                    fom = minOf(vilkår.fom!!, other.vilkår.fom!!),
-                    tom = maxOf(vilkår.tom!!, other.vilkår.tom!!),
-                ),
-            )
-
-        fun kanSlåsSammen(other: VilkårHolder): Boolean =
-            vilkår.type == other.vilkår.type &&
-                vilkår.resultat == other.vilkår.resultat &&
-                vilkår.utgift == other.vilkår.utgift &&
-                vilkår.barnId == other.vilkår.barnId &&
-                overlapperEllerPåfølgesAv(other)
+        return revurderFra.tilFørsteDagIMåneden()
     }
+}
+
+/**
+ * Hjelpeklasse for å kunne bruke funksjonene som finnes på Periode<T>
+ */
+private data class VilkårHolder(
+    val vilkår: Vilkår,
+) : Periode<LocalDate>,
+    KopierPeriode<VilkårHolder> {
+    override val fom: LocalDate
+        get() = vilkår.fom ?: error("Mangler tom")
+    override val tom: LocalDate
+        get() = vilkår.tom ?: error("Mangler tom")
+
+    override fun medPeriode(
+        fom: LocalDate,
+        tom: LocalDate,
+    ): VilkårHolder = VilkårHolder(vilkår.copy(fom = fom, tom = tom))
+
+    fun slåSammen(other: VilkårHolder): VilkårHolder =
+        VilkårHolder(
+            vilkår.copy(
+                fom = minOf(vilkår.fom!!, other.vilkår.fom!!),
+                tom = maxOf(vilkår.tom!!, other.vilkår.tom!!),
+            ),
+        )
+
+    fun kanSlåsSammen(other: VilkårHolder): Boolean =
+        vilkår.type == other.vilkår.type &&
+            vilkår.resultat == other.vilkår.resultat &&
+            vilkår.utgift == other.vilkår.utgift &&
+            vilkår.barnId == other.vilkår.barnId &&
+            overlapperEllerPåfølgesAv(other)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -228,6 +228,8 @@ enum class VilkårType(
                 it.gjelderStønader.contains(stønadstype)
             }
     }
+
+    fun kreverYearMonthDatoer(): Boolean = this == LØPENDE_UTGIFTER_EN_BOLIG || this == LØPENDE_UTGIFTER_TO_BOLIGER || this == PASS_BARN
 }
 
 enum class VilkårStatus {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringServiceTest.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.avslagVedtak
@@ -266,6 +267,66 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
             assertThat(oppsummering.finnesDataÅOppsummere).isTrue()
             assertThat(oppsummering.aktiviteter).hasSize(1)
             assertThat(oppsummering.aktiviteter[0].fom).isEqualTo(LocalDate.of(2025, 1, 1))
+        }
+
+        @Test
+        fun `skal kutte vilkår av type PASSS_BARN fra første dag i samme måned som revurderFra`() {
+            val revurderFra = LocalDate.of(2025, 1, 3)
+            val behandling = testoppsettService.lagBehandlingOgRevurdering(revurderFra = revurderFra)
+            val barn1 = BarnId.random()
+
+            vilkårRepository.insertAll(
+                listOf(
+                    vilkår(
+                        behandlingId = behandling.id,
+                        type = VilkårType.PASS_BARN,
+                        barnId = barn1,
+                        fom = LocalDate.of(2025, 1, 1),
+                        tom = LocalDate.of(2025, 1, 31),
+                    ),
+                ),
+            )
+
+            val oppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
+            assertThat(oppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(oppsummering.vilkår).hasSize(1)
+            assertThat(oppsummering.vilkår[0].vilkår[0].fom).isEqualTo(revurderFra.tilFørsteDagIMåneden())
+        }
+
+        @Test
+        fun `skal kutte vilkår for boutgifter enten fra starten av måneden eller revurder fra`() {
+            val revurderFra = LocalDate.of(2025, 1, 14)
+            val behandling = testoppsettService.lagBehandlingOgRevurdering(revurderFra = revurderFra)
+            val barn1 = BarnId.random()
+
+            vilkårRepository.insertAll(
+                listOf(
+                    vilkår(
+                        behandlingId = behandling.id,
+                        type = VilkårType.UTGIFTER_OVERNATTING,
+                        barnId = barn1,
+                        fom = LocalDate.of(2025, 1, 12),
+                        tom = LocalDate.of(2025, 1, 15),
+                    ),
+                    vilkår(
+                        behandlingId = behandling.id,
+                        type = VilkårType.LØPENDE_UTGIFTER_EN_BOLIG,
+                        barnId = barn1,
+                        fom = LocalDate.of(2025, 1, 1),
+                        tom = LocalDate.of(2025, 1, 31),
+                    ),
+                ),
+            )
+
+            val oppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
+            assertThat(oppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(oppsummering.vilkår).hasSize(2)
+
+            val overnattingVilkår = oppsummering.vilkår.find { it.type == VilkårType.UTGIFTER_OVERNATTING }
+            val løpendeUtgifterEnBoligVilkår = oppsummering.vilkår.find { it.type == VilkårType.LØPENDE_UTGIFTER_EN_BOLIG }
+
+            assertThat(overnattingVilkår!!.vilkår[0].fom).isEqualTo(revurderFra)
+            assertThat(løpendeUtgifterEnBoligVilkår!!.vilkår[0].fom).isEqualTo(revurderFra.tilFørsteDagIMåneden())
         }
     }
 }


### PR DESCRIPTION
…rder fra, fordi validering feiler. Diskutert at det gir mer mening å vise utgiften fra 1. fordi de ikke har lov å legge inn en vilkår fra en annen dato

### Hvorfor er denne endringen nødvendig? ✨
Oppsummeringen i venstremenyen feiler hvis man revurderer pass barn fra noe annet enn første dag i måneden fordi jeg prøver å kutte visningen av pass barn-vilkår til revurder fra. Selve kuttingen skjer rett på `Vilkår` som har en init-validering som slår ut på "fom må være første i måneden". 

To løsninger ble diskutert:
- La typene som har YearMonth kuttes fra første i måneden som revurderFra settes i 
- Flytte avkortingen til etter mappingen til `OppsummertVilkår` siden denne ikke har samme validering. 

Gikk for første fordi det er wierd å vise en dato midt i måneden som fom på perioden når man ikke kan legge inn vilkår med slike datoer.

⚠️ Mulig det er litt wierd at man kutter noe fra `revurderFra` og noe fra første dag i måneden. Så lager et alternativ hvor man i en revurdering kun fjerner perioder som er helt før `revurderFra` i stedet for å avkorte og tilpasse fom på alle periodene