### PR TITLE
Utbetaling tabell i brev

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtgiftBeregningBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtgiftBeregningBoutgifter.kt
@@ -13,6 +13,18 @@ data class UtgiftBeregningBoutgifter(
     }
 }
 
+data class UtgiftBoutgifterMedAndelTilUtbetaling(
+    override val fom: LocalDate,
+    override val tom: LocalDate,
+    val utgift: Int,
+    val tilUtbetaling: Int,
+    val erFørRevurderFra: Boolean,
+) : Periode<LocalDate> {
+    init {
+        validatePeriode()
+    }
+}
+
 // /**
 // * Dersom man har en lang utgiftsperiode for 1.1 - 31.1 så skal den splittes opp fra revurderFra sånn at man får 2 perioder
 // * Eks for revurderFra=15.1 så får man 1.1 - 14.1 og 15.1 - 31.1

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -61,7 +61,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(revurderFra: LocalDate?): Beregni
         makssatsBekreftet = grunnlag.makssatsBekreftet,
     )
 
-private fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(
+fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(
     revurderFra: LocalDate?,
 ): List<UtgiftBoutgifterMedAndelTilUtbetaling> {
     var totalSum = 0

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -69,12 +69,7 @@ fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(
         .flatten()
         .sorted()
         .map { utgift ->
-            val skalUtbetales =
-                when {
-                    totalSum >= grunnlag.makssats -> 0
-                    totalSum + utgift.utgift <= grunnlag.makssats -> utgift.utgift
-                    else -> grunnlag.makssats - totalSum
-                }
+            val skalUtbetales = minOf(utgift.utgift, grunnlag.makssats - totalSum)
             totalSum += skalUtbetales
             UtgiftBoutgifterMedAndelTilUtbetaling(
                 fom = utgift.fom,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
@@ -1,0 +1,181 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto
+
+import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgiftBeregningBoutgifter
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgiftBoutgifterMedAndelTilUtbetaling
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.Beregningsgrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
+import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class BeregningsresultatBoutgifterDtoTest {
+    @Test
+    fun `finnUtgifterMedAndelTilUtbetaling skal finne andel til utbetaling når utgifter ikke avkortes mot makssats`() {
+        val utgift =
+            listOf(
+                UtgiftBeregningBoutgifter(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 5),
+                    utgift = 1000,
+                ),
+                UtgiftBeregningBoutgifter(
+                    fom = LocalDate.of(2023, 1, 11),
+                    tom = LocalDate.of(2023, 1, 16),
+                    utgift = 2000,
+                ),
+            )
+
+        val beregningsresultatForLøpendeMåned =
+            BeregningsresultatForLøpendeMåned(
+                grunnlag =
+                    Beregningsgrunnlag(
+                        fom = LocalDate.of(2023, 1, 1),
+                        tom = LocalDate.of(2023, 1, 31),
+                        utbetalingsdato = LocalDate.of(2023, 2, 1),
+                        utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgift),
+                        makssats = 4953,
+                        makssatsBekreftet = true,
+                        målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                        aktivitet = AktivitetType.TILTAK,
+                    ),
+            )
+
+        val forventetResultat =
+            listOf(
+                UtgiftBoutgifterMedAndelTilUtbetaling(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 5),
+                    utgift = 1000,
+                    tilUtbetaling = 1000,
+                    erFørRevurderFra = false,
+                ),
+                UtgiftBoutgifterMedAndelTilUtbetaling(
+                    fom = LocalDate.of(2023, 1, 11),
+                    tom = LocalDate.of(2023, 1, 16),
+                    utgift = 2000,
+                    tilUtbetaling = 2000,
+                    erFørRevurderFra = false,
+                ),
+            )
+
+        val result =
+            beregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(null)
+
+        assertEquals(forventetResultat, result)
+    }
+
+    @Test
+    fun `finnUtgifterMedAndelTilUtbetaling skal finne andel til utbetaling når utgifter avkortes mot makssats`() {
+        val utgift =
+            listOf(
+                UtgiftBeregningBoutgifter(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 5),
+                    utgift = 4000,
+                ),
+                UtgiftBeregningBoutgifter(
+                    fom = LocalDate.of(2023, 1, 11),
+                    tom = LocalDate.of(2023, 1, 16),
+                    utgift = 2000,
+                ),
+            )
+
+        val beregningsresultatForLøpendeMåned =
+            BeregningsresultatForLøpendeMåned(
+                grunnlag =
+                    Beregningsgrunnlag(
+                        fom = LocalDate.of(2023, 1, 1),
+                        tom = LocalDate.of(2023, 1, 31),
+                        utbetalingsdato = LocalDate.of(2023, 2, 1),
+                        utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgift),
+                        makssats = 4953,
+                        makssatsBekreftet = true,
+                        målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                        aktivitet = AktivitetType.TILTAK,
+                    ),
+            )
+
+        val forventetResultat =
+            listOf(
+                UtgiftBoutgifterMedAndelTilUtbetaling(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 5),
+                    utgift = 4000,
+                    tilUtbetaling = 4000,
+                    erFørRevurderFra = false,
+                ),
+                UtgiftBoutgifterMedAndelTilUtbetaling(
+                    fom = LocalDate.of(2023, 1, 11),
+                    tom = LocalDate.of(2023, 1, 16),
+                    utgift = 2000,
+                    tilUtbetaling = 953,
+                    erFørRevurderFra = false,
+                ),
+            )
+
+        val result =
+            beregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(null)
+
+        assertEquals(forventetResultat, result)
+    }
+
+    @Test
+    fun `finnUtgifterMedAndelTilUtbetaling skal markere utgifter med før revurder fra`() {
+        val utgift =
+            listOf(
+                UtgiftBeregningBoutgifter(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 5),
+                    utgift = 1000,
+                ),
+                UtgiftBeregningBoutgifter(
+                    fom = LocalDate.of(2023, 1, 11),
+                    tom = LocalDate.of(2023, 1, 16),
+                    utgift = 2000,
+                ),
+            )
+
+        val beregningsresultatForLøpendeMåned =
+            BeregningsresultatForLøpendeMåned(
+                grunnlag =
+                    Beregningsgrunnlag(
+                        fom = LocalDate.of(2023, 1, 1),
+                        tom = LocalDate.of(2023, 1, 31),
+                        utbetalingsdato = LocalDate.of(2023, 2, 1),
+                        utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgift),
+                        makssats = 4953,
+                        makssatsBekreftet = true,
+                        målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                        aktivitet = AktivitetType.TILTAK,
+                    ),
+            )
+
+        val forventetResultat =
+            listOf(
+                UtgiftBoutgifterMedAndelTilUtbetaling(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 5),
+                    utgift = 1000,
+                    tilUtbetaling = 1000,
+                    erFørRevurderFra = true,
+                ),
+                UtgiftBoutgifterMedAndelTilUtbetaling(
+                    fom = LocalDate.of(2023, 1, 11),
+                    tom = LocalDate.of(2023, 1, 16),
+                    utgift = 2000,
+                    tilUtbetaling = 2000,
+                    erFørRevurderFra = false,
+                ),
+            )
+
+        val revurderFra = LocalDate.of(2023, 1, 10)
+
+        val result =
+            beregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(revurderFra)
+
+        assertEquals(forventetResultat, result)
+    }
+}

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -193,7 +193,14 @@
       "tom" : "2024-01-31",
       "stønadsbeløp" : 3000,
       "utbetalingsdato" : "2024-01-01",
