### PR TITLE
Sender videre en RoutingContext til SøknadROutingService for å gjøre …

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -12,6 +12,5 @@ enum class Toggle(
 
     HENT_BEHANDLINGER_FOR_OPPFØLGING("sak.hent-behandlinger-for-oppfoelging"),
 
-    SØKNAD_ROUTING_BOUTGIFTER("sak.soknad-routing.boutgifter"),
     SKAL_VISE_DETALJERT_BEREGNINGSRESULTAT("sak.detaljert_beregningsresultat"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/UnleashUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/UnleashUtil.kt
@@ -1,12 +1,13 @@
 package no.nav.tilleggsstonader.sak.infrastruktur.unleash
 
+import no.nav.tilleggsstonader.libs.unleash.ToggleId
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import kotlin.jvm.optionals.getOrNull
 
 object UnleashUtil {
     fun UnleashService.getVariantWithNameOrDefault(
-        toggle: Toggle,
+        toggle: ToggleId,
         name: String,
         defaultValue: Int,
     ): Int {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.migrering.arena
 
-import no.nav.tilleggsstonader.kontrakter.felles.IdentStønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
@@ -85,7 +84,7 @@ class ArenaStatusService(
         identer: Set<String>,
         stønadstype: Stønadstype,
     ): Boolean =
-        identer.any {
-            søknadRoutingService.harLagretRouting(IdentStønadstype(it, stønadstype))
+        identer.any { ident ->
+            søknadRoutingService.harLagretRouting(ident, stønadstype)
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/RoutingContext.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/RoutingContext.kt
@@ -1,0 +1,51 @@
+package no.nav.tilleggsstonader.sak.migrering.routing
+
+import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
+import no.nav.tilleggsstonader.kontrakter.felles.IdentStønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.unleash.ToggleId
+
+sealed interface RoutingContext {
+    val ident: String
+    val stønadstype: Stønadstype
+}
+
+data class SkalRouteAlleSøkereTilNyLøsning(
+    override val ident: String,
+    override val stønadstype: Stønadstype,
+) : RoutingContext {
+    companion object {
+        fun fraIdentStønadstype(identStønadstype: IdentStønadstype) =
+            SkalRouteAlleSøkereTilNyLøsning(
+                ident = identStønadstype.ident,
+                stønadstype = identStønadstype.stønadstype,
+            )
+    }
+}
+
+data class FeatureTogglet(
+    override val ident: String,
+    override val stønadstype: Stønadstype,
+    val toggleId: ToggleId,
+    val harGyldigStateIArena: (ArenaStatusDto) -> Boolean,
+) : RoutingContext {
+    companion object {
+        fun fraIdentStønadstype(
+            identStønadstype: IdentStønadstype,
+            toggleId: ToggleId,
+            harGyldigStateIArena: (ArenaStatusDto) -> Boolean,
+        ) = FeatureTogglet(
+            ident = identStønadstype.ident,
+            stønadstype = identStønadstype.stønadstype,
+            toggleId = toggleId,
+            harGyldigStateIArena = harGyldigStateIArena,
+        )
+    }
+}
+
+fun IdentStønadstype.tilRoutingContext() =
+    when (this.stønadstype) {
+        Stønadstype.BARNETILSYN -> SkalRouteAlleSøkereTilNyLøsning.fraIdentStønadstype(this)
+        Stønadstype.LÆREMIDLER -> SkalRouteAlleSøkereTilNyLøsning.fraIdentStønadstype(this)
+        Stønadstype.BOUTGIFTER -> SkalRouteAlleSøkereTilNyLøsning.fraIdentStønadstype(this)
+    }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SøknadRoutingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SøknadRoutingController.kt
@@ -25,6 +25,6 @@ class SøknadRoutingController(
         feilHvisIkke(SikkerhetContext.kallKommerFra(EksternApplikasjon.SOKNAD_API), HttpStatus.UNAUTHORIZED) {
             "Kallet utføres ikke av en autorisert klient"
         }
-        return søknadRoutingService.sjekkRoutingForPerson(request)
+        return søknadRoutingService.sjekkRoutingForPerson(request.tilRoutingContext())
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/UnleashTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/UnleashTestUtil.kt
@@ -5,6 +5,7 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import no.nav.tilleggsstonader.libs.unleash.ToggleId
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 
 fun mockUnleashService(isEnabled: Boolean = true): UnleashService {
@@ -38,7 +39,7 @@ fun UnleashService.mockIsEnabled(
 }
 
 fun UnleashService.mockGetVariant(
-    toggle: Toggle,
+    toggle: ToggleId,
     variant: Variant,
 ): UnleashService {
     val service = this

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusServiceTest.kt
@@ -52,7 +52,7 @@ class ArenaStatusServiceTest {
 
         verify(exactly = 1) { fagsakService.finnFagsak(any(), any()) }
         verify(exactly = 0) { behandlingService.finnesBehandlingForFagsak(any()) }
-        verify(exactly = 1) { søknadRoutingService.harLagretRouting(any()) }
+        verify(exactly = 1) { søknadRoutingService.harLagretRouting(any(), any()) }
     }
 
     @Test
@@ -63,7 +63,7 @@ class ArenaStatusServiceTest {
 
         verify(exactly = 1) { fagsakService.finnFagsak(any(), any()) }
         verify(exactly = 1) { behandlingService.finnesBehandlingForFagsak(any()) }
-        verify(exactly = 1) { søknadRoutingService.harLagretRouting(any()) }
+        verify(exactly = 1) { søknadRoutingService.harLagretRouting(any(), any()) }
     }
 
     @Test
@@ -74,7 +74,7 @@ class ArenaStatusServiceTest {
 
         verify(exactly = 1) { fagsakService.finnFagsak(any(), any()) }
         verify(exactly = 1) { behandlingService.finnesBehandlingForFagsak(any()) }
-        verify(exactly = 0) { søknadRoutingService.harLagretRouting(any()) }
+        verify(exactly = 0) { søknadRoutingService.harLagretRouting(any(), any()) }
     }
 
     @Test
@@ -87,7 +87,7 @@ class ArenaStatusServiceTest {
 
         verify(exactly = 1) { fagsakService.finnFagsak(any(), any()) }
         verify(exactly = 1) { behandlingService.finnesBehandlingForFagsak(any()) }
-        verify(exactly = 1) { søknadRoutingService.harLagretRouting(any()) }
+        verify(exactly = 1) { søknadRoutingService.harLagretRouting(any(), any()) }
     }
 
     private fun mockFinnFagsak(fagsak: Fagsak?) {
@@ -99,6 +99,6 @@ class ArenaStatusServiceTest {
     }
 
     private fun mockSøknadRouting(svar: Boolean) {
-        every { søknadRoutingService.harLagretRouting(any()) } returns svar
+        every { søknadRoutingService.harLagretRouting(any(), any()) } returns svar
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/RoutingContextTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/RoutingContextTest.kt
@@ -1,0 +1,67 @@
+package no.nav.tilleggsstonader.sak.migrering.routing
+
+import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusDto
+import no.nav.tilleggsstonader.kontrakter.arena.SakStatus
+import no.nav.tilleggsstonader.kontrakter.felles.IdentStønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.unleash.ToggleId
+import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaStatusDtoUtil.vedtakStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import kotlin.reflect.KClass
+
+class RoutingContextTest {
+    val ident = "testIdent"
+
+    @ParameterizedTest
+    @EnumSource(Stønadstype::class)
+    fun `skal mappe stønadstype til riktig context`(stønadstype: Stønadstype) {
+        val routingContext = stønadstype.tilRoutingContext()
+
+        assertThat(routingContext.stønadstype).isEqualTo(stønadstype)
+        assertThat(routingContext.ident).isEqualTo(ident)
+
+        assertThat(routingContext).isInstanceOf(expected[stønadstype]!!.java)
+    }
+
+    /**
+     * Kan erstattes med riktig kode når daglig reise er implementert.
+     */
+    @Disabled
+    @Test
+    fun `skal route daglig reise til arena hvis man ikke har aktivt vedtak`() {
+        val routingContext = Stønadstype.BARNETILSYN.tilRoutingContext()
+
+        assertThat(routingContext).isInstanceOf(FeatureTogglet::class.java)
+
+        with(routingContext as FeatureTogglet) {
+            assertThat(this.toggleId).isEqualTo(MockToggle.MOCK_TOGGLE)
+            assertThat(this.harGyldigStateIArena(arenaStatus(harAktivtVedtak = false))).isTrue
+            assertThat(this.harGyldigStateIArena(arenaStatus(harAktivtVedtak = true))).isFalse
+        }
+    }
+
+    private val expected =
+        mapOf<Stønadstype, KClass<out RoutingContext>>(
+            Stønadstype.BARNETILSYN to SkalRouteAlleSøkereTilNyLøsning::class,
+            Stønadstype.LÆREMIDLER to SkalRouteAlleSøkereTilNyLøsning::class,
+            Stønadstype.BOUTGIFTER to SkalRouteAlleSøkereTilNyLøsning::class,
+        )
+
+    private fun Stønadstype.tilRoutingContext() = IdentStønadstype(ident = ident, stønadstype = this).tilRoutingContext()
+
+    private fun arenaStatus(harAktivtVedtak: Boolean = false) =
+        ArenaStatusDto(
+            SakStatus(harAktivSakUtenVedtak = false),
+            vedtakStatus(harVedtak = false, harAktivtVedtak = harAktivtVedtak, harVedtakUtenUtfall = false),
+        )
+
+    private enum class MockToggle(
+        override val toggleId: String,
+    ) : ToggleId {
+        MOCK_TOGGLE("toggleId"),
+    }
+}


### PR DESCRIPTION
…den enklere å teste då den tidligere var avhengig av oppsettet til hver stønadstype

- Nå kan man teste den selv om man ennå ikke har en stønadstype som skal routes til Arena

### Hvorfor er denne endringen nødvendig? ✨
