### PR TITLE
🐛 Skal være mulig å oppdatere begrunnelse i en revurdering hvor vilkå…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -204,7 +204,9 @@ class VilkårperiodeService(
         validerAtKunTomErEndret(eksisterendeVilkårperiode, vilkårperiode, revurderFra)
         validerAtAldersvilkårErGyldig(eksisterendeVilkårperiode, vilkårperiode, fødselFaktaGrunnlag)
 
-        return vilkårperiodeRepository.update(eksisterendeVilkårperiode.medNyTom(tom = vilkårperiode.tom))
+        return vilkårperiodeRepository.update(
+            eksisterendeVilkårperiode.medNyTomOgBegrunnelse(tom = vilkårperiode.tom, begrunnelse = vilkårperiode.begrunnelse),
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/Vilkårperiode.kt
@@ -182,14 +182,22 @@ data class GeneriskVilkårperiode<T : FaktaOgVurdering>(
         )
     }
 
-    fun medNyTom(tom: LocalDate): GeneriskVilkårperiode<T> {
+    fun medNyTomOgBegrunnelse(
+        tom: LocalDate,
+        begrunnelse: String?,
+    ): GeneriskVilkårperiode<T> {
         val nyStatus =
             if (status == Vilkårstatus.NY) {
                 Vilkårstatus.NY
             } else {
                 Vilkårstatus.ENDRET
             }
-        return this.copy(tom = tom, status = nyStatus, gitVersjon = Applikasjonsversjon.versjon)
+        return this.copy(
+            tom = tom,
+            status = nyStatus,
+            gitVersjon = Applikasjonsversjon.versjon,
+            begrunnelse = begrunnelse,
+        )
     }
 
     /**

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeMålgruppeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeMålgruppeServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.tilOppdatering
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.vurderingDekketAvAnnetRegelverk
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.KildeVilkårsperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
@@ -399,7 +400,31 @@ class VilkårperiodeMålgruppeServiceTest : IntegrationTest() {
 
             val nyTom = now().plusMonths(2)
 
-            validerHarEndretTom(målgruppeFørOppdatering, nyTom)
+            validerHarEndretTom(målgruppeFørOppdatering, nyTom, nyBegrunnelse = "Test")
+        }
+
+        @Test
+        fun `kan ikke fjerne begrunnelse hvis x`() {
+            val originalMålgruppe =
+                målgruppe(
+                    fom = now().minusMonths(1),
+                    tom = now().plusMonths(1),
+                    faktaOgVurdering = faktaOgVurderingMålgruppe(dekketAvAnnetRegelverk = vurderingDekketAvAnnetRegelverk(SvarJaNei.JA)),
+                    begrunnelse = "Begrunnelse",
+                )
+            val behandling = lagRevurderingMedKopiertMålgruppe(originalMålgruppe)
+            val målgruppeFørOppdatering = vilkårperiodeRepository.findByBehandlingId(behandling.id).single()
+
+            val nyTom = now().plusMonths(2)
+
+            assertThatThrownBy {
+                vilkårperiodeService.oppdaterVilkårperiode(
+                    målgruppeFørOppdatering.id,
+                    målgruppeFørOppdatering
+                        .tilOppdatering()
+                        .copy(tom = nyTom, begrunnelse = null),
+                )
+            }.hasMessageContaining("Mangler begrunnelse")
         }
 
         @Test
@@ -528,22 +553,24 @@ class VilkårperiodeMålgruppeServiceTest : IntegrationTest() {
     private fun validerHarEndretTom(
         målgruppeFørOppdatering: Vilkårperiode,
         nyTom: LocalDate,
+        nyBegrunnelse: String? = målgruppeFørOppdatering.begrunnelse,
     ) {
         val oppdatertPeriode =
             vilkårperiodeService.oppdaterVilkårperiode(
                 målgruppeFørOppdatering.id,
                 målgruppeFørOppdatering
                     .tilOppdatering()
-                    .copy(tom = nyTom),
+                    .copy(tom = nyTom, begrunnelse = nyBegrunnelse),
             )
 
         assertThat(oppdatertPeriode)
             .usingRecursiveComparison()
-            .ignoringFields("sporbar", "tom", "status")
+            .ignoringFields("sporbar", "tom", "status", "begrunnelse")
             .isEqualTo(målgruppeFørOppdatering)
 
         assertThat(oppdatertPeriode.tom).isEqualTo(nyTom)
         assertThat(oppdatertPeriode.status).isEqualTo(Vilkårstatus.ENDRET)
+        assertThat(oppdatertPeriode.begrunnelse).isEqualTo(nyBegrunnelse)
     }
 
     private fun lagRevurderingMedKopiertMålgruppe(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeMålgruppeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeMålgruppeServiceTest.kt
@@ -404,7 +404,7 @@ class VilkårperiodeMålgruppeServiceTest : IntegrationTest() {
         }
 
         @Test
-        fun `kan ikke fjerne begrunnelse hvis x`() {
+        fun `kan ikke fjerne begrunnelse hvis den er obligatorisk pga eksisterende svar`() {
             val originalMålgruppe =
                 målgruppe(
                     fom = now().minusMonths(1),


### PR DESCRIPTION
…rperioden krysser revurder fra

### Hvorfor er denne endringen nødvendig? ✨
Endret tidligere slik at oppdatering av vilkårperiode som krysser revurder fra kun oppdaterer tom, men begrunnelse skal også være mulig å endre. Den er nå mulig å endre i frontend, men den blir ikke lagret i backend