-      "utgifter" : [ {
+      "utgifter" : {
+        "UTGIFTER_OVERNATTING" : [ {
+          "fom" : "2024-01-01",
+          "tom" : "2024-01-31",
+          "utgift" : 3000
+        } ]
+      },
+      "utgifterTilUtbetaling" : [ {
         "fom" : "2024-01-01",
         "tom" : "2024-01-31",
         "utgift" : 3000,
@@ -209,7 +216,14 @@
       "tom" : "2024-02-29",
       "stønadsbeløp" : 4000,
       "utbetalingsdato" : "2024-01-01",
-      "utgifter" : [ {
+      "utgifter" : {
+        "UTGIFTER_OVERNATTING" : [ {
+          "fom" : "2024-02-26",
+          "tom" : "2024-02-29",
+          "utgift" : 4000
+        } ]
+      },
+      "utgifterTilUtbetaling" : [ {
         "fom" : "2024-02-26",
         "tom" : "2024-02-29",
         "utgift" : 4000,

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -193,13 +193,13 @@
       "tom" : "2024-01-31",
       "stønadsbeløp" : 3000,
       "utbetalingsdato" : "2024-01-01",
-      "utgifter" : {
-        "UTGIFTER_OVERNATTING" : [ {
-          "fom" : "2024-01-01",
-          "tom" : "2024-01-31",
-          "utgift" : 3000
-        } ]
-      },
+      "utgifter" : [ {
+        "fom" : "2024-01-01",
+        "tom" : "2024-01-31",
+        "utgift" : 3000,
+        "tilUtbetaling" : 3000,
+        "erFørRevurderFra" : false
+      } ],
       "sumUtgifter" : 3000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
@@ -209,13 +209,13 @@
       "tom" : "2024-02-29",
       "stønadsbeløp" : 4000,
       "utbetalingsdato" : "2024-01-01",
-      "utgifter" : {
-        "UTGIFTER_OVERNATTING" : [ {
-          "fom" : "2024-02-26",
-          "tom" : "2024-02-29",
-          "utgift" : 4000
-        } ]
-      },
+      "utgifter" : [ {
+        "fom" : "2024-02-26",
+        "tom" : "2024-02-29",
+        "utgift" : 4000,
+        "tilUtbetaling" : 4000,
+        "erFørRevurderFra" : false
+      } ],
       "sumUtgifter" : 4000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker at det skal være tydlig for brukeren hvor mye hen får utbetalt per samling.

Har utvidet BeregningsresultatForPeriodeDto med informasjon om hvor stor del av hver utgift som utbetales. 

I frontend:
<img width="548" alt="image" src="https://github.com/user-attachments/assets/b9c053e8-b7db-4116-a2f9-1a59e8989716" />
