### PR TITLE
Bumper kontrakt og type for å sjekke respons fra integrasjoner

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20250519094842_e8bd711"
 val tilleggsstønaderLibsVersion = "2025.05.23-10.14.932a51a654b1"
-val tilleggsstønaderKontrakterVersion = "2025.05.26-09.25.f07899b2b19c"
+val tilleggsstønaderKontrakterVersion = "2025.06.04-12.20.facc4fe3a81e"
 val avroVersion = "1.12.0"
 val confluentVersion = "7.9.1"
 val joarkHendelseVersion = "08271806"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
@@ -210,6 +210,7 @@ class OppfølgingOpprettKontrollerService(
     private fun TypeYtelsePeriode.tilMålgruppe() =
         when (this) {
             TypeYtelsePeriode.AAP -> MålgruppeType.AAP
+            TypeYtelsePeriode.DAGPENGER -> MålgruppeType.DAGPENGER
             TypeYtelsePeriode.ENSLIG_FORSØRGER -> MålgruppeType.OVERGANGSSTØNAD
             TypeYtelsePeriode.OMSTILLINGSSTØNAD -> MålgruppeType.OMSTILLINGSSTØNAD
         }
@@ -217,7 +218,7 @@ class OppfølgingOpprettKontrollerService(
     private fun MålgruppeType.tilTypeYtelsePeriode() =
         when (this) {
             MålgruppeType.AAP -> TypeYtelsePeriode.AAP
-            MålgruppeType.DAGPENGER -> TODO("Har ikke mapping for dagpenger ennå")
+            MålgruppeType.DAGPENGER -> TypeYtelsePeriode.DAGPENGER
             MålgruppeType.OMSTILLINGSSTØNAD -> TypeYtelsePeriode.OMSTILLINGSSTØNAD
             MålgruppeType.OVERGANGSSTØNAD -> TypeYtelsePeriode.ENSLIG_FORSØRGER
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelseService.kt
@@ -26,6 +26,7 @@ class YtelseService(
         val typer =
             listOf(
                 TypeYtelsePeriode.AAP,
+                TypeYtelsePeriode.DAGPENGER,
                 TypeYtelsePeriode.ENSLIG_FORSØRGER,
                 TypeYtelsePeriode.OMSTILLINGSSTØNAD,
             )


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For å kunne vise dagpenger under "ytelser-fanen" på personoversikten.

Verifisert at vi henter riktig dato fra ts-integrasjoner -> dp.datadeling.

<img width="1728" alt="Screenshot 2025-06-06 at 11 59 44" src="https://github.com/user-attachments/assets/24d234f8-3214-4cf0-b7a4-d1afcc0a7377" />

NOTE:
Her er egentlig Dagpenger registert i Dolly frem til 30.06.2026 men siden vi kun henter tom et år frem i tid forekommer ikke hele perioden. Burde vi se på denne? 🤔 

_RegisterAktivitetService_
`fun hentAktiviteterMedPerioder(
        fagsakPersonId: FagsakPersonId,
        fom: LocalDate = osloDateNow().minusYears(3),
        tom: LocalDate = osloDateNow().plusYears(1),` 
