### PR TITLE
Legger til håndtering av default-feil i ApiExceptionHandler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/ApiExceptionHandler.kt
@@ -5,18 +5,35 @@ import no.nav.tilleggsstonader.libs.log.SecureLogger
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PdlNotFoundException
 import org.slf4j.LoggerFactory
 import org.springframework.core.NestedExceptionUtils
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import java.net.SocketTimeoutException
 import java.util.concurrent.TimeoutException
 
 @ControllerAdvice
-class ApiExceptionHandler {
+class ApiExceptionHandler : ResponseEntityExceptionHandler() {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = SecureLogger.secureLogger
+
+    override fun handleExceptionInternal(
+        ex: Exception,
+        body: Any?,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any>? {
+        secureLogger.error("En feil har oppstått", ex)
+        logger.error("En feil har oppstått - throwable=${rootCause(ex)} status=${status.value()}")
+        return super.handleExceptionInternal(ex, body, headers, status, request)
+    }
 
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(throwable: Throwable): ProblemDetail {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/TestControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/TestControllerTest.kt
@@ -96,6 +96,21 @@ class TestControllerTest : IntegrationTest() {
         assertInternalServerError(response as InternalServerError)
     }
 
+    @Test
+    fun `endepunkt som ikke eksisterer skal kaste 404`() {
+        val response = catchException { restTemplate.exchange<TestObject>(localhost("api/eksistererIkke"), HttpMethod.GET) }
+        assertThat(response).isInstanceOf(HttpClientErrorException.NotFound::class.java)
+
+        response as HttpClientErrorException.NotFound
+        assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        assertThat(response.responseHeaders?.contentType).isEqualTo(APPLICATION_PROBLEM_JSON)
+        assertThat(response.responseBodyAsString).isEqualTo(
+            """
+            {"type":"about:blank","title":"Not Found","status":404,"detail":"No static resource api/eksistererIkke.","instance":"/api/eksistererIkke"}
+            """.trimIndent(),
+        )
+    }
+
     @Nested
     inner class PrimtiveFelter {
         val headers =


### PR DESCRIPTION
- ResponseEntityExceptionHandler håndtere normale feil som Not Found, feil type etc, og gir riktig feilkode i stedet for å gi 500 og rar logg

### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a

Denne brukes i tilleggsstonader-soknad-api
https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/method/annotation/ResponseEntityExceptionHandler.html 

Denne klassen legger til `ExceptionHandler` for
```kotlin
@ExceptionHandler({
			HttpRequestMethodNotSupportedException.class,
			HttpMediaTypeNotSupportedException.class,
			HttpMediaTypeNotAcceptableException.class,
			MissingPathVariableException.class,
			MissingServletRequestParameterException.class,
			MissingServletRequestPartException.class,
			ServletRequestBindingException.class,
			MethodArgumentNotValidException.class,
			HandlerMethodValidationException.class,
			NoHandlerFoundException.class,
			NoResourceFoundException.class,
			AsyncRequestTimeoutException.class,
			ErrorResponseException.class,
			MaxUploadSizeExceededException.class,
			ConversionNotSupportedException.class,
			TypeMismatchException.class,
			HttpMessageNotReadableException.class,
			HttpMessageNotWritableException.class,
			MethodValidationException.class,
			AsyncRequestNotUsableException.class
		})
```
