### PR TITLE
Skal bruke min av tidspunktet når behandlingen ble opprettet eller da…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeGrunnlagService.kt
@@ -118,10 +118,23 @@ class VilkårperiodeGrunnlagService(
         behandling: Saksbehandling,
         vilkårperioder: Vilkårperioder,
     ): LocalDate {
+        val startdatoVilkårperiode = startdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder)
+
+        return startdatoVilkårperiode
+            ?.let { minOf(it, grunnlagsdatoBehandling(behandling)) }
+            ?: grunnlagsdatoBehandling(behandling)
+    }
+
+    /**
+     * Henter grunnlagsdatoen for en behandling,
+     * som er basert på mottatt eller opprettet tidspunkt minus antall måneder for stønadstypen.
+     * Hvis det gjelder en revurdering, så brukes datoen til første dag i måneden før revurderingsdatoen.
+     */
+    private fun grunnlagsdatoBehandling(behandling: Saksbehandling): LocalDate {
         if (behandling.revurderFra != null) {
-            return startdatoPåFørsteEksisterendeVilkårperiode(vilkårperioder)
-                ?: behandling.revurderFra.minusMonths(1).tilFørsteDagIMåneden()
+            return behandling.revurderFra.minusMonths(1).tilFørsteDagIMåneden()
         }
+
         val mottattTidspunkt =
             søknadService.hentSøknadMetadata(behandling.id)?.mottattTidspunkt
                 ?: behandling.opprettetTid


### PR DESCRIPTION
…to for første vilkårsperioden

- Dette gjør også at denne logikken fungerer fint med at vi fjerner revurder-fra-datoet sånn at man henter grunnlag fra første vilkårperioden i en revurdering

### Hvorfor er denne endringen nødvendig? ✨

I en revurdering burde man bruke `minOf(revurderFra, førsteDatoVilkårperiode)`

Denne endringen vil også gjøre at det "samme" fungerer i en revurdering når man fjerner revurderFra, der man ønsker `minOf(opprettetTidspunkt/mottattTidspunkt, førsteDatoVilkårperiode)`
