### PR TITLE
Flytter logikk å styre om register ytelsen kan brukes i behandlingen til backend

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
@@ -35,6 +35,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.tilMålgruppe
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -224,15 +225,6 @@ class OppfølgingOpprettKontrollerService(
             "Feil ved henting av ytelser fra andre systemer: ${test.joinToString(", ") { it.type.name }}. Prøv å laste inn siden på nytt."
         }
     }
-
-    private fun TypeYtelsePeriode.tilMålgruppe() =
-        when (this) {
-            TypeYtelsePeriode.AAP -> MålgruppeType.AAP
-            TypeYtelsePeriode.DAGPENGER -> MålgruppeType.DAGPENGER
-            TypeYtelsePeriode.ENSLIG_FORSØRGER -> MålgruppeType.OVERGANGSSTØNAD
-            TypeYtelsePeriode.OMSTILLINGSSTØNAD -> MålgruppeType.OMSTILLINGSSTØNAD
-            TypeYtelsePeriode.TILTAKSPENGER -> TODO()
-        }
 
     private fun MålgruppeType.tilTypeYtelsePeriode() =
         when (this) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/MålgruppeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/MålgruppeValidering.kt
@@ -14,58 +14,10 @@ object MålgruppeValidering {
         stønadstype: Stønadstype,
         målgruppeType: MålgruppeType,
     ) {
-        feilHvisIkke(kanMålgruppeBrukesForStønad(stønadstype, målgruppeType)) {
+        feilHvisIkke(målgruppeType.kanBrukesForStønad(stønadstype)) {
             "målgruppe=$målgruppeType er ikke gyldig for $stønadstype"
         }
     }
-
-    fun kanMålgruppeBrukesForStønad(
-        stønadstype: Stønadstype,
-        målgruppeType: MålgruppeType,
-    ): Boolean =
-        when (stønadstype) {
-            Stønadstype.BARNETILSYN, Stønadstype.LÆREMIDLER, Stønadstype.BOUTGIFTER ->
-                when (målgruppeType) {
-                    MålgruppeType.AAP -> true
-                    MålgruppeType.DAGPENGER -> false
-                    MålgruppeType.NEDSATT_ARBEIDSEVNE -> true
-                    MålgruppeType.OMSTILLINGSSTØNAD -> true
-                    MålgruppeType.OVERGANGSSTØNAD -> true
-                    MålgruppeType.UFØRETRYGD -> true
-                    MålgruppeType.SYKEPENGER_100_PROSENT -> true
-                    MålgruppeType.INGEN_MÅLGRUPPE -> true
-                    MålgruppeType.TILTAKSPENGER -> false
-                    MålgruppeType.KVALIFISERINGSSTØNAD -> false
-                }
-
-            Stønadstype.DAGLIG_REISE_TSO ->
-                when (målgruppeType) {
-                    MålgruppeType.AAP -> true
-                    MålgruppeType.DAGPENGER -> false
-                    MålgruppeType.NEDSATT_ARBEIDSEVNE -> true
-                    MålgruppeType.OMSTILLINGSSTØNAD -> true
-                    MålgruppeType.OVERGANGSSTØNAD -> true
-                    MålgruppeType.UFØRETRYGD -> true
-                    MålgruppeType.SYKEPENGER_100_PROSENT -> false
-                    MålgruppeType.INGEN_MÅLGRUPPE -> true
-                    MålgruppeType.TILTAKSPENGER -> false
-                    MålgruppeType.KVALIFISERINGSSTØNAD -> false
-                }
-
-            Stønadstype.DAGLIG_REISE_TSR ->
-                when (målgruppeType) {
-                    MålgruppeType.INGEN_MÅLGRUPPE -> true
-                    MålgruppeType.TILTAKSPENGER -> true
-                    MålgruppeType.KVALIFISERINGSSTØNAD -> true
-                    MålgruppeType.AAP -> false
-                    MålgruppeType.DAGPENGER -> true
-                    MålgruppeType.NEDSATT_ARBEIDSEVNE -> false
-                    MålgruppeType.OMSTILLINGSSTØNAD -> false
-                    MålgruppeType.OVERGANGSSTØNAD -> false
-                    MålgruppeType.UFØRETRYGD -> false
-                    MålgruppeType.SYKEPENGER_100_PROSENT -> false
-                }
-        }
 
     fun validerNyeMålgrupperOverlapperIkkeMedEksisterendeMålgrupper(vilkårperioder: Vilkårperioder) {
         val oppfylteMålgrupper =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/MålgruppeValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/MålgruppeValidering.kt
@@ -8,61 +8,64 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
-import kotlin.collections.contains
 
 object MålgruppeValidering {
     fun validerKanLeggeTilMålgruppeManuelt(
         stønadstype: Stønadstype,
         målgruppeType: MålgruppeType,
     ) {
-        val gyldig =
-            when (stønadstype) {
-                Stønadstype.BARNETILSYN, Stønadstype.LÆREMIDLER, Stønadstype.BOUTGIFTER ->
-                    when (målgruppeType) {
-                        MålgruppeType.AAP -> true
-                        MålgruppeType.DAGPENGER -> false
-                        MålgruppeType.NEDSATT_ARBEIDSEVNE -> true
-                        MålgruppeType.OMSTILLINGSSTØNAD -> true
-                        MålgruppeType.OVERGANGSSTØNAD -> true
-                        MålgruppeType.UFØRETRYGD -> true
-                        MålgruppeType.SYKEPENGER_100_PROSENT -> true
-                        MålgruppeType.INGEN_MÅLGRUPPE -> true
-                        MålgruppeType.TILTAKSPENGER -> false
-                        MålgruppeType.KVALIFISERINGSSTØNAD -> false
-                    }
-
-                Stønadstype.DAGLIG_REISE_TSO ->
-                    when (målgruppeType) {
-                        MålgruppeType.AAP -> true
-                        MålgruppeType.DAGPENGER -> false
-                        MålgruppeType.NEDSATT_ARBEIDSEVNE -> true
-                        MålgruppeType.OMSTILLINGSSTØNAD -> true
-                        MålgruppeType.OVERGANGSSTØNAD -> true
-                        MålgruppeType.UFØRETRYGD -> true
-                        MålgruppeType.SYKEPENGER_100_PROSENT -> false
-                        MålgruppeType.INGEN_MÅLGRUPPE -> true
-                        MålgruppeType.TILTAKSPENGER -> false
-                        MålgruppeType.KVALIFISERINGSSTØNAD -> false
-                    }
-
-                Stønadstype.DAGLIG_REISE_TSR ->
-                    when (målgruppeType) {
-                        MålgruppeType.INGEN_MÅLGRUPPE -> true
-                        MålgruppeType.TILTAKSPENGER -> true
-                        MålgruppeType.KVALIFISERINGSSTØNAD -> true
-                        MålgruppeType.AAP -> false
-                        MålgruppeType.DAGPENGER -> true
-                        MålgruppeType.NEDSATT_ARBEIDSEVNE -> false
-                        MålgruppeType.OMSTILLINGSSTØNAD -> false
-                        MålgruppeType.OVERGANGSSTØNAD -> false
-                        MålgruppeType.UFØRETRYGD -> false
-                        MålgruppeType.SYKEPENGER_100_PROSENT -> false
-                    }
-            }
-        feilHvisIkke(gyldig) {
+        feilHvisIkke(kanMålgruppeBrukesForStønad(stønadstype, målgruppeType)) {
             "målgruppe=$målgruppeType er ikke gyldig for $stønadstype"
         }
     }
+
+    fun kanMålgruppeBrukesForStønad(
+        stønadstype: Stønadstype,
+        målgruppeType: MålgruppeType,
+    ): Boolean =
+        when (stønadstype) {
+            Stønadstype.BARNETILSYN, Stønadstype.LÆREMIDLER, Stønadstype.BOUTGIFTER ->
+                when (målgruppeType) {
+                    MålgruppeType.AAP -> true
+                    MålgruppeType.DAGPENGER -> false
+                    MålgruppeType.NEDSATT_ARBEIDSEVNE -> true
+                    MålgruppeType.OMSTILLINGSSTØNAD -> true
+                    MålgruppeType.OVERGANGSSTØNAD -> true
+                    MålgruppeType.UFØRETRYGD -> true
+                    MålgruppeType.SYKEPENGER_100_PROSENT -> true
+                    MålgruppeType.INGEN_MÅLGRUPPE -> true
+                    MålgruppeType.TILTAKSPENGER -> false
+                    MålgruppeType.KVALIFISERINGSSTØNAD -> false
+                }
+
+            Stønadstype.DAGLIG_REISE_TSO ->
+                when (målgruppeType) {
+                    MålgruppeType.AAP -> true
+                    MålgruppeType.DAGPENGER -> false
+                    MålgruppeType.NEDSATT_ARBEIDSEVNE -> true
+                    MålgruppeType.OMSTILLINGSSTØNAD -> true
+                    MålgruppeType.OVERGANGSSTØNAD -> true
+                    MålgruppeType.UFØRETRYGD -> true
+                    MålgruppeType.SYKEPENGER_100_PROSENT -> false
+                    MålgruppeType.INGEN_MÅLGRUPPE -> true
+                    MålgruppeType.TILTAKSPENGER -> false
+                    MålgruppeType.KVALIFISERINGSSTØNAD -> false
+                }
+
+            Stønadstype.DAGLIG_REISE_TSR ->
+                when (målgruppeType) {
+                    MålgruppeType.INGEN_MÅLGRUPPE -> true
+                    MålgruppeType.TILTAKSPENGER -> true
+                    MålgruppeType.KVALIFISERINGSSTØNAD -> true
+                    MålgruppeType.AAP -> false
+                    MålgruppeType.DAGPENGER -> true
+                    MålgruppeType.NEDSATT_ARBEIDSEVNE -> false
+                    MålgruppeType.OMSTILLINGSSTØNAD -> false
+                    MålgruppeType.OVERGANGSSTØNAD -> false
+                    MålgruppeType.UFØRETRYGD -> false
+                    MålgruppeType.SYKEPENGER_100_PROSENT -> false
+                }
+        }
 
     fun validerNyeMålgrupperOverlapperIkkeMedEksisterendeMålgrupper(vilkårperioder: Vilkårperioder) {
         val oppfylteMålgrupper =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeService.kt
@@ -69,10 +69,11 @@ class VilkårperiodeService(
         val vilkårperioder = hentVilkårperioder(behandlingId)
         val grunnlagsdataVilkårsperioder =
             vilkårperiodeGrunnlagService.hentEllerOpprettGrunnlag(behandlingId, vilkårperioder)
+        val behandling = behandlingService.hentSaksbehandling(behandlingId)
 
         return VilkårperioderResponse(
             vilkårperioder = vilkårperioder.tilDto(),
-            grunnlag = grunnlagsdataVilkårsperioder?.tilDto(),
+            grunnlag = grunnlagsdataVilkårsperioder?.tilDto(stønadstype = behandling.stønadstype),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/MålgruppeType.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/MålgruppeType.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 
 /**
@@ -65,5 +66,50 @@ enum class MålgruppeType(
         when (this) {
             AAP, UFØRETRYGD, NEDSATT_ARBEIDSEVNE, OMSTILLINGSSTØNAD -> true
             OVERGANGSSTØNAD, INGEN_MÅLGRUPPE, SYKEPENGER_100_PROSENT, DAGPENGER, TILTAKSPENGER, KVALIFISERINGSSTØNAD -> false
+        }
+
+    fun kanBrukesForStønad(stønadstype: Stønadstype): Boolean =
+        when (stønadstype) {
+            Stønadstype.BARNETILSYN, Stønadstype.LÆREMIDLER, Stønadstype.BOUTGIFTER ->
+                when (this) {
+                    AAP -> true
+                    DAGPENGER -> false
+                    NEDSATT_ARBEIDSEVNE -> true
+                    OMSTILLINGSSTØNAD -> true
+                    OVERGANGSSTØNAD -> true
+                    UFØRETRYGD -> true
+                    SYKEPENGER_100_PROSENT -> true
+                    INGEN_MÅLGRUPPE -> true
+                    TILTAKSPENGER -> false
+                    KVALIFISERINGSSTØNAD -> false
+                }
+
+            Stønadstype.DAGLIG_REISE_TSO ->
+                when (this) {
+                    AAP -> true
+                    DAGPENGER -> false
+                    NEDSATT_ARBEIDSEVNE -> true
+                    OMSTILLINGSSTØNAD -> true
+                    OVERGANGSSTØNAD -> true
+                    UFØRETRYGD -> true
+                    SYKEPENGER_100_PROSENT -> false
+                    INGEN_MÅLGRUPPE -> true
+                    TILTAKSPENGER -> false
+                    KVALIFISERINGSSTØNAD -> false
+                }
+
+            Stønadstype.DAGLIG_REISE_TSR ->
+                when (this) {
+                    INGEN_MÅLGRUPPE -> true
+                    TILTAKSPENGER -> true
+                    KVALIFISERINGSSTØNAD -> true
+                    AAP -> false
+                    DAGPENGER -> true
+                    NEDSATT_ARBEIDSEVNE -> false
+                    OMSTILLINGSSTØNAD -> false
+                    OVERGANGSSTØNAD -> false
+                    UFØRETRYGD -> false
+                    SYKEPENGER_100_PROSENT -> false
+                }
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperiodeGrunnlagUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperiodeGrunnlagUtil.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.MålgruppeValidering.kanMålgruppeBrukesForStønad
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 
 fun kanYtelseBrukesIBehandling(
@@ -12,7 +11,7 @@ fun kanYtelseBrukesIBehandling(
     if (ytelse.subtype == PeriodeGrunnlagYtelse.YtelseSubtype.AAP_FERDIG_AVKLART) {
         return false
     }
-    return kanMålgruppeBrukesForStønad(stønadstype, ytelse.type.tilMålgruppe())
+    return ytelse.type.tilMålgruppe().kanBrukesForStønad(stønadstype)
 }
 
 fun TypeYtelsePeriode.tilMålgruppe() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperiodeGrunnlagUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperiodeGrunnlagUtil.kt
@@ -1,0 +1,25 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.MålgruppeValidering.kanMålgruppeBrukesForStønad
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+
+fun kanYtelseBrukesIBehandling(
+    stønadstype: Stønadstype,
+    ytelse: PeriodeGrunnlagYtelse,
+): Boolean {
+    if (ytelse.subtype == PeriodeGrunnlagYtelse.YtelseSubtype.AAP_FERDIG_AVKLART) {
+        return false
+    }
+    return kanMålgruppeBrukesForStønad(stønadstype, ytelse.type.tilMålgruppe())
+}
+
+fun TypeYtelsePeriode.tilMålgruppe() =
+    when (this) {
+        TypeYtelsePeriode.AAP -> MålgruppeType.AAP
+        TypeYtelsePeriode.DAGPENGER -> MålgruppeType.DAGPENGER
+        TypeYtelsePeriode.ENSLIG_FORSØRGER -> MålgruppeType.OVERGANGSSTØNAD
+        TypeYtelsePeriode.OMSTILLINGSSTØNAD -> MålgruppeType.OMSTILLINGSSTØNAD
+        TypeYtelsePeriode.TILTAKSPENGER -> MålgruppeType.TILTAKSPENGER
+    }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilkårperioderGrunnlagDto.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.ytelse.ResultatKilde
 import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.GrunnlagYtelse.KildeResultatYtelse
@@ -32,6 +33,7 @@ data class PeriodeGrunnlagYtelseDto(
     val fom: LocalDate,
     val tom: LocalDate?,
     val subtype: PeriodeGrunnlagYtelse.YtelseSubtype?,
+    val kanYtelseBrukesIBehandling: Boolean,
 )
 
 data class HentetInformasjonDto(
@@ -40,10 +42,10 @@ data class HentetInformasjonDto(
     val tidspunktHentet: LocalDateTime,
 )
 
-fun VilkårperioderGrunnlag.tilDto() =
+fun VilkårperioderGrunnlag.tilDto(stønadstype: Stønadstype) =
     VilkårperioderGrunnlagDto(
         aktivitet = this.aktivitet.tilDto(),
-        ytelse = this.ytelse.tilDto(),
+        ytelse = this.ytelse.tilDto(stønadstype = stønadstype),
         hentetInformasjon = this.hentetInformasjon.tilDto(),
     )
 
@@ -69,9 +71,9 @@ private fun RegisterAktivitet.tilDto() =
         kilde = kilde,
     )
 
-fun GrunnlagYtelse.tilDto() =
+fun GrunnlagYtelse.tilDto(stønadstype: Stønadstype) =
     GrunnlagYtelseDto(
-        perioder = this.perioder.map { it.tilDto() },
+        perioder = this.perioder.map { it.tilDto(stønadstype = stønadstype) },
         kildeResultat = this.kildeResultat.map { it.tilDto() },
     )
 
@@ -81,12 +83,17 @@ private fun KildeResultatYtelse.tilDto() =
         resultat = this.resultat,
     )
 
-fun PeriodeGrunnlagYtelse.tilDto() =
+fun PeriodeGrunnlagYtelse.tilDto(stønadstype: Stønadstype) =
     PeriodeGrunnlagYtelseDto(
         type = this.type,
         fom = this.fom,
         tom = this.tom,
         subtype = this.subtype,
+        kanYtelseBrukesIBehandling =
+            kanYtelseBrukesIBehandling(
+                stønadstype = stønadstype,
+                ytelse = this,
+            ),
     )
 
 fun HentetInformasjon.tilDto() =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilårperiodeGrunnlagUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/grunnlag/VilårperiodeGrunnlagUtilTest.kt
@@ -1,0 +1,44 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class VilårperiodeGrunnlagUtilTest {
+    @Nested
+    inner class KanYtelseBrukesIBehandling {
+        val ytelse =
+            PeriodeGrunnlagYtelse(
+                type = TypeYtelsePeriode.AAP,
+                fom = LocalDate.of(2025, 1, 1),
+                tom = LocalDate.of(2025, 2, 1),
+            )
+
+        @Test
+        fun `skal ikke kunne bruke AAP ferdig avklart`() {
+            val ytelseAAPFerdigAvklart = ytelse.copy(subtype = PeriodeGrunnlagYtelse.YtelseSubtype.AAP_FERDIG_AVKLART)
+
+            assertThat(kanYtelseBrukesIBehandling(Stønadstype.LÆREMIDLER, ytelseAAPFerdigAvklart)).isFalse
+        }
+
+        @Test
+        fun `skal kunne bruke AAP for tilsyn barn`() {
+            assertThat(kanYtelseBrukesIBehandling(Stønadstype.BARNETILSYN, ytelse)).isTrue
+        }
+
+        @Test
+        fun `skal kunne bruke dagpenger for daglig reise tsr`() {
+            val ytelseDagpenger = ytelse.copy(type = TypeYtelsePeriode.DAGPENGER)
+            assertThat(kanYtelseBrukesIBehandling(Stønadstype.DAGLIG_REISE_TSR, ytelseDagpenger)).isTrue
+        }
+
+        @Test
+        fun `skal ikke kunne bruke dagpenger for daglig reise tso`() {
+            val ytelseDagpenger = ytelse.copy(type = TypeYtelsePeriode.DAGPENGER)
+            assertThat(kanYtelseBrukesIBehandling(Stønadstype.DAGLIG_REISE_TSO, ytelseDagpenger)).isFalse
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker kun å tillate "bruk"-knappen hvis ytelsen kan brukes i kombinasjon med stønaden. Flytter logikken for dette til backend.

Henger sammen med: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/866