### PR TITLE
Oppdater cucumber tester daglig reise

### DIFF
--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/CucumberParsingUtils.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/CucumberParsingUtils.kt
@@ -1,0 +1,82 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning
+
+import io.cucumber.datatable.DataTable
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.cucumber.DomenenøkkelFelles
+import no.nav.tilleggsstonader.sak.cucumber.mapRad
+import no.nav.tilleggsstonader.sak.cucumber.parseDato
+import no.nav.tilleggsstonader.sak.cucumber.parseInt
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsgrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.tilDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.DagligReiseRegelTestUtil.oppfylteDelvilkårDagligReiseOffentligTransport
+import java.time.LocalDate
+
+fun mapBeregningsresultatForPeriode(dataTable: DataTable) =
+    dataTable.mapRad { rad ->
+        BeregningsresultatForPeriode(
+            grunnlag =
+                Beregningsgrunnlag(
+                    fom = parseDato(DomenenøkkelFelles.FOM, rad),
+                    tom = parseDato(DomenenøkkelFelles.TOM, rad),
+                    prisEnkeltbillett = 0,
+                    pris30dagersbillett = 0,
+                    antallReisedagerPerUke = 0,
+                    antallReisedager = 0,
+                    vedtaksperioder = emptyList(),
+                ),
+            beløp = parseInt(DomenenøkkelFelles.BELØP, rad),
+        )
+    }
+
+fun dummyBehandling(
+    behandlingId: BehandlingId,
+    steg: StegType = StegType.BEREGNE_YTELSE,
+    revurderFra: LocalDate? = null,
+): Saksbehandling =
+    saksbehandling(
+        id = behandlingId,
+        steg = steg,
+        fagsak = fagsak(stønadstype = Stønadstype.DAGLIG_REISE_TSO),
+        forrigeIverksatteBehandlingId = null,
+        revurderFra = revurderFra,
+        type = BehandlingType.FØRSTEGANGSBEHANDLING,
+    )
+
+fun mapTilVilkår(
+    rad: Map<String, String>,
+    behandlingId: BehandlingId,
+): OpprettVilkårDto =
+    OpprettVilkårDto(
+        vilkårType = VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT,
+        barnId = null,
+        behandlingId = behandlingId,
+        delvilkårsett = oppfylteDelvilkårDagligReiseOffentligTransport().map { it.tilDto() },
+        fom = parseDato(DomenenøkkelFelles.FOM, rad),
+        tom = parseDato(DomenenøkkelFelles.TOM, rad),
+        utgift = null,
+        erFremtidigUtgift = false,
+        offentligTransport =
+            OffentligTransport(
+                reisedagerPerUke =
+                    parseInt(
+                        DomenenøkkelOffentligtransport.ANTALL_REISEDAGER_PER_UKE,
+                        rad,
+                    ),
+                prisEnkelbillett = parseInt(DomenenøkkelOffentligtransport.PRIS_ENKELTBILLETT, rad),
+                prisTrettidagersbillett =
+                    parseInt(
+                        DomenenøkkelOffentligtransport.PRIS_TRETTI_DAGERS_BILLETT,
+                        rad,
+                    ),
+            ),
+    )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/OffentligTransportBeregningStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/OffentligTransportBeregningStepDefinitions.kt
@@ -4,21 +4,17 @@ import io.cucumber.datatable.DataTable
 import io.cucumber.java.no.Gitt
 import io.cucumber.java.no.Når
 import io.cucumber.java.no.Så
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.cucumber.Domenenøkkel
-import no.nav.tilleggsstonader.sak.cucumber.DomenenøkkelFelles
 import no.nav.tilleggsstonader.sak.cucumber.mapRad
-import no.nav.tilleggsstonader.sak.cucumber.parseDato
-import no.nav.tilleggsstonader.sak.cucumber.parseInt
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.VilkårRepositoryFake
-import no.nav.tilleggsstonader.sak.interntVedtak.Testdata.behandlingId
 import no.nav.tilleggsstonader.sak.vedtak.cucumberUtils.mapVedtaksperioder
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.UtgiftOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import org.assertj.core.api.Assertions.assertThat
@@ -36,10 +32,11 @@ class OffentligTransportBeregningStepDefinitions {
         )
     val offentligTransportBeregningService = OffentligTransportBeregningService(vilkårService)
 
-    var utgiftOffentligTransport: UtgiftOffentligTransport? = null
     var beregningsResultat: Beregningsresultat? = null
     var forventetBeregningsresultat: Beregningsresultat? = null
     var vedtaksperioder: List<Vedtaksperiode> = emptyList()
