### PR TITLE
Bedre visning av beregningsresultat

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
@@ -40,7 +40,7 @@ data class UtbetalingPeriode(
         løpendeMåned: LøpendeMåned,
     ) : this(
         fom = løpendeMåned.fom,
-        tom = løpendeMåned.vedtaksperioder.maxOf { it.tom },
+        tom = løpendeMåned.tom,
         // TODO: Prioriter hvilken målgruppe+aktivitet som skal være gjeldende til økonomi hvis ulike målgrupper havner innenfor samme løpende måned
         målgruppe =
             løpendeMåned.vedtaksperioder

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
-import no.nav.tilleggsstonader.kontrakter.periode.avkortPerioderFør
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgiftBeregningBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
@@ -14,14 +13,7 @@ import kotlin.math.min
 
 data class BeregningsresultatBoutgifter(
     val perioder: List<BeregningsresultatForLøpendeMåned>,
-) {
-    fun filtrerFraOgMed(dato: LocalDate?): BeregningsresultatBoutgifter {
-        if (dato == null) {
-            return this
-        }
-        return BeregningsresultatBoutgifter(perioder.avkortPerioderFør(dato))
-    }
-}
+)
 
 data class BeregningsresultatForLøpendeMåned(
     val grunnlag: Beregningsgrunnlag,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -5,11 +5,13 @@ import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgiftBeregningBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
+import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import java.time.LocalDate
 
 data class BeregningsresultatBoutgifterDto(
     val perioder: List<BeregningsresultatForPeriodeDto>,
+    val skalBrukeDetaljertVisning: Boolean,
 )
 
 data class BeregningsresultatForPeriodeDto(
@@ -31,6 +33,7 @@ fun BeregningsresultatBoutgifter.tilDto(revurderFra: LocalDate?): Beregningsresu
             filtrerFraOgMed(revurderFra)
                 .perioder
                 .map { it.tilDto() },
+        skalBrukeDetaljertVisning = skalBrukeDetaljertVisning(),
     )
 
 private fun BeregningsresultatBoutgifter.filtrerFraOgMed(dato: LocalDate?): BeregningsresultatBoutgifter {
@@ -39,6 +42,12 @@ private fun BeregningsresultatBoutgifter.filtrerFraOgMed(dato: LocalDate?): Bere
     }
     return BeregningsresultatBoutgifter(perioder.filter { it.tom >= dato })
 }
+
+private fun BeregningsresultatBoutgifter.skalBrukeDetaljertVisning(): Boolean =
+    perioder.any {
+        it.grunnlag.utgifter.keys
+            .contains(TypeBoutgift.UTGIFTER_OVERNATTING)
+    }
 
 fun BeregningsresultatForLøpendeMåned.tilDto(): BeregningsresultatForPeriodeDto =
     BeregningsresultatForPeriodeDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgiftBeregningBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
@@ -16,6 +17,7 @@ data class BeregningsresultatForPeriodeDto(
     override val tom: LocalDate,
     val stønadsbeløp: Int,
     val utbetalingsdato: LocalDate,
+    val utgifter: List<UtgiftBeregningBoutgifter>,
     val sumUtgifter: Int,
     val målgruppe: FaktiskMålgruppe,
     val aktivitet: AktivitetType,
@@ -31,6 +33,13 @@ fun BeregningsresultatBoutgifter.tilDto(revurderFra: LocalDate?): Beregningsresu
                 .map { it.tilDto() },
     )
 
