### PR TITLE
👔 Alltid tillat sletting av vilkår som er fremtidig utgift

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -108,7 +108,7 @@ class VilkårService(
         val vilkår = vilkårRepository.findByIdOrThrow(vilkårId)
         val behandlingId = vilkår.behandlingId
 
-        // TODO burde slettemarkeres hvis opprettet i tidligere behandling?
+        // TODO burde slettemarkeres hvis opprettet i tidligere behandling og ikke er fremtidig utgift?
         feilHvis(!vilkår.kanSlettes()) {
             "Kan ikke slette vilkår opprettet i tidligere behandling"
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårService.kt
@@ -21,7 +21,6 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårRevurderFraVal
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.LagreVilkårDto
@@ -110,7 +109,7 @@ class VilkårService(
         val behandlingId = vilkår.behandlingId
 
         // TODO burde slettemarkeres hvis opprettet i tidligere behandling?
-        feilHvis(vilkår.opphavsvilkår != null || vilkår.status != VilkårStatus.NY) {
+        feilHvis(!vilkår.kanSlettes()) {
             "Kan ikke slette vilkår opprettet i tidligere behandling"
         }
         validerBehandlingIdErLikIRequestOgIVilkåret(behandlingId, oppdaterVilkårDto.behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -122,7 +122,7 @@ data class Vilkår(
             opphavsvilkår = opphavsvilkårForKopiertVilkår(),
         )
 
-    fun kanSlettes() = opphavsvilkår == null || status == VilkårStatus.NY || erFremtidigUtgift
+    fun kanSlettes() = status == VilkårStatus.NY || erFremtidigUtgift
 
     /**
      * Brukes når man skal gjenbruke denne vilkårsvurderingen i en annan vilkårsvurdering

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -122,6 +122,8 @@ data class Vilkår(
             opphavsvilkår = opphavsvilkårForKopiertVilkår(),
         )
 
+    fun kanSlettes() = opphavsvilkår == null || status == VilkårStatus.NY || erFremtidigUtgift
+
     /**
      * Brukes når man skal gjenbruke denne vilkårsvurderingen i en annan vilkårsvurdering
      * Hvis vilkåret er uendret skal gjenbruke det forrige opphavsvilkåret då vilkåret er uendret

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
@@ -255,6 +255,23 @@ internal class VilkårServiceTest {
                 vilkårService.slettVilkår(OppdaterVilkårDto(vilkår.id, behandlingId))
             }.hasMessageContaining("Kan ikke slette vilkår opprettet i tidligere behandling")
         }
+
+        @Test
+        internal fun `skal kunne slette vilkår opprettet i tidligere behandling hvis det er fremtidig utgift`() {
+            val vilkår =
+                vilkår(
+                    behandlingId = behandlingId,
+                    type = VilkårType.PASS_BARN,
+                    opphavsvilkår = Opphavsvilkår(BehandlingId.random(), LocalDateTime.now()),
+                    status = VilkårStatus.UENDRET,
+                    erFremtidigUtgift = true,
+                )
+            every { vilkårRepository.findByIdOrNull(vilkår.id) } returns vilkår
+
+            vilkårService.slettVilkår(OppdaterVilkårDto(vilkår.id, behandlingId))
+
+            verify { vilkårRepository.deleteById(vilkår.id) }
+        }
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal alltid kunne slette vilkår som er fremtidig utgift. Dette trengs hvis en fremtidig utgift ikke taes i bruk.