### PR TITLE
🏷️ Legg til `inneholderUtgifterOvernatting` i `BeregningsresultatForPeriodeDto`

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDto.kt
@@ -26,6 +26,7 @@ data class BeregningsresultatForPeriodeDto(
     val makssatsBekreftet: Boolean,
     val delAvTidligereUtbetaling: Boolean,
     val skalFåDekketFaktiskeUtgifter: Boolean,
+    val inneholderUtgifterOvernatting: Boolean,
 ) : Periode<LocalDate>
 
 data class UtgiftBoutgifterMedAndelTilUtbetalingDto(
@@ -76,6 +77,7 @@ fun BeregningsresultatForLøpendeMåned.tilDto(revurderFra: LocalDate?): Beregni
         makssatsBekreftet = grunnlag.makssatsBekreftet,
         delAvTidligereUtbetaling = delAvTidligereUtbetaling,
         skalFåDekketFaktiskeUtgifter = grunnlag.skalFåDekketFaktiskeUtgifter(),
+        inneholderUtgifterOvernatting = !grunnlag.utgifter[TypeBoutgift.UTGIFTER_OVERNATTING].isNullOrEmpty(),
     )
 
 fun BeregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/dto/BeregningsresultatBoutgifterDtoTest.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatFo
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -229,5 +230,132 @@ class BeregningsresultatBoutgifterDtoTest {
             beregningsresultatForLøpendeMåned.finnUtgifterMedAndelTilUtbetaling(revurderFra)
 
         assertEquals(forventetResultat, result)
+    }
+
+    @Nested
+    inner class BeregningsresultatForLøpendeMånedTilDto {
+        @Test
+        fun `skal vise om perioden inneholder utgift til overnatting`() {
+            val utgiftOvernatting =
+                listOf(
+                    lagUtgiftBeregningBoutgifter(
+                        fom = LocalDate.of(2023, 1, 1),
+                        tom = LocalDate.of(2023, 1, 5),
+                        utgift = 3000,
+                        skalFåDekketFaktiskeUtgifter = false,
+                    ),
+                )
+
+            val beregningsresultatForLøpendeMåned =
+                BeregningsresultatForLøpendeMåned(
+                    grunnlag =
+                        Beregningsgrunnlag(
+                            fom = LocalDate.of(2023, 1, 1),
+                            tom = LocalDate.of(2023, 1, 31),
+                            utgifter = mapOf(TypeBoutgift.UTGIFTER_OVERNATTING to utgiftOvernatting),
+                            makssats = 4953,
+                            makssatsBekreftet = true,
+                            målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                            aktivitet = AktivitetType.TILTAK,
+                        ),
+                    stønadsbeløp = 3000,
+                )
+
+            val forventetResultat =
+                BeregningsresultatForPeriodeDto(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 31),
+                    stønadsbeløp = 3000,
+                    utgifter =
+                        listOf(
+                            UtgiftBoutgifterMedAndelTilUtbetalingDto(
+                                fom = LocalDate.of(2023, 1, 1),
+                                tom = LocalDate.of(2023, 1, 5),
+                                utgift = 3000,
+                                tilUtbetaling = 3000,
+                                erFørRevurderFra = true,
+                                skalFåDekketFaktiskeUtgifter = false,
+                            ),
+                        ),
+                    sumUtgifter = 3000,
+                    målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                    aktivitet = AktivitetType.TILTAK,
+                    makssatsBekreftet = true,
+                    delAvTidligereUtbetaling = false,
+                    skalFåDekketFaktiskeUtgifter = false,
+                    inneholderUtgifterOvernatting = true,
+                )
+
+            val revurderFra = LocalDate.of(2023, 1, 10)
+
+            val result =
+                beregningsresultatForLøpendeMåned.tilDto(revurderFra)
+
+            assertEquals(forventetResultat, result)
+        }
+
+        @Test
+        fun `skal vise om perioden ikke inneholder utgift til overnatting`() {
+            val utgift =
+                listOf(
+                    lagUtgiftBeregningBoutgifter(
+                        fom = LocalDate.of(2023, 1, 1),
+                        tom = LocalDate.of(2023, 1, 31),
+                        utgift = 3000,
+                        skalFåDekketFaktiskeUtgifter = false,
+                    ),
+                )
+
+            val beregningsresultatForLøpendeMåned =
+                BeregningsresultatForLøpendeMåned(
+                    grunnlag =
+                        Beregningsgrunnlag(
+                            fom = LocalDate.of(2023, 1, 1),
+                            tom = LocalDate.of(2023, 1, 31),
+                            utgifter =
+                                mapOf(
+                                    TypeBoutgift.LØPENDE_UTGIFTER_EN_BOLIG to utgift,
+                                    TypeBoutgift.UTGIFTER_OVERNATTING to emptyList(),
+                                ),
+                            makssats = 4953,
+                            makssatsBekreftet = true,
+                            målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                            aktivitet = AktivitetType.TILTAK,
+                        ),
+                    stønadsbeløp = 3000,
+                )
+
+            val forventetResultat =
+                BeregningsresultatForPeriodeDto(
+                    fom = LocalDate.of(2023, 1, 1),
+                    tom = LocalDate.of(2023, 1, 31),
+                    stønadsbeløp = 3000,
+                    utgifter =
+                        listOf(
+                            UtgiftBoutgifterMedAndelTilUtbetalingDto(
+                                fom = LocalDate.of(2023, 1, 1),
+                                tom = LocalDate.of(2023, 1, 31),
+                                utgift = 3000,
+                                tilUtbetaling = 3000,
+                                erFørRevurderFra = false,
+                                skalFåDekketFaktiskeUtgifter = false,
+                            ),
+                        ),
+                    sumUtgifter = 3000,
+                    målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                    aktivitet = AktivitetType.TILTAK,
+                    makssatsBekreftet = true,
+                    delAvTidligereUtbetaling = false,
+                    skalFåDekketFaktiskeUtgifter = false,
+                    inneholderUtgifterOvernatting = false,
+                )
+
+            val revurderFra = LocalDate.of(2023, 1, 10)
+
+            val result =
+                beregningsresultatForLøpendeMåned.tilDto(revurderFra)
+
+            assertEquals(forventetResultat, result)
+        }
     }
 }

