### PR TITLE
Fjerner inneholder som er implisitt med >= revurderFra

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -127,9 +127,8 @@ class BoutgifterBeregningService(
             forrigeBeregningsresultat.perioder.filter { it.grunnlag.fom.sisteDagenILøpendeMåned() < revurderFra }
 
         val reberegnedePerioder =
-            nyttBeregningsresultat.filter {
-                it.inneholder(revurderFra) || it.fom.sisteDagenILøpendeMåned() > revurderFra
-            }
+            nyttBeregningsresultat
+                .filter { it.fom.sisteDagenILøpendeMåned() >= revurderFra }
         return BeregningsresultatBoutgifter(perioderFraForrigeVedtakSomSkalBeholdes + reberegnedePerioder)
     }
 


### PR DESCRIPTION
- Forenklet kode og er mer lik læremidler

### Hvorfor er denne endringen nødvendig? ✨

Når jeg begynte å se på https://github.com/navikt/tilleggsstonader-sak/pull/714 så noterte jeg denne som jeg ikke helt skjønte.
Eller er det noen spesiell grunn til at sjekken her er annerledes? 
