### PR TITLE
Erstatt logback-syslog4j som ikke blir oppdatert med net.logstash.log…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,9 +92,6 @@ dependencies {
     implementation("no.nav.tilleggsstonader.kontrakter:kontrakter-felles:$tilleggsstønaderKontrakterVersion")
     implementation("no.nav.tilleggsstonader.kontrakter:pdl-personhendelser-avro:$tilleggsstønaderKontrakterVersion")
 
-    // For auditlogger. August, 2014, men det er den som blir brukt på NAV
-    implementation("com.papertrailapp:logback-syslog4j:1.0.0")
-
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "mockito-core")

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -28,17 +28,12 @@
         <appender-ref ref="team-logs"/>
     </logger>
 
-    <appender name="auditLogger" class="com.papertrailapp.logback.Syslog4jAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <pattern>%m%n%xEx</pattern>
-        </layout>
-
-        <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
-            <host>audit.nais</host>
-            <port>6514</port>
-            <ident>TILLEGGSTONADER-SAK</ident>
-            <maxMessageLength>128000</maxMessageLength>
-        </syslogConfig>
+    <appender name="auditLogger" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>audit.nais:6514</destination>
+        <writeBufferSize>128000</writeBufferSize>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${HOSTNAME} TILLEGGSTONADER-SAK: %msg%n</pattern>
+        </encoder>
     </appender>
 
     <logger level="INFO" name="auditLogger" additivity="false">


### PR DESCRIPTION
…back.appender.LogstashTcpSocketAppender for auditlogger

### Hvorfor er denne endringen nødvendig? ✨

Fint å få fjernet denne ekstra avhengigheten som ikke gir så mye

Likt 
https://nav-it.slack.com/archives/C60FFACN5/p1748857628612639

Har sendt en melding til arcsight-gjengen for å få bekreftet at loggene ser greie ut