### PR TITLE
♻️ Forenkler mapping til andeler for boutgifter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
@@ -29,12 +29,12 @@ class TilkjentYtelseService(
             ?: error("Fant ikke tilkjent ytelse med behandlingsid $behandlingId")
 
     fun lagreTilkjentYtelse(
-        saksbehandling: Saksbehandling,
+        behandlingId: BehandlingId,
         andeler: List<AndelTilkjentYtelse>,
     ): TilkjentYtelse =
         tilkjentYtelseRepository.insert(
             TilkjentYtelse(
-                behandlingId = saksbehandling.id,
+                behandlingId = behandlingId,
                 andelerTilkjentYtelse = andeler.toSet(),
             ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -24,7 +24,7 @@ import java.util.UUID
  * Når man fått kvittering fra økonomi oppdateres [statusIverksetting] på nytt
  *
  * @param iverksetting når vi iverksetter en andel så oppdateres dette feltet med id og tidspunkt
- * @param utbetalingsdato måneden perioden skal iverksettes
+ * @param utbetalingsdato datoen perioden skal iverksettes
  */
 data class AndelTilkjentYtelse(
     @Id

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -55,6 +55,10 @@ data class AndelTilkjentYtelse(
         if (satstype == Satstype.MÅNED) {
             validerFørsteOgSisteIMåneden()
         }
+        if (satstype == Satstype.DAG) {
+            validerLikFomOgTom()
+            validerFomIkkeLørdagEllerSøndag()
+        }
 
         validerDataForType()
         feilHvisIkke(utbetalingsdato.toYearMonth() == fom.toYearMonth()) {
@@ -67,38 +71,18 @@ data class AndelTilkjentYtelse(
             TypeAndel.TILSYN_BARN_ENSLIG_FORSØRGER,
             TypeAndel.TILSYN_BARN_AAP,
             TypeAndel.TILSYN_BARN_ETTERLATTE,
-            -> validerTilsynBarn()
 
             TypeAndel.LÆREMIDLER_ENSLIG_FORSØRGER,
             TypeAndel.LÆREMIDLER_AAP,
             TypeAndel.LÆREMIDLER_ETTERLATTE,
-            -> validerLæremidler()
 
             TypeAndel.BOUTGIFTER_AAP,
             TypeAndel.BOUTGIFTER_ENSLIG_FORSØRGER,
             TypeAndel.BOUTGIFTER_ETTERLATTE,
-            -> validerBoutgifter()
+            -> validerErDagsats()
 
             TypeAndel.UGYLDIG -> {}
         }
-    }
-
-    private fun validerTilsynBarn() {
-        validerSatstype(Satstype.DAG)
-        validerLikFomOgTom()
-        validerFomIkkeLørdagEllerSøndag()
-    }
-
-    private fun validerLæremidler() {
-        validerSatstype(Satstype.DAG)
-        validerLikFomOgTom()
-        validerFomIkkeLørdagEllerSøndag()
-    }
-
-    private fun validerBoutgifter() {
-        validerSatstype(Satstype.DAG)
-        validerLikFomOgTom()
-        validerFomIkkeLørdagEllerSøndag()
     }
 
     private fun validerFomIkkeLørdagEllerSøndag() {
@@ -107,9 +91,9 @@ data class AndelTilkjentYtelse(
         }
     }
 
-    private fun validerSatstype(forventetSatstype: Satstype) {
-        feilHvis(satstype != forventetSatstype) {
-            "Ugyldig satstype=$satstype forventetSatsType=$forventetSatstype for type=$type"
+    private fun validerErDagsats() {
+        feilHvis(satstype != Satstype.DAG) {
+            "Ugyldig satstype=$satstype forventetSatsType=${Satstype.DAG} for type=$type"
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -24,7 +24,7 @@ import java.util.UUID
  * Når man fått kvittering fra økonomi oppdateres [statusIverksetting] på nytt
  *
  * @param iverksetting når vi iverksetter en andel så oppdateres dette feltet med id og tidspunkt
- * @param utbetalingsmåned måneden perioden skal iverksettes
+ * @param utbetalingsdato måneden perioden skal iverksettes
  */
 data class AndelTilkjentYtelse(
     @Id
@@ -183,4 +183,17 @@ enum class StatusIverksetting {
     ;
 
     fun erOk() = this == OK || this == OK_UTEN_UTBETALING
+
+    companion object {
+        /**
+         * Hvis utbetalingsmåneden er fremover i tid og det er nytt år så skal det ventes på satsendring før iverksetting.
+         */
+        fun fraSatsBekreftet(satsBekreftet: Boolean): StatusIverksetting {
+            if (!satsBekreftet) {
+                return VENTER_PÅ_SATS_ENDRING
+            }
+
+            return UBEHANDLET
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -165,7 +165,7 @@ class TilsynBarnBeregnYtelseSteg(
                 }
             }
 
-        tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling, andelerTilkjentYtelse)
+        tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling.id, andelerTilkjentYtelse)
     }
 
     private fun lagInnvilgetVedtak(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
@@ -15,7 +15,7 @@ object BoutgifterAndelTilkjentYtelseMapper {
         beregningsresultat: BeregningsresultatBoutgifter,
     ): List<AndelTilkjentYtelse> =
         beregningsresultat.perioder
-            .sortedBy { it.fom }
+            .sorted()
             .map {
                 val førsteUkedagIMåneden = it.fom.tilFørsteDagIMåneden().datoEllerNesteMandagHvisLørdagEllerSøndag()
                 AndelTilkjentYtelse(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
@@ -2,31 +2,26 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.tilFørsteDagIMåneden
-import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 
-object BoutgifterAndelTilkjentYtelseMapper {
-    fun finnAndelTilkjentYtelse(
-        saksbehandling: Saksbehandling,
-        beregningsresultat: BeregningsresultatBoutgifter,
-    ): List<AndelTilkjentYtelse> =
-        beregningsresultat.perioder
-            .sorted()
-            .map {
-                val førsteUkedagIMåneden = it.fom.tilFørsteDagIMåneden().datoEllerNesteMandagHvisLørdagEllerSøndag()
-                AndelTilkjentYtelse(
-                    beløp = it.stønadsbeløp,
-                    fom = førsteUkedagIMåneden,
-                    tom = førsteUkedagIMåneden,
-                    satstype = Satstype.DAG,
-                    type = it.grunnlag.målgruppe.tilTypeAndel(Stønadstype.BOUTGIFTER),
-                    kildeBehandlingId = saksbehandling.id,
-                    statusIverksetting = StatusIverksetting.fraSatsBekreftet(it.grunnlag.makssatsBekreftet),
-                    utbetalingsdato = it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
-                )
-            }
-}
+fun BeregningsresultatBoutgifter.mapTilAndelTilkjentYtelse(behandlingId: BehandlingId): List<AndelTilkjentYtelse> =
+    perioder
+        .sorted()
+        .map {
+            val førsteUkedagIMåneden = it.fom.tilFørsteDagIMåneden().datoEllerNesteMandagHvisLørdagEllerSøndag()
+            AndelTilkjentYtelse(
+                beløp = it.stønadsbeløp,
+                fom = førsteUkedagIMåneden,
+                tom = førsteUkedagIMåneden,
+                satstype = Satstype.DAG,
+                type = it.grunnlag.målgruppe.tilTypeAndel(Stønadstype.BOUTGIFTER),
+                kildeBehandlingId = behandlingId,
+                statusIverksetting = StatusIverksetting.fraSatsBekreftet(it.grunnlag.makssatsBekreftet),
+                utbetalingsdato = it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
+            )
+        }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
@@ -3,74 +3,32 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.tilFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
-import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
-import java.time.LocalDate
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 object BoutgifterAndelTilkjentYtelseMapper {
     fun finnAndelTilkjentYtelse(
         saksbehandling: Saksbehandling,
         beregningsresultat: BeregningsresultatBoutgifter,
-    ): List<AndelTilkjentYtelse> {
-        val andeler =
-            beregningsresultat.perioder
-                .groupBy { it.grunnlag.utbetalingsdato }
-                .entries
-                .sortedBy { (utbetalingsdato, _) -> utbetalingsdato }
-                .flatMap { (utbetalingsdato, perioder) ->
-                    val førstePerioden = perioder.first()
-                    val satsBekreftet = førstePerioden.grunnlag.makssatsBekreftet
-
-                    feilHvisIkke(perioder.all { it.grunnlag.makssatsBekreftet == satsBekreftet }) {
-                        "Alle perioder for et utbetalingsdato må være bekreftet eller ikke bekreftet"
-                    }
-
-                    mapTilAndeler(
-                        perioder = perioder,
-                        saksbehandling = saksbehandling,
-                        utbetalingsdato = utbetalingsdato.datoEllerNesteMandagHvisLørdagEllerSøndag(),
-                        satsBekreftet = satsBekreftet,
-                    )
-                }
-        return andeler
-    }
-
-    /**
-     * Andeler grupperes per [TypeAndel], sånn at hvis man har 2 ulike målgrupper men som er av samme [TypeAndel]
-     * så summeres beløpet sammen for disse 2 andelene
-     * Hvis man har 2 [BeregningsresultatForLøpendeMåned] med med 2 ulike [TypeAndel]
-     * så blir det mappet til ulike andeler for at regnskapet i økonomi skal få riktig type for gitt utbetalingsmåned
-     */
-    private fun mapTilAndeler(
-        perioder: List<BeregningsresultatForLøpendeMåned>,
-        saksbehandling: Saksbehandling,
-        utbetalingsdato: LocalDate,
-        satsBekreftet: Boolean,
-    ): List<AndelTilkjentYtelse> {
-        val førsteUkedagIMåneden = utbetalingsdato.tilFørsteDagIMåneden().datoEllerNesteMandagHvisLørdagEllerSøndag()
-        return perioder
-            .groupBy { it.grunnlag.målgruppe.tilTypeAndel(Stønadstype.BOUTGIFTER) }
-            .map { (typeAndel, perioder) ->
+    ): List<AndelTilkjentYtelse> =
+        beregningsresultat.perioder
+            .sortedBy { it.fom }
+            .map {
+                val førsteUkedagIMåneden = it.fom.tilFørsteDagIMåneden().datoEllerNesteMandagHvisLørdagEllerSøndag()
                 AndelTilkjentYtelse(
-                    beløp = perioder.sumOf { it.stønadsbeløp },
+                    beløp = it.stønadsbeløp,
                     fom = førsteUkedagIMåneden,
                     tom = førsteUkedagIMåneden,
                     satstype = Satstype.DAG,
-                    type = typeAndel,
+                    type = it.grunnlag.målgruppe.tilTypeAndel(Stønadstype.BOUTGIFTER),
                     kildeBehandlingId = saksbehandling.id,
-                    statusIverksetting = statusIverksettingForSatsBekreftet(satsBekreftet),
-                    utbetalingsdato = utbetalingsdato,
+                    statusIverksetting = statusIverksettingForSatsBekreftet(it.grunnlag.makssatsBekreftet),
+                    utbetalingsdato = it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
                 )
             }
-    }
 
     /**
      * Hvis utbetalingsmåneden er fremover i tid og det er nytt år så skal det ventes på satsendring før iverksetting.

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
@@ -25,19 +25,8 @@ object BoutgifterAndelTilkjentYtelseMapper {
                     satstype = Satstype.DAG,
                     type = it.grunnlag.målgruppe.tilTypeAndel(Stønadstype.BOUTGIFTER),
                     kildeBehandlingId = saksbehandling.id,
-                    statusIverksetting = statusIverksettingForSatsBekreftet(it.grunnlag.makssatsBekreftet),
+                    statusIverksetting = StatusIverksetting.fraSatsBekreftet(it.grunnlag.makssatsBekreftet),
                     utbetalingsdato = it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
                 )
             }
-
-    /**
-     * Hvis utbetalingsmåneden er fremover i tid og det er nytt år så skal det ventes på satsendring før iverksetting.
-     */
-    private fun statusIverksettingForSatsBekreftet(satsBekreftet: Boolean): StatusIverksetting {
-        if (!satsBekreftet) {
-            return StatusIverksetting.VENTER_PÅ_SATS_ENDRING
-        }
-
-        return StatusIverksetting.UBEHANDLET
-    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
@@ -13,7 +13,6 @@ import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.BoutgifterAndelTilkjentYtelseMapper.finnAndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
@@ -72,7 +71,7 @@ class BoutgifterBeregnYtelseSteg(
             vedtaksperioder = vedtaksperioder,
             begrunnelse = vedtak.begrunnelse,
         )
-        lagreTilkjentYtelse(saksbehandling, beregningsresultat)
+        lagreTilkjentYtelse(saksbehandling.id, beregningsresultat)
     }
 
     private fun beregnOgLagreOpphør(
@@ -99,7 +98,7 @@ class BoutgifterBeregnYtelseSteg(
         val beregningsresultat = beregningService.beregn(saksbehandling, avkortedeVedtaksperioder, TypeVedtak.OPPHØR)
 
         lagreOpphørsvedtak(saksbehandling, avkortedeVedtaksperioder, beregningsresultat, vedtak)
-        lagreTilkjentYtelse(saksbehandling, beregningsresultat)
+        lagreTilkjentYtelse(saksbehandling.id, beregningsresultat)
     }
 
     private fun avkortVedtaksperiodeVedOpphør(
@@ -174,16 +173,12 @@ class BoutgifterBeregnYtelseSteg(
     }
 
     private fun lagreTilkjentYtelse(
-        saksbehandling: Saksbehandling,
+        behandlingId: BehandlingId,
         beregningsresultat: BeregningsresultatBoutgifter,
     ) {
         tilkjentYtelseService.lagreTilkjentYtelse(
-            saksbehandling = saksbehandling,
-            andeler =
-                finnAndelTilkjentYtelse(
-                    saksbehandling,
-                    beregningsresultat,
-                ),
+            behandlingId = behandlingId,
+            andeler = beregningsresultat.mapTilAndelTilkjentYtelse(behandlingId),
         )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregnUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregnUtil.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
 import no.nav.tilleggsstonader.kontrakter.felles.sisteDagIÅret
-import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.util.sisteDagenILøpendeMåned
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterVedtaksperiodeUtil.splitPerLøpendeMåneder
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.Beregningsgrunnlag
@@ -55,7 +54,6 @@ object BoutgifterBeregnUtil {
             utgifter = utgifterIPerioden,
             makssats = sats.beløp,
             makssatsBekreftet = sats.bekreftet,
-            utbetalingsdato = periode.utbetalingsdato,
             målgruppe = periode.målgruppe,
             aktivitet = periode.aktivitet,
         )
@@ -114,7 +112,6 @@ object BoutgifterBeregnUtil {
             LøpendeMåned(
                 fom = fom,
                 tom = minOf(fom.sisteDagenILøpendeMåned(), this.tom.sisteDagIÅret()),
-                utbetalingsdato = this.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
             ).medVedtaksperiode(
                 VedtaksperiodeInnenforLøpendeMåned(
                     fom = fom,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtbetalingPeriode.kt
@@ -15,10 +15,6 @@ import java.time.LocalDate
  * @param tom er maks dato for vedtaksperiode inne i en løpende måned.
  * I de tilfeller man kun har en vedtaksperiode som gjelder 5 jan - 7 jan så vil tom= 7 jan.
  *
- * @param utbetalingsdato utbetalingsdato for når en utbetalingsperiode skal utbetales.
- * Eks hvis man innvilger jan-juni så skal man utbetale hele beløpet for fom i første utbetalingsperioden,
- * dvs 5 jan i tidligere eksemplet
- *
  */
 @ConsistentCopyVisibility
 data class UtbetalingPeriode private constructor(
@@ -26,7 +22,6 @@ data class UtbetalingPeriode private constructor(
     override val tom: LocalDate,
     val målgruppe: FaktiskMålgruppe,
     val aktivitet: AktivitetType,
-    val utbetalingsdato: LocalDate,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
@@ -58,14 +53,12 @@ data class UtbetalingPeriode private constructor(
                 ?: brukerfeil(
                     "Det finnes flere ulike målgrupper i utbetalingsperioden ${løpendeMåned.formatertPeriodeNorskFormat()}. Dette er foreløpig ikke noe vi har støtte for.",
                 ),
-        utbetalingsdato = løpendeMåned.fom,
     )
 }
 
 data class LøpendeMåned(
     override val fom: LocalDate,
     override val tom: LocalDate,
-    val utbetalingsdato: LocalDate,
 ) : Periode<LocalDate> {
     /**
      * backing property for vedtaksperioder.

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
@@ -33,7 +33,6 @@ data class BeregningsresultatForLøpendeMåned(
 data class Beregningsgrunnlag(
     override val fom: LocalDate,
     override val tom: LocalDate,
-    val utbetalingsdato: LocalDate,
     val utgifter: Map<TypeBoutgift, List<UtgiftBeregningBoutgifter>>,
     val makssats: Int,
     val makssatsBekreftet: Boolean,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -20,7 +20,6 @@ data class BeregningsresultatForPeriodeDto(
     override val fom: LocalDate,
     override val tom: LocalDate,
     val stønadsbeløp: Int,
-    val utbetalingsdato: LocalDate,
     @Deprecated("Skal gå over til å bruke utgifterTilUtbetaling")
     val utgifter: Map<TypeBoutgift, List<UtgiftBeregningBoutgifter>>,
     // Kan renames til utgifter når frontend er klar
@@ -58,7 +57,6 @@ fun BeregningsresultatForLøpendeMåned.tilDto(revurderFra: LocalDate?): Beregni
         fom = fom,
         tom = tom,
         stønadsbeløp = stønadsbeløp,
-        utbetalingsdato = grunnlag.utbetalingsdato,
         sumUtgifter = grunnlag.summerUtgifter(),
         utgifter = grunnlag.utgifter,
         utgifterTilUtbetaling = finnUtgifterMedAndelTilUtbetaling(revurderFra),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -188,7 +188,7 @@ class LæremidlerBeregnYtelseSteg(
 
                     mapTilAndeler(perioder, saksbehandling, utbetalingsdato, satsBekreftet)
                 }
-        tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling, andeler)
+        tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling.id, andeler)
     }
 
     /**

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -212,7 +212,7 @@ class LæremidlerBeregnYtelseSteg(
                 satstype = Satstype.DAG,
                 type = typeAndel,
                 kildeBehandlingId = saksbehandling.id,
-                statusIverksetting = statusIverksettingForSatsBekreftet(satsBekreftet),
+                statusIverksetting = StatusIverksetting.fraSatsBekreftet(satsBekreftet),
                 utbetalingsdato = utbetalingsdato,
             )
         }
@@ -234,15 +234,4 @@ class LæremidlerBeregnYtelseSteg(
                 ),
             gitVersjon = Applikasjonsversjon.versjon,
         )
-
-    /**
-     * Hvis utbetalingsmåneden er fremover i tid og det er nytt år så skal det ventes på satsendring før iverksetting.
-     */
-    private fun statusIverksettingForSatsBekreftet(satsBekreftet: Boolean): StatusIverksetting {
-        if (!satsBekreftet) {
-            return StatusIverksetting.VENTER_PÅ_SATS_ENDRING
-        }
-
-        return StatusIverksetting.UBEHANDLET
-    }
 }

--- a/src/main/resources/db/migration/V85__fjern_utbetalingsdato_fra_beregningsresultat_boutgifter.sql
+++ b/src/main/resources/db/migration/V85__fjern_utbetalingsdato_fra_beregningsresultat_boutgifter.sql
@@ -1,0 +1,11 @@
+UPDATE vedtak
+SET data = jsonb_set(
+        data,
+        '{beregningsresultat,perioder}',
+        (SELECT jsonb_agg(
+                        vedtaksdata - 'grunnlag' ||
+                        jsonb_build_object('grunnlag', (vedtaksdata -> 'grunnlag') - 'utbetalingsdato')
+                )
+         FROM jsonb_array_elements(data -> 'beregningsresultat' -> 'perioder') AS vedtaksdata)
+           )
+WHERE data ->> 'type' IN ('INNVILGELSE_BOUTGIFTER', 'OPPHØR_BOUTGIFTER');

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/InterntVedtakServiceTest.kt
@@ -386,7 +386,6 @@ class InterntVedtakServiceTest {
             with(interntVedtak.beregningsresultat.boutgifter.first()) {
                 assertThat(fom).isEqualTo(forventet.fom)
                 assertThat(tom).isEqualTo(forventet.tom)
-                assertThat(utbetalingsdato).isEqualTo(forventet.grunnlag.utbetalingsdato)
                 assertThat(målgruppe).isEqualTo(forventet.grunnlag.målgruppe)
                 assertThat(aktivitet).isEqualTo(forventet.grunnlag.aktivitet)
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/interntVedtak/Testdata.kt
@@ -453,7 +453,6 @@ object Testdata {
                                 no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.Beregningsgrunnlag(
                                     fom = LocalDate.of(2024, 1, 1),
                                     tom = LocalDate.of(2024, 1, 31),
-                                    utbetalingsdato = LocalDate.of(2024, 1, 1),
                                     makssats = 4953,
                                     makssatsBekreftet = true,
                                     målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
@@ -477,7 +476,6 @@ object Testdata {
                                 no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.Beregningsgrunnlag(
                                     fom = LocalDate.of(2024, 2, 1),
                                     tom = LocalDate.of(2024, 2, 29),
-                                    utbetalingsdato = LocalDate.of(2024, 1, 1),
                                     makssats = 4953,
                                     makssatsBekreftet = true,
                                     målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/BoutgifterUtbetalingerTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/BoutgifterUtbetalingerTestdata.kt
@@ -49,7 +49,6 @@ fun lagBoutgifterInnvilgelseMedBeløp(
         Beregningsgrunnlag(
             fom = fom,
             tom = tom,
-            utbetalingsdato = fom,
             utgifter = mapOf(alleUtgifter),
             makssats = makssats,
             makssatsBekreftet = true,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -99,7 +99,7 @@ class TilsynBarnBeregnYtelseStegTest {
             simuleringService.slettSimuleringForBehandling(saksbehandling)
 
             repository.insert(any())
-            tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling, any())
+            tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling.id, any())
         }
         verify(exactly = 0) {
             simuleringService.hentOgLagreSimuleringsresultat(any())

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapperTest.kt
@@ -9,7 +9,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverks
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
-import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregnUtil.beregnStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgiftBeregningBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.Beregningsgrunnlag
@@ -161,7 +160,6 @@ class BoutgifterAndelTilkjentYtelseMapperTest {
 private fun finnAndelTilkjentYtelse(vararg beregningsgrunnlag: Beregningsgrunnlag): List<AndelTilkjentYtelse> {
     val fagsak = fagsak(stønadstype = Stønadstype.BOUTGIFTER)
     val behandling = behandling(fagsak = fagsak, steg = StegType.BEREGNE_YTELSE)
-    val saksbehandling = saksbehandling(fagsak = fagsak, behandling = behandling)
 
     val beregningsresultat =
         BeregningsresultatBoutgifter(
@@ -170,7 +168,7 @@ private fun finnAndelTilkjentYtelse(vararg beregningsgrunnlag: Beregningsgrunnla
                     BeregningsresultatForLøpendeMåned(grunnlag = it, stønadsbeløp = it.beregnStønadsbeløp())
                 },
         )
-    return BoutgifterAndelTilkjentYtelseMapper.finnAndelTilkjentYtelse(saksbehandling, beregningsresultat)
+    return beregningsresultat.mapTilAndelTilkjentYtelse(behandling.id)
 }
 
 private fun lagBeregningsgrunnlagMedEnkeltutgift(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapperTest.kt
@@ -56,7 +56,6 @@ class BoutgifterAndelTilkjentYtelseMapperTest {
             lagBeregningsgrunnlagMedEnkeltutgift(
                 fom = lørdag8Mars,
                 tom = søndag9Mars,
-                utbetalingsdato = mandag10Mars,
             )
 
         val andeler = finnAndelTilkjentYtelse(beregningsgrunnlag)
@@ -96,40 +95,6 @@ class BoutgifterAndelTilkjentYtelseMapperTest {
             assertThat(fom).isEqualTo(torsdag1Mai)
             assertThat(tom).isEqualTo(torsdag1Mai)
             assertThat(utbetalingsdato).isEqualTo(torsdag1Mai)
-        }
-    }
-
-    @Test
-    fun `Utbetalingsperioder med NEDSATT_ARBEIDSEVNE summeres opp til én andel så lenge de har samme utbetalingsdato`() {
-        val mandag10Februar = LocalDate.of(2025, FEBRUARY, 10)
-        val torsdag27Feb = LocalDate.of(2025, FEBRUARY, 27)
-        val fredag7Mars = LocalDate.of(2025, MARCH, 7)
-
-        val aap =
-            lagBeregningsgrunnlagMedEnkeltutgift(
-                fom = mandag10Februar,
-                utbetalingsdato = mandag10Februar,
-            ).copy(målgruppe = NEDSATT_ARBEIDSEVNE)
-
-        val uføretrygd =
-            lagBeregningsgrunnlagMedEnkeltutgift(
-                fom = torsdag27Feb,
-                utbetalingsdato = mandag10Februar,
-            ).copy(målgruppe = NEDSATT_ARBEIDSEVNE)
-
-        val nedsattArbeidsevne =
-            lagBeregningsgrunnlagMedEnkeltutgift(
-                fom = fredag7Mars,
-                utbetalingsdato = mandag10Februar,
-            ).copy(målgruppe = NEDSATT_ARBEIDSEVNE)
-
-        val andel = finnAndelTilkjentYtelse(aap, uføretrygd, nedsattArbeidsevne)
-
-        with(andel.single()) {
-            assertThat { fom == mandag10Februar }
-            assertThat { tom == mandag10Februar }
-            assertThat { type == TypeAndel.BOUTGIFTER_AAP }
-            assertThat { beløp == 1000 * 3 }
         }
     }
 
@@ -211,11 +176,9 @@ private fun finnAndelTilkjentYtelse(vararg beregningsgrunnlag: Beregningsgrunnla
 private fun lagBeregningsgrunnlagMedEnkeltutgift(
     fom: LocalDate,
     tom: LocalDate = fom,
-    utbetalingsdato: LocalDate = fom,
 ) = Beregningsgrunnlag(
     fom = fom,
     tom = tom,
-    utbetalingsdato = utbetalingsdato,
     utgifter =
         mapOf(
             TypeBoutgift.UTGIFTER_OVERNATTING to

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterTestUtil.kt
@@ -106,7 +106,6 @@ object BoutgifterTestUtil {
             Beregningsgrunnlag(
                 fom = fom,
                 tom = tom,
-                utbetalingsdato = fom,
                 utgifter = utgifter,
                 makssats = finnMakssats(fom).beløp,
                 makssatsBekreftet = true,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
@@ -69,7 +69,6 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 1, 1),
                         tom = LocalDate.of(2025, 1, 31),
-                        utbetalingsdato = LocalDate.of(2025, 1, 1),
                         utgifter = løpendeUtgifterEnBolig,
                         makssats = 4953,
                         makssatsBekreftet = true,
@@ -83,7 +82,6 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 2, 1),
                         tom = LocalDate.of(2025, 2, 28),
-                        utbetalingsdato = LocalDate.of(2025, 2, 1),
                         utgifter = løpendeUtgifterEnBolig,
                         makssats = 4953,
                         makssatsBekreftet = true,
@@ -97,7 +95,6 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 3, 1),
                         tom = LocalDate.of(2025, 3, 31),
-                        utbetalingsdato = LocalDate.of(2025, 3, 1),
                         utgifter = løpendeUtgifterEnBolig,
                         makssats = 4953,
                         makssatsBekreftet = true,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterToBoliger.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterToBoliger.kt
@@ -69,7 +69,6 @@ class BoutgifterBeregningLøpendeUtgifterToBoliger {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 1, 1),
                         tom = LocalDate.of(2025, 1, 31),
-                        utbetalingsdato = LocalDate.of(2025, 1, 1),
                         utgifter = løpendeUtgifterToBoliger,
                         makssats = 4953,
                         makssatsBekreftet = true,
@@ -83,7 +82,6 @@ class BoutgifterBeregningLøpendeUtgifterToBoliger {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 2, 1),
                         tom = LocalDate.of(2025, 2, 28),
-                        utbetalingsdato = LocalDate.of(2025, 2, 1),
                         utgifter = løpendeUtgifterToBoliger,
                         makssats = 4953,
                         makssatsBekreftet = true,
@@ -97,7 +95,6 @@ class BoutgifterBeregningLøpendeUtgifterToBoliger {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 3, 1),
                         tom = LocalDate.of(2025, 3, 31),
-                        utbetalingsdato = LocalDate.of(2025, 3, 1),
                         utgifter = løpendeUtgifterToBoliger,
                         makssats = 4953,
                         makssatsBekreftet = true,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
@@ -74,7 +74,6 @@ class BoutgifterBeregningMidlertidigUtgiftTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2025, 1, 1),
                         tom = LocalDate.of(2025, 1, 31),
-                        utbetalingsdato = LocalDate.of(2025, 1, 1),
                         utgifter = utgiftMidlertidigOvernatting,
                         makssats = 4953,
                         makssatsBekreftet = true,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/CucumberParsingUtils.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/CucumberParsingUtils.kt
@@ -93,7 +93,6 @@ fun mapBeregningsresultat(
         Beregningsgrunnlag(
             fom = fom,
             tom = tom,
-            utbetalingsdato = parseDato(BoutgifterDomenenøkkel.UTBETALINGSDATO, rad),
             utgifter = finnRelevanteUtgifter(utgifter = utgifter, fom = fom, tom = tom),
             makssats = parseInt(BoutgifterDomenenøkkel.MAKS_SATS, rad),
             makssatsBekreftet = true,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
@@ -34,7 +34,6 @@ class BeregningsresultatBoutgifterDtoTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2023, 1, 1),
                         tom = LocalDate.of(2023, 1, 31),
-                        utbetalingsdato = LocalDate.of(2023, 2, 1),
                         utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgift),
                         makssats = 4953,
                         makssatsBekreftet = true,
@@ -90,7 +89,6 @@ class BeregningsresultatBoutgifterDtoTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2023, 1, 1),
                         tom = LocalDate.of(2023, 1, 31),
-                        utbetalingsdato = LocalDate.of(2023, 2, 1),
                         utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgift),
                         makssats = 4953,
                         makssatsBekreftet = true,
@@ -146,7 +144,6 @@ class BeregningsresultatBoutgifterDtoTest {
                     Beregningsgrunnlag(
                         fom = LocalDate.of(2023, 1, 1),
                         tom = LocalDate.of(2023, 1, 31),
-                        utbetalingsdato = LocalDate.of(2023, 2, 1),
                         utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgift),
                         makssats = 4953,
                         makssatsBekreftet = true,

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -206,7 +206,6 @@
       "fom" : "2024-01-01",
       "tom" : "2024-01-31",
       "stønadsbeløp" : 3000,
-      "utbetalingsdato" : "2024-01-01",
       "utgifter" : {
         "UTGIFTER_OVERNATTING" : [ {
           "fom" : "2024-01-01",
@@ -229,7 +228,6 @@
       "fom" : "2024-02-01",
       "tom" : "2024-02-29",
       "stønadsbeløp" : 4953,
-      "utbetalingsdato" : "2024-01-01",
       "utgifter" : {
         "UTGIFTER_OVERNATTING" : [ {
           "fom" : "2024-02-26",

--- a/src/test/resources/vedtak/BOUTGIFTER/INNVILGELSE_BOUTGIFTER.json
+++ b/src/test/resources/vedtak/BOUTGIFTER/INNVILGELSE_BOUTGIFTER.json
@@ -16,7 +16,6 @@
         "grunnlag": {
           "fom": "2024-01-01",
           "tom": "2024-01-31",
-          "utbetalingsdato": "2024-01-01",
           "utgifter": {
             "UTGIFTER_OVERNATTING": [
               {

--- a/src/test/resources/vedtak/BOUTGIFTER/OPPHØR_BOUTGIFTER.json
+++ b/src/test/resources/vedtak/BOUTGIFTER/OPPHØR_BOUTGIFTER.json
@@ -19,7 +19,6 @@
         "grunnlag": {
           "fom": "2025-01-01",
           "tom": "2025-01-31",
-          "utbetalingsdato": "2025-01-01",
           "utgifter": {
             "LØPENDE_UTGIFTER_EN_BOLIG": [
               {


### PR DESCRIPTION
Vi vil aldri ha flere beregningssresultat for samme beregningsperiode, slik vi har for læremidler, så vi trenger ikke gruppere på utbetalingsdato eller andelstype. 

Utbetalingsdatoen lå i flere ulike "utregningsobjekter", og var ikke den samme datoen for alle, som var forvirrende. Fjernet derfor utbetalingsdato fra alt unntatt "sluttobjektet" `AndelTilkjentYtelse`

### Hvorfor er denne endringen nødvendig? ✨
