### PR TITLE
Tar i bruk spring actuator sine kubernetes probes ved deploy på kubernetes

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -12,11 +12,11 @@ spec:
   ingresses:
     - https://tilleggsstonader-sak.intern.dev.nav.no
   liveness:
-    path: /internal/status/isAlive
+    path: /internal/health/liveness
     initialDelay: 30
     failureThreshold: 10
   readiness:
-    path: /internal/status/isAlive
+    path: /internal/health/readiness
     initialDelay: 30
     failureThreshold: 10
   prometheus:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -12,11 +12,11 @@ spec:
   ingresses:
     - https://tilleggsstonader-sak.intern.nav.no
   liveness:
-    path: /internal/status/isAlive
+    path: /internal/health/liveness
     initialDelay: 30
     failureThreshold: 10
   readiness:
-    path: /internal/status/isAlive
+    path: /internal/health/readiness
     initialDelay: 30
     failureThreshold: 10
   prometheus:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,8 +68,6 @@ management:
   endpoints.web:
     exposure.include: info, health, metrics, prometheus
     base-path: "/internal"
-    path-mapping:
-      info: "status/isAlive"
   prometheus.metrics.export.enabled: true
 
 prosessering:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,7 +60,11 @@ spring:
 
 
 management:
-  endpoint.health.show-details: always
+  endpoint:
+    health:
+      show-details: always
+      probes:
+        enabled: true
   endpoints.web:
     exposure.include: info, health, metrics, prometheus
     base-path: "/internal"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Kom over at vi bare bruker spring actuator sitt info-endepunkt for readiness og liveness. Spring actuator tilbyr liveness og readiness-probes. Tar i bruk disse her.

Info om liveness og readiness: https://spring.io/blog/2020/03/25/liveness-and-readiness-probes-with-spring-boot#liveness-and-readiness-in-kubernetes

Vil i praksis ikke gi oss veldig mye mer med ut-av-boksen config, men gir bedre støtte for graceful-shutdown (se https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes-lifecycle), som vi har konfigurert med `server.shutdown: graceful` i `application.yml`

Gir oss og mer fleksibilitet om vi vil sette opp mer logikk knyttet til når vi anser appen klar til å ta i mot trafikk ved oppstart på kubernetes.