### PR TITLE
🏷️ Legg til informasjon om bruker skal få dekket faktiske utgifter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -25,6 +25,7 @@ data class BeregningsresultatForPeriodeDto(
     val aktivitet: AktivitetType,
     val makssatsBekreftet: Boolean,
     val delAvTidligereUtbetaling: Boolean,
+    val skalFåDekketFaktiskeUtgifter: Boolean,
 ) : Periode<LocalDate>
 
 data class UtgiftBoutgifterMedAndelTilUtbetalingDto(
@@ -33,6 +34,7 @@ data class UtgiftBoutgifterMedAndelTilUtbetalingDto(
     val utgift: Int,
     val tilUtbetaling: Int,
     val erFørRevurderFra: Boolean,
+    val skalFåDekketFaktiskeUtgifter: Boolean,
 ) : Periode<LocalDate> {
     init {
         validatePeriode()
@@ -73,6 +75,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(revurderFra: LocalDate?): Beregni
         aktivitet = grunnlag.aktivitet,
         makssatsBekreftet = grunnlag.makssatsBekreftet,
         delAvTidligereUtbetaling = delAvTidligereUtbetaling,
+        skalFåDekketFaktiskeUtgifter = grunnlag.skalFåDekketFaktiskeUtgifter(),
     )
 
 fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(
@@ -96,6 +99,7 @@ fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(
                 utgift = utgift.utgift,
                 tilUtbetaling = skalUtbetales,
                 erFørRevurderFra = revurderFra != null && utgift.tom < revurderFra,
+                skalFåDekketFaktiskeUtgifter = utgift.skalFåDekketFaktiskeUtgifter,
             )
         }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
@@ -50,6 +50,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 1000,
                     tilUtbetaling = 1000,
                     erFørRevurderFra = false,
+                    skalFåDekketFaktiskeUtgifter = false,
                 ),
                 UtgiftBoutgifterMedAndelTilUtbetalingDto(
                     fom = LocalDate.of(2023, 1, 11),
@@ -57,6 +58,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 2000,
                     tilUtbetaling = 2000,
                     erFørRevurderFra = false,
+                    skalFåDekketFaktiskeUtgifter = false,
                 ),
             )
 
@@ -105,6 +107,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 4000,
                     tilUtbetaling = 4000,
                     erFørRevurderFra = false,
+                    skalFåDekketFaktiskeUtgifter = false,
                 ),
                 UtgiftBoutgifterMedAndelTilUtbetalingDto(
                     fom = LocalDate.of(2023, 1, 11),
@@ -112,6 +115,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 2000,
                     tilUtbetaling = 953,
                     erFørRevurderFra = false,
+                    skalFåDekketFaktiskeUtgifter = false,
                 ),
             )
 
@@ -160,6 +164,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 1000,
                     tilUtbetaling = 1000,
                     erFørRevurderFra = true,
+                    skalFåDekketFaktiskeUtgifter = false,
                 ),
                 UtgiftBoutgifterMedAndelTilUtbetalingDto(
                     fom = LocalDate.of(2023, 1, 11),
@@ -167,6 +172,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 2000,
                     tilUtbetaling = 2000,
                     erFørRevurderFra = false,
+                    skalFåDekketFaktiskeUtgifter = false,
                 ),
             )
 
@@ -213,6 +219,7 @@ class BeregningsresultatBoutgifterDtoTest {
                     utgift = 20_000,
                     tilUtbetaling = 20_000,
                     erFørRevurderFra = true,
+                    skalFåDekketFaktiskeUtgifter = true,
                 ),
             )
 

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -213,13 +213,15 @@
         "tom" : "2024-01-31",
         "utgift" : 3000,
         "tilUtbetaling" : 3000,
-        "erFørRevurderFra" : false
+        "erFørRevurderFra" : false,
+        "skalFåDekketFaktiskeUtgifter" : false
       } ],
       "sumUtgifter" : 3000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
       "makssatsBekreftet" : true,
-      "delAvTidligereUtbetaling" : false
+      "delAvTidligereUtbetaling" : false,
+      "skalFåDekketFaktiskeUtgifter" : false
     }, {
       "fom" : "2024-02-01",
       "tom" : "2024-02-29",
@@ -229,13 +231,15 @@
         "tom" : "2024-02-29",
         "utgift" : 4000,
         "tilUtbetaling" : 4000,
-        "erFørRevurderFra" : false
+        "erFørRevurderFra" : false,
+        "skalFåDekketFaktiskeUtgifter" : false
       } ],
       "sumUtgifter" : 4000,
       "målgruppe" : "NEDSATT_ARBEIDSEVNE",
       "aktivitet" : "TILTAK",
       "makssatsBekreftet" : true,
-      "delAvTidligereUtbetaling" : false
+      "delAvTidligereUtbetaling" : false,
+      "skalFåDekketFaktiskeUtgifter" : false
     } ]
   }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne skjule astriks for statsendring i utbetalingsplanen dersom faktiske utgifter. 

Slik ser det ut før endringen:
<img width="1132" height="876" alt="image" src="https://github.com/user-attachments/assets/e00e96f2-b9ed-4509-af8c-46861e32d337" />

