### PR TITLE
Ingen duplikater i fakta grunnlag

### DIFF
--- a/src/main/resources/db/migration/V89__unike_verdier_fakta_grunnlag.sql
+++ b/src/main/resources/db/migration/V89__unike_verdier_fakta_grunnlag.sql
@@ -1,0 +1,7 @@
+-- Drop eksisterende constraint
+ALTER TABLE fakta_grunnlag DROP CONSTRAINT unique_behandling_type;
+
+-- Legg til unik index som behandler NULL type_id som en verdi
+-- dette gir unike verdier selv om type_id skulle være NULL
+CREATE UNIQUE INDEX unique_behandling_type_idx ON fakta_grunnlag
+    (behandling_id, type, COALESCE(type_id, 'NULL_VALUE'));

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/GeneriskFaktaGrunnlagTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/GeneriskFaktaGrunnlagTestUtil.kt
@@ -25,10 +25,37 @@ object GeneriskFaktaGrunnlagTestUtil {
     fun faktaGrunnlagAnnenForelder(
         ident: String = "forelder1",
         harBehandlingUnderArbeid: Boolean = true,
-        oppfyltePerioderForBarn: List<Datoperiode> = listOf(Datoperiode(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 31))),
+        oppfyltePerioderForBarn: List<Datoperiode> =
+            listOf(
+                Datoperiode(
+                    LocalDate.of(2025, 1, 1),
+                    LocalDate.of(2025, 1, 31),
+                ),
+            ),
     ) = FaktaGrunnlagAnnenForelderSaksinformasjon(
         ident = ident,
         harBehandlingUnderArbeid = harBehandlingUnderArbeid,
         vedtaksperioderBarn = oppfyltePerioderForBarn,
     )
+
+    fun faktaGrunnlagPersonopplysninger(
+        behandlingId: BehandlingId = BehandlingId.random(),
+    ): GeneriskFaktaGrunnlag<FaktaGrunnlagPersonopplysninger> =
+        GeneriskFaktaGrunnlag(
+            behandlingId = behandlingId,
+            data =
+                FaktaGrunnlagPersonopplysninger(
+                    navn =
+                        Navn(
+                            fornavn = "Maximus",
+                            mellomnavn = "Decimus",
+                            etternavn = "Meridius",
+                        ),
+                    fødsel = null,
+                    barn = emptyList(),
+                ),
+            type = TypeFaktaGrunnlag.PERSONOPPLYSNINGER,
+            typeId = null,
+            sporbar = Sporbar(opprettetAv = "id123", opprettetTid = LocalDate.of(2025, 1, 2).atStartOfDay()),
+        )
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger til indeks i faktagrunnlag som sørger for at det ikke kan opprettes duplikater også når type_id er null

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-25609