### PR TITLE
✨ Hent Tiltakspenger og Dagpenger fra register for daglig reise

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/ytelse/YtelserUtil.kt
@@ -9,6 +9,13 @@ object YtelserUtil {
             Stønadstype.BARNETILSYN,
             Stønadstype.LÆREMIDLER,
             Stønadstype.BOUTGIFTER,
+            ->
+                listOf(
+                    TypeYtelsePeriode.AAP,
+                    TypeYtelsePeriode.ENSLIG_FORSØRGER,
+                    TypeYtelsePeriode.OMSTILLINGSSTØNAD,
+                )
+
             Stønadstype.DAGLIG_REISE_TSO,
             Stønadstype.DAGLIG_REISE_TSR,
             ->
@@ -16,6 +23,8 @@ object YtelserUtil {
                     TypeYtelsePeriode.AAP,
                     TypeYtelsePeriode.ENSLIG_FORSØRGER,
                     TypeYtelsePeriode.OMSTILLINGSSTØNAD,
+                    TypeYtelsePeriode.TILTAKSPENGER,
+                    TypeYtelsePeriode.DAGPENGER,
                 )
 
             else -> error("Finner ikke relevante ytelser for stønadstype $type")


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne bruke Tiltakspenger og Dagpenger fra register-ytelser så saksbehandler slipper å kopiere dette maunelt. Henger sammen med: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/866