### PR TITLE
Oppsett swagger

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -63,6 +63,12 @@ spec:
   secureLogs:
     enabled: true
   azure:
+    sidecar:
+      enabled: true
+      autoLogin: true
+      autoLoginIgnorePaths:
+        - /internal/**
+        - /api/**
     application:
       enabled: true
       claims:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -67,6 +67,13 @@ spec:
   secureLogs:
     enabled: true
   azure:
+    sidecar:
+      enabled: true
+      autoLogin: true
+      autoLoginIgnorePaths:
+        - /internal/**
+        - /api/**
+
     application:
       enabled: true
       claims:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ val tokenSupportVersion = "5.0.34"
 val wiremockVersion = "3.13.1"
 val mockkVersion = "1.14.5"
 val testcontainerVersion = "1.21.3"
+val springDocVersion = "2.8.12"
 
 group = "no.nav.tilleggsstonader.sak"
 version = "1.0.0"
@@ -81,6 +82,8 @@ dependencies {
     implementation("net.logstash.logback:logstash-logback-encoder:8.1")
 
     implementation("io.micrometer:micrometer-registry-prometheus")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springDocVersion")
 
     implementation("no.nav.familie:prosessering-core:$familieProsesseringVersion")
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/TaskProsesseringConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/TaskProsesseringConfig.kt
@@ -27,6 +27,6 @@ class TaskProsesseringConfig(
                     throw Feil("Mangler preferred_username på request")
                 }
 
-            override fun harTilgang(): Boolean = SikkerhetContext.hentGrupperFraToken().contains(rolleConfig.prosessering)
+            override fun harTilgang(): Boolean = SikkerhetContext.hentGrupperFraToken().contains(rolleConfig.utvikler)
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/RolleConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/RolleConfig.kt
@@ -17,8 +17,8 @@ data class RolleConfig(
     val kode7: String,
     @Value("\${rolle.egenAnsatt}")
     val egenAnsatt: String,
-    @Value("\${rolle.prosessering}")
-    val prosessering: String,
+    @Value("\${rolle.utvikler}")
+    val utvikler: String,
 ) {
     val rollerMedBeskrivelse: AdRoller by lazy {
         AdRoller(
@@ -28,6 +28,7 @@ data class RolleConfig(
             kode6 = AdRolle(rolleId = kode6, beskrivelse = "Strengt fortrolig adresse"),
             kode7 = AdRolle(rolleId = kode7, beskrivelse = "Fortrolig adresse"),
             egenAnsatt = AdRolle(rolleId = egenAnsatt, beskrivelse = "Nav-ansatt"),
+            utvikler = AdRolle(rolleId = utvikler, beskrivelse = "Utvikler"),
         )
     }
 }
@@ -39,6 +40,7 @@ data class AdRoller(
     val kode6: AdRolle,
     val kode7: AdRolle,
     val egenAnsatt: AdRolle,
+    val utvikler: AdRolle,
 )
 
 data class AdRolle(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -121,4 +121,6 @@ object SikkerhetContext {
 
         return rollerForBruker.contains(minimumsrolle)
     }
+
+    fun harRolle(rolleId: String): Boolean = hentGrupperFraToken().contains(rolleId)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/GjenopprettOppgaveController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/GjenopprettOppgaveController.kt
@@ -1,0 +1,22 @@
+package no.nav.tilleggsstonader.sak.opplysninger.oppgave
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/forvaltning/oppgave")
+@ProtectedWithClaims(issuer = "azuread")
+@Validated
+class GjenopprettOppgaveController(
+    private val tilgangService: TilgangService,
+) {
+    @GetMapping("/gjenopprett")
+    fun gjenopprettOppgave(): Any {
+        tilgangService.validerHarUtviklerrolle()
+        return mapOf("status" to "TODO")
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
@@ -176,6 +176,8 @@ class TilgangService(
         validerTilgangTilRolle(BehandlerRolle.BESLUTTER)
     }
 
+    fun validerHarUtviklerrolle() = SikkerhetContext.harRolle(rolleConfig.utvikler)
+
     fun validerTilgangTilRolle(minimumsrolle: BehandlerRolle) {
         if (!harTilgangTilRolle(minimumsrolle)) {
             throw ManglerTilgang(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
@@ -10,6 +10,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ManglerTilgang
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.infrastruktur.logging.BehandlingLogService
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.RolleConfig
@@ -176,7 +177,10 @@ class TilgangService(
         validerTilgangTilRolle(BehandlerRolle.BESLUTTER)
     }
 
-    fun validerHarUtviklerrolle() = SikkerhetContext.harRolle(rolleConfig.utvikler)
+    fun validerHarUtviklerrolle() =
+        feilHvisIkke(SikkerhetContext.harRolle(rolleConfig.utvikler)) {
+            "Innlogget bruker har ikke utviklerrolle"
+        }
 
     fun validerTilgangTilRolle(minimumsrolle: BehandlerRolle) {
         if (!harTilgangTilRolle(minimumsrolle)) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,7 +7,7 @@ rolle:
   kode6: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
   kode7: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
-  prosessering: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS gir alle tilgang i preprod til prosessering
+  utvikler: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS gir tilgang til forvaltning-endepunkt og prosessering i preprod
 
 DVH_BEHANDLING_TOPIC: tilleggsstonader.aapen-tilleggsstonader-dvh-behandling-test
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,7 +82,7 @@ rolle:
   kode6: "ad7b87a6-9180-467c-affc-20a566b0fec0" # 0000-GA-Strengt_Fortrolig_Adresse
   kode7: "9ec6487d-f37a-4aad-a027-cd221c1ac32b" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "e750ceb5-b70b-4d94-b4fa-9d22467b786b" # 0000-GA-Egne_ansatte
-  prosessering: "9f2c914f-9619-41a2-bea6-d62910514c8a" # Team Tilleggsstønader - Utviklere # tilgang ti prosessering
+  utvikler: "9f2c914f-9619-41a2-bea6-d62910514c8a" # Team Tilleggsstønader - Utviklere # tilgang til forvaltning-endepunkt og prosessering
 
 
 CLIENT_ENV: prod

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangskontrollServiceTest.kt
@@ -39,7 +39,7 @@ internal class TilgangskontrollServiceTest {
             kode7 = kode7Id,
             kode6 = kode6Id,
             egenAnsatt = egenAnsattId,
-            prosessering = "",
+            utvikler = "",
         )
 
     private val tilgangskontrollService =

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -21,7 +21,7 @@ rolle:
   kode6: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
   kode7: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
-  prosessering: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS gir alle tilgang i preprod til prosessering
+  utvikler: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS gir tilgang til forvaltning-endepunkt og prosessering i preprod
 
 AZURE_APP_TENANT_ID: navq.onmicrosoft.com
 AZURE_OPENID_CONFIG_TOKEN_ENDPOINT: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne kalle endpunkter for forvaltningsoppgaver. Eksempelvis:
- Opprette oppgaver på behandlinger som mangler dette
- Trigge satsjustering

Drar da inn springdoc for å legge til swagger. Swagger da tilgjengelig på `/swagger-ui.html`.

Siden api'et trenger å validere at man har tilgang til disse forvaltningsoppgavene, trenger vi å autentisere den som aksesserer swagger. Legger derfor på en `azure.sidecar` i nais-manifestet slik at man må logge inn på `/swagger-ui.html`. Ignorerer innlogging på endepunkter `/api/**` og `/internal/**`.

Må teste litt i dev, så kommer mulig noe endringer