### PR TITLE
Send brev til kontaktinformasjon for dødsbo dersom mottaker er død

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevService.kt
@@ -1,0 +1,112 @@
+package no.nav.tilleggsstonader.sak.brev.vedtaksbrev
+
+import no.nav.tilleggsstonader.kontrakter.dokdist.AdresseType
+import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
+import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
+import no.nav.tilleggsstonader.kontrakter.dokdist.ManuellAdresse
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsbo
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException
+
+@Service
+class DistribuerVedtaksbrevService(
+    private val journalpostClient: JournalpostClient,
+    private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
+    private val personService: PersonService,
+    private val transactionHandler: TransactionHandler,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    interface ResultatBrevutsendelse {
+        data object BrevDistribuert : ResultatBrevutsendelse
+
+        data class FeiletFordiMottakerErDødOgManglerAdresse(
+            val feilmelding: String?,
+        ) : ResultatBrevutsendelse
+    }
+
+    @Transactional
+    fun distribuerVedtaksbrev(mottaker: BrevmottakerVedtaksbrev): ResultatBrevutsendelse {
+        try {
+            return distribuerVedtaksbrevOgOppdaterMottakerHvisSuksess(mottaker)
+        } catch (ex: ProblemDetailException) {
+            logger.warn("Distribusjon av vedtaksbrev for journalpost ${mottaker.journalpostId} feilet: ${ex.message}")
+            if (ex.responseException is HttpClientErrorException.Gone) {
+                logger.warn(
+                    "Kan ikke sende vedtaksbrev da personen er død og mangler adresse. Forsøker å sende til kontaktinformasjon for dødsboet.",
+                )
+                return distribuerVedtaksbrevTilKontaktpersonForDødsbo(dødMottaker = mottaker, opprinneligFeilmelding = ex.message)
+            } else {
+                throw ex
+            }
+        }
+    }
+
+    private fun distribuerVedtaksbrevOgOppdaterMottakerHvisSuksess(
+        mottaker: BrevmottakerVedtaksbrev,
+        manuellAdresse: ManuellAdresse? = null,
+    ): ResultatBrevutsendelse {
+        val bestillingsId =
+            journalpostClient.distribuerJournalpost(
+                DistribuerJournalpostRequest(
+                    journalpostId = mottaker.journalpostId ?: error("journalpostId er påkrevd"),
+                    bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
+                    dokumentProdApp = "TILLEGGSSTONADER-SAK",
+                    distribusjonstype = Distribusjonstype.VEDTAK,
+                    adresse = manuellAdresse,
+                ),
+            )
+        mottaker.lagreDistribusjonGjennomført(bestillingsId)
+        logger.info(
+            "Distribuert vedtaksbrev (journalpost=${mottaker.journalpostId}) med bestillingId=$bestillingsId",
+        )
+        return ResultatBrevutsendelse.BrevDistribuert
+    }
+
+    private fun distribuerVedtaksbrevTilKontaktpersonForDødsbo(
+        dødMottaker: BrevmottakerVedtaksbrev,
+        opprinneligFeilmelding: String? = null,
+    ): ResultatBrevutsendelse {
+        val kontaktinformasjonDødsbo = personService.hentSøker(dødMottaker.mottaker.ident).kontaktinformasjonForDoedsbo.firstOrNull()
+
+        if (kontaktinformasjonDødsbo == null) {
+            logger.warn("Fant ikke kontaktinformasjon for dødsboet. Kan ikke sende ut vedtaksbrev.")
+            return ResultatBrevutsendelse.FeiletFordiMottakerErDødOgManglerAdresse(
+                "$opprinneligFeilmelding - fant heller ikke kontaktinformasjon for dødsboet",
+            )
+        }
+
+        return distribuerVedtaksbrevOgOppdaterMottakerHvisSuksess(
+            mottaker = dødMottaker,
+            manuellAdresse = kontaktinformasjonDødsbo.tilManuellAdresse(),
+        )
+    }
+
+    private fun KontaktinformasjonForDoedsbo.tilManuellAdresse(): ManuellAdresse {
+        val landkode = adresse.landkode ?: "NO"
+        val adresseType = if (landkode == "NO") AdresseType.norskPostadresse else AdresseType.utenlandskPostadresse
+        return ManuellAdresse(
+            adresseType = adresseType,
+            adresselinje1 = adresse.adresselinje1,
+            adresselinje2 = adresse.adresselinje2,
+            postnummer = adresse.postnummer,
+            poststed = adresse.poststedsnavn,
+            land = landkode,
+        )
+    }
+
+    private fun BrevmottakerVedtaksbrev.lagreDistribusjonGjennomført(bestillingId: String) {
+        transactionHandler.runInNewTransaction {
+            brevmottakerVedtaksbrevRepository.update(this.copy(bestillingId = bestillingId))
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
@@ -23,7 +23,7 @@ import java.util.Properties
 @Service
 @TaskStepBeskrivelse(
     taskStepType = DistribuerVedtaksbrevTask.TYPE,
-    maxAntallFeil = 75,
+    maxAntallFeil = 50,
     settTilManuellOppfølgning = true,
     triggerTidVedFeilISekunder = 3 * 60L,
     beskrivelse = "Distribuerer vedtaksbrev etter journalføring",
@@ -49,13 +49,7 @@ class DistribuerVedtaksbrevTask(
     private fun List<ResultatBrevutsendelse>.håndterRekjøringSenereHvisMottakerErDød(task: Task) {
         filterIsInstance<ResultatBrevutsendelse.FeiletFordiMottakerErDødOgManglerAdresse>()
             .firstOrNull()
-            ?.let {
-                taskService.stoppTaskOgRekjørSenere(
-                    task,
-                    årsak = "Mottaker er død og har ikke fått dødsbo. Forsøker å rekjøre tasken automatisk om et gitt antall dager.",
-                    melding = it.feilmelding,
-                )
-            }
+            ?.let { taskService.stoppTaskOgRekjørSenere(task, årsak = "Mottaker er død", melding = it.feilmelding) }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
@@ -4,29 +4,21 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
-import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
-import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
-import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.DistribuerVedtaksbrevService.ResultatBrevutsendelse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
 import no.nav.tilleggsstonader.sak.util.stoppTaskOgRekjørSenere
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.web.client.HttpClientErrorException
 import java.util.Properties
 
 /**
  * Distribuering av vedtaksbrev skjer asynkront etter at journalposten er opprettet.
  * Det er ikke en del av behandlingsflyten sånn at en distribuering ikke skal stoppe behandlingen.
  *
- * I tilfelle en person er død, vil distribueringen feile med 410 Gone. Og denne tasken vil da kjøre på nytt.
+ * I tilfelle en person er død, vil distribueringen feile med 410 Gone, og denne tasken vil avbrytes og kjøres på nytt senere.
  */
 @Service
 @TaskStepBeskrivelse(
@@ -38,8 +30,7 @@ import java.util.Properties
 )
 class DistribuerVedtaksbrevTask(
     private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
-    private val journalpostClient: JournalpostClient,
-    private val transactionHandler: TransactionHandler,
+    private val distribuerVedtaksbrevService: DistribuerVedtaksbrevService,
     private val taskService: TaskService,
 ) : AsyncTaskStep {
     val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -51,58 +42,20 @@ class DistribuerVedtaksbrevTask(
             .findByBehandlingId(behandlingId)
             .ifEmpty { throw Feil("Ingen brevmottakere funnet") }
             .filter { it.harIkkeFåttBrevet() }
-            .map { distribuerBrevet(mottaker = it) }
+            .map { distribuerVedtaksbrevService.distribuerVedtaksbrev(mottaker = it) }
             .håndterRekjøringSenereHvisMottakerErDød(task)
     }
 
-    private sealed interface ResultatBrevutsendelse {
-        data object BrevDistribuert : ResultatBrevutsendelse
-
-        data class FeiletFordiMottakerErDød(
-            val feilmelding: String?,
-        ) : ResultatBrevutsendelse
-    }
-
-    private fun distribuerBrevet(mottaker: BrevmottakerVedtaksbrev): ResultatBrevutsendelse {
-        feilHvis(mottaker.journalpostId == null) { "Ugyldig tilstand. Mangler journalpostId for brev som skal distribueres" }
-
-        try {
-            val bestillingId = distribuerVedtaksbrev(mottaker.journalpostId)
-            mottaker.lagreDistribusjonGjennomført(bestillingId)
-            return ResultatBrevutsendelse.BrevDistribuert
-        } catch (ex: ProblemDetailException) {
-            logger.warn("Distribusjon av vedtaksbrev for journalpost ${mottaker.journalpostId} feilet: ${ex.message}")
-            if (ex.responseException is HttpClientErrorException.Gone) {
-                return ResultatBrevutsendelse.FeiletFordiMottakerErDød(ex.message)
-            } else {
-                throw ex
-            }
-        }
-    }
-
-    private fun BrevmottakerVedtaksbrev.lagreDistribusjonGjennomført(bestillingId: String) {
-        transactionHandler.runInNewTransaction {
-            brevmottakerVedtaksbrevRepository.update(this.copy(bestillingId = bestillingId))
-        }
-        logger.info(
-            "Distribuert vedtaksbrev (journalpost=$journalpostId) med bestillingId=$bestillingId",
-        )
-    }
-
-    private fun distribuerVedtaksbrev(journalpostId: String): String =
-        journalpostClient.distribuerJournalpost(
-            DistribuerJournalpostRequest(
-                journalpostId = journalpostId,
-                bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
-                dokumentProdApp = "TILLEGGSSTONADER-SAK",
-                distribusjonstype = Distribusjonstype.VEDTAK,
-            ),
-        )
-
     private fun List<ResultatBrevutsendelse>.håndterRekjøringSenereHvisMottakerErDød(task: Task) {
-        filterIsInstance<ResultatBrevutsendelse.FeiletFordiMottakerErDød>()
+        filterIsInstance<ResultatBrevutsendelse.FeiletFordiMottakerErDødOgManglerAdresse>()
             .firstOrNull()
-            ?.let { taskService.stoppTaskOgRekjørSenere(task, årsak = "Mottaker er død", melding = it.feilmelding) }
+            ?.let {
+                taskService.stoppTaskOgRekjørSenere(
+                    task,
+                    årsak = "Mottaker er død og har ikke fått dødsbo. Forsøker å rekjøre tasken automatisk om et gitt antall dager.",
+                    melding = it.feilmelding,
+                )
+            }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/dto/PdlPerson.kt
@@ -21,7 +21,7 @@ data class PdlBolkResponse<T>(
     val errors: List<PdlError>?,
     val extensions: PdlExtensions?,
 ) {
-    fun errorMessages(): String = errors?.joinToString { it -> it.message } ?: ""
+    fun errorMessages(): String = errors?.joinToString { it.message } ?: ""
 
     fun harAdvarsel(): Boolean = !extensions?.warnings.isNullOrEmpty()
 }
@@ -106,6 +106,7 @@ data class PdlSøker(
     @JsonProperty("foedselsdato") override val fødselsdato: List<Fødselsdato>,
     val folkeregisterpersonstatus: List<Folkeregisterpersonstatus>,
     val kontaktadresse: List<Kontaktadresse>,
+    val kontaktinformasjonForDoedsbo: List<KontaktinformasjonForDoedsbo>,
     val navn: List<Navn>,
     val opphold: List<Opphold>,
     val oppholdsadresse: List<Oppholdsadresse>,
@@ -377,3 +378,45 @@ data class VergemaalEllerFremtidsfullmakt(
     val type: String?,
     val vergeEllerFullmektig: VergeEllerFullmektig,
 )
+
+data class KontaktinformasjonForDoedsbo(
+    val adresse: KontaktinformasjonForDoedsboAdresse,
+    val advokatSomKontakt: KontaktinformasjonForDoedsboAdvokatSomKontakt?,
+    val attestutstedelsesdato: LocalDate,
+    val folkeregistermetadata: Folkeregistermetadata,
+    val metadata: Metadata,
+    val organisasjonSomKontakt: KontaktinformasjonForDoedsboOrganisasjonSomKontakt?,
+    val personSomKontakt: KontaktinformasjonForDoedsboPersonSomKontakt?,
+    val skifteform: KontaktinformasjonForDoedsboSkifteform,
+)
+
+data class KontaktinformasjonForDoedsboAdresse(
+    val adresselinje1: String,
+    val adresselinje2: String?,
+    val landkode: String?,
+    val postnummer: String,
+    val poststedsnavn: String,
+)
+
+data class KontaktinformasjonForDoedsboAdvokatSomKontakt(
+    val organisasjonsnavn: String?,
+    val organisasjonsnummer: String?,
+    val personnavn: Personnavn,
+)
+
+data class KontaktinformasjonForDoedsboOrganisasjonSomKontakt(
+    val kontaktperson: Personnavn?,
+    val organisasjonsnavn: String,
+    val organisasjonsnummer: String?,
+)
+
+data class KontaktinformasjonForDoedsboPersonSomKontakt(
+    val foedselsdato: LocalDate?,
+    val identifikasjonsnummer: String?,
+    val personnavn: Personnavn?,
+)
+
+enum class KontaktinformasjonForDoedsboSkifteform {
+    ANNET,
+    OFFENTLIG,
+}

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -148,6 +148,51 @@ query($ident: ID!){
                 matrikkelId
             }
         }
+        kontaktinformasjonForDoedsbo {
+            adresse {
+                adresselinje1
+                adresselinje2
+                landkode
+                postnummer
+                poststedsnavn
+            }
+            advokatSomKontakt {
+                organisasjonsnavn
+                organisasjonsnummer
+                personnavn {
+                    fornavn
+                    mellomnavn
+                    etternavn
+                }
+            }
+            attestutstedelsesdato
+            folkeregistermetadata {
+                gyldighetstidspunkt
+                opphoerstidspunkt
+            }
+            metadata {
+                historisk
+            }
+            organisasjonSomKontakt {
+                organisasjonsnavn
+                organisasjonsnummer
+                kontaktperson {
+                    fornavn
+                    mellomnavn
+                    etternavn
+                }
+            }
+            personSomKontakt {
+                identifikasjonsnummer
+                foedselsdato
+                personnavn {
+                    fornavn
+                    mellomnavn
+                    etternavn
+                }
+            }
+            skifteform
+        }
         oppholdsadresse(historikk: true) {
             gyldigFraOgMed
             gyldigTilOgMed

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevServiceTest.kt
@@ -1,0 +1,178 @@
+package no.nav.tilleggsstonader.sak.brev.vedtaksbrev
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.dokdist.AdresseType
+import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
+import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.DistribuerVedtaksbrevService.ResultatBrevutsendelse.FeiletFordiMottakerErDødOgManglerAdresse
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Dødsfall
+import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper
+import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.kontaktinformasjonDødsbo
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.web.client.HttpClientErrorException
+import java.time.LocalDate
+
+class DistribuerVedtaksbrevServiceTest {
+    private val journalpostClient = mockk<JournalpostClient>()
+    private val brevmottakerVedtaksbrevRepository = mockk<BrevmottakerVedtaksbrevRepository>()
+    private val personService = mockk<PersonService>()
+
+    private val service =
+        DistribuerVedtaksbrevService(
+            journalpostClient = journalpostClient,
+            brevmottakerVedtaksbrevRepository = brevmottakerVedtaksbrevRepository,
+            personService = personService,
+            transactionHandler = TransactionHandler(),
+        )
+
+    private val saksbehandling = saksbehandling()
+    private val journalpostId = "journalpostId123"
+    private val bestillingId = "bestillingId123"
+    private val mottaker =
+        BrevmottakerVedtaksbrev(
+            behandlingId = saksbehandling.id,
+            mottaker = mottakerPerson(ident = saksbehandling.ident),
+            journalpostId = journalpostId,
+            bestillingId = null,
+        )
+
+    private val utførteDistribusjoner = mutableListOf<DistribuerJournalpostRequest>()
+    private val oppdaterteBrevmottakere = mutableListOf<BrevmottakerVedtaksbrev>()
+
+    @BeforeEach
+    fun setUp() {
+        utførteDistribusjoner.clear()
+        oppdaterteBrevmottakere.clear()
+
+        every { brevmottakerVedtaksbrevRepository.update(capture(oppdaterteBrevmottakere)) } answers { firstArg() }
+    }
+
+    @Test
+    fun `vedtaksbrev distribueres til mottaker (happy path)`() {
+        every {
+            journalpostClient.distribuerJournalpost(
+                request = capture(utførteDistribusjoner),
+            )
+        } returns bestillingId
+
+        every { personService.hentSøker(saksbehandling.ident) } returns PdlTestdataHelper.pdlSøker()
+
+        val resultat = service.distribuerVedtaksbrev(mottaker)
+
+        assertThat(resultat).isEqualTo(DistribuerVedtaksbrevService.ResultatBrevutsendelse.BrevDistribuert)
+
+        assertThat(utførteDistribusjoner).hasSize(1)
+        with(utførteDistribusjoner[0]) {
+            assertThat(journalpostId).isEqualTo(journalpostId)
+            assertThat(bestillendeFagsystem).isEqualTo(Fagsystem.TILLEGGSSTONADER)
+            assertThat(dokumentProdApp).isEqualTo("TILLEGGSSTONADER-SAK")
+            assertThat(distribusjonstype).isEqualTo(Distribusjonstype.VEDTAK)
+            assertThat(adresse).isNull() // Ingen manuell adresse ved vanlig distribusjon
+        }
+
+        assertThat(oppdaterteBrevmottakere).hasSize(1)
+        assertThat(oppdaterteBrevmottakere[0].bestillingId).isEqualTo(bestillingId)
+    }
+
+    @Test
+    fun `dersom personen er død distribueres brevet til kontaktperson for dødsbo`() {
+        val avdødPerson =
+            PdlTestdataHelper.pdlSøker(
+                dødsfall = listOf(Dødsfall(LocalDate.now().minusDays(10))),
+                kontaktinformasjonForDoedsbo = listOf(kontaktinformasjonDødsbo()),
+            )
+
+        val problemDetailException =
+            ProblemDetailException(
+                detail = ProblemDetail.forStatus(HttpStatus.GONE),
+                responseException = HttpClientErrorException.create(HttpStatus.GONE, "", HttpHeaders(), byteArrayOf(), null),
+                httpStatus = HttpStatus.GONE,
+            )
+
+        // første distribusjon feiler, neste skal fullføre OK
+        every {
+            journalpostClient.distribuerJournalpost(
+                capture(utførteDistribusjoner),
+            )
+        } throws problemDetailException andThen bestillingId
+
+        every { personService.hentSøker(saksbehandling.ident) } returns avdødPerson
+
+        val resultat = service.distribuerVedtaksbrev(mottaker)
+
+        assertThat(resultat).isEqualTo(DistribuerVedtaksbrevService.ResultatBrevutsendelse.BrevDistribuert)
+
+        assertThat(utførteDistribusjoner).hasSize(2)
+
+        // Første forsøk på distribusjon skal være direkte til søkeren
+        val firstRequest = utførteDistribusjoner[0]
+        assertThat(firstRequest.journalpostId).isEqualTo(journalpostId)
+        assertThat(firstRequest.adresse).isNull()
+
+        // Andre forsøk på distribusjon skal være til kontakt for dødsbo
+        with(utførteDistribusjoner[1]) {
+            assertThat(journalpostId).isEqualTo(journalpostId)
+            assertThat(adresse).isNotNull
+            assertThat(adresse!!.adresseType).isEqualTo(AdresseType.norskPostadresse)
+            assertThat(adresse!!.adresselinje1).isEqualTo("Dødsbogate 1")
+            assertThat(adresse!!.postnummer).isEqualTo("0123")
+            assertThat(adresse!!.poststed).isEqualTo("OSLO")
+            assertThat(adresse!!.land).isEqualTo("NO")
+        }
+
+        assertThat(oppdaterteBrevmottakere).hasSize(1)
+        assertThat(oppdaterteBrevmottakere[0].bestillingId).isEqualTo(bestillingId)
+    }
+
+    @Test
+    fun `dersom personen er død og mangler kontaktinfo for dødsbo returneres feilmelding og det gjøres ikke nytt distribusjonskall`() {
+        val avdødPersonUtenKontaktinfoForDødsbo =
+            PdlTestdataHelper.pdlSøker(
+                dødsfall = listOf(Dødsfall(LocalDate.now().minusDays(10))),
+                kontaktinformasjonForDoedsbo = emptyList(),
+            )
+
+        val problemDetailException =
+            ProblemDetailException(
+                detail = ProblemDetail.forStatus(HttpStatus.GONE),
+                responseException = HttpClientErrorException.create(HttpStatus.GONE, "", HttpHeaders(), byteArrayOf(), null),
+                httpStatus = HttpStatus.GONE,
+            )
+
+        every {
+            journalpostClient.distribuerJournalpost(
+                capture(utførteDistribusjoner),
+            )
+        } throws problemDetailException
+
+        every { personService.hentSøker(saksbehandling.ident) } returns avdødPersonUtenKontaktinfoForDødsbo
+
+        val resultat = service.distribuerVedtaksbrev(mottaker)
+
+        assertThat(resultat).isInstanceOf(FeiletFordiMottakerErDødOgManglerAdresse::class.java)
+        val feilResultat = resultat as FeiletFordiMottakerErDødOgManglerAdresse
+        assertThat(feilResultat.feilmelding).contains("fant heller ikke kontaktinformasjon for dødsboet")
+
+        assertThat(utførteDistribusjoner).hasSize(1)
+        val request = utførteDistribusjoner[0]
+        assertThat(request.journalpostId).isEqualTo(journalpostId)
+        assertThat(request.adresse).isNull()
+
+        assertThat(oppdaterteBrevmottakere).isEmpty()
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
@@ -22,6 +22,8 @@ import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.MottakerRolle
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper.pdlSøker
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -40,13 +42,21 @@ class DistribuerVedtaksbrevTaskTest {
     val taskService = mockk<TaskService>(relaxed = true)
     val brevSteg = BrevSteg(taskService)
     val behandlingSerice = mockk<BehandlingService>()
+    val personService = mockk<PersonService>()
+
+    val distribuerVedtaksbrevService =
+        DistribuerVedtaksbrevService(
+            journalpostClient = journalpostClient,
+            brevmottakerVedtaksbrevRepository = brevmottakerVedtaksbrevRepository,
+            personService = personService,
+            transactionHandler = TransactionHandler(),
+        )
 
     val saksbehandling = saksbehandling(steg = StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)
     val distribuerVedtaksbrevTask =
         DistribuerVedtaksbrevTask(
             brevmottakerVedtaksbrevRepository,
-            journalpostClient,
-            TransactionHandler(),
+            distribuerVedtaksbrevService,
             taskService,
         )
     val task = Task(type = DistribuerVedtaksbrevTask.TYPE, payload = saksbehandling.id.toString())
@@ -58,6 +68,7 @@ class DistribuerVedtaksbrevTaskTest {
     fun setUp() {
         every { behandlingSerice.hentSaksbehandling(saksbehandling.id) } returns saksbehandling
         every { stegService.håndterSteg(any<BehandlingId>(), brevSteg) } returns mockk()
+        every { personService.hentSøker(any()) } returns pdlSøker()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
@@ -157,7 +157,7 @@ class DistribuerVedtaksbrevTaskTest {
     }
 
     @Nested
-    inner class `Mottaker er død og mangler adresse` {
+    inner class `Rekjøring senere` {
         @Test
         internal fun `skal rekjøre senere hvis man får GONE fra dokdist`() {
             val distribuerrequestSlots = mutableListOf<DistribuerJournalpostRequest>()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/pdl/PdlTestdata.kt
@@ -16,6 +16,12 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.IdentifiserendeInformasj
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktadresseType
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsbo
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboAdresse
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboAdvokatSomKontakt
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboOrganisasjonSomKontakt
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboPersonSomKontakt
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboSkifteform
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Matrikkeladresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Metadata
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Navn
@@ -115,6 +121,57 @@ object PdlTestdata {
 
     private val utflyttingFraNorge = listOf(UtflyttingFraNorge("", "", LocalDate.now(), folkeregistermetadata))
 
+    private val kontaktinformasjonForDoedsbo =
+        listOf(
+            KontaktinformasjonForDoedsbo(
+                adresse =
+                    KontaktinformasjonForDoedsboAdresse(
+                        adresselinje1 = "Fyrstikkalleen 1, Helsfyr",
+                        adresselinje2 = "",
+                        landkode = "",
+                        postnummer = "0001",
+                        poststedsnavn = "OSLO",
+                    ),
+                advokatSomKontakt =
+                    KontaktinformasjonForDoedsboAdvokatSomKontakt(
+                        organisasjonsnavn = "",
+                        organisasjonsnummer = "",
+                        personnavn =
+                            Personnavn(
+                                etternavn = "",
+                                fornavn = "",
+                                mellomnavn = "",
+                            ),
+                    ),
+                attestutstedelsesdato = LocalDate.now(),
+                folkeregistermetadata = folkeregistermetadata,
+                metadata = metadataGjeldende,
+                organisasjonSomKontakt =
+                    KontaktinformasjonForDoedsboOrganisasjonSomKontakt(
+                        kontaktperson =
+                            Personnavn(
+                                etternavn = "",
+                                fornavn = "",
+                                mellomnavn = "",
+                            ),
+                        organisasjonsnavn = "",
+                        organisasjonsnummer = "",
+                    ),
+                personSomKontakt =
+                    KontaktinformasjonForDoedsboPersonSomKontakt(
+                        foedselsdato = LocalDate.of(2000, 1, 1),
+                        identifikasjonsnummer = "1",
+                        personnavn =
+                            Personnavn(
+                                etternavn = "",
+                                fornavn = "",
+                                mellomnavn = "",
+                            ),
+                    ),
+                skifteform = KontaktinformasjonForDoedsboSkifteform.ANNET,
+            ),
+        )
+
     val søkerIdentifikator = "1"
 
     val folkeregisteridentifikatorSøker =
@@ -150,6 +207,7 @@ object PdlTestdata {
                             vegadresse = vegadresse,
                         ),
                     ),
+                kontaktinformasjonForDoedsbo = kontaktinformasjonForDoedsbo,
                 navn = navn,
                 opphold = opphold,
                 oppholdsadresse = oppholdsadresse,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Fødselsdato
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.IdentifiserendeInformasjon
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsbo
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Metadata
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Navn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Opphold
@@ -52,6 +53,7 @@ object PdlTestdataHelper {
         fødselsdato: List<Fødselsdato> = listOf(fødsel(år = 2000)),
         folkeregisterpersonstatus: List<Folkeregisterpersonstatus> = emptyList(),
         kontaktadresse: List<Kontaktadresse> = emptyList(),
+        kontaktinformasjonForDoedsbo: List<KontaktinformasjonForDoedsbo> = emptyList(),
         navn: List<Navn> = listOf(lagNavn()),
         opphold: List<Opphold> = emptyList(),
         oppholdsadresse: List<Oppholdsadresse> = emptyList(),
@@ -69,6 +71,7 @@ object PdlTestdataHelper {
         fødselsdato = fødselsdato,
         folkeregisterpersonstatus = folkeregisterpersonstatus,
         kontaktadresse = kontaktadresse,
+        kontaktinformasjonForDoedsbo = kontaktinformasjonForDoedsbo,
         navn = navn,
         opphold = opphold,
         oppholdsadresse = oppholdsadresse,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/PdlTestdataHelper.kt
@@ -13,6 +13,8 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.IdentifiserendeInformasj
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.InnflyttingTilNorge
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Kontaktadresse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsbo
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboAdresse
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.KontaktinformasjonForDoedsboSkifteform
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Metadata
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Navn
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Opphold
@@ -171,4 +173,29 @@ object PdlTestdataHelper {
         identifiserendeInformasjon = IdentifiserendeInformasjon(navn = navn),
         omfang = omfang,
     )
+
+    fun folkeregistermetadata() =
+        Folkeregistermetadata(
+            gyldighetstidspunkt = java.time.LocalDateTime.now(),
+            opphørstidspunkt = null,
+        )
+
+    fun kontaktinformasjonDødsbo() =
+        KontaktinformasjonForDoedsbo(
+            adresse =
+                KontaktinformasjonForDoedsboAdresse(
+                    adresselinje1 = "Dødsbogate 1",
+                    adresselinje2 = null,
+                    landkode = "NO",
+                    postnummer = "0123",
+                    poststedsnavn = "OSLO",
+                ),
+            advokatSomKontakt = null,
+            attestutstedelsesdato = LocalDate.now(),
+            folkeregistermetadata = folkeregistermetadata(),
+            metadata = metadataGjeldende,
+            organisasjonSomKontakt = null,
+            personSomKontakt = null,
+            skifteform = KontaktinformasjonForDoedsboSkifteform.OFFENTLIG,
+        )
 }

--- a/src/test/resources/pdl/søker.json
+++ b/src/test/resources/pdl/søker.json
@@ -102,6 +102,7 @@
           }
         }
       ],
+      "kontaktinformasjonForDoedsbo": [],
       "oppholdsadresse": [
         {
           "metadata":  {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi har et vedtaksbrev som ikke kan bli sendt ut ettersom mottaker er død. Vi har forsøkt å sende brevet i et halvt år nå.

I følge PDL vil noen ganger dødsbo legges til feltet `kontaktinformasjonForDoedsbo`. 

I løsningen jeg har laget nå, er flyten sånn:
1. Vi prøver å sende brevet til mottaker 
2. Hvis mottaker er død, forsøker vi å hente ut kontaktinformasjon for dødsbo
     - Hvis kontaktinformasjon finnes, vil vi distribuere brevet til den adressen 
     -  Hvis ikke kontaktinformasjonen finnes, blir det satt opp en rekjøring av tasken én uke etterpå, så lenge ikke maks antall rekjøringer (26) er nådd. 