### PR TITLE
Gauge for å sjekke om det finnes behandlinger uten oppgave

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepository.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.Oppgavestatus
 import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 
@@ -213,8 +214,11 @@ interface BehandlingRepository :
         """
             select id from behandling
             where status != 'FERDIGSTILT'
-            and id not in (select behandling_id from oppgave where status = 'ÅPEN');
+            and id not in (select behandling_id from oppgave where status = :status and tildelt_enhetsnummer in (:gyldigeEnheterForOppgave));
         """,
     )
-    fun finnBehandlingerUtenOppgave(): List<BehandlingId>
+    fun finnÅpneBehandlingerUtenOppgaveMedStatusOgTildeltEnhetsnummer(
+        status: Oppgavestatus,
+        gyldigeEnheterForOppgave: Collection<String>,
+    ): List<BehandlingId>
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/domain/BehandlingRepository.kt
@@ -208,4 +208,13 @@ interface BehandlingRepository :
         """,
     )
     fun finnBehandlingerMedAndelerSomVenterPåSatsjustering(stønadstype: Stønadstype): List<BehandlingId>
+
+    @Query(
+        """
+            select id from behandling
+            where status != 'FERDIGSTILT'
+            and id not in (select behandling_id from oppgave where status = 'ÅPEN');
+        """,
+    )
+    fun finnBehandlingerUtenOppgave(): List<BehandlingId>
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/metrics/AntallBehandlingerUtenOppgaveConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/metrics/AntallBehandlingerUtenOppgaveConfig.kt
@@ -1,0 +1,36 @@
+package no.nav.tilleggsstonader.sak.metrics
+
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Metrics
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+import java.time.Instant
+
+@Configuration
+class AntallBehandlingerUtenOppgaveConfig(
+    behandlingRepository: BehandlingRepository,
+) {
+    private val logger = LoggerFactory.getLogger(AntallBehandlingerUtenOppgaveConfig::class.java)
+
+    var sistHentet = Instant.MIN
+    var sisteVerdi = 0.0
+
+    init {
+        // Funksjonen her kalles for hver forspørsel på prometheus-endepunkt. Sørger for at v
+        Gauge
+            .builder<BehandlingRepository>("behandlinger_uten_oppgave", behandlingRepository) {
+                // Slår ikke opp i databasen oftere enn hvert 30. minutt
+                if (sistHentet.isBefore(Instant.now().minus(Duration.ofMinutes(30)))) {
+                    val behandlingerUtenOppgave = it.finnBehandlingerUtenOppgave()
+                    logger.info("Behandlinger uten oppgave: {}", behandlingerUtenOppgave)
+
+                    sisteVerdi = behandlingerUtenOppgave.size.toDouble()
+                    sistHentet = Instant.now()
+                }
+
+                sisteVerdi
+            }.register(Metrics.globalRegistry)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/metrics/AntallBehandlingerUtenOppgaveGaugeConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/metrics/AntallBehandlingerUtenOppgaveGaugeConfig.kt
@@ -3,16 +3,18 @@ package no.nav.tilleggsstonader.sak.metrics
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.Metrics
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveUtil.GYLDIGE_ENHETER_TILLEGGSTØNADER
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.Oppgavestatus
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
 import java.time.Duration
 import java.time.Instant
 
 @Configuration
-class AntallBehandlingerUtenOppgaveConfig(
+class AntallBehandlingerUtenOppgaveGaugeConfig(
     behandlingRepository: BehandlingRepository,
 ) {
-    private val logger = LoggerFactory.getLogger(AntallBehandlingerUtenOppgaveConfig::class.java)
+    private val logger = LoggerFactory.getLogger(AntallBehandlingerUtenOppgaveGaugeConfig::class.java)
 
     var sistHentet = Instant.MIN
     var sisteVerdi = 0.0
@@ -23,8 +25,14 @@ class AntallBehandlingerUtenOppgaveConfig(
             .builder<BehandlingRepository>("behandlinger_uten_oppgave", behandlingRepository) {
                 // Slår ikke opp i databasen oftere enn hvert 30. minutt
                 if (sistHentet.isBefore(Instant.now().minus(Duration.ofMinutes(30)))) {
-                    val behandlingerUtenOppgave = it.finnBehandlingerUtenOppgave()
-                    logger.info("Behandlinger uten oppgave: {}", behandlingerUtenOppgave)
+                    val behandlingerUtenOppgave =
+                        it.finnÅpneBehandlingerUtenOppgaveMedStatusOgTildeltEnhetsnummer(
+                            status = Oppgavestatus.ÅPEN,
+                            gyldigeEnheterForOppgave = GYLDIGE_ENHETER_TILLEGGSTØNADER,
+                        )
+                    if (behandlingerUtenOppgave.isNotEmpty()) {
+                        logger.info("Behandlinger uten oppgave: {}", behandlingerUtenOppgave)
+                    }
 
                     sisteVerdi = behandlingerUtenOppgave.size.toDouble()
                     sistHentet = Instant.now()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/metrics/AntallBehandlingerUtenOppgaveGaugeConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/metrics/AntallBehandlingerUtenOppgaveGaugeConfig.kt
@@ -31,7 +31,7 @@ class AntallBehandlingerUtenOppgaveGaugeConfig(
                             gyldigeEnheterForOppgave = GYLDIGE_ENHETER_TILLEGGSTØNADER,
                         )
                     if (behandlingerUtenOppgave.isNotEmpty()) {
-                        logger.info("Behandlinger uten oppgave: {}", behandlingerUtenOppgave)
+                        logger.warn("Behandlinger uten oppgave: {}", behandlingerUtenOppgave)
                     }
 
                     sisteVerdi = behandlingerUtenOppgave.size.toDouble()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OppgaveUtil.kt
@@ -15,6 +15,8 @@ object OppgaveUtil {
     val ENHET_NR_EGEN_ANSATT = "4483" // NAV Arbeid og ytelser Egne ansatte
     val ENHET_NR_STRENGT_FORTROLIG = "2103" // NAV Vikafossen
 
+    val GYLDIGE_ENHETER_TILLEGGSTØNADER = setOf(ENHET_NR_NAY, ENHET_NR_EGEN_ANSATT, ENHET_NR_STRENGT_FORTROLIG)
+
     fun utledBehandlesAvApplikasjon(oppgavetype: Oppgavetype) =
         when (oppgavetype) {
             Oppgavetype.Journalføring,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å minimere risiko for at vi får behandlinger uten en tilknyttet oppgave. Dette kan skje om oppgave blir flyttet til annen enhet i gosys eller om den blir feilregistrert manuelt i gosys.

Oppretter en gauge for dette. En gauge evalueres hver gang det trengs, altså hver gang vårt `/internal/prometheus`-endepunkt kalles (er typisk hver 15. eller 30. sekund). Legger på litt logikk for at den ikke skal kjøre spørringen alt for ofte. Kanskje litt overkill, men er ikke indekser på feltene som filtreres på i oppgave-tabellen.

Vil videre lage en alert på dette i Grafana.