### PR TITLE
Legger til støtte for vilkår - daglig reise med offentlig transport

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation.VilkårPeriodeValidering.validerIkkeOverlappendeVilkår
 import org.springframework.stereotype.Service
@@ -33,7 +34,7 @@ class VilkårSteg(
         val manglerVerdierPåOppfylteVilkår =
             vilkår
                 .filter { it.resultat == Vilkårsresultat.OPPFYLT }
-                .any { it.fom == null || it.tom == null || (!it.erFremtidigUtgift && it.offentligTransport == null && it.utgift == null) }
+                .any { it.fom == null || it.tom == null || (manglerPåkrevdUtgift(it)) }
         brukerfeilHvis(manglerVerdierPåOppfylteVilkår) {
             "Mangler fom, tom eller utgift på et eller flere vilkår. " +
                 "Vennligst ta stilling til hvilken periode vilkåret gjelder for."
@@ -49,4 +50,11 @@ class VilkårSteg(
     }
 
     override fun stegType(): StegType = StegType.VILKÅR
+
+    private fun manglerPåkrevdUtgift(vilkår: Vilkår): Boolean =
+        !vilkår.erFremtidigUtgift &&
+            harIkkeOffentligTransport(vilkår) &&
+            vilkår.utgift == null
+
+    private fun harIkkeOffentligTransport(vilkår: Vilkår) = vilkår.offentligTransport == null
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -33,7 +33,7 @@ class VilkårSteg(
         val manglerVerdierPåOppfylteVilkår =
             vilkår
                 .filter { it.resultat == Vilkårsresultat.OPPFYLT }
-                .any { it.fom == null || it.tom == null || (!it.erFremtidigUtgift && it.utgift == null) }
+                .any { it.fom == null || it.tom == null || (!it.erFremtidigUtgift && it.offentligTransport == null && it.utgift == null) }
         brukerfeilHvis(manglerVerdierPåOppfylteVilkår) {
             "Mangler fom, tom eller utgift på et eller flere vilkår. " +
                 "Vennligst ta stilling til hvilken periode vilkåret gjelder for."

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårUtil.kt
@@ -63,6 +63,7 @@ object VilkårUtil {
                 VilkårType.UTGIFTER_OVERNATTING -> false
                 VilkårType.LØPENDE_UTGIFTER_EN_BOLIG -> true
                 VilkårType.LØPENDE_UTGIFTER_TO_BOLIGER -> true
+                VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> false
                 VilkårType.EKSEMPEL2 -> false
                 VilkårType.EKSEMPEL -> false
             }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårUtil.kt
@@ -63,7 +63,7 @@ object VilkårUtil {
                 VilkårType.UTGIFTER_OVERNATTING -> false
                 VilkårType.LØPENDE_UTGIFTER_EN_BOLIG -> true
                 VilkårType.LØPENDE_UTGIFTER_TO_BOLIGER -> true
-                VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> false
+                VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> true
                 VilkårType.EKSEMPEL2 -> false
                 VilkårType.EKSEMPEL -> false
             }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -38,6 +38,8 @@ data class Vilkår(
     val utgift: Int? = null,
     val barnId: BarnId? = null,
     val erFremtidigUtgift: Boolean,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "offentlig_transport_")
+    val offentligTransport: OffentligTransport?,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
     @Column("delvilkar")
@@ -89,6 +91,10 @@ data class Vilkår(
 
             VilkårType.UTGIFTER_OVERNATTING -> {
                 validerPåkrevdBeløpHvisOppfylt()
+            }
+
+            VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> {
+                // Dette er kun for tester foreløpig
             }
 
             VilkårType.EKSEMPEL -> {
@@ -209,6 +215,12 @@ data class Vurdering(
     val begrunnelse: String? = null,
 )
 
+data class OffentligTransport(
+    val reisedagerPerUke: Int,
+    val prisEnkelbillett: Int,
+    val prisTrettidagersbillett: Int,
+)
+
 fun List<Vurdering>.harSvar(svarId: SvarId) = this.any { it.svar == svarId }
 
 enum class Vilkårsresultat(
@@ -247,6 +259,12 @@ enum class VilkårType(
     UTGIFTER_OVERNATTING("Utgifter overnatting", listOf(Stønadstype.BOUTGIFTER)),
     LØPENDE_UTGIFTER_EN_BOLIG("Løpende utgifter en bolig", listOf(Stønadstype.BOUTGIFTER)),
     LØPENDE_UTGIFTER_TO_BOLIGER("Løpende utgifter to boliger", listOf(Stønadstype.BOUTGIFTER)),
+
+    //
+    DAGLIG_REISE_OFFENTLIG_TRANSPORT(
+        "Offentlig transport daglig reise",
+        listOf(Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSO),
+    ),
     ;
 
     fun gjelderFlereBarn(): Boolean = this == PASS_BARN

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -260,10 +260,10 @@ enum class VilkårType(
     LØPENDE_UTGIFTER_EN_BOLIG("Løpende utgifter en bolig", listOf(Stønadstype.BOUTGIFTER)),
     LØPENDE_UTGIFTER_TO_BOLIGER("Løpende utgifter to boliger", listOf(Stønadstype.BOUTGIFTER)),
 
-    //
+    // Daglig reise
     DAGLIG_REISE_OFFENTLIG_TRANSPORT(
         "Offentlig transport daglig reise",
-        listOf(Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSO),
+        listOf(Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR),
     ),
     ;
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/Vilkår.kt
@@ -106,7 +106,7 @@ data class Vilkår(
     }
 
     private fun validerPåkrevdBeløpHvisOppfylt() {
-        if (resultat == Vilkårsresultat.OPPFYLT && !erFremtidigUtgift) {
+        if (resultat == Vilkårsresultat.OPPFYLT && !erFremtidigUtgift && offentligTransport == null) {
             require(utgift != null) { "Utgift er påkrevd når resultat er oppfylt" }
         }
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/LagreVilkårDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/LagreVilkårDto.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import java.time.LocalDate
 
@@ -13,6 +14,7 @@ sealed interface LagreVilkårDto {
     val tom: LocalDate?
     val utgift: Int?
     val erFremtidigUtgift: Boolean?
+    val offentligTransport: OffentligTransport?
 }
 
 data class SvarPåVilkårDto(
@@ -23,6 +25,7 @@ data class SvarPåVilkårDto(
     override val tom: LocalDate?,
     override val utgift: Int?,
     override val erFremtidigUtgift: Boolean?,
+    override val offentligTransport: OffentligTransport?,
 ) : LagreVilkårDto
 
 data class OpprettVilkårDto(
@@ -34,4 +37,5 @@ data class OpprettVilkårDto(
     override val tom: LocalDate?,
     override val utgift: Int?,
     override val erFremtidigUtgift: Boolean?,
+    override val offentligTransport: OffentligTransport?,
 ) : LagreVilkårDto

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/VilkårDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dto/VilkårDto.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.SlettetVilkårResultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Delvilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -31,6 +32,7 @@ data class VilkårDto(
     val delvilkårsett: List<DelvilkårDto> = emptyList(),
     val opphavsvilkår: OpphavsvilkårDto?,
     val slettetKommentar: String?,
+    val offentligTransport: OffentligTransport?,
 )
 
 data class OpphavsvilkårDto(
@@ -94,6 +96,7 @@ fun Vilkår.tilDto() =
                 .map { it.tilDto() },
         opphavsvilkår = this.opphavsvilkår?.let { OpphavsvilkårDto(it.behandlingId, it.vurderingstidspunkt) },
         slettetKommentar = this.slettetKommentar,
+        offentligTransport = this.offentligTransport,
     )
 
 fun DelvilkårDto.svarTilDomene() = this.vurderinger.map { it.tilDomene() }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelId.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/RegelId.kt
@@ -27,4 +27,9 @@ enum class RegelId(
     HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER("Har søker høyere utgifter grunnet helsemessige årsaker?"),
     DOKUMENTERT_UTGIFTER_BOLIG("Har søker dokumentert utgifter til bolig tilfredsstillende?"),
     DOKUMENTERT_DELTAKELSE("Har søker dokumentert at de har samling/eksamen/opptaksprøve/kurs på datoene for overnatting?"),
+
+    // DAGLIG REISE
+    AVSTAND_OVER_SEKS_KM("Er avstanden mellom brukers aktivitet og hjemadresse lengre enn seks km?"),
+    KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT("Kan bruker reise med offentlig transport?"),
+    KAN_BRUKER_KJØRE_SELV("Kan bruker kjøre med egen bil?"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/Vilkårsregler.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.DagligReiseOffentiligTransportRegel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.LøpendeUtgifterEnBoligRegel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.LøpendeUtgifterToBoligerRegel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegel
@@ -27,6 +28,7 @@ fun vilkårsreglerForStønad(stønadstype: Stønadstype): List<Vilkårsregel> =
             listOf(
                 PassBarnRegel(),
             )
+
         Stønadstype.LÆREMIDLER -> emptyList()
         Stønadstype.BOUTGIFTER ->
             listOf(
@@ -34,8 +36,9 @@ fun vilkårsreglerForStønad(stønadstype: Stønadstype): List<Vilkårsregel> =
                 LøpendeUtgifterEnBoligRegel(),
                 LøpendeUtgifterToBoligerRegel(),
             )
-        Stønadstype.DAGLIG_REISE_TSO -> emptyList()
-        Stønadstype.DAGLIG_REISE_TSR -> emptyList()
+
+        Stønadstype.DAGLIG_REISE_TSO -> listOf(DagligReiseOffentiligTransportRegel())
+        Stønadstype.DAGLIG_REISE_TSR -> listOf(DagligReiseOffentiligTransportRegel())
     }
 
 private val vilkårstyperPerStønad: Map<Stønadstype, Set<VilkårType>> =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -78,6 +78,7 @@ object OppdaterVilkår {
             vilkårType in vilkårMedUtgift &&
                 oppdatering.erFremtidigUtgift != true &&
                 resultat == Vilkårsresultat.OPPFYLT &&
+                oppdatering.offentligTransport == null &&
                 oppdatering.utgift == null,
         ) {
             "Mangler utgift på vilkår"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkår.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.util.erFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.util.erSisteDagIMåneden
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -123,6 +124,7 @@ object OppdaterVilkår {
             utgift = oppdatering.utgift,
             erFremtidigUtgift = oppdatering.erFremtidigUtgift == true,
             gitVersjon = Applikasjonsversjon.versjon,
+            offentligTransport = oppdatering.offentligTransport,
         )
     }
 
@@ -155,6 +157,10 @@ object OppdaterVilkår {
                     it
                 }
 
+                VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> {
+                    it
+                }
+
                 else -> error("Har ikke tatt stilling til type dato for ${vilkår.type}")
             }
         }
@@ -174,6 +180,10 @@ object OppdaterVilkår {
                 }
 
                 VilkårType.UTGIFTER_OVERNATTING -> {
+                    it
+                }
+
+                VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> {
                     it
                 }
 
@@ -254,6 +264,7 @@ object OppdaterVilkår {
         metadata: HovedregelMetadata,
         behandlingId: BehandlingId,
         barnId: BarnId? = null,
+        offentligTransport: OffentligTransport? = null,
     ): Vilkår {
         val delvilkårsett = vilkårsregel.initiereDelvilkår(metadata, barnId = barnId)
         return Vilkår(
@@ -265,6 +276,7 @@ object OppdaterVilkår {
             resultat = utledResultat(vilkårsregel, delvilkårsett.map { it.tilDto() }).vilkår,
             status = VilkårStatus.NY,
             opphavsvilkår = null,
+            offentligTransport = offentligTransport,
             gitVersjon = Applikasjonsversjon.versjon,
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/DagligReiseOffentiligTransportRegel.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/DagligReiseOffentiligTransportRegel.kt
@@ -1,0 +1,57 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår
+
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.NesteRegel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelSteg
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SluttSvarRegel.Companion.OPPFYLT_MED_VALGFRI_BEGRUNNELSE
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.Vilkårsregel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.jaNeiSvarRegel
+
+class DagligReiseOffentiligTransportRegel :
+    Vilkårsregel(
+        vilkårType = VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT,
+        regler =
+            setOf(
+                AVSTAND_OVER_SEKS_KM,
+                KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT,
+                KAN_BRUKER_KJØRE_SELV,
+            ),
+    ) {
+    companion object {
+        private val KAN_BRUKER_KJØRE_SELV =
+            RegelSteg(
+                regelId = RegelId.KAN_BRUKER_KJØRE_SELV,
+                erHovedregel = false,
+                svarMapping =
+                    mapOf(
+                        SvarId.JA to OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                        SvarId.NEI to OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                    ),
+            )
+
+        private val KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT =
+            RegelSteg(
+                regelId = RegelId.KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT,
+                erHovedregel = false,
+                svarMapping =
+                    jaNeiSvarRegel(
+                        hvisJa = OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
+                        hvisNei = NesteRegel(KAN_BRUKER_KJØRE_SELV.regelId),
+                    ),
+            )
+
+        private val AVSTAND_OVER_SEKS_KM =
+            RegelSteg(
+                regelId = RegelId.AVSTAND_OVER_SEKS_KM,
+                erHovedregel = true,
+                svarMapping =
+                    jaNeiSvarRegel(
+                        hvisJa = NesteRegel(KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT.regelId),
+                        hvisNei = IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
+                    ),
+            )
+    }
+}

--- a/src/main/resources/db/migration/V93__offentlig_transport_vilkår.sql
+++ b/src/main/resources/db/migration/V93__offentlig_transport_vilkår.sql
@@ -1,0 +1,6 @@
+ALTER TABLE vilkar
+    ADD COLUMN offentlig_transport_reisedager_per_uke INT;
+ALTER TABLE vilkar
+    ADD COLUMN offentlig_transport_pris_enkelbillett INT;
+ALTER TABLE vilkar
+    ADD COLUMN offentlig_transport_pris_trettidagersbillett INT;

--- a/src/main/resources/db/migration/V93__offentlig_transport_vilkår.sql
+++ b/src/main/resources/db/migration/V93__offentlig_transport_vilkår.sql
@@ -1,6 +1,4 @@
 ALTER TABLE vilkar
-    ADD COLUMN offentlig_transport_reisedager_per_uke INT;
-ALTER TABLE vilkar
-    ADD COLUMN offentlig_transport_pris_enkelbillett INT;
-ALTER TABLE vilkar
+    ADD COLUMN offentlig_transport_reisedager_per_uke       INT,
+    ADD COLUMN offentlig_transport_pris_enkelbillett        INT,
     ADD COLUMN offentlig_transport_pris_trettidagersbillett INT;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
@@ -321,12 +321,7 @@ class BehandlingFlytTest : IntegrationTest() {
                 tom = LocalDate.of(2024, 1, 31),
                 utgift = 1000,
                 erFremtidigUtgift = false,
-                offentligTransport =
-                    OffentligTransport(
-                        reisedagerPerUke = 2,
-                        prisEnkelbillett = 44,
-                        prisTrettidagersbillett = 750,
-                    ),
+                offentligTransport = null,
             ),
         )
         stegService.håndterSteg(behandlingId, StegType.VILKÅR)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
@@ -40,7 +40,6 @@ import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.SendTilBeslutterR
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.TotrinnkontrollStatus
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.ÅrsakUnderkjent
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårController
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarnDto

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/BehandlingFlytTest.kt
@@ -40,6 +40,7 @@ import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.SendTilBeslutterR
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.TotrinnkontrollStatus
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.ÅrsakUnderkjent
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårController
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarnDto
@@ -320,6 +321,12 @@ class BehandlingFlytTest : IntegrationTest() {
                 tom = LocalDate.of(2024, 1, 31),
                 utgift = 1000,
                 erFremtidigUtgift = false,
+                offentligTransport =
+                    OffentligTransport(
+                        reisedagerPerUke = 2,
+                        prisEnkelbillett = 44,
+                        prisTrettidagersbillett = 750,
+                    ),
             ),
         )
         stegService.håndterSteg(behandlingId, StegType.VILKÅR)
@@ -346,7 +353,10 @@ class BehandlingFlytTest : IntegrationTest() {
         kommentarTilBeslutter: String? = null,
     ) {
         kjørTasks()
-        totrinnskontrollController.sendTilBeslutter(behandlingId, SendTilBeslutterRequest(kommentarTilBeslutter = kommentarTilBeslutter))
+        totrinnskontrollController.sendTilBeslutter(
+            behandlingId,
+            SendTilBeslutterRequest(kommentarTilBeslutter = kommentarTilBeslutter),
+        )
         kjørTasks()
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -44,6 +44,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveDomain
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Delvilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.DelvilkårWrapper
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Opphavsvilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
@@ -313,6 +314,7 @@ fun vilkår(
     tom: LocalDate? = YearMonth.now().atEndOfMonth(),
     utgift: Int? = 100,
     erFremtidigUtgift: Boolean = false,
+    offentligTransport: OffentligTransport? = null,
 ): Vilkår =
     Vilkår(
         behandlingId = behandlingId,
@@ -327,6 +329,7 @@ fun vilkår(
         utgift = utgift,
         erFremtidigUtgift = erFremtidigUtgift,
         gitVersjon = Applikasjonsversjon.versjon,
+        offentligTransport = offentligTransport,
     )
 
 fun vedtaksperiode(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -201,6 +201,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
                 tom = parseDato(DomenenøkkelFelles.TOM, rad),
                 utgift = parseInt(BoutgifterDomenenøkkel.UTGIFT, rad),
                 erFremtidigUtgift = false,
+                offentligTransport = null,
             )
         }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
@@ -162,6 +162,7 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
                 tom = LocalDate.of(2024, 1, 31),
                 utgift = 1,
                 erFremtidigUtgift = false,
+                offentligTransport = null,
             )
 
         @BeforeEach
@@ -238,6 +239,7 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
                 tom = LocalDate.of(2024, 1, 31),
                 utgift = 1,
                 erFremtidigUtgift = false,
+                offentligTransport = null,
             )
 
         @BeforeEach
@@ -261,6 +263,7 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
                     tom = LocalDate.of(2025, 1, 31),
                     utgift = 1000,
                     erFremtidigUtgift = false,
+                    offentligTransport = null,
                 ),
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceIntegrasjonsTest.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.behandlingBarn
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.vilkår.VilkårTestUtils.opprettVilkårsvurderinger
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Opphavsvilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
@@ -280,6 +281,41 @@ internal class VilkårServiceIntegrasjonsTest : IntegrationTest() {
             assertThat(vilkårFraDb.delvilkårsett.map { it.hovedregel })
                 .containsExactlyInAnyOrderElementsOf(opprettOppfyltDelvilkår.delvilkårsett.map { it.hovedregel() })
             assertThat(vilkårFraDb.gitVersjon).isEqualTo(Applikasjonsversjon.versjon)
+        }
+
+        @Test
+        fun `skal kunne oppdatere vilkår med offentlig transport uten utgift`() {
+            val gitVersjon = UUID.randomUUID().toString()
+            val vilkår = vilkårService.opprettNyttVilkår(opprettOppfyltDelvilkår)
+            jdbcTemplate.update("UPDATE vilkar SET git_versjon=:versjon", mapOf("versjon" to gitVersjon))
+            vilkårService.oppdaterVilkår(
+                SvarPåVilkårDto(
+                    id = vilkår.id,
+                    behandlingId = behandling.id,
+                    delvilkårsett = vilkår.delvilkårsett.map { it.tilDto() },
+                    fom = LocalDate.of(2025, 1, 1),
+                    tom = LocalDate.of(2025, 1, 31),
+                    utgift = null,
+                    erFremtidigUtgift = false,
+                    offentligTransport =
+                        OffentligTransport(
+                            reisedagerPerUke = 3,
+                            prisEnkelbillett = 44,
+                            prisTrettidagersbillett = 750,
+                        ),
+                ),
+            )
+
+            val vilkårFraDb = vilkårRepository.findByBehandlingId(behandling.id).single()
+            assertThat(vilkårFraDb.utgift).isNull()
+            assertThat(vilkårFraDb.offentligTransport).isEqualTo(
+                OffentligTransport(
+                    reisedagerPerUke = 3,
+                    prisEnkelbillett = 44,
+                    prisTrettidagersbillett = 750,
+                ),
+            )
+            assertThat(vilkårFraDb.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårServiceTest.kt
@@ -146,6 +146,7 @@ internal class VilkårServiceTest {
                             tom = null,
                             utgift = null,
                             erFremtidigUtgift = false,
+                            offentligTransport = null,
                         ),
                     )
                 },
@@ -166,6 +167,7 @@ internal class VilkårServiceTest {
                     tom = LocalDate.of(2024, 1, 31),
                     utgift = 1,
                     erFremtidigUtgift = false,
+                    offentligTransport = null,
                 ),
             )
 
@@ -200,6 +202,7 @@ internal class VilkårServiceTest {
                     tom = LocalDate.of(2024, 1, 31),
                     utgift = 100,
                     erFremtidigUtgift = true,
+                    offentligTransport = null,
                 ),
             )
 
@@ -326,6 +329,7 @@ internal class VilkårServiceTest {
                         tom = null,
                         utgift = null,
                         erFremtidigUtgift = false,
+                        offentligTransport = null,
                     ),
                 )
             },
@@ -362,6 +366,7 @@ internal class VilkårServiceTest {
                         tom = null,
                         utgift = null,
                         erFremtidigUtgift = false,
+                        offentligTransport = null,
                     ),
                 )
             },
@@ -393,6 +398,7 @@ internal class VilkårServiceTest {
                     tom = tom.atEndOfMonth(),
                     utgift = 1,
                     erFremtidigUtgift = false,
+                    offentligTransport = null,
                 )
 
             assertThatThrownBy {
@@ -421,6 +427,7 @@ internal class VilkårServiceTest {
                     tom = LocalDate.of(2024, 1, 31),
                     utgift = 1,
                     erFremtidigUtgift = false,
+                    offentligTransport = null,
                 )
             assertThatThrownBy {
                 vilkårService.oppdaterVilkår(svarPåVilkårDto)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -54,6 +54,7 @@ internal class OppdaterVilkårTest {
                     tom = LocalDate.now().plusDays(1),
                     utgift = 1,
                     erFremtidigUtgift = false,
+                    offentligTransport = null,
                 )
 
             @Test
@@ -94,6 +95,7 @@ internal class OppdaterVilkårTest {
                         tom = LocalDate.now().plusDays(1),
                         utgift = 1,
                         erFremtidigUtgift = false,
+                        offentligTransport = null,
                     )
                 val utgifterOvernattingVilkår =
                     vilkår(
@@ -110,6 +112,7 @@ internal class OppdaterVilkårTest {
                         tom = LocalDate.now().plusDays(1),
                         utgift = 1,
                         erFremtidigUtgift = false,
+                        offentligTransport = null,
                     )
                 val utgifterFremtidigUtgiftVilkår =
                     vilkår(
@@ -202,6 +205,7 @@ internal class OppdaterVilkårTest {
                         tom = LocalDate.now().plusDays(1),
                         utgift = 1,
                         erFremtidigUtgift = false,
+                        offentligTransport = null,
                     )
                 val vilkår =
                     vilkår(
@@ -250,6 +254,7 @@ internal class OppdaterVilkårTest {
                         tom = LocalDate.now().plusDays(1),
                         utgift = 1,
                         erFremtidigUtgift = false,
+                        offentligTransport = null,
                     )
                 val vilkår =
                     vilkår(
@@ -370,6 +375,7 @@ internal class OppdaterVilkårTest {
                 tom = originaltVilkår.tom,
                 utgift = 100,
                 erFremtidigUtgift = false,
+                offentligTransport = null,
             )
     }
 }

--- a/src/test/resources/vilkår/regler/DAGLIG_REISE_OFFENTLIG_TRANSPORT.json
+++ b/src/test/resources/vilkår/regler/DAGLIG_REISE_OFFENTLIG_TRANSPORT.json
@@ -1,0 +1,47 @@
+{
+  "vilkårType" : "DAGLIG_REISE_OFFENTLIG_TRANSPORT",
+  "regler" : {
+    "AVSTAND_OVER_SEKS_KM" : {
+      "regelId" : "AVSTAND_OVER_SEKS_KM",
+      "erHovedregel" : true,
+      "svarMapping" : {
+        "JA" : {
+          "regelId" : "KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT",
+          "begrunnelseType" : "UTEN"
+        },
+        "NEI" : {
+          "begrunnelseType" : "PÅKREVD",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    },
+    "KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT" : {
+      "regelId" : "KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT",
+      "erHovedregel" : false,
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "regelId" : "KAN_BRUKER_KJØRE_SELV",
+          "begrunnelseType" : "UTEN"
+        }
+      }
+    },
+    "KAN_BRUKER_KJØRE_SELV" : {
+      "regelId" : "KAN_BRUKER_KJØRE_SELV",
+      "erHovedregel" : false,
+      "svarMapping" : {
+        "JA" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        },
+        "NEI" : {
+          "begrunnelseType" : "VALGFRI",
+          "regelId" : "SLUTT_NODE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Denne endringen legger til rette for at man kan opprette vilkår for daglig reise. Med "regletre" av vilkår for offentlig transport, taxi og kjøreliste.
PR-en er kun for offentlig transport -se db migrering.
