### PR TITLE
🐛 Håndter ingen vedtaksperioder etter revurder-fra dato

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
@@ -82,8 +82,8 @@ object VedtakDtoMapper {
                 InnvilgelseLæremidlerResponse(
                     vedtaksperioder = data.vedtaksperioder.tilDto(),
                     beregningsresultat = data.beregningsresultat.tilDto(revurderFra = revurderFra),
-                    gjelderFraOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).minOf { it.fom },
-                    gjelderTilOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).maxOf { it.tom },
+                    gjelderFraOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).minOfOrNull { it.fom },
+                    gjelderTilOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).maxOfOrNull { it.tom },
                     begrunnelse = data.begrunnelse,
                 )
 
@@ -110,8 +110,8 @@ object VedtakDtoMapper {
                 InnvilgelseBoutgifterResponse(
                     vedtaksperioder = data.vedtaksperioder.tilVedtaksperiodeDto(),
                     beregningsresultat = data.beregningsresultat.tilDto(revurderFra = revurderFra),
-                    gjelderFraOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).minOf { it.fom },
-                    gjelderTilOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).maxOf { it.tom },
+                    gjelderFraOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).minOfOrNull { it.fom },
+                    gjelderTilOgMed = data.vedtaksperioder.avkortPerioderFør(revurderFra).maxOfOrNull { it.tom },
                     begrunnelse = data.begrunnelse,
                 )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/InnvilgelseBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/InnvilgelseBoutgifterDto.kt
@@ -13,8 +13,8 @@ import java.time.LocalDate
 data class InnvilgelseBoutgifterResponse(
     val vedtaksperioder: List<VedtaksperiodeDto>?,
     val beregningsresultat: BeregningsresultatBoutgifterDto,
-    val gjelderFraOgMed: LocalDate,
-    val gjelderTilOgMed: LocalDate,
+    val gjelderFraOgMed: LocalDate?,
+    val gjelderTilOgMed: LocalDate?,
     val begrunnelse: String? = null,
 ) : VedtakBoutgifterDto(TypeVedtak.INNVILGELSE),
     VedtakBoutgifterResponse

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/dto/InnvilgelseLæremidlerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/dto/InnvilgelseLæremidlerDto.kt
@@ -12,8 +12,8 @@ import java.time.LocalDate
 data class InnvilgelseLæremidlerResponse(
     val vedtaksperioder: List<VedtaksperiodeLæremidlerDto>,
     val beregningsresultat: BeregningsresultatLæremidlerDto,
-    val gjelderFraOgMed: LocalDate,
-    val gjelderTilOgMed: LocalDate,
+    val gjelderFraOgMed: LocalDate?,
+    val gjelderTilOgMed: LocalDate?,
     val begrunnelse: String? = null,
 ) : VedtakLæremidlerDto(TypeVedtak.INNVILGELSE),
     VedtakLæremidlerResponse


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis man innvilger læremidler eller boutgifter for en random periode, så revurder fra en dato etter denne perioden der man beregner og lagre vedtak uten å legge til en ny vedtaksperiode kaster koden nullpointer-exception. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-25352