### PR TITLE
Tidligste endring for beregning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20250624093734_e06ed70"
 val tilleggsstønaderLibsVersion = "2025.06.25-07.59.55db83b77624"
-val tilleggsstønaderKontrakterVersion = "2025.07.02-11.12.1001cd94eded"
+val tilleggsstønaderKontrakterVersion = "2025.07.28-10.25.80a5a24aa7a4"
 val avroVersion = "1.12.0"
 val confluentVersion = "8.0.0"
 val joarkHendelseVersion = "08271806"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.io.ByteArrayOutputStream
 val javaVersion = JavaLanguageVersion.of(21)
 val familieProsesseringVersion = "2.20250624093734_e06ed70"
 val tilleggsstønaderLibsVersion = "2025.06.25-07.59.55db83b77624"
-val tilleggsstønaderKontrakterVersion = "2025.07.28-10.25.80a5a24aa7a4"
+val tilleggsstønaderKontrakterVersion = "2025.07.29-10.14.653aa5c5bb71"
 val avroVersion = "1.12.0"
 val confluentVersion = "8.0.0"
 val joarkHendelseVersion = "08271806"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/søknad/SøknadService.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.opplysninger.søknad
 
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.søknad.Skjema
+import no.nav.tilleggsstonader.kontrakter.søknad.SøknadskjemaDagligreise
 import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBoutgifterFyllUtSendInn
@@ -91,6 +92,8 @@ class SøknadService(
                         journalpost,
                         søknadsskjema,
                     )
