### PR TITLE
Marker del av tidligere utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
+import java.time.LocalDate
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
@@ -18,6 +19,7 @@ import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregnUtil.beregnStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregnUtil.lagBeregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregnUtil.splittTilLøpendeMåneder
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.MarkerSomDelAvTidligereUtbetlingUtils.markerSomDelAvTidligereUtbetaling
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.UtgifterValideringUtil.validerUtgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
@@ -30,7 +32,6 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeBeregningUtil.spl
 import no.nav.tilleggsstonader.sak.vedtak.domain.tilVedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vedtak.validering.VedtaksperiodeValideringService
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 
 @Service
 class BoutgifterBeregningService(
@@ -124,11 +125,15 @@ class BoutgifterBeregningService(
         forrigeBeregningsresultat: BeregningsresultatBoutgifter,
     ): BeregningsresultatBoutgifter {
         val perioderFraForrigeVedtakSomSkalBeholdes =
-            forrigeBeregningsresultat.perioder.filter { it.grunnlag.fom.sisteDagenILøpendeMåned() < revurderFra }
+            forrigeBeregningsresultat.perioder
+                .filter { it.grunnlag.fom.sisteDagenILøpendeMåned() < revurderFra }
+                .markerSomDelAvTidligereUtbetaling()
 
         val reberegnedePerioder =
             nyttBeregningsresultat
-                .filter { it.fom.sisteDagenILøpendeMåned() >= revurderFra }
+                .filter {
+                    it.fom.sisteDagenILøpendeMåned() >= revurderFra
+                }.markerSomDelAvTidligereUtbetaling(forrigeBeregningsresultat.perioder)
         return BeregningsresultatBoutgifter(perioderFraForrigeVedtakSomSkalBeholdes + reberegnedePerioder)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
-import java.time.LocalDate
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
@@ -32,6 +31,7 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeBeregningUtil.spl
 import no.nav.tilleggsstonader.sak.vedtak.domain.tilVedtaksperiodeBeregning
 import no.nav.tilleggsstonader.sak.vedtak.validering.VedtaksperiodeValideringService
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class BoutgifterBeregningService(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtils.kt
@@ -1,12 +1,17 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
+import java.time.LocalDate
 
 object MarkerSomDelAvTidligereUtbetlingUtils {
+    /**
+     * @param dagensDato Brukes kun for testing. I koden skal default verdi `LocalDate.now()` brukes.
+     */
     fun List<BeregningsresultatForLøpendeMåned>.markerSomDelAvTidligereUtbetaling(
         perioderFraForrigeVedtak: List<BeregningsresultatForLøpendeMåned>? = null,
+        dagensDato: LocalDate = LocalDate.now(),
     ) = map { periode ->
-        if (periode.skalMarkereSomDelAvTidligereUtbetaling(perioderFraForrigeVedtak)) {
+        if (periode.skalMarkereSomDelAvTidligereUtbetaling(perioderFraForrigeVedtak, dagensDato)) {
             periode.markerSomDelAvTidligereUtbetaling()
         } else {
             periode
@@ -15,9 +20,15 @@ object MarkerSomDelAvTidligereUtbetlingUtils {
 
     private fun BeregningsresultatForLøpendeMåned.skalMarkereSomDelAvTidligereUtbetaling(
         perioderFraForrigeVedtak: List<BeregningsresultatForLøpendeMåned>?,
+        dagensDato: LocalDate,
     ) = (perioderFraForrigeVedtak.orEmpty().noenOverlapper(this) || perioderFraForrigeVedtak == null) &&
-        this.harUtgiftFørDagensDato()
+        this.harUtgiftFørDagensDato(dagensDato)
 
     private fun List<BeregningsresultatForLøpendeMåned>.noenOverlapper(periode: BeregningsresultatForLøpendeMåned): Boolean =
         this.any { it.overlapper(periode) }
+
+    private fun BeregningsresultatForLøpendeMåned.harUtgiftFørDagensDato(dagensDato: LocalDate): Boolean =
+        this.grunnlag.utgifter.values
+            .flatten()
+            .any { utgift -> utgift.fom < dagensDato }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtils.kt
@@ -1,0 +1,23 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
+
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
+
+object MarkerSomDelAvTidligereUtbetlingUtils {
+    fun List<BeregningsresultatForLøpendeMåned>.markerSomDelAvTidligereUtbetaling(
+        perioderFraForrigeVedtak: List<BeregningsresultatForLøpendeMåned>? = null,
+    ) = map { periode ->
+        if (periode.skalMarkereSomDelAvTidligereUtbetaling(perioderFraForrigeVedtak)) {
+            periode.markerSomDelAvTidligereUtbetaling()
+        } else {
+            periode
+        }
+    }
+
+    private fun BeregningsresultatForLøpendeMåned.skalMarkereSomDelAvTidligereUtbetaling(
+        perioderFraForrigeVedtak: List<BeregningsresultatForLøpendeMåned>?,
+    ) = (perioderFraForrigeVedtak.orEmpty().noenOverlapper(this) || perioderFraForrigeVedtak == null) &&
+        this.harUtgiftFørDagensDato()
+
+    private fun List<BeregningsresultatForLøpendeMåned>.noenOverlapper(periode: BeregningsresultatForLøpendeMåned): Boolean =
+        this.any { it.overlapper(periode) }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
@@ -31,11 +31,6 @@ data class BeregningsresultatForLøpendeMåned(
     ): BeregningsresultatForLøpendeMåned = this.copy(grunnlag = this.grunnlag.copy(fom = fom, tom = tom))
 
     fun markerSomDelAvTidligereUtbetaling() = this.copy(delAvTidligereUtbetaling = true)
-
-    fun harUtgiftFørDagensDato(): Boolean =
-        this.grunnlag.utgifter.values
-            .flatten()
-            .any { utgift -> utgift.fom < LocalDate.now() }
 }
 
 data class Beregningsgrunnlag(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/domain/BeregningsresultatBoutgifter.kt
@@ -16,6 +16,7 @@ data class BeregningsresultatBoutgifter(
 data class BeregningsresultatForLøpendeMåned(
     val grunnlag: Beregningsgrunnlag,
     val stønadsbeløp: Int,
+    val delAvTidligereUtbetaling: Boolean = false,
 ) : Periode<LocalDate>,
     KopierPeriode<BeregningsresultatForLøpendeMåned> {
     @get:JsonIgnore
@@ -28,6 +29,13 @@ data class BeregningsresultatForLøpendeMåned(
         fom: LocalDate,
         tom: LocalDate,
     ): BeregningsresultatForLøpendeMåned = this.copy(grunnlag = this.grunnlag.copy(fom = fom, tom = tom))
+
+    fun markerSomDelAvTidligereUtbetaling() = this.copy(delAvTidligereUtbetaling = true)
+
+    fun harUtgiftFørDagensDato(): Boolean =
+        this.grunnlag.utgifter.values
+            .flatten()
+            .any { utgift -> utgift.fom < LocalDate.now() }
 }
 
 data class Beregningsgrunnlag(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -28,6 +28,7 @@ data class BeregningsresultatForPeriodeDto(
     val målgruppe: FaktiskMålgruppe,
     val aktivitet: AktivitetType,
     val makssatsBekreftet: Boolean,
+    val delAvTidligereUtbetaling: Boolean,
 ) : Periode<LocalDate>
 
 fun BeregningsresultatBoutgifter.tilDto(revurderFra: LocalDate?): BeregningsresultatBoutgifterDto =
@@ -63,6 +64,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(revurderFra: LocalDate?): Beregni
         målgruppe = grunnlag.målgruppe,
         aktivitet = grunnlag.aktivitet,
         makssatsBekreftet = grunnlag.makssatsBekreftet,
+        delAvTidligereUtbetaling = delAvTidligereUtbetaling,
     )
 
 fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterTestUtil.kt
@@ -101,6 +101,7 @@ object BoutgifterTestUtil {
         fom: LocalDate,
         tom: LocalDate = fom.withDayOfMonth(fom.lengthOfMonth()),
         utgifter: Map<TypeBoutgift, List<UtgiftBeregningBoutgifter>>,
+        delAvTidligereUtbetaling: Boolean = false,
     ): BeregningsresultatForLøpendeMåned {
         val grunnlag =
             Beregningsgrunnlag(
@@ -116,6 +117,7 @@ object BoutgifterTestUtil {
             grunnlag =
             grunnlag,
             stønadsbeløp = grunnlag.beregnStønadsbeløp(),
+            delAvTidligereUtbetaling = delAvTidligereUtbetaling,
         )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
@@ -183,14 +183,17 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 1, 1),
                     utgifter = løpendeUtgifterEnBolig,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 2, 1),
                     utgifter = løpendeUtgifterEnBolig,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 3, 1),
                     utgifter = løpendeUtgifterEnBolig,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 4, 1),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterToBoliger.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterToBoliger.kt
@@ -181,14 +181,17 @@ class BoutgifterBeregningLøpendeUtgifterToBoliger {
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 1, 1),
                     utgifter = løpendeUtgifterToBoliger,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 2, 1),
                     utgifter = løpendeUtgifterToBoliger,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 3, 1),
                     utgifter = løpendeUtgifterToBoliger,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 4, 1),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
@@ -233,6 +233,7 @@ class BoutgifterBeregningMidlertidigUtgiftTest {
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 1, 1),
                     utgifter = utgiftMidlertidigOvernatting,
+                    delAvTidligereUtbetaling = true,
                 ),
                 lagBeregningsresultatMåned(
                     fom = LocalDate.of(2025, 3, 10),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/CucumberParsingUtils.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/CucumberParsingUtils.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.cucumber.mapRad
 import no.nav.tilleggsstonader.sak.cucumber.parseDato
 import no.nav.tilleggsstonader.sak.cucumber.parseEnum
 import no.nav.tilleggsstonader.sak.cucumber.parseInt
+import no.nav.tilleggsstonader.sak.cucumber.parseValgfriBoolean
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriDato
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriEnum
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
@@ -107,6 +108,9 @@ fun mapBeregningsresultat(
     BeregningsresultatForLøpendeMåned(
         grunnlag = grunnlag,
         stønadsbeløp = parseInt(BoutgifterDomenenøkkel.STØNADSBELØP, rad),
+        delAvTidligereUtbetaling =
+            parseValgfriBoolean(BoutgifterDomenenøkkel.DEL_AV_TIDLIGERE_UTBETALING, rad)
+                ?: false,
     )
 }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtilsTest.kt
@@ -1,7 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
-import io.mockk.every
-import io.mockk.spyk
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.BoutgifterTestUtil.lagBeregningsresultatMåned
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.MarkerSomDelAvTidligereUtbetlingUtils.markerSomDelAvTidligereUtbetaling
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
@@ -35,21 +33,17 @@ class MarkerSomDelAvTidligereUtbetlingUtilsTest {
         )
 
     private val periode1 =
-        spyk(
-            lagBeregningsresultatMåned(
-                fom = LocalDate.of(2025, 1, 1),
-                tom = LocalDate.of(2025, 1, 31),
-                utgifter = utgift1,
-            ),
+        lagBeregningsresultatMåned(
+            fom = LocalDate.of(2025, 1, 1),
+            tom = LocalDate.of(2025, 1, 31),
+            utgifter = utgift1,
         )
 
     private val periode2 =
-        spyk(
-            lagBeregningsresultatMåned(
-                fom = LocalDate.of(2025, 2, 7),
-                tom = LocalDate.of(2025, 3, 6),
-                utgifter = utgift2,
-            ),
+        lagBeregningsresultatMåned(
+            fom = LocalDate.of(2025, 2, 7),
+            tom = LocalDate.of(2025, 3, 6),
+            utgifter = utgift2,
         )
 
     @Test
@@ -62,12 +56,13 @@ class MarkerSomDelAvTidligereUtbetlingUtilsTest {
 
     @Test
     fun `Ikke marker perioder fra forrgie behandling hvis utgiften er etter dagens dato`() {
-        // Mocker dagens dato til å ligge mellom periode1 og periode2
-        every { periode1.harUtgiftFørDagensDato() } returns true
-        every { periode2.harUtgiftFørDagensDato() } returns false
-
+        val dagensDato = LocalDate.of(2025, 2, 5)
         val perioder = listOf(periode1, periode2)
-        val result = perioder.markerSomDelAvTidligereUtbetaling()
+        val result =
+            perioder.markerSomDelAvTidligereUtbetaling(
+                perioderFraForrigeVedtak = null,
+                dagensDato = dagensDato,
+            )
 
         assertThat(result[0].delAvTidligereUtbetaling).isTrue
         assertThat(result[1].delAvTidligereUtbetaling).isFalse
@@ -88,12 +83,14 @@ class MarkerSomDelAvTidligereUtbetlingUtilsTest {
     // det ikke finnes en utgift i den beregningsperiode som er før dagens dato
     @Test
     fun `Ikke marker nye perioder hvis datokrav ikke oppfylt`() {
-        // Mocker dagens dato til å ligge før periode1 og periode2
-        every { periode1.harUtgiftFørDagensDato() } returns false
-        every { periode2.harUtgiftFørDagensDato() } returns false
+        val dagensDato = LocalDate.of(2024, 12, 5)
 
         val perioder = listOf(periode1, periode2)
-        val result = perioder.markerSomDelAvTidligereUtbetaling()
+        val result =
+            perioder.markerSomDelAvTidligereUtbetaling(
+                perioderFraForrigeVedtak = listOf(periode1),
+                dagensDato = dagensDato,
+            )
 
         assertThat(result[0].delAvTidligereUtbetaling).isFalse
         assertThat(result[1].delAvTidligereUtbetaling).isFalse

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MarkerSomDelAvTidligereUtbetlingUtilsTest.kt
@@ -1,0 +1,108 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
+
+import io.mockk.every
+import io.mockk.spyk
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.BoutgifterTestUtil.lagBeregningsresultatMåned
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.MarkerSomDelAvTidligereUtbetlingUtils.markerSomDelAvTidligereUtbetaling
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
+import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class MarkerSomDelAvTidligereUtbetlingUtilsTest {
+    val utgift1 =
+        mapOf(
+            TypeBoutgift.UTGIFTER_OVERNATTING to
+                listOf(
+                    UtgiftBeregningBoutgifter(
+                        fom = LocalDate.of(2025, 1, 1),
+                        tom = LocalDate.of(2025, 1, 4),
+                        utgift = 3000,
+                    ),
+                ),
+        )
+    val utgift2 =
+        mapOf(
+            TypeBoutgift.UTGIFTER_OVERNATTING to
+                listOf(
+                    UtgiftBeregningBoutgifter(
+                        fom = LocalDate.of(2025, 2, 7),
+                        tom = LocalDate.of(2025, 2, 13),
+                        utgift = 3000,
+                    ),
+                ),
+        )
+
+    private val periode1 =
+        spyk(
+            lagBeregningsresultatMåned(
+                fom = LocalDate.of(2025, 1, 1),
+                tom = LocalDate.of(2025, 1, 31),
+                utgifter = utgift1,
+            ),
+        )
+
+    private val periode2 =
+        spyk(
+            lagBeregningsresultatMåned(
+                fom = LocalDate.of(2025, 2, 7),
+                tom = LocalDate.of(2025, 3, 6),
+                utgifter = utgift2,
+            ),
+        )
+
+    @Test
+    fun `Marker perioder fra forrige behandling hvis utgiften er før dagens dato`() {
+        val perioder = listOf(periode1, periode2)
+        val result = perioder.markerSomDelAvTidligereUtbetaling()
+        assertThat(result[0].delAvTidligereUtbetaling).isTrue
+        assertThat(result[1].delAvTidligereUtbetaling).isTrue
+    }
+
+    @Test
+    fun `Ikke marker perioder fra forrgie behandling hvis utgiften er etter dagens dato`() {
+        // Mocker dagens dato til å ligge mellom periode1 og periode2
+        every { periode1.harUtgiftFørDagensDato() } returns true
+        every { periode2.harUtgiftFørDagensDato() } returns false
+
+        val perioder = listOf(periode1, periode2)
+        val result = perioder.markerSomDelAvTidligereUtbetaling()
+
+        assertThat(result[0].delAvTidligereUtbetaling).isTrue
+        assertThat(result[1].delAvTidligereUtbetaling).isFalse
+    }
+
+    // Marker nye perioder hvis det finnes overlappende tidligere beregningsperiode og
+    // det finnes en utgift i den beregningsperiode som er før dagens dato
+    @Test
+    fun `Marker nye perioder hvis krav oppfylt`() {
+        val perioder = listOf(periode1, periode2)
+        val result = perioder.markerSomDelAvTidligereUtbetaling(listOf(periode1))
+
+        assertThat(result[0].delAvTidligereUtbetaling).isTrue
+        assertThat(result[1].delAvTidligereUtbetaling).isFalse
+    }
+
+    // Ikke marker nye perioder når det finnes overlappende tidligere beregningsperiode og
+    // det ikke finnes en utgift i den beregningsperiode som er før dagens dato
+    @Test
+    fun `Ikke marker nye perioder hvis datokrav ikke oppfylt`() {
+        // Mocker dagens dato til å ligge før periode1 og periode2
+        every { periode1.harUtgiftFørDagensDato() } returns false
+        every { periode2.harUtgiftFørDagensDato() } returns false
+
+        val perioder = listOf(periode1, periode2)
+        val result = perioder.markerSomDelAvTidligereUtbetaling()
+
+        assertThat(result[0].delAvTidligereUtbetaling).isFalse
+        assertThat(result[1].delAvTidligereUtbetaling).isFalse
+    }
+
+    @Test
+    fun `Håndterer tom liste`() {
+        val result = emptyList<BeregningsresultatForLøpendeMåned>().markerSomDelAvTidligereUtbetaling()
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/BoutgifterDomenenøkkel.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/beregning/BoutgifterDomenenøkkel.kt
@@ -11,4 +11,5 @@ enum class BoutgifterDomenenøkkel(
     STØNADSBELØP("Stønadsbeløp"),
     AKTIVITET("Aktivitet"),
     MÅLGRUPPE("Målgruppe"),
+    DEL_AV_TIDLIGERE_UTBETALING("Del av tidligere utbetaling"),
 }

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -223,7 +223,8 @@
       "sumUtgifter" : 3000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
-      "makssatsBekreftet" : true
+      "makssatsBekreftet" : true,
+      "delAvTidligereUtbetaling" : false
     }, {
       "fom" : "2024-02-01",
       "tom" : "2024-02-29",
@@ -245,7 +246,8 @@
       "sumUtgifter" : 4000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
-      "makssatsBekreftet" : true
+      "makssatsBekreftet" : true,
+      "delAvTidligereUtbetaling" : false
     } ]
   }
 }

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregn_ytelse_opphør.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregn_ytelse_opphør.feature
@@ -38,9 +38,9 @@ Egenskap: Beregning ved opphør av boutgifter
       Og vi opphører boutgifter behandling=2 med revurderFra=15.02.2025
 
       Så kan vi forvente følgende beregningsresultat for behandling=2
-        | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato |
-        | 01.01.2025 | 31.01.2025 | 1000         | 4953      | 01.01.2025      |
-        | 01.02.2025 | 14.02.2025 | 1000         | 4953      | 01.02.2025      |
+        | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Del av tidligere utbetaling |
+        | 01.01.2025 | 31.01.2025 | 1000         | 4953      | 01.01.2025      | Ja                          |
+        | 01.02.2025 | 14.02.2025 | 1000         | 4953      | 01.02.2025      | Ja                          |
 
       Og følgende andeler for behandling=2
         | Fom        | Beløp | Type           | Utbetalingsdato |
@@ -67,8 +67,8 @@ Egenskap: Beregning ved opphør av boutgifter
       Når vi opphører boutgifter behandling=2 med revurderFra=01.02.2025
 
       Så kan vi forvente følgende beregningsresultat for behandling=2
-        | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato |
-        | 01.01.2025 | 31.01.2025 | 99999        | 4953      | 01.01.2025      |
+        | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Del av tidligere utbetaling |
+        | 01.01.2025 | 31.01.2025 | 99999        | 4953      | 01.01.2025      | Ja                          |
 
       Og følgende andeler for behandling=2
         | Fom        | Beløp | Type           | Utbetalingsdato |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregn_ytelse_revurdering_innvilgelse.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregn_ytelse_revurdering_innvilgelse.feature
@@ -38,9 +38,9 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | 15.02.2025 | 18.02.2025 |
 
     Så kan vi forvente følgende beregningsresultat for behandling=2
-      | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato |
-      | 07.01.2025 | 06.02.2025 | 1000         | 4953      | 07.01.2025      |
-      | 15.02.2025 | 14.03.2025 | 3000         | 4953      | 15.02.2025      |
+      | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Del av tidligere utbetaling |
+      | 07.01.2025 | 06.02.2025 | 1000         | 4953      | 07.01.2025      | Ja                          |
+      | 15.02.2025 | 14.03.2025 | 3000         | 4953      | 15.02.2025      | Nei                         |
 
     Og følgende vedtaksperioder for behandling=2
       | Fom        | Tom        |
@@ -74,8 +74,8 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | 04.03.2025 | 06.03.2025 |
 
     Så kan vi forvente følgende beregningsresultat for behandling=2
-      | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato |
-      | 25.02.2025 | 24.03.2025 | 4953         | 4953      | 25.02.2025      |
+      | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Del av tidligere utbetaling |
+      | 25.02.2025 | 24.03.2025 | 4953         | 4953      | 25.02.2025      | Ja                          |
 
     Og følgende vedtaksperioder for behandling=2
       | Fom        | Tom        |
@@ -120,10 +120,10 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | 17.08.2024 | 20.10.2024 |
 
     Så kan vi forvente følgende beregningsresultat for behandling=2
-      | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato |
-      | 17.08.2024 | 16.09.2024 | 4500         | 4809      | 17.08.2024      |
-      | 17.09.2024 | 16.10.2024 | 4500         | 4809      | 17.09.2024      |
-      | 17.10.2024 | 20.10.2024 | 4500         | 4809      | 17.10.2024      |
+      | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Del av tidligere utbetaling |
+      | 17.08.2024 | 16.09.2024 | 4500         | 4809      | 17.08.2024      | Ja                          |
+      | 17.09.2024 | 16.10.2024 | 4500         | 4809      | 17.09.2024      | Ja                          |
+      | 17.10.2024 | 20.10.2024 | 4500         | 4809      | 17.10.2024      | Ja                          |
 
     Og følgende andeler for behandling=2
       | Fom        | Beløp | Type           | Utbetalingsdato |
@@ -132,7 +132,7 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | 01.10.2024 | 4500  | BOUTGIFTER_AAP | 17.10.2024      |
 
   Scenario: Aktiviteten blir forskjøvet en uke framover i tid, inn i neste måned
-    Resultat: Forventer nye nye beregningsperioder, mens andelen får ny dato
+  Resultat: Forventer nye nye beregningsperioder, mens andelen får ny dato
     Gitt følgende boutgifter av type LØPENDE_UTGIFTER_EN_BOLIG for behandling=1
       | Fom        | Tom        | Utgift |
       | 01.01.2025 | 30.02.2025 | 1000   |
@@ -156,7 +156,7 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | 03.02.2025 | 1000  | BOUTGIFTER_AAP | 03.02.2025      |
 
   Scenario: Har faste utgifter fra før, legger inn en midlertidig overnatting
-    Resultat: Forventer feilmelding, ettersom det ikke er støttet i løsningen enda
+  Resultat: Forventer feilmelding, ettersom det ikke er støttet i løsningen enda
     Gitt følgende boutgifter av type LØPENDE_UTGIFTER_EN_BOLIG for behandling=1
       | Fom        | Tom        | Utgift |
       | 01.01.2025 | 31.11.2025 | 1000   |

--- a/src/test/resources/vedtak/BOUTGIFTER/INNVILGELSE_BOUTGIFTER.json
+++ b/src/test/resources/vedtak/BOUTGIFTER/INNVILGELSE_BOUTGIFTER.json
@@ -30,7 +30,8 @@
           "målgruppe": "NEDSATT_ARBEIDSEVNE",
           "aktivitet": "TILTAK"
         },
-        "stønadsbeløp": 2000
+        "stønadsbeløp": 2000,
+        "delAvTidligereUtbetaling" : false
       }
     ]
   }

--- a/src/test/resources/vedtak/BOUTGIFTER/OPPHØR_BOUTGIFTER.json
+++ b/src/test/resources/vedtak/BOUTGIFTER/OPPHØR_BOUTGIFTER.json
@@ -33,7 +33,8 @@
           "målgruppe": "NEDSATT_ARBEIDSEVNE",
           "aktivitet": "TILTAK"
         },
-        "stønadsbeløp" : 2500
+        "stønadsbeløp" : 2500,
+        "delAvTidligereUtbetaling" : false
       }
     ]
   }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne markere en utbetalingsperiode som del av tidligere utbetaling i vedtak og beregning fanen.

Det ble diskutert å flytte denne koden vekk fra beregning da det egentlig er en visningsgreie og egentlig ikke har noe med beregning å gjøre. Det ville krevd mye omskrivning i fronted da brevkoden deles på tvers av alle stønadene.

Logikken for å bestemme om en utbetalngsperiode er en del av tidligere utbetaling er:
- Perioder fra forrgie vedtak er del av tidligere utbetaling hvis: "utgift.fom < dagens dato"
- Nye perioder er del av tidligre utbetaling hvis:  "finnes overlappende tidligere beregningsperiode og utgift.fom < dagens dato"

I frontend blir det seende slik ut:
<img width="985" alt="image" src="https://github.com/user-attachments/assets/c21edf5e-a36a-44b8-a1c1-b08556d1afa6" />
