### PR TITLE
Minimerer returtyper fra behandlingController

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
@@ -11,7 +11,6 @@ import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
 import no.nav.tilleggsstonader.sak.behandling.dto.OpprettBehandlingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.tilDto
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
@@ -110,35 +109,35 @@ class BehandlingController(
     }
 
     @PostMapping("{behandlingId}/henlegg")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun henleggBehandling(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody henlagt: HenlagtDto,
-    ): BehandlingDto {
+    ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
-        val henlagtBehandling = henleggService.henleggBehandling(behandlingId, henlagt)
-        val fagsak: Fagsak = fagsakService.hentFagsak(henlagtBehandling.fagsakId)
-        return henlagtBehandling.tilDto(fagsak.stønadstype, fagsak.fagsakPersonId, null)
+        henleggService.henleggBehandling(behandlingId, henlagt)
     }
 
     @GetMapping("/ekstern/{eksternBehandlingId}")
     fun hentBehandling(
         @PathVariable eksternBehandlingId: Long,
-    ): BehandlingDto {
+    ): BehandlingId {
         val saksbehandling = behandlingService.hentSaksbehandling(eksternBehandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling.id, AuditLoggerEvent.ACCESS)
-        return saksbehandling.tilDto(null)
+        return saksbehandling.id
     }
 
     @PostMapping("{behandlingId}/revurder-fra/{revurderFra}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun oppdaterRevurderFra(
         @PathVariable behandlingId: BehandlingId,
         @PathVariable revurderFra: LocalDate,
-    ): BehandlingDto {
+    ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        return revurderFraService.oppdaterRevurderFra(behandlingId, revurderFra).tilDto(null)
+        revurderFraService.oppdaterRevurderFra(behandlingId, revurderFra)
     }
 
     @PostMapping("{behandlingId}/nullstill")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingControllerTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.behandling
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.libs.test.httpclient.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
@@ -15,12 +16,14 @@ import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -29,6 +32,9 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.exchange
 
 internal class BehandlingControllerTest : IntegrationTest() {
+    @Autowired
+    lateinit var behandlingRepository: BehandlingRepository
+
     @BeforeEach
     fun setUp() {
         headers.setBearerAuth(onBehalfOfToken())
@@ -51,10 +57,12 @@ internal class BehandlingControllerTest : IntegrationTest() {
         val respons =
             henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.FEILREGISTRERT, begrunnelse = henlagtBegrunnelse))
 
-        assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(respons.body!!.resultat).isEqualTo(BehandlingResultat.HENLAGT)
-        assertThat(respons.body!!.henlagtÅrsak).isEqualTo(HenlagtÅrsak.FEILREGISTRERT)
-        assertThat(respons.body!!.henlagtBegrunnelse).isEqualTo(henlagtBegrunnelse)
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+
+        val oppdatert = behandlingRepository.findByIdOrThrow(behandling.id)
+        assertThat(oppdatert.resultat).isEqualTo(BehandlingResultat.HENLAGT)
+        assertThat(oppdatert.henlagtÅrsak).isEqualTo(HenlagtÅrsak.FEILREGISTRERT)
+        assertThat(oppdatert.henlagtBegrunnelse).isEqualTo(henlagtBegrunnelse)
     }
 
     @Test
@@ -65,10 +73,13 @@ internal class BehandlingControllerTest : IntegrationTest() {
         val respons =
             henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.FEILREGISTRERT, begrunnelse = henlagtBegrunnelse))
 
-        assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(respons.body!!.resultat).isEqualTo(BehandlingResultat.HENLAGT)
-        assertThat(respons.body!!.henlagtÅrsak).isEqualTo(HenlagtÅrsak.FEILREGISTRERT)
-        assertThat(respons.body!!.henlagtBegrunnelse).isEqualTo(henlagtBegrunnelse)
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+
+        val oppdatert = behandlingRepository.findByIdOrThrow(behandling.id)
+
+        assertThat(oppdatert.resultat).isEqualTo(BehandlingResultat.HENLAGT)
+        assertThat(oppdatert.henlagtÅrsak).isEqualTo(HenlagtÅrsak.FEILREGISTRERT)
+        assertThat(oppdatert.henlagtBegrunnelse).isEqualTo(henlagtBegrunnelse)
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å slippe og returnere hele behandlingDto-en på endepunkt som ikke bruker hele objektet. 
Returnerer no-content på update kall. 