### PR TITLE
🏷️ Oppdaterer typen til `BeregningsresultatForPeriodeDto.utgifter` 

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregnUtil.summerUtgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatForLøpendeMåned
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BoutgifterPerUtgiftstype
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import java.time.LocalDate
@@ -21,7 +20,7 @@ data class BeregningsresultatForPeriodeDto(
     override val tom: LocalDate,
     val stønadsbeløp: Int,
     @Deprecated("Skal gå over til å bruke utgifterTilUtbetaling")
-    val utgifter: BoutgifterPerUtgiftstype,
+    val utgifter: List<UtgiftBoutgifterMedAndelTilUtbetalingDto>,
     // Kan renames til utgifter når frontend er klar
     val utgifterTilUtbetaling: List<UtgiftBoutgifterMedAndelTilUtbetalingDto>,
     val sumUtgifter: Int,
@@ -72,7 +71,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(revurderFra: LocalDate?): Beregni
         tom = tom,
         stønadsbeløp = stønadsbeløp,
         sumUtgifter = grunnlag.summerUtgifter(),
-        utgifter = grunnlag.utgifter,
+        utgifter = finnUtgifterMedAndelTilUtbetaling(revurderFra),
         utgifterTilUtbetaling = finnUtgifterMedAndelTilUtbetaling(revurderFra),
         målgruppe = grunnlag.målgruppe,
         aktivitet = grunnlag.aktivitet,

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -206,14 +206,13 @@
       "fom" : "2024-01-01",
       "tom" : "2024-01-31",
       "stønadsbeløp" : 3000,
-      "utgifter" : {
-        "UTGIFTER_OVERNATTING" : [ {
-          "fom" : "2024-01-01",
-          "tom" : "2024-01-31",
-          "utgift" : 3000,
-          "skalFåDekketFaktiskeUtgifter" : false
-        } ]
-      },
+      "utgifter" : [ {
+        "fom" : "2024-01-01",
+        "tom" : "2024-01-31",
+        "utgift" : 3000,
+        "tilUtbetaling" : 3000,
+        "erFørRevurderFra" : false
+      } ],
       "utgifterTilUtbetaling" : [ {
         "fom" : "2024-01-01",
         "tom" : "2024-01-31",
@@ -230,14 +229,13 @@
       "fom" : "2024-02-01",
       "tom" : "2024-02-29",
       "stønadsbeløp" : 4953,
-      "utgifter" : {
-        "UTGIFTER_OVERNATTING" : [ {
-          "fom" : "2024-02-26",
-          "tom" : "2024-02-29",
-          "utgift" : 4000,
-          "skalFåDekketFaktiskeUtgifter" : false
-        } ]
-      },
+      "utgifter" : [ {
+        "fom" : "2024-02-26",
+        "tom" : "2024-02-29",
+        "utgift" : 4000,
+        "tilUtbetaling" : 4000,
+        "erFørRevurderFra" : false
+      } ],
       "utgifterTilUtbetaling" : [ {
         "fom" : "2024-02-26",
         "tom" : "2024-02-29",


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Oppdaterer typen til `BeregningsresultatForPeriodeDto.utgifter` slik at frontend kan bruke denne og vi kan slette den midlertidige `utgifterTilUtbetaling`