+
+                is SøknadskjemaDagligreise -> TODO()
             }
         val lagretSøknad =
             when (søknad) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -102,7 +102,10 @@ class UtledTidligsteEndringService(
 data class TidligsteEndringResultat(
     val tidligsteEndring: LocalDate,
     val tidligsteEndringSomPåvirkerUtbetalinger: LocalDate?,
-)
+) {
+    fun tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring(): LocalDate =
+        tidligsteEndringSomPåvirkerUtbetalinger ?: tidligsteEndring
+}
 
 data class TidligsteEndringIBehandlingUtleder(
     val vilkår: List<Vilkår>,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -31,28 +31,38 @@ class UtledTidligsteEndringService(
     private val unleashService: UnleashService,
 ) {
     /**
-     * Vil plukke opp alle endringer i vilkår, aktiviteter, målgrupper og vedtaksperioder og betrakte det som en endring i revurderingen.
-     * Noe som kan vurderes om vi bør ta hensyn til:
-     * Vil også plukke oppe endringer som ikke har noe å si for beregning, eksempelvis om man legger til en ny målgruppe.
+     * Sammenligner gitt behandling med tidligere iverksatte behandling, for å finne tidligste endring i vilkårsperioder,
+     * vilkår og vedtaksperioder. Sjekker deretter denne datoen mot alle vedtaksperioder for å finne første dato som
+     * vil påvirke beregningen.
+     *
+     * - Om det ikke finnes noen tidligere iverksatte behandlinger, returneres null.
+     * - Om det ikke utledes endringer, returnreres null.
+     * - Om utbetalinger ikke vil påvirkes av endringer, returneres tidligste endring hvis det finnes en.
      */
-    fun utledTidligsteEndring(
+    fun utledTidligsteEndringForBeregning(
         behandlingId: BehandlingId,
         vedtaksperioder: List<Vedtaksperiode>,
-    ): TidligsteEndringResultat? =
+    ): LocalDate? =
         utledTidligsteEndring(
             behandlingId = behandlingId,
             vedtaksperioder = vedtaksperioder,
             hentVedtaksperioderTidligereBehandlingFunction = { behandlingId ->
                 vedtaksperiodeService.finnVedtaksperioderForBehandling(behandlingId, null)
             },
-        )
+        )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
 
-    fun utledTidligsteEndringIgnorerVedtaksperioder(behandlingId: BehandlingId): TidligsteEndringResultat? =
+    /**
+     * Sammenligner gitt behandling med tidligere iverksatte behandling, for å finne tidligste endring i vilkårsperioder og vilkår.
+     *
+     * - Om det ikke finnes noen tidligere iverksatte behandlinger, returneres null.
+     * - Om det ikke utledes endringer, returnreres null.
+     */
+    fun utledTidligsteEndringIgnorerVedtaksperioder(behandlingId: BehandlingId): LocalDate? =
         utledTidligsteEndring(
             behandlingId = behandlingId,
             vedtaksperioder = emptyList(),
             hentVedtaksperioderTidligereBehandlingFunction = { _ -> emptyList() },
-        )
+        )?.tidligsteEndring
 
     private fun utledTidligsteEndring(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.tidligsteendring
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.finnFørsteTreffFraOgMedDato
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
@@ -148,8 +149,8 @@ data class TidligsteEndringIBehandlingUtleder(
             TidligsteEndringResultat(
                 tidligsteEndring = it,
                 tidligsteEndringSomPåvirkerUtbetalinger =
-                    finnTidligsteOverlappEllerNestePeriode(
-                        vedtaksperioder = vedtaksperioder + vedtaksperioderTidligereBehandling,
+                    finnFørsteTreffFraOgMedDato(
+                        perioder = vedtaksperioder + vedtaksperioderTidligereBehandling,
                         dato = it,
                     ),
             )
@@ -266,16 +267,3 @@ data class PeriodeWrapper<T>(
     override val fom: LocalDate,
     override val tom: LocalDate,
 ) : Periode<LocalDate>
-
-fun finnTidligsteOverlappEllerNestePeriode(
-    vedtaksperioder: List<Vedtaksperiode>,
-    dato: LocalDate,
-): LocalDate? {
-    val overlapp = vedtaksperioder.firstOrNull { it.fom <= dato && it.tom >= dato }
-
-    return if (overlapp != null) {
-        dato
-    } else {
-        vedtaksperioder.filter { it.fom >= dato }.minByOrNull { it.fom }?.fom
-    }
-}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -67,7 +67,7 @@ class TilsynBarnBeregnYtelseSteg(
                 .utledTidligsteEndring(
                     saksbehandling.id,
                     vedtak.vedtaksperioder.tilDomene(),
-                )?.tidligsteEndringSomPåvirkerUtbetalinger
+                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -62,7 +62,12 @@ class TilsynBarnBeregnYtelseSteg(
         saksbehandling: Saksbehandling,
         vedtak: InnvilgelseTilsynBarnRequest,
     ) {
-        val tidligsteEndring = utledTidligsteEndringService.utledTidligsteEndring(saksbehandling.id, vedtak.vedtaksperioder.tilDomene())
+        val tidligsteEndring =
+            utledTidligsteEndringService
+                .utledTidligsteEndring(
+                    saksbehandling.id,
+                    vedtak.vedtaksperioder.tilDomene(),
+                )?.tidligsteEndringSomPåvirkerUtbetalinger
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -63,11 +63,10 @@ class TilsynBarnBeregnYtelseSteg(
         vedtak: InnvilgelseTilsynBarnRequest,
     ) {
         val tidligsteEndring =
-            utledTidligsteEndringService
-                .utledTidligsteEndring(
-                    saksbehandling.id,
-                    vedtak.vedtaksperioder.tilDomene(),
-                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                saksbehandling.id,
+                vedtak.vedtaksperioder.tilDomene(),
+            )
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -80,11 +80,10 @@ class TilsynBarnVedtakController(
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val vedtaksperioder = vedtak.vedtaksperioder.tilDomene()
         val tidligsteEndring =
-            utledTidligsteEndringService
-                .utledTidligsteEndring(
-                    behandling.id,
-                    vedtaksperioder,
-                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandling.id,
+                vedtaksperioder,
+            )
 
         return beregningService
             .beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -79,7 +79,12 @@ class TilsynBarnVedtakController(
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val vedtaksperioder = vedtak.vedtaksperioder.tilDomene()
-        val tidligsteEndring = utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder)
+        val tidligsteEndring =
+            utledTidligsteEndringService
+                .utledTidligsteEndring(
+                    behandling.id,
+                    vedtaksperioder,
+                )?.tidligsteEndringSomPåvirkerUtbetalinger
 
         return beregningService
             .beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -84,7 +84,7 @@ class TilsynBarnVedtakController(
                 .utledTidligsteEndring(
                     behandling.id,
                     vedtaksperioder,
-                )?.tidligsteEndringSomPåvirkerUtbetalinger
+                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
 
         return beregningService
             .beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
@@ -66,11 +66,10 @@ class BoutgifterBeregnYtelseSteg(
     ) {
         val vedtaksperioder = vedtak.vedtaksperioder.tilDomene().sorted()
         val tidligsteEndring =
-            utledTidligsteEndringService
-                .utledTidligsteEndring(
-                    saksbehandling.id,
-                    vedtaksperioder,
-                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                saksbehandling.id,
+                vedtaksperioder,
+            )
         val beregningsresultat =
             beregningService.beregn(
                 vedtaksperioder = vedtaksperioder,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
@@ -65,7 +65,12 @@ class BoutgifterBeregnYtelseSteg(
         vedtak: InnvilgelseBoutgifterRequest,
     ) {
         val vedtaksperioder = vedtak.vedtaksperioder.tilDomene().sorted()
-        val tidligsteEndring = utledTidligsteEndringService.utledTidligsteEndring(saksbehandling.id, vedtaksperioder)
+        val tidligsteEndring =
+            utledTidligsteEndringService
+                .utledTidligsteEndring(
+                    saksbehandling.id,
+                    vedtaksperioder,
+                )?.tidligsteEndringSomPåvirkerUtbetalinger
         val beregningsresultat =
             beregningService.beregn(
                 vedtaksperioder = vedtaksperioder,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
@@ -70,7 +70,7 @@ class BoutgifterBeregnYtelseSteg(
                 .utledTidligsteEndring(
                     saksbehandling.id,
                     vedtaksperioder,
-                )?.tidligsteEndringSomPåvirkerUtbetalinger
+                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
         val beregningsresultat =
             beregningService.beregn(
                 vedtaksperioder = vedtaksperioder,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
@@ -89,7 +89,7 @@ class BoutgifterVedtakController(
                 .utledTidligsteEndring(
                     behandling.id,
                     vedtak.vedtaksperioder.tilDomene(),
-                )?.tidligsteEndringSomPåvirkerUtbetalinger
+                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
         return beregningService
             .beregn(
                 behandling = behandling,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
@@ -85,11 +85,10 @@ class BoutgifterVedtakController(
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val tidligsteEndring =
-            utledTidligsteEndringService
-                .utledTidligsteEndring(
-                    behandling.id,
-                    vedtak.vedtaksperioder.tilDomene(),
-                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandling.id,
+                vedtak.vedtaksperioder.tilDomene(),
+            )
         return beregningService
             .beregn(
                 behandling = behandling,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
@@ -84,7 +84,12 @@ class BoutgifterVedtakController(
     ): BeregningsresultatBoutgifterDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
-        val tidligsteEndring = utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtak.vedtaksperioder.tilDomene())
+        val tidligsteEndring =
+            utledTidligsteEndringService
+                .utledTidligsteEndring(
+                    behandling.id,
+                    vedtak.vedtaksperioder.tilDomene(),
+                )?.tidligsteEndringSomPåvirkerUtbetalinger
         return beregningService
             .beregn(
                 behandling = behandling,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -95,12 +95,13 @@ class LæremidlerBeregnYtelseSteg(
         begrunnelse: String?,
     ) {
         val tidligsteEndring =
-            utledTidligsteEndringService.utledTidligsteEndring(
-                saksbehandling.id,
-                vedtaksperioder.map {
-                    it.tilFellesDomeneVedtaksperiode()
-                },
-            )
+            utledTidligsteEndringService
+                .utledTidligsteEndring(
+                    saksbehandling.id,
+                    vedtaksperioder.map {
+                        it.tilFellesDomeneVedtaksperiode()
+                    },
+                )?.tidligsteEndringSomPåvirkerUtbetalinger
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -101,7 +101,7 @@ class LæremidlerBeregnYtelseSteg(
                     vedtaksperioder.map {
                         it.tilFellesDomeneVedtaksperiode()
                     },
-                )?.tidligsteEndringSomPåvirkerUtbetalinger
+                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -95,13 +95,12 @@ class LæremidlerBeregnYtelseSteg(
         begrunnelse: String?,
     ) {
         val tidligsteEndring =
-            utledTidligsteEndringService
-                .utledTidligsteEndring(
-                    saksbehandling.id,
-                    vedtaksperioder.map {
-                        it.tilFellesDomeneVedtaksperiode()
-                    },
-                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                saksbehandling.id,
+                vedtaksperioder.map {
+                    it.tilFellesDomeneVedtaksperiode()
+                },
+            )
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
@@ -85,7 +85,7 @@ class LæremidlerVedtakController(
                 .utledTidligsteEndring(
                     behandling.id,
                     vedtaksperioder.tilDomene().map { it.tilFellesDomeneVedtaksperiode() },
-                )?.tidligsteEndringSomPåvirkerUtbetalinger
+                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
         return beregningService
             .beregn(
                 behandling,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
@@ -81,10 +81,11 @@ class LæremidlerVedtakController(
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val tidligsteEndring =
-            utledTidligsteEndringService.utledTidligsteEndring(
-                behandling.id,
-                vedtaksperioder.tilDomene().map { it.tilFellesDomeneVedtaksperiode() },
-            )
+            utledTidligsteEndringService
+                .utledTidligsteEndring(
+                    behandling.id,
+                    vedtaksperioder.tilDomene().map { it.tilFellesDomeneVedtaksperiode() },
+                )?.tidligsteEndringSomPåvirkerUtbetalinger
         return beregningService
             .beregn(
                 behandling,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
@@ -81,11 +81,10 @@ class LæremidlerVedtakController(
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val tidligsteEndring =
-            utledTidligsteEndringService
-                .utledTidligsteEndring(
-                    behandling.id,
-                    vedtaksperioder.tilDomene().map { it.tilFellesDomeneVedtaksperiode() },
-                )?.tidligsteEndringSomPåvirkerUtbetalingerEllerTidligsteEndring()
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandling.id,
+                vedtaksperioder.tilDomene().map { it.tilFellesDomeneVedtaksperiode() },
+            )
         return beregningService
             .beregn(
                 behandling,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
@@ -133,7 +133,7 @@ class UtledTidligsteEndringServiceTest {
 
         val result = utledTidligsteEndringService.utledTidligsteEndringIgnorerVedtaksperioder(behandling.id)
 
-        assertThat(result).isNull()
+        assertThat(result?.tidligsteEndring).isNull()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
@@ -118,7 +118,7 @@ class UtledTidligsteEndringServiceTest {
             }
         vedtaksperioder = vedtaksperioderSisteIverksatteBehandling
 
-        val result = utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder)
+        val result = utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder)?.tidligsteEndring
 
         assertThat(result).isEqualTo(nyttVilkår.fom)
     }
@@ -141,7 +141,7 @@ class UtledTidligsteEndringServiceTest {
         vedtaksperioder = vedtaksperioderSisteIverksatteBehandling // Må initialiseres
         every { unleashService.isEnabled(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK) } returns false
         behandling = behandling.copy(type = BehandlingType.REVURDERING, revurderFra = LocalDate.of(2023, 1, 1))
-        assertThat(utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder))
+        assertThat(utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder)?.tidligsteEndring)
             .isEqualTo(behandling.revurderFra)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
@@ -118,7 +118,7 @@ class UtledTidligsteEndringServiceTest {
             }
         vedtaksperioder = vedtaksperioderSisteIverksatteBehandling
 
-        val result = utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder)?.tidligsteEndring
+        val result = utledTidligsteEndringService.utledTidligsteEndringForBeregning(behandling.id, vedtaksperioder)
 
         assertThat(result).isEqualTo(nyttVilkår.fom)
     }
@@ -141,7 +141,7 @@ class UtledTidligsteEndringServiceTest {
         vedtaksperioder = vedtaksperioderSisteIverksatteBehandling // Må initialiseres
         every { unleashService.isEnabled(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK) } returns false
         behandling = behandling.copy(type = BehandlingType.REVURDERING, revurderFra = LocalDate.of(2023, 1, 1))
-        assertThat(utledTidligsteEndringService.utledTidligsteEndring(behandling.id, vedtaksperioder)?.tidligsteEndring)
+        assertThat(utledTidligsteEndringService.utledTidligsteEndringForBeregning(behandling.id, vedtaksperioder))
             .isEqualTo(behandling.revurderFra)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
@@ -133,7 +133,7 @@ class UtledTidligsteEndringServiceTest {
 
         val result = utledTidligsteEndringService.utledTidligsteEndringIgnorerVedtaksperioder(behandling.id)
 
-        assertThat(result?.tidligsteEndring).isNull()
+        assertThat(result).isNull()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -152,7 +152,7 @@ class UtledTidligsteEndringStepDefinitions {
                 barnIdTilIdentMap =
                     barnIder.entries.associate { it.value to it.key } +
                         barnIderForrigeBehandling.entries.associate { it.value to it.key },
-            ).utledTidligsteEndring()
+            ).utledTidligsteEndring()?.tidligsteEndring
     }
 
     @Så("forvent følgende dato for tidligste endring: {}")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -35,7 +35,6 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
 import org.assertj.core.api.Assertions.assertThat
-import java.time.LocalDate
 
 enum class TidligsteEndringFellesNøkler(
     override val nøkkel: String,
@@ -93,7 +92,7 @@ class UtledTidligsteEndringStepDefinitions {
     var barnIderForrigeBehandling = mutableMapOf<String, BarnId>()
 
     var exception: Exception? = null
-    var tidligsteEndring: LocalDate? = null
+    var tidligsteEndring: TidligsteEndringResultat? = null
 
     @Gitt("følgende vilkår i forrige behandling - utledTidligsteEndring")
     fun `følgende vilkår i forrige behandling`(dataTable: DataTable) {
@@ -152,18 +151,29 @@ class UtledTidligsteEndringStepDefinitions {
                 barnIdTilIdentMap =
                     barnIder.entries.associate { it.value to it.key } +
                         barnIderForrigeBehandling.entries.associate { it.value to it.key },
-            ).utledTidligsteEndring()?.tidligsteEndring
+            ).utledTidligsteEndring()
     }
 
     @Så("forvent følgende dato for tidligste endring: {}")
     fun `forvent følgende dato for tidligste endring`(forventetDatoStr: String) {
         val forventetDato = parseDato(forventetDatoStr)
-        assertThat(tidligsteEndring).isEqualTo(forventetDato)
+        assertThat(tidligsteEndring?.tidligsteEndring).isEqualTo(forventetDato)
+    }
+
+    @Så("forvent følgende dato for tidligste endring som påvirker utbetaling: {}")
+    fun `forvent følgende dato for tidligste endring som påvirker utbetaling`(forventetDatoStr: String) {
+        val forventetDato = parseDato(forventetDatoStr)
+        assertThat(tidligsteEndring?.tidligsteEndringSomPåvirkerUtbetalinger).isEqualTo(forventetDato)
     }
 
     @Så("forvent ingen endring")
     fun `forvent ingen endring`() {
-        assertThat(tidligsteEndring).isNull()
+        assertThat(tidligsteEndring?.tidligsteEndring).isNull()
+    }
+
+    @Så("forvent ingen endring som påvirker utbetaling")
+    fun `forvent ingen endring som påvirker utbetaling`() {
+        assertThat(tidligsteEndring?.tidligsteEndringSomPåvirkerUtbetalinger).isNull()
     }
 
     private fun mapVilkår(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegTest.kt
@@ -50,7 +50,7 @@ class TilsynBarnBeregnYtelseStegTest {
     private val vedtaksperiodeService = mockk<VedtaksperiodeService>(relaxed = true)
     private val utledTidligsteEndringService =
         mockk<UtledTidligsteEndringService> {
-            every { utledTidligsteEndring(any(), any()) } returns null
+            every { utledTidligsteEndringForBeregning(any(), any()) } returns null
         }
     private val unleashService = mockUnleashService()
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -28,6 +28,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.Vilkårperi
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
+import no.nav.tilleggsstonader.sak.tidligsteendring.TidligsteEndringResultat
 import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
@@ -285,7 +286,8 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
         val revurderFra = parseDato(revurderFraStr)
 
-        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns revurderFra
+        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns
+            TidligsteEndringResultat(revurderFra, revurderFra)
 
         kjørMedFeilkontekst {
             steg.utførSteg(
@@ -309,7 +311,8 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val revurderFra = parseDato(revurderFraStr)
         val vedtaksperioder = mapVedtaksperioder(vedtaksperiodeData).map { it.tilDto() }
 
-        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns revurderFra
+        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns
+            TidligsteEndringResultat(revurderFra, revurderFra)
 
         kjørMedFeilkontekst {
             steg.utførSteg(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -28,7 +28,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.Vilkårperi
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
-import no.nav.tilleggsstonader.sak.tidligsteendring.TidligsteEndringResultat
 import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
@@ -83,7 +82,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     val behandlingServiceMock = mockk<BehandlingService>()
     val utledTidligsteEndringService =
         mockk<UtledTidligsteEndringService> {
-            every { utledTidligsteEndring(any(), any()) } returns null
+            every { utledTidligsteEndringForBeregning(any(), any()) } returns null
         }
     val vilkårperiodeServiceMock =
         mockk<VilkårperiodeService>().apply {
@@ -286,8 +285,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
         val revurderFra = parseDato(revurderFraStr)
 
-        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns
-            TidligsteEndringResultat(revurderFra, revurderFra)
+        every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(behandlingId, any()) } returns revurderFra
 
         kjørMedFeilkontekst {
             steg.utførSteg(
@@ -311,8 +309,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val revurderFra = parseDato(revurderFraStr)
         val vedtaksperioder = mapVedtaksperioder(vedtaksperiodeData).map { it.tilDto() }
 
-        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns
-            TidligsteEndringResultat(revurderFra, revurderFra)
+        every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(behandlingId, any()) } returns revurderFra
 
         kjørMedFeilkontekst {
             steg.utførSteg(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegStepDefinitions.kt
@@ -29,7 +29,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.VedtakRepos
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.VilkårperiodeRepositoryFake
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
-import no.nav.tilleggsstonader.sak.tidligsteendring.TidligsteEndringResultat
 import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
@@ -79,7 +78,7 @@ class LæremidlerBeregnYtelseStegStepDefinitions {
     val behandlingService = mockk<BehandlingService>()
     val utledTidligsteEndringService =
         mockk<UtledTidligsteEndringService> {
-            every { utledTidligsteEndring(any(), any()) } returns null
+            every { utledTidligsteEndringForBeregning(any(), any()) } returns null
         }
     val vilkårperiodeService =
         mockk<VilkårperiodeService>().apply {
@@ -159,8 +158,7 @@ class LæremidlerBeregnYtelseStegStepDefinitions {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
         val revurderFra = parseDato(revurderFraStr)
 
-        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns
-            TidligsteEndringResultat(revurderFra, revurderFra)
+        every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(behandlingId, any()) } returns revurderFra
 
         val vedtaksperioder = mapVedtaksperioderDto(dataTable)
         steg.utførSteg(dummyBehandling(behandlingId, revurderFra), InnvilgelseLæremidlerRequest(vedtaksperioder))

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegStepDefinitions.kt
@@ -29,6 +29,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.VedtakRepos
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.VilkårperiodeRepositoryFake
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
+import no.nav.tilleggsstonader.sak.tidligsteendring.TidligsteEndringResultat
 import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
@@ -158,7 +159,8 @@ class LæremidlerBeregnYtelseStegStepDefinitions {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
         val revurderFra = parseDato(revurderFraStr)
 
-        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns revurderFra
+        every { utledTidligsteEndringService.utledTidligsteEndring(behandlingId, any()) } returns
+            TidligsteEndringResultat(revurderFra, revurderFra)
 
         val vedtaksperioder = mapVedtaksperioderDto(dataTable)
         steg.utførSteg(dummyBehandling(behandlingId, revurderFra), InnvilgelseLæremidlerRequest(vedtaksperioder))

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/tidligste_endring_paavirker_beregning.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/tidligste_endring_paavirker_beregning.feature
@@ -1,0 +1,97 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Utled tidligste endring med betydning for beregning
+
+  Regel: Endring av sluttdato skal gi tidligste endring som tidligste av ny og gammel fom
+
+    Scenario: Endring i aktivitet, ingen endring i vedtaksperioder
+      Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 31.01.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 31.03.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | ENDRET |
+
+      Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.01.2024 | 31.01.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Gitt følgende vedtaksperioder i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.01.2024 | 31.01.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.02.2024
+      Så forvent ingen endring som påvirker utbetaling
+
+    Scenario: Lagt til ny aktivitet etter vedtaksperiode, vedtaksperioder uendret
+      Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+        | 01.08.2024 | 31.08.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.02.2024 | 30.06.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Gitt følgende vedtaksperioder i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.02.2024 | 30.06.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.08.2024
+      Så forvent ingen endring som påvirker utbetaling
+
+
+    Scenario: Ingen endring i aktivitet, vedtaksperioder forlenget
+      Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.01.2024 | 31.01.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Gitt følgende vedtaksperioder i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.01.2024 | 19.03.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.02.2024
+      Så forvent følgende dato for tidligste endring som påvirker utbetaling: 01.02.2024
+
+    Scenario: Lagt til ny aktivitet før vedtaksperiode, vedtaksperioder uendret
+      Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
+        | 01.12.2023 | 31.12.2023 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+
+      Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.02.2024 | 20.02.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Gitt følgende vedtaksperioder i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.01.2024 | 20.02.2024 | TILTAK    | NEDSATT_ARBEIDSEVNE |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.12.2023
+      Så forvent følgende dato for tidligste endring som påvirker utbetaling: 01.01.2024

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/tidligste_endring_paavirker_beregning.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/tidligste_endring_paavirker_beregning.feature
@@ -5,7 +5,7 @@ Egenskap: Utled tidligste endring med betydning for beregning
 
   Regel: Endring av sluttdato skal gi tidligste endring som tidligste av ny og gammel fom
 
-    Scenario: Endring i aktivitet, ingen endring i vedtaksperioder
+    Scenario: Endring i aktivitet, målgruppe og vilkår, ingen endring i vedtaksperioder
       Gitt følgende aktiviteter i forrige behandling - utledTidligsteEndring
         | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
         | 01.01.2024 | 31.01.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
@@ -13,6 +13,22 @@ Egenskap: Utled tidligste endring med betydning for beregning
       Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
         | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
         | 01.01.2024 | 31.03.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | ENDRET |
+
+      Gitt følgende målgrupper i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Type | Resultat | Status |
+        | 01.01.2024 | 31.01.2024 | AAP  | OPPFYLT  | NY     |
+
+      Gitt følgende målgrupper i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Type | Resultat | Status |
+        | 01.01.2024 | 31.03.2024 | AAP  | OPPFYLT  | ENDRET |
+
+      Gitt følgende vilkår i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Type      | Resultat | Status |
+        | 01.01.2024 | 31.01.2024 | PASS_BARN | OPPFYLT  | NY     |
+
+      Gitt følgende vilkår i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Type      | Resultat | Status |
+        | 01.01.2024 | 31.03.2024 | PASS_BARN | OPPFYLT  | ENDRET |
 
       Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
         | Fom        | Tom        | Aktivitet | Målgruppe           |

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/tidligste_endring_paavirker_beregning.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/tidligste_endring_paavirker_beregning.feature
@@ -33,9 +33,9 @@ Egenskap: Utled tidligste endring med betydning for beregning
         | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
 
       Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
-        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
-        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
-        | 01.08.2024 | 31.08.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status  |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | UENDRET |
+        | 01.08.2024 | 31.08.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY      |
 
       Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
         | Fom        | Tom        | Aktivitet | Målgruppe           |
@@ -57,8 +57,8 @@ Egenskap: Utled tidligste endring med betydning for beregning
         | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
 
       Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
-        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
-        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status  |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | UENDRET |
 
       Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
         | Fom        | Tom        | Aktivitet | Målgruppe           |
@@ -79,9 +79,9 @@ Egenskap: Utled tidligste endring med betydning for beregning
         | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
 
       Gitt følgende aktiviteter i revurdering - utledTidligsteEndring
-        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status |
-        | 01.12.2023 | 31.12.2023 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
-        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY     |
+        | Fom        | Tom        | Stønadstype | Type   | Aktivitetsdager | Resultat | Status  |
+        | 01.12.2023 | 31.12.2023 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | NY      |
+        | 01.01.2024 | 30.06.2024 | BARNETILSYN | TILTAK | 5               | OPPFYLT  | UENDRET |
 
       Gitt følgende vedtaksperioder i forrige behandling - utledTidligsteEndring
         | Fom        | Tom        | Aktivitet | Målgruppe           |


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Endrer UtledTidligsteEndringService, slik at man kan hente ut dato for tidligste endring som har betydning for beregningen. Dette gjøres ved å finne tidligste endring som før, også finne nærmeste fremtidige dato i en vedtaksperiode etter denne endringen. Saksbehandler bør da få en dato som gir litt mer mening enn om vi kun utleder tidligste endring.

Tydeliggjør også forskjellen på funksjonene i servicen i navn og javadoc