### PR TITLE
Fix tidligste endring logikk

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/Behandling.kt
@@ -48,8 +48,10 @@ data class Behandling(
 
     fun vedtakstidspunktEllerFeil(): LocalDateTime = this.vedtakstidspunkt ?: error("Mangler vedtakstidspunkt for behandling=$id")
 
+    fun erHenlagt(): Boolean = resultat == BehandlingResultat.HENLAGT
+
     init {
-        if (resultat == BehandlingResultat.HENLAGT) {
+        if (erHenlagt()) {
             feilHvis(henlagtÅrsak == null) { "Kan ikke henlegge behandling uten en årsak" }
         }
         feilHvis(revurderFra != null && type != BehandlingType.REVURDERING) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -146,7 +146,7 @@ data class TidligsteEndringIBehandlingUtleder(
     ): Boolean =
         vilkårperiode.resultat != tidligereVilkårperiode.resultat ||
             vilkårperiode.type != tidligereVilkårperiode.type ||
-            vilkårperiode.faktaOgVurdering != tidligereVilkårperiode.faktaOgVurdering
+            vilkårperiode.faktaOgVurdering.fakta != tidligereVilkårperiode.faktaOgVurdering.fakta
 
     private fun erVedtaksperiodeEndret(
         vedtaksperiode: Vedtaksperiode,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -162,26 +162,33 @@ data class TidligsteEndringIBehandlingUtleder(
     ): LocalDate? {
         val antallPerioder = min(perioderNå.size, perioderTidligere.size)
 
-        perioderNå.take(antallPerioder).forEachIndexed { index, periodeNå ->
-            val periodeTidligere = perioderTidligere[index]
+        val minsteEndringVedSammenligningAvPerioder =
+            perioderNå
+                .take(antallPerioder)
+                .mapIndexedNotNull { index, periodeNå ->
+                    val periodeTidligere = perioderTidligere[index]
 
-            if (periodeNå.fom != periodeTidligere.fom || erEndret(periodeNå, periodeTidligere)) {
-                return minOf(periodeNå.fom, periodeTidligere.fom)
-            }
-            if (periodeNå.tom != periodeTidligere.tom) {
-                // Legger på en dag, da det først er fra dagen etter tom-datoen at det er en endring
-                return minOf(periodeNå.tom, periodeTidligere.tom).plusDays(1)
-            }
-        }
+                    if (periodeNå.fom != periodeTidligere.fom || erEndret(periodeNå, periodeTidligere)) {
+                        minOf(periodeNå.fom, periodeTidligere.fom)
+                    } else if (periodeNå.tom != periodeTidligere.tom) {
+                        // Legger på en dag, da det først er fra dagen etter tom-datoen at det er en endring
+                        minOf(periodeNå.tom, periodeTidligere.tom).plusDays(1)
+                    } else {
+                        null
+                    }
+                }.minOrNull()
 
-        return when {
-            // Ny periode i ny behandling
-            perioderNå.size > antallPerioder -> perioderNå[antallPerioder].fom
-            // Periode har blitt slettet i ny behandling
-            perioderTidligere.size > antallPerioder -> perioderTidligere[antallPerioder].fom
-            // Ingen endringer i perioder
-            else -> null
-        }
+        val minsteEndringIResterendePerioder =
+            when {
+                // Ny periode i ny behandling
+                perioderNå.size > antallPerioder -> perioderNå[antallPerioder].fom
+                // Periode har blitt slettet i ny behandling
+                perioderTidligere.size > antallPerioder -> perioderTidligere[antallPerioder].fom
+                // Ingen endringer i perioder
+                else -> null
+            }
+
+        return listOfNotNull(minsteEndringVedSammenligningAvPerioder, minsteEndringIResterendePerioder).minOrNull()
     }
 }
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/beregnFra/aktivitet_beregn_fra.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/beregnFra/aktivitet_beregn_fra.feature
@@ -268,5 +268,35 @@ Egenskap: Utled tidligste endring av aktivitet
 
       Så forvent følgende dato for tidligste endring: 01.04.2024
 
+    Scenario: En aktivitet blir kortet ned, og ny aktivitet som overlapper med forrige legges til
+      Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Resultat | Status |
+        | 01.02.2024 | 31.03.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | NY     |
+
+      Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Resultat | Status  |
+        | 01.02.2024 | 28.02.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | ENDRET  |
+        | 20.02.2024 | 15.03.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | NY      |
+
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 20.02.2024
+
+    Scenario: To aktiviteter hvor overlapper, første aktivitet endres og siste aktivitet slettes
+      Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Resultat | Status |
+        | 01.02.2024 | 31.03.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | NY     |
+        | 20.03.2024 | 10.04.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | NY     |
+
+      Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Resultat | Status  |
+        | 01.02.2024 | 25.03.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | ENDRET  |
+        | 20.03.2024 | 10.04.2024 | BOUTGIFTER  | TILTAK | OPPFYLT  | SLETTET |
+
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 20.03.2024
 
 #    Burde man ha noe om at kildeId er endret? Feks. samme periode men ny aktivitet?


### PR DESCRIPTION
Fiksing etter caser funnet ved sammenligning av data:

- Utledet ikke riktig dato ved eks overlappende aktiviteter. Eksempelvis
  - Aktiviteter `01.01 - 30.01` + `20.01 - 20.02`
  - Endres til `01.01 - 25.01` og siste aktivitet slettes
  - Første endring er 20.01, logikken utledet til 26.01.
  Så ikke på resterende perioder etter det ble funnet en diff
- Filtrerer ut henlagte og avslåtte behandlinger i sammenligning
- Sammenligner kun fakta på vilkårsperioder. Dette for å håndtere at aldersvilkår har blitt lagt til ved en migrering, og gammel data har `GAMMEL_MANGLER_DATA` som svar. Dette slår ut som en endring, selv om begge vilkårsperiodene fortsatt er oppfylte