### PR TITLE
Sjekker for TSO og TSR og skipper validering

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/VilkårPeriodeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/VilkårPeriodeValidering.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.evalutation
 
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.førsteOverlappendePeriode
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeil
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
@@ -28,6 +29,12 @@ object VilkårPeriodeValidering {
         vilkårliste: List<Datoperiode>,
     ) {
         val overlappendePeriode = vilkårliste.førsteOverlappendePeriode()
+        // Hopp over validering da det må være lov, dersom man f.eks først skal reise med tog så buss.
+        if (vilkårType.gjelderStønader.contains(Stønadstype.DAGLIG_REISE_TSO) ||
+            vilkårType.gjelderStønader.contains(Stønadstype.DAGLIG_REISE_TSR)
+        ) {
+            return
+        }
         if (overlappendePeriode != null) {
             brukerfeil(
                 "Det er ikke gyldig med overlappende perioder for ${vilkårType.tilFeilmeldingTekst()}. " +


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fjerner validering av overlappende perioder for daglig-reise-TSO og -TSR da det skal være lov å legge inn overlappende perioder for offentlig transport.
Denne må kanskje endres på sikt for å sjekke at man ikke overlapper offentlig transport og taxi reiser - men tenker at dette er godt nok for nå.