+private fun BeregningsresultatBoutgifter.filtrerFraOgMed(dato: LocalDate?): BeregningsresultatBoutgifter {
+    if (dato == null) {
+        return this
+    }
+    return BeregningsresultatBoutgifter(perioder.filter { it.tom >= dato })
+}
+
 fun BeregningsresultatForLøpendeMåned.tilDto(): BeregningsresultatForPeriodeDto =
     BeregningsresultatForPeriodeDto(
         fom = grunnlag.fom,
@@ -38,6 +47,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(): BeregningsresultatForPeriodeDt
         stønadsbeløp = stønadsbeløp,
         utbetalingsdato = grunnlag.utbetalingsdato,
         sumUtgifter = summerUtgifter(),
+        utgifter = grunnlag.utgifter.values.flatten(),
         målgruppe = grunnlag.målgruppe,
         aktivitet = grunnlag.aktivitet,
         makssatsBekreftet = grunnlag.makssatsBekreftet,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -11,7 +11,6 @@ import java.time.LocalDate
 
 data class BeregningsresultatBoutgifterDto(
     val perioder: List<BeregningsresultatForPeriodeDto>,
-    val skalBrukeDetaljertVisning: Boolean,
 )
 
 data class BeregningsresultatForPeriodeDto(
@@ -19,7 +18,7 @@ data class BeregningsresultatForPeriodeDto(
     override val tom: LocalDate,
     val stønadsbeløp: Int,
     val utbetalingsdato: LocalDate,
-    val utgifter: List<UtgiftBeregningBoutgifter>,
+    val utgifter: Map<TypeBoutgift, List<UtgiftBeregningBoutgifter>>,
     val sumUtgifter: Int,
     val målgruppe: FaktiskMålgruppe,
     val aktivitet: AktivitetType,
@@ -33,7 +32,6 @@ fun BeregningsresultatBoutgifter.tilDto(revurderFra: LocalDate?): Beregningsresu
             filtrerFraOgMed(revurderFra)
                 .perioder
                 .map { it.tilDto() },
-        skalBrukeDetaljertVisning = skalBrukeDetaljertVisning(),
     )
 
 private fun BeregningsresultatBoutgifter.filtrerFraOgMed(dato: LocalDate?): BeregningsresultatBoutgifter {
@@ -56,7 +54,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(): BeregningsresultatForPeriodeDt
         stønadsbeløp = stønadsbeløp,
         utbetalingsdato = grunnlag.utbetalingsdato,
         sumUtgifter = summerUtgifter(),
-        utgifter = grunnlag.utgifter.values.flatten(),
+        utgifter = grunnlag.utgifter,
         målgruppe = grunnlag.målgruppe,
         aktivitet = grunnlag.aktivitet,
         makssatsBekreftet = grunnlag.makssatsBekreftet,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
@@ -233,7 +233,7 @@ class BoutgifterBeregningMidlertidigUtgiftTest {
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 3, 10),
-                    tom = LocalDate.of(2025, 3, 12),
+                    tom = LocalDate.of(2025, 4, 9),
                     utgifter = utgiftEtterRevurderFra,
                     delAvTidligere = false,
                 ),

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -193,6 +193,11 @@
       "tom" : "2024-01-31",
       "stønadsbeløp" : 3000,
       "utbetalingsdato" : "2024-01-01",
+      "utgifter" : [ {
+        "fom" : "2024-01-01",
+        "tom" : "2024-01-31",
+        "utgift" : 3000
+      } ],
       "sumUtgifter" : 3000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
@@ -203,6 +208,11 @@
       "tom" : "2024-02-29",
       "stønadsbeløp" : 4000,
       "utbetalingsdato" : "2024-01-01",
+      "utgifter" : [ {
+        "fom" : "2024-02-26",
+        "tom" : "2024-02-29",
+        "utgift" : 4000
+      } ],
       "sumUtgifter" : 4000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -193,11 +193,13 @@
       "tom" : "2024-01-31",
       "stønadsbeløp" : 3000,
       "utbetalingsdato" : "2024-01-01",
-      "utgifter" : [ {
-        "fom" : "2024-01-01",
-        "tom" : "2024-01-31",
-        "utgift" : 3000
-      } ],
+      "utgifter" : {
+        "UTGIFTER_OVERNATTING" : [ {
+          "fom" : "2024-01-01",
+          "tom" : "2024-01-31",
+          "utgift" : 3000
+        } ]
+      },
       "sumUtgifter" : 3000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
@@ -208,11 +210,13 @@
       "tom" : "2024-02-29",
       "stønadsbeløp" : 4000,
       "utbetalingsdato" : "2024-01-01",
-      "utgifter" : [ {
-        "fom" : "2024-02-26",
-        "tom" : "2024-02-29",
-        "utgift" : 4000
-      } ],
+      "utgifter" : {
+        "UTGIFTER_OVERNATTING" : [ {
+          "fom" : "2024-02-26",
+          "tom" : "2024-02-29",
+          "utgift" : 4000
+        } ]
+      },
       "sumUtgifter" : 4000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_faste_utgifter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_faste_utgifter.feature
@@ -68,7 +68,7 @@ Egenskap: Beregning av faste utgifter
       | 15.11.2024 | 14.12.2024 | 1              | 4809         | 4809      | 15.11.2024      | NEDSATT_ARBEIDSEVNE | TILTAK    |
       | 15.12.2024 | 14.01.2025 | 1              | 4809         | 4809      | 15.12.2024      | NEDSATT_ARBEIDSEVNE | TILTAK    |
       | 15.01.2025 | 14.02.2025 | 1              | 4953         | 4953      | 15.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
-      | 15.02.2025 | 18.02.2025 | 1              | 4953         | 4953      | 15.02.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 15.02.2025 | 14.03.2025 | 1              | 4953         | 4953      | 15.02.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: To påfølgende vedtaksperioder som dekker utgiften
     Gitt følgende vedtaksperioder for boutgifter
@@ -107,7 +107,7 @@ Egenskap: Beregning av faste utgifter
         | 15.03.2025 | 14.04.2025 | 1              | 4000         | 4953      | 15.03.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
         | 15.04.2025 | 14.05.2025 | 1              | 4000         | 4953      | 15.04.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
         | 15.05.2025 | 14.06.2025 | 1              | 4000         | 4953      | 15.05.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
-        | 15.06.2025 | 20.06.2025 | 1              | 4000         | 4953      | 15.06.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
+        | 15.06.2025 | 14.07.2025 | 1              | 4000         | 4953      | 15.06.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
 
     Eksempel: Bruker leier ekstrabolig mye lengre enn hva som er nødvendig for utdanningen
       Gitt følgende vedtaksperioder for boutgifter
@@ -123,4 +123,4 @@ Egenskap: Beregning av faste utgifter
       Så skal beregnet stønad for boutgifter være
         | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
         | 15.01.2025 | 14.02.2025 | 1              | 4000         | 4953      | 15.01.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
-        | 15.02.2025 | 20.02.2025 | 1              | 4000         | 4953      | 15.02.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
+        | 15.02.2025 | 14.03.2025 | 1              | 4000         | 4953      | 15.02.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_midlertidig_overnatting.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_midlertidig_overnatting.feature
@@ -16,7 +16,7 @@ Egenskap: Beregning av midlertidig overnatting
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 07.01.2025 | 09.01.2025 | 1              | 1000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 07.01.2025 | 06.02.2025 | 1              | 1000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: Vedtaksperiode krysser nyttår
     Gitt følgende vedtaksperioder for boutgifter
@@ -31,7 +31,7 @@ Egenskap: Beregning av midlertidig overnatting
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 30.12.2024 | 02.01.2025 | 1              | 4809         | 4809      | 30.12.2024      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 30.12.2024 | 29.01.2025 | 1              | 4809         | 4809      | 30.12.2024      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: Flere vedtaksperioder med ulik utbetalingsperiode
     Gitt følgende vedtaksperioder for boutgifter
@@ -48,8 +48,8 @@ Egenskap: Beregning av midlertidig overnatting
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 07.01.2025 | 09.01.2025 | 1              | 1000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
-      | 12.03.2025 | 15.03.2025 | 1              | 4953         | 4953      | 12.03.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 07.01.2025 | 06.02.2025 | 1              | 1000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 12.03.2025 | 11.04.2025 | 1              | 4953         | 4953      | 12.03.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
 
   Scenario: Flere vedtaksperioder med samme utbetalingsperiode
@@ -67,7 +67,7 @@ Egenskap: Beregning av midlertidig overnatting
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 07.01.2025 | 24.01.2025 | 1              | 2000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 07.01.2025 | 06.02.2025 | 1              | 2000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: Vedtaksperiode kun i helg
     Gitt følgende vedtaksperioder for boutgifter
@@ -82,7 +82,7 @@ Egenskap: Beregning av midlertidig overnatting
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 11.01.2025 | 12.01.2025 | 1              | 1500         | 4953      | 11.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 11.01.2025 | 10.02.2025 | 1              | 1500         | 4953      | 11.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: Vedtaksperiode krysser utbetalingsperiode
     Gitt følgende vedtaksperioder for boutgifter

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_revurdering_midlertidig_overnatting.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_revurdering_midlertidig_overnatting.feature
@@ -16,7 +16,7 @@ Egenskap: Beregning - med revurderFra
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 07.01.2025 | 09.01.2025 | 1              | 1000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 07.01.2025 | 06.02.2025 | 1              | 1000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
 
   Scenario: Skal ikke ta med perioder som slutter før revurderFra - to ulike utbetalingsperioder
@@ -34,7 +34,7 @@ Egenskap: Beregning - med revurderFra
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 16.02.2025 | 19.02.2025 | 1              | 1000         | 4953      | 16.02.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 16.02.2025 | 15.03.2025 | 1              | 1000         | 4953      | 16.02.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: Skal ta med perioder fra den utbetalingsperioden man revurder dersom de overlapper
     Gitt følgende vedtaksperioder for boutgifter
@@ -51,7 +51,7 @@ Egenskap: Beregning - med revurderFra
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 07.01.2025 | 25.01.2025 | 1              | 2000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 07.01.2025 | 06.02.2025 | 1              | 2000         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
 
   Scenario: Skal ta med perioder fra den utbetalingsperioden man revurder dersom de overlapper - beløpet når maks sats
     Gitt følgende vedtaksperioder for boutgifter
@@ -68,4 +68,4 @@ Egenskap: Beregning - med revurderFra
 
     Så skal beregnet stønad for boutgifter være
       | Fom        | Tom        | Antall måneder | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
-      | 07.01.2025 | 25.01.2025 | 1              | 4953         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |
+      | 07.01.2025 | 06.02.2025 | 1              | 4953         | 4953      | 07.01.2025      | NEDSATT_ARBEIDSEVNE | TILTAK    |


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å forbedre visningen av beregningsresultatet for at det skal bli enklere for SB å forstå utregningen. 

Det som har blitt gjort er:
- Utbetalingsperiode avkortes ikke til tom i siste vedtaksperiode. Dette er for å gjøre det tydligere hva som er 30-dagers perioden
- I en revurdering viss hele utbetalingsperioden som overlapper med revurder fra datoen. Tidligere ble den avkortet på revurder fra. Dette er for å gjøre det tydligere hva som er 30-dagers perioden
- Lagt til flagg som sier om detaljert visning skal brukes