### PR TITLE
Håndter overlappende målgrupper tidligsteendring

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -226,26 +226,13 @@ data class TidligsteEndringIBehandlingUtleder(
             .flatten()
             .sortedWith(forenkletMålgruppeComparator)
 
-    private fun tilForenkletMålgruppe(vilkårperiode: GeneriskVilkårperiode<*>): ForenkletMålgruppe {
-        // I tilfeller hvor bruker har AAP men søker om stønad utover hva som per nå er innvilget har saksbehandler tidligere (AAP ikke forlenget enda)
-        // har man tidligere hatt praksis å legge inn NEDSATT_ARBEIDSEVNE for å anta at AAP blir forlenget.
-        // Når saksbehandler i en revurdering ønsker å rydde opp i dette, så fører det til at vi utleder en for tidlige endringsdato.
-        // Dette er da et forsøk på å rydde opp i det, slik at vi ikke får en for tidlig endringsdato.
-        // Kan være en mulighet å generelt bruke MålgruppeType.faktiskMålgruppe() istedenfor.
-        val type =
-            if (vilkårperiode.type == MålgruppeType.NEDSATT_ARBEIDSEVNE) {
-                MålgruppeType.AAP
-            } else {
-                vilkårperiode.type as MålgruppeType
-            }
-
-        return ForenkletMålgruppe(
-            type = type,
+    private fun tilForenkletMålgruppe(vilkårperiode: GeneriskVilkårperiode<*>): ForenkletMålgruppe =
+        ForenkletMålgruppe(
+            type = vilkårperiode.type as MålgruppeType,
             fom = vilkårperiode.fom,
             tom = vilkårperiode.tom,
             resultat = vilkårperiode.resultat,
         )
-    }
 
     private fun List<GeneriskVilkårperiode<*>>.fjernSlettede() = this.filterNot { it.status == Vilkårstatus.SLETTET }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -1,7 +1,11 @@
 package no.nav.tilleggsstonader.sak.tidligsteendring
 
+import no.nav.tilleggsstonader.kontrakter.felles.Mergeable
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.førstePeriodeEtter
+import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
+import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
+import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
@@ -14,8 +18,12 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.GeneriskVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import org.springframework.stereotype.Service
@@ -147,6 +155,12 @@ data class TidligsteEndringIBehandlingUtleder(
                 )
             }
 
+    private val forenkletMålgruppeComparator =
+        Comparator
+            .comparing<ForenkletMålgruppe, LocalDate> { it.fom }
+            .thenComparing { o1, o2 -> o1.tom.compareTo(o2.tom) }
+            .thenComparing { o1, o2 -> o1.type.toString().compareTo(o2.type.toString()) }
+
     /**
      * Utleder tidligste endring i vilkår, aktiviteter, målgrupper og vedtaksperioder.
      * Gjør dette ved å sortere listene med perioder og sammenligne med periode i tidligere behandling
@@ -197,12 +211,43 @@ data class TidligsteEndringIBehandlingUtleder(
             erEndret = ::erMålgruppeEllerAktivitetEndret,
         )
 
-    private fun utledTidligsteEndringForMålgrupper(): LocalDate? =
+    private fun utledTidligsteEndringForMålgrupper() =
         utledEndringIPeriode(
-            perioderNå = vilkårsperioder.målgrupper.fjernSlettede().sortedWith(vilkårsperioderComparator),
-            perioderTidligere = vilkårsperioderTidligereBehandling.målgrupper.fjernSlettede().sortedWith(vilkårsperioderComparator),
-            erEndret = ::erMålgruppeEllerAktivitetEndret,
+            perioderNå = vilkårsperioder.målgrupper.mapTilForenkletMålgruppeOgMergeOverlappendeOgSammenhengende(),
+            perioderTidligere = vilkårsperioderTidligereBehandling.målgrupper.mapTilForenkletMålgruppeOgMergeOverlappendeOgSammenhengende(),
+            erEndret = ::erMålgruppeEndret,
         )
+
+    private fun List<VilkårperiodeMålgruppe>.mapTilForenkletMålgruppeOgMergeOverlappendeOgSammenhengende() =
+        fjernSlettede()
+            .map { tilForenkletMålgruppe(it) }
+            .sortedWith(forenkletMålgruppeComparator)
+            .groupBy { it.type }
+            .values
+            .map { it.mergeSammenhengende { m1, m2 -> m1.overlapperEllerPåfølgesAv(m2) } }
+            .flatten()
+            .sortedWith(forenkletMålgruppeComparator)
+
+    private fun tilForenkletMålgruppe(vilkårperiode: GeneriskVilkårperiode<*>): ForenkletMålgruppe {
+        // I tilfeller hvor bruker har AAP men søker om stønad utover hva som per nå er innvilget har saksbehandler tidligere (AAP ikke forlenget enda)
+        // har man tidligere hatt praksis å legge inn NEDSATT_ARBEIDSEVNE for å anta at AAP blir forlenget.
+        // Når saksbehandler i en revurdering ønsker å rydde opp i dette, så fører det til at vi utleder en for tidlige endringsdato.
+        // Dette er da et forsøk på å rydde opp i det, slik at vi ikke får en for tidlig endringsdato.
+        // Kan være en mulighet å generelt bruke MålgruppeType.faktiskMålgruppe() istedenfor.
+        val type =
+            if (vilkårperiode.type == MålgruppeType.NEDSATT_ARBEIDSEVNE) {
+                MålgruppeType.AAP
+            } else {
+                vilkårperiode.type as MålgruppeType
+            }
+
+        return ForenkletMålgruppe(
+            type = type,
+            fom = vilkårperiode.fom,
+            tom = vilkårperiode.tom,
+            resultat = vilkårperiode.resultat,
+        )
+    }
 
     private fun List<GeneriskVilkårperiode<*>>.fjernSlettede() = this.filterNot { it.status == Vilkårstatus.SLETTET }
 
@@ -232,6 +277,13 @@ data class TidligsteEndringIBehandlingUtleder(
             vilkårperiode.type != tidligereVilkårperiode.type ||
             vilkårperiode.faktaOgVurdering.fakta != tidligereVilkårperiode.faktaOgVurdering.fakta ||
             vilkårperiode.kildeId != tidligereVilkårperiode.kildeId
+
+    private fun erMålgruppeEndret(
+        vilkårperiode: ForenkletMålgruppe,
+        tidligereVilkårperiode: ForenkletMålgruppe,
+    ): Boolean =
+        vilkårperiode.resultat != tidligereVilkårperiode.resultat ||
+            vilkårperiode.type != tidligereVilkårperiode.type
 
     private fun erVedtaksperiodeEndret(
         vedtaksperiode: Vedtaksperiode,
@@ -290,3 +342,19 @@ data class PeriodeWrapper<T>(
     override val fom: LocalDate,
     override val tom: LocalDate,
 ) : Periode<LocalDate>
+
+data class ForenkletMålgruppe(
+    val type: MålgruppeType,
+    override val fom: LocalDate,
+    override val tom: LocalDate,
+    val resultat: ResultatVilkårperiode,
+) : Periode<LocalDate>,
+    Mergeable<LocalDate, ForenkletMålgruppe> {
+    override fun merge(other: ForenkletMålgruppe) =
+        ForenkletMålgruppe(
+            type = type,
+            fom = minOf(this.fom, other.fom),
+            tom = maxOf(this.tom, other.tom),
+            resultat = this.resultat,
+        )
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.førstePeriodeEtter
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
-import no.nav.tilleggsstonader.kontrakter.felles.påfølgesAv
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
@@ -18,7 +17,6 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.GeneriskVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -31,6 +31,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.GeneriskVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
@@ -220,13 +221,15 @@ class UtledTidligsteEndringStepDefinitions {
 
     private fun mapMålgrupper(dataTable: DataTable) =
         dataTable.mapRad { rad ->
+            val type: MålgruppeType = parseEnum(VilkårperiodeNøkler.TYPE, rad)
             målgruppe(
                 behandlingId = behandlingId,
                 fom = parseDato(DomenenøkkelFelles.FOM, rad),
                 tom = parseDato(DomenenøkkelFelles.TOM, rad),
-                faktaOgVurdering = faktaOgVurderingMålgruppe(type = parseEnum(VilkårperiodeNøkler.TYPE, rad)),
+                faktaOgVurdering = faktaOgVurderingMålgruppe(type = type),
                 resultat = parseEnum(TidligsteEndringFellesNøkler.RESULTAT, rad),
                 status = parseEnum(TidligsteEndringFellesNøkler.STATUS, rad),
+                begrunnelse = if (type == MålgruppeType.NEDSATT_ARBEIDSEVNE) "test" else null,
             )
         }
 

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/målgruppe_tidligste_endring.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/målgruppe_tidligste_endring.feature
@@ -102,7 +102,7 @@ Egenskap: Utled tidligste endring endring av målgruppe
 
       Når utleder tidligste endring
 
-      Så forvent følgende dato for tidligste endring: 14.03.2024
+      Så forvent følgende dato for tidligste endring: 01.04.2024
 
   Regel: Endring i fakta og vurderinger skal gi tidligste endring dato lik fom på periode
     Scenario: Endring i resultat
@@ -206,3 +206,19 @@ Egenskap: Utled tidligste endring endring av målgruppe
       Når utleder tidligste endring
 
       Så forvent følgende dato for tidligste endring: 12.03.2024
+
+    Scenario: Eksisterer AAP påfulgt av nedsatt arbeidsevne som erstattes av AAP
+      Gitt følgende målgrupper i forrige behandling - utledTidligsteEndring
+        | Fom        | Tom        | Type                | Resultat | Status |
+        | 01.03.2024 | 30.04.2024 | AAP                 | OPPFYLT  | NY     |
+        | 01.05.2024 | 30.06.2024 | NEDSATT_ARBEIDSEVNE | OPPFYLT  | NY     |
+
+      Gitt følgende målgrupper i revurdering - utledTidligsteEndring
+        | Fom        | Tom        | Type                | Resultat | Status  |
+        | 01.03.2024 | 30.04.2024 | AAP                 | OPPFYLT  | SLETTET |
+        | 01.05.2024 | 30.06.2024 | NEDSATT_ARBEIDSEVNE | OPPFYLT  | SLETTET |
+        | 01.03.2024 | 30.08.2024 | AAP                 | OPPFYLT  | NY      |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.07.2024

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/målgruppe_tidligste_endring.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/målgruppe_tidligste_endring.feature
@@ -207,18 +207,19 @@ Egenskap: Utled tidligste endring endring av målgruppe
 
       Så forvent følgende dato for tidligste endring: 12.03.2024
 
-    Scenario: Eksisterer AAP påfulgt av nedsatt arbeidsevne som erstattes av AAP
+    Scenario: Flere sammenhengende og overlappende AAP-perioder lagt inn hver for seg, gjøres om til en sammenhengende i revurdering
       Gitt følgende målgrupper i forrige behandling - utledTidligsteEndring
-        | Fom        | Tom        | Type                | Resultat | Status |
-        | 01.03.2024 | 30.04.2024 | AAP                 | OPPFYLT  | NY     |
-        | 01.05.2024 | 30.06.2024 | NEDSATT_ARBEIDSEVNE | OPPFYLT  | NY     |
+        | Fom        | Tom        | Type | Resultat | Status |
+        | 01.03.2024 | 30.04.2024 | AAP  | OPPFYLT  | NY     |
+        | 01.05.2024 | 30.06.2024 | AAP  | OPPFYLT  | NY     |
+        | 01.06.2024 | 30.07.2024 | AAP  | OPPFYLT  | NY     |
 
       Gitt følgende målgrupper i revurdering - utledTidligsteEndring
-        | Fom        | Tom        | Type                | Resultat | Status  |
-        | 01.03.2024 | 30.04.2024 | AAP                 | OPPFYLT  | SLETTET |
-        | 01.05.2024 | 30.06.2024 | NEDSATT_ARBEIDSEVNE | OPPFYLT  | SLETTET |
-        | 01.03.2024 | 30.08.2024 | AAP                 | OPPFYLT  | NY      |
+        | Fom        | Tom        | Type | Resultat | Status  |
+        | 01.03.2024 | 30.04.2024 | AAP  | OPPFYLT  | SLETTET |
+        | 01.05.2024 | 30.06.2024 | AAP  | OPPFYLT  | SLETTET |
+        | 01.03.2024 | 30.07.2024 | AAP  | OPPFYLT  | NY      |
 
       Når utleder tidligste endring
 
-      Så forvent følgende dato for tidligste endring: 01.07.2024
+      Så forvent ingen endring


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Håndterer tilfeller ved utleding av tidligste endring hvor man i forrige behandling eksempelvis har flere AAP-perioder som overlapper og/eller etterfølger hverandre, og i gjør disse om til en sammenhengende periode. 

Eks man har AAP (eller annen målgrupper av samme type) i forrige behandling 
`01.01.2025 - 31.03.2025`
`01.02.2025 - 31.05.2025`
`01.06.2025 - 30.06.2025`

og i revurdering slår disse sammen til
`01.01.2025 - 31.08.2025`

..så skal tidligste endring bli `01.07.2025`, og ikke `01.04.2025` som det ville blitt før denne endringen.