### PR TITLE
Fjernet fom fra OppsummeringForPeriodeDto i simulering

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDto.kt
@@ -20,8 +20,6 @@ data class SimuleringOppsummering(
 
 data class OppsummeringForPeriodeDto(
     val måned: YearMonth,
-    @Deprecated("bruk måned når frontend tatt den i bruk")
-    val fom: LocalDate,
     val tidligereUtbetalt: Int,
     val nyUtbetaling: Int,
     val totalEtterbetaling: Int,
@@ -39,12 +37,15 @@ fun Simuleringsresultat.tilDto(): SimuleringDto =
         oppsummering = lagSimuleringOppsummering(this),
     )
 
+/**
+ * På grunn av at vi summerer perioder per måned, så må fom og tom være i samme måned.
+ * Hvis ikke burde man vurdere å endre til å bruke fom/tom i stedet
+ */
 private fun OppsummeringForPeriode.tilDto(): OppsummeringForPeriodeDto {
     val måned = YearMonth.from(fom)
     require(måned == YearMonth.from(tom))
     return OppsummeringForPeriodeDto(
         måned = måned,
-        fom = fom,
         tidligereUtbetalt = tidligereUtbetalt,
         nyUtbetaling = nyUtbetaling,
         totalEtterbetaling = totalEtterbetaling,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/dto/SimuleringDtoTest.kt
@@ -22,7 +22,6 @@ class SimuleringDtoTest {
             .containsExactlyInAnyOrder(
                 OppsummeringForPeriodeDto(
                     måned = YearMonth.of(2024, 1),
-                    fom = LocalDate.of(2024, 1, 2),
                     tidligereUtbetalt = 11,
                     nyUtbetaling = 22,
                     totalEtterbetaling = 33,
@@ -30,7 +29,6 @@ class SimuleringDtoTest {
                 ),
                 OppsummeringForPeriodeDto(
                     måned = YearMonth.of(2024, 2),
-                    fom = LocalDate.of(2024, 2, 5),
                     tidligereUtbetalt = 101,
                     nyUtbetaling = 202,
                     totalEtterbetaling = 303,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

**Har kun opprettet PR for å huske å merge denne etter at frontend vært i prod en time eller 2**

Fjernet bruk av fom i frontend
https://github.com/navikt/tilleggsstonader-sak-frontend/commit/3bd9777c93fb9a2e8eab8bb96bbf6ce5a1235a37