### PR TITLE
Fjerner bruk av private constructor i dataklasser der hvor det ikke er nødvendig

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringDto.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.behandling.oppsummering
 
+import com.fasterxml.jackson.annotation.JsonGetter
 import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
@@ -19,21 +20,8 @@ data class BehandlingOppsummeringDto(
     val vilkår: List<Stønadsvilkår>,
     val vedtak: OppsummertVedtak?,
 ) {
-    val finnesDataÅOppsummere: Boolean
-        get() =
-            finnesDataÅOppsummere(
-                aktiviteter = aktiviteter,
-                målgrupper = målgrupper,
-                vilkår = vilkår,
-                vedtak = vedtak,
-            )
-
-    private fun finnesDataÅOppsummere(
-        aktiviteter: List<OppsummertVilkårperiode>,
-        målgrupper: List<OppsummertVilkårperiode>,
-        vilkår: List<Stønadsvilkår>,
-        vedtak: OppsummertVedtak?,
-    ): Boolean =
+    @JsonGetter
+    fun finnesDataÅOppsummere(): Boolean =
         aktiviteter.isNotEmpty() ||
             målgrupper.isNotEmpty() ||
             vilkår.isNotEmpty() ||

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringDto.kt
@@ -13,45 +13,31 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeT
 import java.time.LocalDate
 import java.util.UUID
 
-data class BehandlingOppsummeringDto private constructor(
+data class BehandlingOppsummeringDto(
     val aktiviteter: List<OppsummertVilkårperiode>,
     val målgrupper: List<OppsummertVilkårperiode>,
     val vilkår: List<Stønadsvilkår>,
     val vedtak: OppsummertVedtak?,
-    val finnesDataÅOppsummere: Boolean,
 ) {
-    constructor(
+    val finnesDataÅOppsummere: Boolean
+        get() =
+            finnesDataÅOppsummere(
+                aktiviteter = aktiviteter,
+                målgrupper = målgrupper,
+                vilkår = vilkår,
+                vedtak = vedtak,
+            )
+
+    private fun finnesDataÅOppsummere(
         aktiviteter: List<OppsummertVilkårperiode>,
         målgrupper: List<OppsummertVilkårperiode>,
         vilkår: List<Stønadsvilkår>,
         vedtak: OppsummertVedtak?,
-    ) :
-        this(
-            aktiviteter = aktiviteter,
-            målgrupper = målgrupper,
-            vilkår = vilkår,
-            vedtak = vedtak,
-            finnesDataÅOppsummere =
-                finnesDataÅOppsummere(
-                    aktiviteter,
-                    målgrupper,
-                    vilkår,
-                    vedtak,
-                ),
-        )
-
-    companion object {
-        private fun finnesDataÅOppsummere(
-            aktiviteter: List<OppsummertVilkårperiode>,
-            målgrupper: List<OppsummertVilkårperiode>,
-            vilkår: List<Stønadsvilkår>,
-            vedtak: OppsummertVedtak?,
-        ): Boolean =
-            aktiviteter.isNotEmpty() ||
-                målgrupper.isNotEmpty() ||
-                vilkår.isNotEmpty() ||
-                vedtak != null
-    }
+    ): Boolean =
+        aktiviteter.isNotEmpty() ||
+            målgrupper.isNotEmpty() ||
+            vilkår.isNotEmpty() ||
+            vedtak != null
 }
 
 data class OppsummertVilkårperiode(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/Vurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/Vurdering.kt
@@ -29,11 +29,10 @@ enum class ResultatDelvilkårperiode {
     IKKE_AKTUELT,
 }
 
-data class VurderingLønnet private constructor(
+data class VurderingLønnet(
     override val svar: SvarJaNei?,
-    override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {
-    constructor(svar: SvarJaNei?) : this(svar, utledResultat(svar))
+    override val resultat: ResultatDelvilkårperiode = utledResultat(svar)
 
     companion object {
         private fun utledResultat(svar: SvarJaNei?): ResultatDelvilkårperiode =
@@ -47,11 +46,10 @@ data class VurderingLønnet private constructor(
     }
 }
 
-data class VurderingHarUtgifter private constructor(
+data class VurderingHarUtgifter(
     override val svar: SvarJaNei?,
-    override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {
-    constructor(svar: SvarJaNei?) : this(svar, utledResultat(svar))
+    override val resultat: ResultatDelvilkårperiode = utledResultat(svar)
 
     companion object {
         private fun utledResultat(svar: SvarJaNei?): ResultatDelvilkårperiode =
@@ -65,11 +63,10 @@ data class VurderingHarUtgifter private constructor(
     }
 }
 
-data class VurderingHarRettTilUtstyrsstipend private constructor(
+data class VurderingHarRettTilUtstyrsstipend(
     override val svar: SvarJaNei?,
-    override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {
-    constructor(svar: SvarJaNei?) : this(svar, utledResultat(svar))
+    override val resultat: ResultatDelvilkårperiode = utledResultat(svar)
 
     companion object {
         private fun utledResultat(svar: SvarJaNei?): ResultatDelvilkårperiode =
@@ -87,11 +84,10 @@ data class VurderingHarRettTilUtstyrsstipend private constructor(
     }
 }
 
-data class VurderingMedlemskap private constructor(
+data class VurderingMedlemskap(
     override val svar: SvarJaNei?,
-    override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {
-    constructor(svar: SvarJaNei?) : this(svar, utledResultat(svar))
+    override val resultat: ResultatDelvilkårperiode = utledResultat(svar)
 
     companion object {
         private fun utledResultat(svar: SvarJaNei?): ResultatDelvilkårperiode =
@@ -110,11 +106,10 @@ data class VurderingMedlemskap private constructor(
     }
 }
 
-data class VurderingDekketAvAnnetRegelverk private constructor(
+data class VurderingDekketAvAnnetRegelverk(
     override val svar: SvarJaNei?,
-    override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {
-    constructor(svar: SvarJaNei?) : this(svar, utledResultat(svar))
+    override val resultat: ResultatDelvilkårperiode = utledResultat(svar)
 
     companion object {
         private fun utledResultat(svar: SvarJaNei?): ResultatDelvilkårperiode =
@@ -167,7 +162,7 @@ data class VurderingAldersVilkår(
     }
 }
 
-data class VurderingMottarSykepengerForFulltidsstilling constructor(
+data class VurderingMottarSykepengerForFulltidsstilling(
     override val svar: SvarJaNei?,
     override val resultat: ResultatDelvilkårperiode,
 ) : Vurdering {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/oppsummering/BehandlingOppsummeringServiceTest.kt
@@ -47,7 +47,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
 
         val behandlingOppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
 
-        assertThat(behandlingOppsummering.finnesDataÅOppsummere).isFalse()
+        assertThat(behandlingOppsummering.finnesDataÅOppsummere()).isFalse()
         assertThat(behandlingOppsummering.aktiviteter).isEmpty()
         assertThat(behandlingOppsummering.målgrupper).isEmpty()
         assertThat(behandlingOppsummering.vilkår).isEmpty()
@@ -76,7 +76,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
 
             val behandlingOppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
 
-            assertThat(behandlingOppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(behandlingOppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(behandlingOppsummering.målgrupper).hasSize(1)
             assertThat(behandlingOppsummering.målgrupper[0].fom).isEqualTo(LocalDate.of(2025, 1, 1))
             assertThat(behandlingOppsummering.målgrupper[0].tom).isEqualTo(LocalDate.of(2025, 1, 31))
@@ -112,7 +112,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
 
             val behandlingOppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
 
-            assertThat(behandlingOppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(behandlingOppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(behandlingOppsummering.målgrupper).hasSize(3)
         }
     }
@@ -145,7 +145,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
 
             val behandlingOppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
 
-            assertThat(behandlingOppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(behandlingOppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(behandlingOppsummering.vilkår).hasSize(1)
             assertThat(behandlingOppsummering.vilkår[0].barnId).isEqualTo(barn1)
             assertThat(behandlingOppsummering.vilkår[0].vilkår).hasSize(1)
@@ -176,7 +176,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
 
             val behandlingOppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
 
-            assertThat(behandlingOppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(behandlingOppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(behandlingOppsummering.vilkår).hasSize(1)
             assertThat(behandlingOppsummering.vilkår[0].vilkår).hasSize(2)
         }
@@ -208,7 +208,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
 
             val behandlingOppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
 
-            assertThat(behandlingOppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(behandlingOppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(behandlingOppsummering.vilkår).hasSize(2)
         }
     }
@@ -302,7 +302,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
             )
 
             val oppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
-            assertThat(oppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(oppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(oppsummering.aktiviteter).hasSize(1)
             assertThat(oppsummering.aktiviteter[0].fom).isEqualTo(LocalDate.of(2024, 8, 1))
         }
@@ -331,7 +331,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
             )
 
             val oppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
-            assertThat(oppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(oppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(oppsummering.vilkår).hasSize(1)
             assertThat(oppsummering.vilkår[0].type).isEqualTo(VilkårType.LØPENDE_UTGIFTER_EN_BOLIG)
 
@@ -363,7 +363,7 @@ class BehandlingOppsummeringServiceTest : IntegrationTest() {
             )
 
             val oppsummering = behandlingOppsummeringService.hentBehandlingOppsummering(behandling.id)
-            assertThat(oppsummering.finnesDataÅOppsummere).isTrue()
+            assertThat(oppsummering.finnesDataÅOppsummere()).isTrue()
             assertThat(oppsummering.vilkår[0].vilkår[0].fom).isEqualTo(LocalDate.of(2025, 1, 1))
         }
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Sett gjennom en del compiler-warnings og er en del warnings på privat konstruktør på dataklasser. Dette fører til warning siden den private konstruktøren uansett blir eksponert gjennom generert copy-funksjon, og vil bli en feil i kotlin 2.3. Endrer da noen dataklasser der det ikke er nødvendig med privat konstruktør/lett å refaktorere.

Alternativt kan man bruke `ConsistentCopyVisibility` for å fjerne disse warningene som det er gjort på `UtbetalingPeriode.kt`, men den har et litt annet behov.