### PR TITLE
Legg alle oppgaver for TSR på oslo enheten

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -62,6 +62,12 @@ class ArbeidsfordelingService(
                 stønadstype = stønadstype,
                 oppgavetype = oppgavetype,
             )
+        if (stønadstype == Stønadstype.DAGLIG_REISE_TSR) {
+            return Arbeidsfordelingsenhet(
+                enhetNr = "0387",
+                navn = "0387 - Nav tiltak Oslo",
+            )
+        }
         return finnArbeidsfordelingsenhet(arbeidsfordelingskriterie)
             .firstOrNull() ?: error("Fant ikke Nav-enhet for oppgave av type $oppgavetype")
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -56,18 +56,18 @@ class ArbeidsfordelingService(
         stønadstype: Stønadstype,
         oppgavetype: Oppgavetype,
     ): Arbeidsfordelingsenhet? {
-        val arbeidsfordelingskriterie =
-            lagArbeidsfordelingKritierieForPerson(
-                personIdent = ident,
-                stønadstype = stønadstype,
-                oppgavetype = oppgavetype,
-            )
         if (stønadstype == Stønadstype.DAGLIG_REISE_TSR) {
             return Arbeidsfordelingsenhet(
                 enhetNr = "0387",
                 navn = "0387 - Nav tiltak Oslo",
             )
         }
+        val arbeidsfordelingskriterie =
+            lagArbeidsfordelingKritierieForPerson(
+                personIdent = ident,
+                stønadstype = stønadstype,
+                oppgavetype = oppgavetype,
+            )
         return finnArbeidsfordelingsenhet(arbeidsfordelingskriterie)
             .firstOrNull() ?: error("Fant ikke Nav-enhet for oppgave av type $oppgavetype")
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -46,6 +46,12 @@ class ArbeidsfordelingService(
         ident: String,
         stønadstype: Stønadstype,
     ): Arbeidsfordelingsenhet? {
+        if (stønadstype == Stønadstype.DAGLIG_REISE_TSR) {
+            return Arbeidsfordelingsenhet(
+                enhetNr = "0387",
+                navn = "0387 - Nav tiltak Oslo",
+            )
+        }
         val kriterie = lagArbeidsfordelingKritierieForPerson(ident, stønadstype)
         val enheter = finnArbeidsfordelingsenhet(kriterie)
         return enheter.firstOrNull()
@@ -56,12 +62,6 @@ class ArbeidsfordelingService(
         stønadstype: Stønadstype,
         oppgavetype: Oppgavetype,
     ): Arbeidsfordelingsenhet? {
-        if (stønadstype == Stønadstype.DAGLIG_REISE_TSR) {
-            return Arbeidsfordelingsenhet(
-                enhetNr = "0387",
-                navn = "0387 - Nav tiltak Oslo",
-            )
-        }
         val arbeidsfordelingskriterie =
             lagArbeidsfordelingKritierieForPerson(
                 personIdent = ident,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne lage en komplett verdiflyt for opprettelse av oppgaver på TSR. Hardkoder derfor at alle oppgaver på daglig reise TSR til å ligge på Oslo enhenten. For Oslo enhenten er det opprettet mapper i gosys i dev. Det er ikke gjort for andre enheter.
