### PR TITLE
Tillat midlertidig og løpende utgifter i samme behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -17,4 +17,6 @@ enum class Toggle(
     BOUTGIFTER_TILLAT_HOYERE_UTGIFTER("sak.boutgifter-tillat-hoyere-utgifter"),
 
     SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK("sak.utled-endringsdato-revurdering"),
+
+    TILLAT_LØPENDE_OG_MIDLERTIDIG_UTGIFT_SAMME_BEHANDLING("sak.tillat-lopende-og-midlertidig-utgift-samme-behandling"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenLøpendeOgMidlertidigUtgiftISammeLøpendeMåned.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenLøpendeOgMidlertidigUtgiftISammeLøpendeMåned.kt
@@ -1,0 +1,39 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
+
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BoutgifterPerUtgiftstype
+import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
+
+fun List<UtbetalingPeriode>.validerIngenLøpendeOgMidlertidigUtgiftISammeUtbetalingsperiode(
+    utgifter: BoutgifterPerUtgiftstype,
+): List<UtbetalingPeriode> {
+    val perioderMedBådeLøpendeOgMidlertidigUtgifter = filter { it.harLøpendeOgMidlertidigUtgift(utgifter) }
+
+    brukerfeilHvis(perioderMedBådeLøpendeOgMidlertidigUtgifter.isNotEmpty()) {
+        "Det er foreløpig ikke mulig å legge både løpende utgifter og utgifter til overnatting i samme utbetalingsperiode. " +
+            "Dette gjelder perioden(e): ${
+                perioderMedBådeLøpendeOgMidlertidigUtgifter.joinToString(", ") {
+                    it.formatertPeriodeNorskFormat()
+                }
+            }."
+    }
+
+    return this
+}
+
+fun UtbetalingPeriode.harLøpendeOgMidlertidigUtgift(utgifter: BoutgifterPerUtgiftstype): Boolean {
+    val harLøpendeUtgifter =
+        listOf(
+            TypeBoutgift.LØPENDE_UTGIFTER_EN_BOLIG,
+            TypeBoutgift.LØPENDE_UTGIFTER_TO_BOLIGER,
+        ).flatMap { type -> utgifter[type].orEmpty() }
+            .any { utgift -> utgift.overlapper(this) }
+
+    val harUtgifterOvernatting =
+        utgifter[TypeBoutgift.UTGIFTER_OVERNATTING]
+            .orEmpty()
+            .any { utgift -> utgift.overlapper(this) }
+
+    return harLøpendeUtgifter && harUtgifterOvernatting
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtgifterValideringUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/UtgifterValideringUtil.kt
@@ -13,12 +13,17 @@ object UtgifterValideringUtil {
      * gir rett på stønad (hhv. 3/6 mnd for utgifter overnatting/løpende utgifter).
      *
      */
-    fun validerUtgifter(utgifter: BoutgifterPerUtgiftstype) {
+    fun validerUtgifter(
+        utgifter: BoutgifterPerUtgiftstype,
+        tillatLøpendeOgMidlertidigUtgiftSammeBehandling: Boolean,
+    ) {
         brukerfeilHvis(utgifter.values.flatten().isEmpty()) {
             "Det er ikke lagt inn noen oppfylte utgiftsperioder"
         }
-        brukerfeilHvis(detFinnesBådeLøpendeOgMidlertidigeUtgifter(utgifter)) {
-            "Foreløpig støtter vi ikke løpende og midlertidige utgifter i samme behandling"
+        if (!tillatLøpendeOgMidlertidigUtgiftSammeBehandling) {
+            brukerfeilHvis(detFinnesBådeLøpendeOgMidlertidigeUtgifter(utgifter)) {
+                "Foreløpig støtter vi ikke løpende og midlertidige utgifter i samme behandling"
+            }
         }
         utgifter.entries.forEach { (type, utgiftsperioderAvGittType) ->
             feilHvis(utgiftsperioderAvGittType.overlapper()) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -119,6 +119,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
             boutgifterUtgiftService = boutgifterUtgiftService,
             vedtaksperiodeValideringService = vedtaksperiodeValideringService,
             vedtakRepository = vedtakRepositoryFake,
+            unleashService = unleashService,
         )
     val opphørValideringService =
         OpphørValideringService(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
@@ -32,7 +32,7 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
     val boutgifterUtgiftService = mockk<BoutgifterUtgiftService>()
     val vedtakRepository = mockk<VedtakRepository>()
     val vilkårperiodeService = mockk<VilkårperiodeService>()
-    val unleashService = mockk<UnleashService>()
+    val unleashService = mockk<UnleashService>(relaxed = true)
 
     val vedtaksperiodeValideringService =
         VedtaksperiodeValideringService(
@@ -45,6 +45,7 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
             boutgifterUtgiftService = boutgifterUtgiftService,
             vedtaksperiodeValideringService = vedtaksperiodeValideringService,
             vedtakRepository = vedtakRepository,
+            unleashService = unleashService,
         )
 
     val løpendeUtgifterEnBolig: BoutgifterPerUtgiftstype =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterToBoliger.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterToBoliger.kt
@@ -32,7 +32,7 @@ class BoutgifterBeregningLøpendeUtgifterToBoliger {
     val boutgifterUtgiftService = mockk<BoutgifterUtgiftService>()
     val vedtakRepository = mockk<VedtakRepository>()
     val vilkårperiodeService = mockk<VilkårperiodeService>()
-    val unleashService = mockk<UnleashService>()
+    val unleashService = mockk<UnleashService>(relaxed = true)
 
     val vedtaksperiodeValideringService =
         VedtaksperiodeValideringService(
@@ -45,6 +45,7 @@ class BoutgifterBeregningLøpendeUtgifterToBoliger {
             boutgifterUtgiftService = boutgifterUtgiftService,
             vedtaksperiodeValideringService = vedtaksperiodeValideringService,
             vedtakRepository = vedtakRepository,
+            unleashService = unleashService,
         )
 
     val løpendeUtgifterToBoliger: BoutgifterPerUtgiftstype =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningMidlertidigUtgiftTest.kt
@@ -33,7 +33,7 @@ class BoutgifterBeregningMidlertidigUtgiftTest {
     val boutgifterUtgiftService = mockk<BoutgifterUtgiftService>()
     val vedtakRepository = mockk<VedtakRepository>()
     val vilkårperiodeService = mockk<VilkårperiodeService>()
-    val unleashService = mockk<UnleashService>()
+    val unleashService = mockk<UnleashService>(relaxed = true)
 
     val vedtaksperiodeValideringService =
         VedtaksperiodeValideringService(
@@ -46,6 +46,7 @@ class BoutgifterBeregningMidlertidigUtgiftTest {
             boutgifterUtgiftService = boutgifterUtgiftService,
             vedtaksperiodeValideringService = vedtaksperiodeValideringService,
             vedtakRepository = vedtakRepository,
+            unleashService = unleashService,
         )
 
     val utgiftMidlertidigOvernatting: BoutgifterPerUtgiftstype =

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregn_ytelse_revurdering_innvilgelse.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregn_ytelse_revurdering_innvilgelse.feature
@@ -155,8 +155,8 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | Fom        | Beløp | Type           | Utbetalingsdato |
       | 03.02.2025 | 1000  | BOUTGIFTER_AAP | 03.02.2025      |
 
-  Scenario: Har faste utgifter fra før, legger inn en midlertidig overnatting
-  Resultat: Forventer feilmelding, ettersom det ikke er støttet i løsningen enda
+  Scenario: Har faste utgifter fra før, legger inn en midlertidig overnatting som ikke overlapper med tidligere utgift
+  Resultat: Forventer dette skal gå bra da periodene ikke overlapper
     Gitt følgende boutgifter av type LØPENDE_UTGIFTER_EN_BOLIG for behandling=1
       | Fom        | Tom        | Utgift |
       | 01.01.2025 | 31.01.2025 | 1000   |
@@ -176,4 +176,29 @@ Egenskap: Innvilgelse av boutgifter - revurdering
       | 01.01.2025 | 31.01.2025 |
       | 15.02.2025 | 16.02.2025 |
 
-    Så forvent følgende feilmelding: Foreløpig støtter vi ikke løpende og midlertidige utgifter i samme behandling
+    Så kan vi forvente følgende andeler for behandling=2
+      | Fom        | Beløp | Type           | Utbetalingsdato |
+      | 01.01.2025 | 1000  | BOUTGIFTER_AAP | 01.01.2025      |
+      | 03.02.2025 | 1000  | BOUTGIFTER_AAP | 17.02.2025      |
+
+  Scenario: Har faste utgifter fra før, legger inn en midlertidig overnatting som overlapper med tidligere utgift
+  Resultat: Forventer feilmelding, ettersom det ikke er støttet i løsningen enda
+    Gitt følgende boutgifter av type LØPENDE_UTGIFTER_EN_BOLIG for behandling=1
+      | Fom        | Tom        | Utgift |
+      | 01.01.2025 | 31.03.2025 | 1000   |
+
+    Og vi innvilger boutgifter for behandling=1 med følgende vedtaksperioder
+      | Fom        | Tom        |
+      | 01.01.2025 | 31.03.2025 |
+
+    Og vi kopierer perioder fra forrige behandling for behandling=2
+
+    Og vi legger inn følgende nye utgifter av type UTGIFTER_OVERNATTING for behandling=2
+      | Fom        | Tom        | Utgift |
+      | 15.02.2025 | 16.02.2025 | 1000   |
+
+    Når vi innvilger boutgifter behandling=2 med revurderFra=15.02.2025 med følgende vedtaksperioder
+      | Fom        | Tom        |
+      | 01.01.2025 | 31.03.2025 |
+
+    Så forvent følgende feilmelding: Det er foreløpig ikke mulig å legge både løpende utgifter og utgifter til overnatting i samme utbetalingsperiode.

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_faste_utgifter.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/beregning_faste_utgifter.feature
@@ -154,7 +154,7 @@ Egenskap: Beregning av faste utgifter
         | 15.01.2025 | 14.02.2025 | 4000         | 4953      | 15.01.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
         | 15.02.2025 | 20.02.2025 | 4000         | 4953      | 15.02.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
 
-    Scenario: Kan ikke ha midlertidige utgifter og faste utgifter i samme behandling
+    Scenario: Kan ikke ha midlertidige utgifter og faste utgifter i samme utbetalingsperiode
       Gitt følgende boutgifter av type LØPENDE_UTGIFTER_EN_BOLIG for behandling=1
         | Fom        | Tom        | Utgift |
         | 01.01.2025 | 31.03.2025 | 3000   |
@@ -167,7 +167,27 @@ Egenskap: Beregning av faste utgifter
         | Fom        | Tom        | Aktivitet | Målgruppe           |
         | 01.01.2025 | 31.01.2025 | UTDANNING | NEDSATT_ARBEIDSEVNE |
 
-      Så forvent følgende feilmelding: Foreløpig støtter vi ikke løpende og midlertidige utgifter i samme behandling
+      Så forvent følgende feilmelding: Det er foreløpig ikke mulig å legge både løpende utgifter og utgifter til overnatting i samme utbetalingsperiode.
+
+    Scenario: Kan ha midlertidige utgifter og faste utgifter i samme behandling hvis forskjellige utbetalingsperioder
+      Gitt følgende boutgifter av type LØPENDE_UTGIFTER_EN_BOLIG for behandling=1
+        | Fom        | Tom        | Utgift |
+        | 01.01.2025 | 31.03.2025 | 3000   |
+
+      Og følgende boutgifter av type UTGIFTER_OVERNATTING for behandling=1
+        | Fom        | Tom        | Utgift |
+        | 01.04.2025 | 03.04.2025 | 1000   |
+
+      Når vi innvilger boutgifter for behandling=1 med følgende vedtaksperioder
+        | Fom        | Tom        | Aktivitet | Målgruppe           |
+        | 01.01.2025 | 03.04.2025 | UTDANNING | NEDSATT_ARBEIDSEVNE |
+
+      Så kan vi forvente følgende beregningsresultat for behandling=1
+        | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet |
+        | 01.01.2025 | 31.01.2025 | 3000         | 4953      | 01.01.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
+        | 01.02.2025 | 28.02.2025 | 3000         | 4953      | 01.02.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
+        | 01.03.2025 | 31.03.2025 | 3000         | 4953      | 01.03.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
+        | 01.04.2025 | 30.04.2025 | 1000         | 4953      | 02.04.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING |
 
     Scenario: Skal få dekket for faktiske utgifter
 
@@ -177,8 +197,8 @@ Egenskap: Beregning av faste utgifter
 
       Når vi innvilger boutgifter for behandling=1 med følgende vedtaksperioder
         | Fom        | Tom        | Aktivitet | Målgruppe           |
-        | 01.01.2025 | 31.01.2025 | UTDANNING    | NEDSATT_ARBEIDSEVNE |
+        | 01.01.2025 | 31.01.2025 | UTDANNING | NEDSATT_ARBEIDSEVNE |
 
       Så kan vi forvente følgende beregningsresultat for behandling=1
         | Fom        | Tom        | Stønadsbeløp | Maks sats | Utbetalingsdato | Målgruppe           | Aktivitet | Høyere utgifter |
-        | 01.01.2025 | 31.01.2025 | 20000        | 4953      | 01.01.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING    | Ja              |
+        | 01.01.2025 | 31.01.2025 | 20000        | 4953      | 01.01.2025      | NEDSATT_ARBEIDSEVNE | UTDANNING | Ja              |


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Har en case i prod der vi må behandle midlertidig og løpende utgifter i samme behandling. Dette tillates nå så lenge det ikke er samme løpende måned.

🚩 Endringe er feature togglet til det er blitt testet av funksjonelle og brevene er gjennomgått.

Beregningstabellen ser slik ut ved både midlertidig og løpende utgifter:
<img width="1055" height="438" alt="image" src="https://github.com/user-attachments/assets/a419452d-e662-4662-84d0-91b80fed6e89" />


Feilmelding ved midlertidig og løpende utgift i samme løpende måned:
<img width="1096" height="598" alt="image" src="https://github.com/user-attachments/assets/5eddbc96-0618-44fb-a93d-2c19253ef66d" />
