### PR TITLE
Håndterer at man kan ha like, overlappende målgrupper ved utleding av tidligste endring

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -1,7 +1,11 @@
 package no.nav.tilleggsstonader.sak.tidligsteendring
 
+import no.nav.tilleggsstonader.kontrakter.felles.Mergeable
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.førstePeriodeEtter
+import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
+import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
+import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
@@ -14,8 +18,12 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.GeneriskVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import org.springframework.stereotype.Service
@@ -147,6 +155,12 @@ data class TidligsteEndringIBehandlingUtleder(
                 )
             }
 
+    private val forenkletMålgruppeComparator =
+        Comparator
+            .comparing<ForenkletMålgruppe, LocalDate> { it.fom }
+            .thenComparing { o1, o2 -> o1.tom.compareTo(o2.tom) }
+            .thenComparing { o1, o2 -> o1.type.toString().compareTo(o2.type.toString()) }
+
     /**
      * Utleder tidligste endring i vilkår, aktiviteter, målgrupper og vedtaksperioder.
      * Gjør dette ved å sortere listene med perioder og sammenligne med periode i tidligere behandling
@@ -197,12 +211,43 @@ data class TidligsteEndringIBehandlingUtleder(
             erEndret = ::erMålgruppeEllerAktivitetEndret,
         )
 
-    private fun utledTidligsteEndringForMålgrupper(): LocalDate? =
+    private fun utledTidligsteEndringForMålgrupper() =
         utledEndringIPeriode(
-            perioderNå = vilkårsperioder.målgrupper.fjernSlettede().sortedWith(vilkårsperioderComparator),
-            perioderTidligere = vilkårsperioderTidligereBehandling.målgrupper.fjernSlettede().sortedWith(vilkårsperioderComparator),
-            erEndret = ::erMålgruppeEllerAktivitetEndret,
+            perioderNå = vilkårsperioder.målgrupper.mapTilForenkletMålgruppeOgMergeOverlappendeOgSammenhengende(),
+            perioderTidligere = vilkårsperioderTidligereBehandling.målgrupper.mapTilForenkletMålgruppeOgMergeOverlappendeOgSammenhengende(),
+            erEndret = ::erMålgruppeEndret,
         )
+
+    private fun List<VilkårperiodeMålgruppe>.mapTilForenkletMålgruppeOgMergeOverlappendeOgSammenhengende() =
+        fjernSlettede()
+            .map { tilForenkletMålgruppe(it) }
+            .sortedWith(forenkletMålgruppeComparator)
+            .groupBy { it.type }
+            .values
+            .map { it.mergeSammenhengende { m1, m2 -> m1.overlapperEllerPåfølgesAv(m2) } }
+            .flatten()
+            .sortedWith(forenkletMålgruppeComparator)
+
+    private fun tilForenkletMålgruppe(vilkårperiode: GeneriskVilkårperiode<*>): ForenkletMålgruppe {
+        // I tilfeller hvor bruker har AAP men søker om stønad utover hva som per nå er innvilget har saksbehandler tidligere (AAP ikke forlenget enda)
+        // har man tidligere hatt praksis å legge inn NEDSATT_ARBEIDSEVNE for å anta at AAP blir forlenget.
+        // Når saksbehandler i en revurdering ønsker å rydde opp i dette, så fører det til at vi utleder en for tidlige endringsdato.
+        // Dette er da et forsøk på å rydde opp i det, slik at vi ikke får en for tidlig endringsdato.
+        // Kan være en mulighet å generelt bruke MålgruppeType.faktiskMålgruppe() istedenfor.
+        val type =
+            if (vilkårperiode.type == MålgruppeType.NEDSATT_ARBEIDSEVNE) {
+                MålgruppeType.AAP
+            } else {
+                vilkårperiode.type as MålgruppeType
+            }
+
+        return ForenkletMålgruppe(
+            type = type,
+            fom = vilkårperiode.fom,
+            tom = vilkårperiode.tom,
+            resultat = vilkårperiode.resultat,
+        )
+    }
 
     private fun List<GeneriskVilkårperiode<*>>.fjernSlettede() = this.filterNot { it.status == Vilkårstatus.SLETTET }
 
@@ -232,6 +277,13 @@ data class TidligsteEndringIBehandlingUtleder(
             vilkårperiode.type != tidligereVilkårperiode.type ||
             vilkårperiode.faktaOgVurdering.fakta != tidligereVilkårperiode.faktaOgVurdering.fakta ||
             vilkårperiode.kildeId != tidligereVilkårperiode.kildeId
+
+    private fun erMålgruppeEndret(
+        vilkårperiode: ForenkletMålgruppe,
+        tidligereVilkårperiode: ForenkletMålgruppe,
+    ): Boolean =
+        vilkårperiode.resultat != tidligereVilkårperiode.resultat ||
+            vilkårperiode.type != tidligereVilkårperiode.type
 
     private fun erVedtaksperiodeEndret(
         vedtaksperiode: Vedtaksperiode,
@@ -290,3 +342,19 @@ data class PeriodeWrapper<T>(
     override val fom: LocalDate,
     override val tom: LocalDate,
 ) : Periode<LocalDate>
+
+data class ForenkletMålgruppe(
+    val type: MålgruppeType,
+    override val fom: LocalDate,
+    override val tom: LocalDate,
+    val resultat: ResultatVilkårperiode,
+) : Periode<LocalDate>,
+    Mergeable<LocalDate, ForenkletMålgruppe> {
+    override fun merge(other: ForenkletMålgruppe) =
+        ForenkletMålgruppe(
+            type = type,
+            fom = minOf(this.fom, other.fom),
+            tom = maxOf(this.tom, other.tom),
+            resultat = this.resultat,
+        )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -31,6 +31,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.GeneriskVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
@@ -220,13 +221,15 @@ class UtledTidligsteEndringStepDefinitions {
 
     private fun mapMålgrupper(dataTable: DataTable) =
         dataTable.mapRad { rad ->
+            val type: MålgruppeType = parseEnum(VilkårperiodeNøkler.TYPE, rad)
             målgruppe(
                 behandlingId = behandlingId,
                 fom = parseDato(DomenenøkkelFelles.FOM, rad),
                 tom = parseDato(DomenenøkkelFelles.TOM, rad),
-                faktaOgVurdering = faktaOgVurderingMålgruppe(type = parseEnum(VilkårperiodeNøkler.TYPE, rad)),
+                faktaOgVurdering = faktaOgVurderingMålgruppe(type = type),
                 resultat = parseEnum(TidligsteEndringFellesNøkler.RESULTAT, rad),
                 status = parseEnum(TidligsteEndringFellesNøkler.STATUS, rad),
+                begrunnelse = if (type == MålgruppeType.NEDSATT_ARBEIDSEVNE) "test" else null,
             )
         }
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/målgruppe_tidligste_endring.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/målgruppe_tidligste_endring.feature
@@ -102,7 +102,7 @@ Egenskap: Utled tidligste endring endring av målgruppe
 
       Når utleder tidligste endring
 
-      Så forvent følgende dato for tidligste endring: 14.03.2024
+      Så forvent følgende dato for tidligste endring: 01.04.2024
 
   Regel: Endring i fakta og vurderinger skal gi tidligste endring dato lik fom på periode
     Scenario: Endring i resultat
@@ -206,3 +206,19 @@ Egenskap: Utled tidligste endring endring av målgruppe
       Når utleder tidligste endring
 
       Så forvent følgende dato for tidligste endring: 12.03.2024
+
+    Scenario: Eksisterer AAP påfulgt av nedsatt arbeidsevne som erstattes av AAP
+      Gitt følgende målgrupper i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Type                | Resultat | Status |
+        | 01.03.2024 | 30.04.2024 | AAP                 | OPPFYLT  | NY     |
+        | 01.05.2024 | 30.06.2024 | NEDSATT_ARBEIDSEVNE | OPPFYLT  | NY     |
+
+      Gitt følgende målgrupper i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Type                | Resultat | Status  |
+        | 01.03.2024 | 30.04.2024 | AAP                 | OPPFYLT  | SLETTET |
+        | 01.05.2024 | 30.06.2024 | NEDSATT_ARBEIDSEVNE | OPPFYLT  | SLETTET |
+        | 01.03.2024 | 30.08.2024 | AAP                 | OPPFYLT  | NY      |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.07.2024


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Er en utfordring i dag ved at man tidligere har hatt praksis i å bruke målgruppetype NEDSATT_ARBEIDSEVNE i perioder hvor man antar at AAP forlenges.

Forsøker meg på et eksempel:

---

**Førstegangbehandling**
- Bruker søker om læremidler skoleår 24/25
- Henter fra register at har AAP `01.01.2024 - 31.01.2025`
- Saksbehandler antar at får utvidet AAP ut skoleåret

Saksbehandler har lagt inn målgrupper:
| Type                | Fom        | Tom        | Status |
|---------------------|------------|------------|--------|
| AAP                 | 01.01.2024 | 31.01.2025 | NY     |
| NEDSATT_ARBEIDSEVNE | 01.02.2025 | 30.06.2025 | NY     |

Innvilger `15.08.2024 - 30.06.2025`

---
**Revurdering**
- Bruker søker nå om læremidler skoleår 25/26
- Når vi nå henter fra register står det at bruker har AAP `01.01.2024 - 31.01.2026`
- Saksbehandler antar at får utvidet AAP ut skoleåret
  - Nå har saksbehandlere byttet praksis, og utvider heller AAP frem til når de forventer at bruker for utvidet istedenfor å legge inn NEDSATT_ARBEIDSEVNE

Saksbehandler endrer da målgrupper (trykker på `bruk`-knapp på AAP fra register og sletter perioder fra forrige behandling):

| Type                | Fom        | Tom        | Status  |
|---------------------|------------|------------|---------|
| AAP                 | 01.01.2024 | 31.01.2025 | SLETTET |
| NEDSATT_ARBEIDSEVNE | 01.02.2025 | 30.06.2025 | SLETTET |
| AAP                 | 01.01.2024 | 30.06.2025 | NY      |

Innvilger ny vedtaksperioder `15.08.2025 - 30.06.2026`

---

Her utleder vi da endringsdato i revurderingen til å bli `01.02.2025`, altså startdato på slettet NEDSATT_ARBEIDSEVNE-periode. Men i praksis så er dette bare en forlengelse av AAP, så man hadde ønsket seg at endringsdatoen ble `15.08.2025`, altså startdatoen på den nye vedtaksperioden.

---

Ved utleding av tidligste endring sammenlignes perioder fra tidligere vedtak med nåværende. Tar her og slår sammen målgrupper som har samme målgruppetype og overlapper/påfølger hverandre, samt mapper om NEDSATT_ARBEIDSEVNE til AAP, da faktisk målgruppe til AAP er NEDSATT_ARBEIDSEVNE... 