+
+    val behandlingId = BehandlingId.random()
 
     @Gitt("følgende vedtaksperioder for daglig reise offentlig transport")
     fun `følgende vedtaksperioder`(dataTable: DataTable) {
@@ -47,34 +44,17 @@ class OffentligTransportBeregningStepDefinitions {
     }
 
     @Gitt("følgende beregningsinput for offentlig transport")
-    fun `følgende beregnins input offentlig transport`(dataTable: DataTable) {
-        val reiseInformasjon =
-            dataTable.mapRad { rad ->
-                UtgiftOffentligTransport(
-                    fom = parseDato(DomenenøkkelFelles.FOM, rad),
-                    tom = parseDato(DomenenøkkelFelles.TOM, rad),
-                    antallReisedagerPerUke =
-                        parseInt(
-                            DomenenøkkelOffentligtransport.ANTALL_REISEDAGER_PER_UKE,
-                            rad,
-                        ),
-                    prisEnkelbillett = parseInt(DomenenøkkelOffentligtransport.PRIS_ENKELTBILLETT, rad),
-                    pris30dagersbillett =
-                        parseInt(
-                            DomenenøkkelOffentligtransport.PRIS_TRETTI_DAGERS_BILLETT,
-                            rad,
-                        ),
-                )
-            }
-
-        utgiftOffentligTransport =
-            UtgiftOffentligTransport(
-                fom = reiseInformasjon.first().fom,
-                tom = reiseInformasjon.first().tom,
-                antallReisedagerPerUke = reiseInformasjon.sumOf { it.antallReisedagerPerUke },
-                prisEnkelbillett = reiseInformasjon.sumOf { it.prisEnkelbillett },
-                pris30dagersbillett = reiseInformasjon.sumOf { it.pris30dagersbillett },
+    fun `følgende beregnins input offentlig transport`(utgiftData: DataTable) {
+        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
+            dummyBehandling(
+                behandlingId = behandlingId,
+                steg = StegType.VILKÅR,
             )
+
+        utgiftData.mapRad { rad ->
+            val nyttVilkår = mapTilVilkår(rad, behandlingId)
+            vilkårService.opprettNyttVilkår(opprettVilkårDto = nyttVilkår)
+        }
     }
 
     @Når("beregner for daglig reise offentlig transport")
@@ -86,34 +66,23 @@ class OffentligTransportBeregningStepDefinitions {
             )
     }
 
-    @Så("forventer vi følgende beregningsrsultat for daglig resie offentlig transport")
-    fun `forventer vi følgende beregningsrsultat for daglig resie offentlig transport`(dataTable: DataTable) {
-        val forventetBeregninsresultat =
-            Beregningsresultat(
-                reiser =
-                    listOf(
-                        BeregningsresultatForReise(
-                            perioder = mapBeregningsresultatForPeriode(dataTable),
-                        ),
-                    ),
+    @Så("forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr={}")
+    fun `forventer vi følgende beregningsrsultat for daglig resie offentlig transport`(
+        reiserNummer: Int,
+        dataTable: DataTable,
+    ) {
+        val forventetBeregningsresultatForReise =
+            BeregningsresultatForReise(
+                perioder = mapBeregningsresultatForPeriode(dataTable),
             )
+        val beregningsreulsresultatForReise =
+            beregningsResultat!!.reiser[reiserNummer - 1]
 
-        beregningsResultat!!.reiser.forEachIndexed { index, reise ->
-            reise.perioder.forEachIndexed { index2, periode ->
-                assertThat(periode.grunnlag.fom).isEqualTo(
-                    forventetBeregninsresultat.reiser[index]
-                        .perioder[index2]
-                        .grunnlag.fom,
-                )
-                assertThat(periode.grunnlag.tom).isEqualTo(
-                    forventetBeregninsresultat.reiser[index]
-                        .perioder[index2]
-                        .grunnlag.tom,
-                )
-                assertThat(periode.beløp).isEqualTo(
-                    forventetBeregninsresultat.reiser[index].perioder[index2].beløp,
-                )
-            }
+        assertThat(beregningsreulsresultatForReise.perioder.size).isEqualTo(forventetBeregningsresultatForReise.perioder.size)
+        forventetBeregningsresultatForReise.perioder.forEachIndexed { index, periode ->
+            assertThat(beregningsreulsresultatForReise.perioder[index].grunnlag.fom).isEqualTo(periode.grunnlag.fom)
+            assertThat(beregningsreulsresultatForReise.perioder[index].grunnlag.tom).isEqualTo(periode.grunnlag.tom)
+            assertThat(beregningsreulsresultatForReise.perioder[index].beløp).isEqualTo(periode.beløp)
         }
     }
 }
@@ -127,20 +96,3 @@ enum class DomenenøkkelOffentligtransport(
         "Pris tretti-dagersbillett",
     ),
 }
-
-private fun mapBeregningsresultatForPeriode(dataTable: DataTable) =
-    dataTable.mapRad { rad ->
-        BeregningsresultatForPeriode(
-            grunnlag =
-                Beregningsgrunnlag(
-                    fom = parseDato(DomenenøkkelFelles.FOM, rad),
-                    tom = parseDato(DomenenøkkelFelles.TOM, rad),
-                    prisEnkeltbillett = 0,
-                    pris30dagersbillett = 0,
-                    antallReisedagerPerUke = 0,
-                    antallReisedager = 0,
-                    vedtaksperioder = emptyList(),
-                ),
-            beløp = parseInt(DomenenøkkelFelles.BELØP, rad),
-        )
-    }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.OffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -21,6 +22,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.Boutgi
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.BoutgifterRegelTestUtil.oppfylteDelvilkårLøpendeUtgifterEnBolig
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.BoutgifterRegelTestUtil.oppfylteDelvilkårLøpendeUtgifterToBoliger
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.BoutgifterRegelTestUtil.oppfylteDelvilkårUtgifterOvernatting
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.DagligReiseRegelTestUtil.oppfylteDelvilkårDagligReiseOffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.ikkeOppfylteDelvilkårPassBarnDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarn
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.vilkår.PassBarnRegelTestUtil.oppfylteDelvilkårPassBarnDto
@@ -309,6 +311,37 @@ internal class OppdaterVilkårTest {
                         .isEqualTo(Vilkårsresultat.OPPFYLT)
                 }
             }
+        }
+    }
+
+    @Nested
+    inner class DagligReise {
+        val opprettVilkårDto =
+            OpprettVilkårDto(
+                vilkårType = VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT,
+                behandlingId = behandlingId,
+                delvilkårsett = oppfylteDelvilkårDagligReiseOffentligTransport().map { it.tilDto() },
+                fom = LocalDate.now(),
+                tom = LocalDate.now().plusDays(1),
+                utgift = null,
+                erFremtidigUtgift = false,
+                offentligTransport =
+                    OffentligTransport(
+                        reisedagerPerUke = 5,
+                        prisEnkelbillett = 44,
+                        prisTrettidagersbillett = 780,
+                    ),
+            )
+        val vilkårDagligReise =
+            vilkår(
+                behandlingId = behandlingId,
+                type = VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT,
+                delvilkår = oppfylteDelvilkårDagligReiseOffentligTransport(),
+            )
+
+        @Test
+        fun `skal skal ikke kaste feil på et gyldig vilkår`() {
+            validerVilkårOgBeregnResultat(vilkårDagligReise, opprettVilkårDto)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/DagligReiseRegelTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/regler/vilkår/DagligReiseRegelTestUtil.kt
@@ -13,10 +13,13 @@ object DagligReiseRegelTestUtil {
                 Vurdering(
                     regelId = RegelId.AVSTAND_OVER_SEKS_KM,
                     svar = SvarId.JA,
+                ),
+                Vurdering(
+                    regelId = RegelId.KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT,
+                    svar = SvarId.JA,
                     begrunnelse = "En begrunnelse på delvilkåret",
                 ),
             ),
-            delvilkår(Vurdering(regelId = RegelId.KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT, svar = SvarId.JA)),
         )
 
     private fun delvilkår(vararg vurderinger: Vurdering) =

--- a/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/OffentligTransport.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/OffentligTransport.feature
@@ -14,7 +14,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
 
@@ -29,7 +29,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
 
@@ -44,7 +44,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 440   |
 
@@ -59,7 +59,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
       | 31.01.2025 | 01.03.2025 | 778   |
@@ -78,7 +78,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.03.2025 | 30.03.2025 | 352   |
 
@@ -94,7 +94,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
       | 31.01.2025 | 01.03.2025 | 778   |
@@ -112,7 +112,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
       | 31.01.2025 | 01.03.2025 | 0     |
@@ -133,12 +133,19 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
-      | 01.01.2025 | 30.01.2025 | 4147  |
+      | 01.01.2025 | 30.01.2025 | 778   |
       | 31.01.2025 | 01.03.2025 | 0     |
       | 02.03.2025 | 31.03.2025 | 0     |
-      | 01.04.2025 | 30.04.2025 | 4147  |
+      | 01.04.2025 | 30.04.2025 | 778   |
+
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=2
+      | Fom        | Tom        | Beløp |
+      | 01.01.2025 | 30.01.2025 | 3369  |
+      | 31.01.2025 | 01.03.2025 | 0     |
+      | 02.03.2025 | 31.03.2025 | 0     |
+      | 01.04.2025 | 30.04.2025 | 3369  |
 
   # Lønner seg med mnd kort selv om det er opphold (f.eks tre dager på slutten første og 10 dager på starten av siste)
   Scenario: Månedskort lønner seg selv om vedtaksperiodene har opphold og mer enn rene 30 dagersperioder
@@ -153,7 +160,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
       | 31.01.2025 | 01.03.2025 | 778   |
@@ -172,7 +179,7 @@ Egenskap: Beregning av offentlig transport for daglig reise
 
     Når beregner for daglig reise offentlig transport
 
-    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport
+    Så forventer vi følgende beregningsrsultat for daglig resie offentlig transport, reiseNr=1
       | Fom        | Tom        | Beløp |
       | 01.01.2025 | 30.01.2025 | 778   |
       | 31.01.2025 | 01.03.2025 | 704   |


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Cucumber-testene for daglig reise brukte ikke utgiften fra `.feature`-filen. I stedet hentet de vilkår fra VilkårRepositoryFake, som var tomt. Dette gjorde at testene alltid passerte uten å kjøre noen reelle assertThat-sjekker.

Har oppdatert testene slik at utgiften i `.feature` filen blir lagt inn i VilkårRepositoryFaken når testene kjører.