--- a/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
+++ b/src/test/resources/interntVedtak/BOUTGIFTER/internt_vedtak.json
@@ -221,7 +221,8 @@
       "aktivitet" : "TILTAK",
       "makssatsBekreftet" : true,
       "delAvTidligereUtbetaling" : false,
-      "skalFåDekketFaktiskeUtgifter" : false
+      "skalFåDekketFaktiskeUtgifter" : false,
+      "inneholderUtgifterOvernatting" : true
     }, {
       "fom" : "2024-02-01",
       "tom" : "2024-02-29",
@@ -239,7 +240,8 @@
       "aktivitet" : "TILTAK",
       "makssatsBekreftet" : true,
       "delAvTidligereUtbetaling" : false,
-      "skalFåDekketFaktiskeUtgifter" : false
+      "skalFåDekketFaktiskeUtgifter" : false,
+      "inneholderUtgifterOvernatting" : true
     } ]
   }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Endring for å kunne vise rett utbetalingplan for vedtak med både midlertidig og løpende utgifter. 

Etter vi la inn støtte for både midlertidig og løpende utgift i samme vedtak fikk alle periodene i utbetalingsplanen utgiftsperioden til utgiften. Tidligere holdt det å sjekke på hele behandlingen om den inneholdt en midlertidig utgift, nå må vi gjøre det per beregningsperiode. 

Frontend: https://github.com/navikt/tilleggsstonader-sak-frontend/compare/bug-perioder-boutgifter?expand=1