### PR TITLE
👔 Kopierer over barn fra forrige behandling som ikke finnes i behandling som tas av vent

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingService.kt
@@ -78,7 +78,7 @@ class NullstillBehandlingService(
     private fun gjenbrukData(behandling: Behandling) {
         val behandlingIdForGjenbruk =
             gjennbrukDataRevurderingService.finnBehandlingIdForGjenbruk(behandling)
-                ?: error("Kan ikke nullstille behandling som ikke har behandlingIdForGjenbruk")
+                ?: error("Fant ingen behandling å gjenbruke data fra")
         val barnMap = gjennbrukDataRevurderingService.finnNyttIdForBarn(behandling.id, behandlingIdForGjenbruk)
         gjennbrukDataRevurderingService.gjenbrukData(behandling, behandlingIdForGjenbruk, barnMap)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnService.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.behandling.barn
 
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
@@ -29,6 +30,25 @@ class BarnService(
                 .associate { it.id to it.copy(id = BarnId.random(), behandlingId = nyBehandlingId, sporbar = Sporbar()) }
         barnRepository.insertAll(nyeBarnPåGammelId.values.toList())
         return nyeBarnPåGammelId.map { it.key to it.value.id }.toMap()
+    }
+
+    fun kopierManglendeBarnFraForrigeBehandling(
+        forrigeBehandlingId: BehandlingId,
+        nyBehandling: Behandling,
+    ) {
+        val barnPåForrigeBehandling = finnBarnPåBehandling(forrigeBehandlingId)
+        val barnPåBehandlingSomSkalTasAvVent = finnBarnPåBehandling(nyBehandling.id)
+
+        val identerPåVent = barnPåBehandlingSomSkalTasAvVent.map { it.ident }.toSet()
+        val barnSomMåLeggesTilBehandlingSomSkalTasAvVent =
+            barnPåForrigeBehandling.filter { it.ident !in identerPåVent }
+
+        val nyeBarn =
+            barnSomMåLeggesTilBehandlingSomSkalTasAvVent.map {
+                it.copy(behandlingId = nyBehandling.id, id = BarnId.random(), sporbar = Sporbar())
+            }
+
+        barnRepository.insertAll(nyeBarn)
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentService.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
+import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.FaktaGrunnlagService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +31,7 @@ class TaAvVentService(
     private val gjennbrukDataRevurderingService: GjennbrukDataRevurderingService,
     private val barnService: BarnService,
     private val fagsakService: FagsakService,
+    private val faktaGrunnlagService: FaktaGrunnlagService,
 ) {
     @Transactional
     fun taAvVent(
@@ -107,6 +109,7 @@ class TaAvVentService(
                     ?: error("Forventer å finne en ferdigstilt behandling på fagsaken")
 
             barnService.kopierManglendeBarnFraForrigeBehandling(idForGjenbruk, behandlingSomTasAvVent)
+            faktaGrunnlagService.slettOgOpprettNyttGrunnlag(behandlingSomTasAvVent.id)
         }
 
         nullstillBehandlingService.nullstillBehandling(behandlingSomTasAvVent)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentService.kt
@@ -1,14 +1,18 @@
 package no.nav.tilleggsstonader.sak.behandling.vent
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.oppgave.vent.TaAvVentRequest
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.GjennbrukDataRevurderingService
 import no.nav.tilleggsstonader.sak.behandling.NullstillBehandlingService
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkService
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
 import no.nav.tilleggsstonader.sak.behandling.vent.KanTaAvVent.Ja.PåkrevdHandling
 import no.nav.tilleggsstonader.sak.behandling.vent.KanTaAvVent.Nei.Årsak
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
@@ -23,6 +27,9 @@ class TaAvVentService(
     private val behandlingshistorikkService: BehandlingshistorikkService,
     private val settPåVentRepository: SettPåVentRepository,
     private val oppgaveService: OppgaveService,
+    private val gjennbrukDataRevurderingService: GjennbrukDataRevurderingService,
+    private val barnService: BarnService,
+    private val fagsakService: FagsakService,
 ) {
     @Transactional
     fun taAvVent(
@@ -38,6 +45,7 @@ class TaAvVentService(
                     Årsak.AnnenAktivBehandlingPåFagsaken -> brukerfeil("Det finnes allerede en aktiv behandling på denne fagsaken")
                 }
             }
+
             is KanTaAvVent.Ja -> {
                 val behandlingTattAvVent = behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES)
                 opprettHistorikkInnslagTaAvVent(behandling, taAvVentDto?.kommentar)
@@ -85,10 +93,23 @@ class TaAvVentService(
      * Dersom behandling A har ligger på vent, og en annen behandling på fagsaken har fått et vedtak i mellomtiden, så
      * må behandling A nullstilles før den kan settes av vent, ettersom både vilkår og annen historikk kan ha endret
      * seg.
+     *
+     * For tilsyn barn må vi også sørge for at barna fra forrige behandling blir med over i den nullstilte behandlingen, ellers blir det
+     * kluss når stønadsvilkårene gjenbrukes.
      */
     private fun håndterAtNyBehandlingHarBlittFerdigstiltPåFagsaken(behandlingSomTasAvVent: Behandling) {
-        nullstillBehandlingService.nullstillBehandling(behandlingSomTasAvVent)
         val sisteIverksatteBehandlingId = behandlingService.finnSisteIverksatteBehandling(behandlingSomTasAvVent.fagsakId)
+        val fagsak = fagsakService.hentFagsakForBehandling(behandlingSomTasAvVent.id)
+
+        if (fagsak.stønadstype == Stønadstype.BARNETILSYN) {
+            val idForGjenbruk =
+                gjennbrukDataRevurderingService.finnBehandlingIdForGjenbruk(behandlingSomTasAvVent)
+                    ?: error("Forventer å finne en ferdigstilt behandling på fagsaken")
+
+            barnService.kopierManglendeBarnFraForrigeBehandling(idForGjenbruk, behandlingSomTasAvVent)
+        }
+
+        nullstillBehandlingService.nullstillBehandling(behandlingSomTasAvVent)
         behandlingService.gjørOmTilRevurdering(behandlingSomTasAvVent, sisteIverksatteBehandlingId?.id)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/FaktaGrunnlagRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/FaktaGrunnlagRepository.kt
@@ -5,6 +5,8 @@ import no.nav.tilleggsstonader.sak.felles.domain.FaktaGrunnlagId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.faktagrunnlag.TypeFaktaGrunnlag
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -22,4 +24,8 @@ interface FaktaGrunnlagRepository :
     ): List<FaktaGrunnlag>
 
     fun existsByBehandlingId(behandlingId: BehandlingId): Boolean
+
+    @Modifying
+    @Query("DELETE from fakta_grunnlag where behandling_id = :behandlingId")
+    fun deleteAllByBehandlingId(behandlingId: BehandlingId)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/FaktaGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/FaktaGrunnlagService.kt
@@ -55,6 +55,15 @@ class FaktaGrunnlagService(
             }
         }
 
+    @Transactional
+    fun slettOgOpprettNyttGrunnlag(behandlingId: BehandlingId): FaktaGrunnlagOpprettResultat {
+        advisoryLockService.lockForTransaction(behandlingId) {
+            faktaGrunnlagRepository.deleteAllByBehandlingId(behandlingId)
+            opprettGrunnlag(behandlingId)
+        }
+        return FaktaGrunnlagOpprettResultat.Opprettet
+    }
+
     private fun opprettGrunnlag(behandlingId: BehandlingId) {
         logger.info("Oppretter faktaGrunnlag for behandling=$behandlingId")
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnServiceTest.kt
@@ -1,0 +1,248 @@
+package no.nav.tilleggsstonader.sak.behandling.barn
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+class BarnServiceTest : IntegrationTest() {
+    @Autowired
+    lateinit var barnService: BarnService
+
+    val dummySaksbehandler = "saksbehandler1"
+    val fagsak = fagsak()
+    val behandling = behandling(fagsak = fagsak)
+
+    @BeforeEach
+    fun setUp() {
+        testoppsettService.lagreFagsak(fagsak)
+        testoppsettService.lagre(behandling)
+    }
+
+    @Nested
+    inner class KopierMangelendeBarnFraForrgieBehandling {
+        @Test
+        fun `kan kopiere maglende barn fra forrgie behandling`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                val barn = dummyBarn(behandling.id, "barn1")
+                barnService.opprettBarn(listOf(barn))
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+                val barnNyBehandling = dummyBarn(nyBehandling.id, "barnNyBehandling")
+                barnService.opprettBarn(listOf(barnNyBehandling))
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(2)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barn1",
+                    "barnNyBehandling",
+                )
+            }
+        }
+
+        @Test
+        fun `to barn på forrgie behandling`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                val barn1 = dummyBarn(behandling.id, "barn1")
+                val barn2 = dummyBarn(behandling.id, "barn2")
+                barnService.opprettBarn(listOf(barn1, barn2))
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+                val barnNyBehandling = dummyBarn(nyBehandling.id, "barnNyBehandling")
+                barnService.opprettBarn(listOf(barnNyBehandling))
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(3)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barn1",
+                    "barn2",
+                    "barnNyBehandling",
+                )
+            }
+        }
+
+        @Test
+        fun `tre barn på forrgie behandling`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                val barn1 = dummyBarn(behandling.id, "barn1")
+                val barn2 = dummyBarn(behandling.id, "barn2")
+                val barn3 = dummyBarn(behandling.id, "barn3")
+                barnService.opprettBarn(listOf(barn1, barn2, barn3))
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+                val barnNyBehandling = dummyBarn(nyBehandling.id, "barnNyBehandling")
+                barnService.opprettBarn(listOf(barnNyBehandling))
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(4)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barn1",
+                    "barn2",
+                    "barn3",
+                    "barnNyBehandling",
+                )
+            }
+        }
+
+        @Test
+        fun `ingen barn på forrgie behandling`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+                val barnNyBehandling = dummyBarn(nyBehandling.id, "barnNyBehandling")
+                barnService.opprettBarn(listOf(barnNyBehandling))
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(1)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barnNyBehandling",
+                )
+            }
+        }
+
+        @Test
+        fun `ingen barn på ny behandling`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                val barn = dummyBarn(behandling.id, "barn1")
+                barnService.opprettBarn(listOf(barn))
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(1)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barn1",
+                )
+            }
+        }
+
+        @Test
+        fun `to barn på ny behandling`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                val barn = dummyBarn(behandling.id, "barn1")
+                barnService.opprettBarn(listOf(barn))
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+                val barnNyBehandling1 = dummyBarn(nyBehandling.id, "barnNyBehandling1")
+                val barnNyBehandling2 = dummyBarn(nyBehandling.id, "barnNyBehandling2")
+                barnService.opprettBarn(listOf(barnNyBehandling1, barnNyBehandling2))
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(3)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barn1",
+                    "barnNyBehandling1",
+                    "barnNyBehandling2",
+                )
+            }
+        }
+
+        @Test
+        fun `duplikerer ikke barn`() {
+            testWithBrukerContext(dummySaksbehandler) {
+                val barn = dummyBarn(behandling.id, "barn1")
+                barnService.opprettBarn(listOf(barn))
+                testoppsettService.ferdigstillBehandling(behandling)
+
+                val nyBehandling =
+                    behandling(
+                        fagsak = fagsak,
+                        status = BehandlingStatus.UTREDES,
+                        resultat = BehandlingResultat.INNVILGET,
+                        vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                    )
+                testoppsettService.lagre(nyBehandling)
+                val barn1Kopi = dummyBarn(nyBehandling.id, "barn1")
+                barnService.opprettBarn(listOf(barn1Kopi))
+
+                barnService.kopierManglendeBarnFraForrigeBehandling(behandling.id, nyBehandling)
+
+                val barnEtterTaAvVent = barnService.finnBarnPåBehandling(nyBehandling.id)
+                assertThat(barnEtterTaAvVent).hasSize(1)
+                assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
+                    "barn1",
+                )
+            }
+        }
+    }
+
+    /**
+     * Utility method for creating a dummy test barn (child)
+     */
+    private fun dummyBarn(
+        behandlingId: BehandlingId,
+        ident: String,
+    ) = BehandlingBarn(
+        behandlingId = behandlingId,
+        ident = ident,
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.behandling.vent
 
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkService
@@ -43,6 +44,9 @@ class TaAvVentServiceTest : IntegrationTest() {
 
     @Autowired
     lateinit var vilkårperiodeService: VilkårperiodeService
+
+    @Autowired
+    lateinit var barnService: no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 
     val fagsak = fagsak()
     val behandling = behandling(fagsak = fagsak)
@@ -192,6 +196,55 @@ class TaAvVentServiceTest : IntegrationTest() {
             assertThat(nullstiltBehandling.forrigeIverksatteBehandlingId).isEqualTo(behandlingSomSniker.id)
             assertThat(nullstilteVilkår.målgrupper).isEmpty()
             assertThat(nullstilteVilkår.aktiviteter).isNotEmpty()
+        }
+    }
+
+    /**
+     * Utility method for creating a dummy test barn (child)
+     */
+    private fun dummyBarn(
+        behandlingId: BehandlingId,
+        ident: String,
+    ) = BehandlingBarn(
+        behandlingId = behandlingId,
+        ident = ident,
+    )
+
+    @Test
+    fun `skal legge til barn fra forrige behandling som ikke finnes i behandling som tas av vent`() {
+        testWithBrukerContext(dummySaksbehandler) {
+            // Lagre informasjon på behandlingen som skal nullstilles
+            taAvVentService.taAvVent(behandling.id)
+            settPåVentService.settPåVent(behandling.id, settPåVentDto.copy(beholdOppgave = true))
+
+            // Lag ny behandling med ett barn som blir iverksatt, og legg til en kid på den
+            val behandlingSomBlirIverksatt =
+                behandling(
+                    fagsak = fagsak,
+                    status = BehandlingStatus.UTREDES,
+                    resultat = BehandlingResultat.INNVILGET,
+                    vedtakstidspunkt = LocalDateTime.now().plusDays(1),
+                )
+            testoppsettService.lagre(behandlingSomBlirIverksatt)
+
+            val barnPåIverksattBehandling = dummyBarn(behandlingSomBlirIverksatt.id, "barn1")
+            barnService.opprettBarn(listOf(barnPåIverksattBehandling))
+
+            // Legg til et annet barn på behandlingen som tas av vent
+            val barnPåBehandlingSomTasAvVent = dummyBarn(behandling.id, "barn2")
+            barnService.opprettBarn(listOf(barnPåBehandlingSomTasAvVent))
+
+            // Iverksett behandlingen med barn1
+            testoppsettService.ferdigstillBehandling(behandlingSomBlirIverksatt)
+
+            // Vi forventer at barn1 (fra forrige behandling) nå skal bli lagt til behandlingen som tas av vent
+            // siden barn1 ikke finnes i behandling som tas av vent fra før
+            taAvVentService.taAvVent(behandling.id)
+
+            // Verifiser at begge barna nå er på behandlingen som ble tatt av vent
+            val barnEtterTaAvVent = barnService.finnBarnPåBehandling(behandling.id)
+            assertThat(barnEtterTaAvVent).hasSize(2)
+            assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder("barn1", "barn2")
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentServiceTest.kt
@@ -12,12 +12,12 @@ import no.nav.tilleggsstonader.sak.behandling.historikk.BehandlingshistorikkServ
 import no.nav.tilleggsstonader.sak.behandling.historikk.domain.StegUtfall
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.OppgaveClientConfig.Companion.MAPPE_ID_KLAR
+import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientConfig
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.dummyVilkårperiodeAktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.dummyVilkårperiodeMålgruppe
@@ -230,11 +230,11 @@ class TaAvVentServiceTest : IntegrationTest() {
                 )
             testoppsettService.lagre(behandlingSomBlirIverksatt)
 
-            val barnPåIverksattBehandling = dummyBarn(behandlingSomBlirIverksatt.id, TilsynBarnTestUtil.BARN_FNR)
+            val barnPåIverksattBehandling = dummyBarn(behandlingSomBlirIverksatt.id, PdlClientConfig.BARN_FNR)
             barnService.opprettBarn(listOf(barnPåIverksattBehandling))
 
             // Legg til et annet barn på behandlingen som tas av vent
-            val barnPåBehandlingSomTasAvVent = dummyBarn(behandling.id, TilsynBarnTestUtil.BARN2_FNR)
+            val barnPåBehandlingSomTasAvVent = dummyBarn(behandling.id, PdlClientConfig.BARN2_FNR)
             barnService.opprettBarn(listOf(barnPåBehandlingSomTasAvVent))
 
             // Iverksett behandlingen med barn1
@@ -248,8 +248,8 @@ class TaAvVentServiceTest : IntegrationTest() {
             val barnEtterTaAvVent = barnService.finnBarnPåBehandling(behandling.id)
             assertThat(barnEtterTaAvVent).hasSize(2)
             assertThat(barnEtterTaAvVent.map { it.ident }).containsExactlyInAnyOrder(
-                TilsynBarnTestUtil.BARN_FNR,
-                TilsynBarnTestUtil.BARN2_FNR,
+                PdlClientConfig.BARN_FNR,
+                PdlClientConfig.BARN2_FNR,
             )
 
             // Sjekk at fakta har blitt kopiert rett for barn

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.behandling.vent
 
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
@@ -46,7 +47,7 @@ class TaAvVentServiceTest : IntegrationTest() {
     lateinit var vilkårperiodeService: VilkårperiodeService
 
     @Autowired
-    lateinit var barnService: no.nav.tilleggsstonader.sak.behandling.barn.BarnService
+    lateinit var barnService: BarnService
 
     val fagsak = fagsak()
     val behandling = behandling(fagsak = fagsak)
@@ -213,10 +214,6 @@ class TaAvVentServiceTest : IntegrationTest() {
     @Test
     fun `skal legge til barn fra forrige behandling som ikke finnes i behandling som tas av vent`() {
         testWithBrukerContext(dummySaksbehandler) {
-            // Lagre informasjon på behandlingen som skal nullstilles
-            taAvVentService.taAvVent(behandling.id)
-            settPåVentService.settPåVent(behandling.id, settPåVentDto.copy(beholdOppgave = true))
-
             // Lag ny behandling med ett barn som blir iverksatt, og legg til en kid på den
             val behandlingSomBlirIverksatt =
                 behandling(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -32,6 +32,9 @@ import java.time.YearMonth
 import java.util.UUID
 
 object TilsynBarnTestUtil {
+    const val BARN_FNR = "01012067050"
+    const val BARN2_FNR = "14041385481"
+
     fun innvilgelseDto(
         vedtaksperioder: List<VedtaksperiodeDto>,
         begrunnelse: String? = null,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnTestUtil.kt
@@ -32,9 +32,6 @@ import java.time.YearMonth
 import java.util.UUID
 
 object TilsynBarnTestUtil {
-    const val BARN_FNR = "01012067050"
-    const val BARN2_FNR = "14041385481"
-
     fun innvilgelseDto(
         vedtaksperioder: List<VedtaksperiodeDto>,
         begrunnelse: String? = null,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨


> _Alle barna ble kopiert over i ny behandling
bortsett fra Geil
han forsvant i en IndexOutOfBoundsFeil_


Når en behandling tas av vent, og det har blitt nye vedtak på den i perioden behandlingen lå på vent, så kopierer vi over data fra iverksatt behandling til behandlingen som tas av vent. 

For tilsyn barn feiler det dersom det er andre barn på forrige behandling enn på behandlingen som nullstilles. 
