### PR TITLE
Refaktorering av REST-kall fra integrasjonstester

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "mockito-core")
     }
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.junit.platform:junit-platform-suite")
     testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "mockito-core")
     }
+    // Kun for å kunne bruke WebTestClient. Kan fjernes og erstattes av RestTestClient i spring-boot 4
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.junit.platform:junit-platform-suite")
     testImplementation("org.wiremock:wiremock-standalone:$wiremockVersion")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/IntegrationTest.kt
@@ -42,6 +42,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.grunnlag.VilkårperioderGrunnlagDomain
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -57,6 +58,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.client.RestTemplate
 
 // Slett denne når RestTemplateConfiguration er tatt i bruk?
@@ -106,7 +108,7 @@ abstract class IntegrationTest {
     protected lateinit var jdbcTemplate: NamedParameterJdbcTemplate
 
     @Autowired
-    protected lateinit var rolleConfig: RolleConfig
+    lateinit var rolleConfig: RolleConfig
 
     @Autowired
     protected lateinit var testoppsettService: TestoppsettService
@@ -121,6 +123,17 @@ abstract class IntegrationTest {
     protected lateinit var mockService: MockService
 
     val logger = LoggerFactory.getLogger(javaClass)
+
+    lateinit var webTestClient: WebTestClient
+
+    @BeforeEach
+    fun setup() {
+        webTestClient =
+            WebTestClient
+                .bindToServer()
+                .baseUrl(localhost("/"))
+                .build()
+    }
 
     @AfterEach
     fun tearDown() {
@@ -193,5 +206,12 @@ abstract class IntegrationTest {
 
     companion object {
         private const val LOCALHOST = "http://localhost:"
+    }
+
+    fun WebTestClient.RequestHeadersSpec<*>.medOnBehalfOfToken(
+        role: String = rolleConfig.beslutterRolle,
+        saksbehandler: String = "julenissen",
+    ) = this.headers {
+        it.setBearerAuth(onBehalfOfToken(role, saksbehandler))
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegControllerTest.kt
@@ -2,22 +2,12 @@ package no.nav.tilleggsstonader.sak.behandlingsflyt
 
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.kall.resetSteg
 import no.nav.tilleggsstonader.sak.util.behandling
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod
-import org.springframework.web.client.exchange
-import java.util.UUID
 
 class StegControllerTest : IntegrationTest() {
-    @BeforeEach
-    fun setUp() {
-        headers.setBearerAuth(onBehalfOfToken())
-    }
-
     @Test
     fun `skal resette steg`() {
         val behandling =
@@ -27,17 +17,8 @@ class StegControllerTest : IntegrationTest() {
 
         assertThat(behandling.steg).isEqualTo(StegType.BEREGNE_YTELSE)
 
-        resetSteg(behandling.id, StegType.INNGANGSVILKÅR)
+        resetSteg(behandling.id, StegController.ResetStegRequest(StegType.INNGANGSVILKÅR))
 
         assertThat(testoppsettService.hentBehandling(behandling.id).steg).isEqualTo(StegType.INNGANGSVILKÅR)
     }
-
-    private fun resetSteg(
-        behandlingId: BehandlingId,
-        stegType: StegType,
-    ) = restTemplate.exchange<UUID>(
-        localhost("api/steg/behandling/$behandlingId/reset"),
-        HttpMethod.POST,
-        HttpEntity(StegController.ResetStegRequest(stegType), headers),
-    )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/SøkControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/søk/SøkControllerTest.kt
@@ -3,33 +3,24 @@ package no.nav.tilleggsstonader.sak.fagsak.søk
 import io.mockk.every
 import no.nav.tilleggsstonader.kontrakter.arena.ArenaStatusHarSakerDto
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.libs.test.httpclient.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
-import no.nav.tilleggsstonader.sak.infrastruktur.felles.PersonIdentDto
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.ArenaClientConfig
+import no.nav.tilleggsstonader.sak.kall.søkPerson
+import no.nav.tilleggsstonader.sak.kall.søkPersonKall
+import no.nav.tilleggsstonader.sak.kall.søkPersonPåEksternFagsakId
+import no.nav.tilleggsstonader.sak.kall.søkPersonPåEksternFagsakIdKall
 import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaClient
 import no.nav.tilleggsstonader.sak.util.fagsak
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
-import org.springframework.web.client.exchange
 
 internal class SøkControllerTest : IntegrationTest() {
     @Autowired
     lateinit var arenaClient: ArenaClient
-
-    @BeforeEach
-    fun setUp() {
-        headers.setBearerAuth(onBehalfOfToken())
-    }
 
     @AfterEach
     override fun tearDown() {
@@ -43,52 +34,58 @@ internal class SøkControllerTest : IntegrationTest() {
 
         val response = søkPerson("01010199999")
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.fagsakPersonId).isEqualTo(fagsak.fagsakPersonId)
-        assertThat(response.body?.personIdent).isEqualTo("01010199999")
+        assertThat(response.fagsakPersonId).isEqualTo(fagsak.fagsakPersonId)
+        assertThat(response.personIdent).isEqualTo("01010199999")
     }
 
     @Test
     internal fun `person uten fagsak men finnes i arena skal svare med fagsakPersonId=null`() {
         val response = søkPerson("01010199999")
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.fagsakPersonId).isNull()
-        assertThat(response.body?.personIdent).isEqualTo("01010199999")
+        assertThat(response.fagsakPersonId).isNull()
+        assertThat(response.personIdent).isEqualTo("01010199999")
     }
 
     @Test
     internal fun `person uten fagsak og ikke finnes i arena skal svare med BAD_REQUEST`() {
         every { arenaClient.harSaker(any()) } returns ArenaStatusHarSakerDto(false)
-        val response = catchProblemDetailException { søkPerson("01010166666") }
 
-        assertThat(response.responseException.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
-        assertThat(response.detail.status).isEqualTo(HttpStatus.BAD_REQUEST.value())
-        assertThat(response.detail.detail).isEqualTo("Personen har ikke fagsak eller sak i arena")
+        søkPersonKall("01010166666")
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.detail")
+            .isEqualTo("Personen har ikke fagsak eller sak i arena")
     }
 
     @Test
     internal fun `Skal feile hvis personIdenten ikke finnes i pdl`() {
-        val response = catchProblemDetailException { søkPerson("19117313797") }
-
-        assertThat(response.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
-        assertThat(response.detail.detail).isEqualTo("Finner ingen personer for valgt personident")
+        søkPersonKall("19117313797")
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.detail")
+            .isEqualTo("Finner ingen personer for valgt personident")
     }
 
     @Test
     internal fun `Skal feile hvis personIdenten har feil lengde`() {
-        val response = catchProblemDetailException { søkPerson("010101999990") }
-
-        assertThat(response.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
-        assertThat(response.detail.detail).isEqualTo("Ugyldig personident. Det må være 11 sifre")
+        søkPersonKall("010101999990")
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.detail")
+            .isEqualTo("Ugyldig personident. Det må være 11 sifre")
     }
 
     @Test
     internal fun `Skal feile hvis personIdenten inneholder noe annet enn tall`() {
-        val response = catchProblemDetailException { søkPerson("010et1ord02") }
-
-        assertThat(response.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
-        assertThat(response.detail.detail).isEqualTo("Ugyldig personident. Det kan kun inneholde tall")
+        søkPersonKall("010et1ord02")
+            .expectStatus()
+            .isBadRequest
+            .expectBody()
+            .jsonPath("$.detail")
+            .isEqualTo("Ugyldig personident. Det kan kun inneholde tall")
     }
 
     @Nested
@@ -100,36 +97,18 @@ internal class SøkControllerTest : IntegrationTest() {
             val fagsak =
                 testoppsettService.lagreFagsak(fagsak(person = fagsakPerson, stønadstype = Stønadstype.BARNETILSYN))
 
-            val response = søkPerson(fagsak.eksternId.id)
-
-            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-            val data = response.body!!
+            val data = søkPersonPåEksternFagsakId(fagsak.eksternId.id)
             assertThat(data.personIdent).isEqualTo(fagsak.hentAktivIdent())
         }
 
         @Test
         internal fun `skal kaste feil hvis fagsaken ikke eksisterer`() {
-            testoppsettService.lagreFagsak(fagsak())
-            val response = catchProblemDetailException { søkPerson(100L) }
-
-            assertThat(response.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
-            val data = response.detail
-            assertThat(data.detail)
+            søkPersonPåEksternFagsakIdKall(100L)
+                .expectStatus()
+                .isBadRequest
+                .expectBody()
+                .jsonPath("$.detail")
                 .isEqualTo("Finner ikke fagsak for eksternFagsakId=100")
         }
-
-        private fun søkPerson(eksternFagsakId: Long): ResponseEntity<Søkeresultat> =
-            restTemplate.exchange(
-                localhost("/api/sok/person/fagsak-ekstern/$eksternFagsakId"),
-                HttpMethod.GET,
-                HttpEntity<Any>(headers),
-            )
     }
-
-    private fun søkPerson(personIdent: String): ResponseEntity<Søkeresultat> =
-        restTemplate.exchange(
-            localhost("/api/sok"),
-            HttpMethod.POST,
-            HttpEntity(PersonIdentDto(personIdent = personIdent), headers),
-        )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/AddSecurityHeadersFiltersTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/AddSecurityHeadersFiltersTest.kt
@@ -4,33 +4,26 @@ import no.nav.security.token.support.core.api.Unprotected
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
+import org.springframework.test.web.reactive.server.expectBody
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.client.getForEntity
 
 class AddSecurityHeadersFiltersTest : IntegrationTest() {
     @Test
-    internal fun `ping svarer med pong`() {
-        val response = restTemplate.getForEntity<String>(localhost("api/ping"))
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body!!).isEqualTo("pong")
-    }
-
-    @Test
-    fun `mime-type sniffing er deaktivert i header`() {
-        val response = restTemplate.getForEntity<String>(localhost("api/ping"))
-
-        assertThat(response.headers["X-Content-Type-Options"]).contains("nosniff")
-    }
-
-    @Test
-    fun `headers har riktig cache-control`() {
-        val response = restTemplate.getForEntity<String>(localhost("api/ping"))
-
-        assertThat(response.headers["Cache-Control"]).contains("private, max-age=0, no-cache, no-store")
+    internal fun `verifiser ping svarer med pong, mimetype sniffing deaktivert og cache-control`() {
+        webTestClient
+            .get()
+            .uri("/api/ping")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody<String>()
+            .consumeWith {
+                assertThat(it.responseBody).isEqualTo("pong")
+                assertThat(it.responseHeaders["X-Content-Type-Options"]).contains("nosniff")
+                assertThat(it.responseHeaders["Cache-Control"]).contains("private, max-age=0, no-cache, no-store")
+            }
     }
 }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/ArenaKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/ArenaKall.kt
@@ -1,0 +1,23 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
+import no.nav.tilleggsstonader.sak.migrering.arena.ArenaFinnesPersonRequest
+import no.nav.tilleggsstonader.sak.migrering.arena.ArenaFinnesPersonResponse
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.hentStatusFraArenaKall(arenaFinnesPersonRequest: ArenaFinnesPersonRequest) =
+    webTestClient
+        .post()
+        .uri("/api/ekstern/arena/status")
+        .bodyValue(arenaFinnesPersonRequest)
+        .medClientCredentials(EksternApplikasjon.ARENA.namespaceAppNavn, true)
+        .exchange()
+
+fun IntegrationTest.hentStatusFraArena(arenaFinnesPersonRequest: ArenaFinnesPersonRequest) =
+    hentStatusFraArenaKall(arenaFinnesPersonRequest)
+        .expectStatus()
+        .isOk
+        .expectBody<ArenaFinnesPersonResponse>()
+        .returnResult()
+        .responseBody!!

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/BehandlingKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/BehandlingKall.kt
@@ -1,0 +1,71 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
+import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
+import no.nav.tilleggsstonader.sak.behandling.historikk.dto.BehandlingshistorikkDto
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.hentBehandlingKall(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/behandling/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+fun IntegrationTest.hentBehandling(behandlingId: BehandlingId) =
+    hentBehandlingKall(behandlingId)
+        .expectStatus()
+        .isOk
+        .expectBody<BehandlingDto>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.hentBehandlingMedEksternId(behandlingIdEksternId: Long) =
+    webTestClient
+        .get()
+        .uri("/api/behandling/ekstern/$behandlingIdEksternId")
+        .medOnBehalfOfToken()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<BehandlingId>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.henleggBehandlingKall(
+    behandlingId: BehandlingId,
+    henlagtDto: HenlagtDto,
+) = webTestClient
+    .post()
+    .uri("/api/behandling/$behandlingId/henlegg")
+    .bodyValue(henlagtDto)
+    .medOnBehalfOfToken()
+    .exchange()
+
+fun IntegrationTest.henleggBehandling(
+    behandlingId: BehandlingId,
+    henlagtDto: HenlagtDto,
+) {
+    henleggBehandlingKall(behandlingId, henlagtDto)
+        .expectStatus()
+        .isNoContent
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.hentBehandlingshistorikkKall(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/behandlingshistorikk/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+fun IntegrationTest.hentBehandlingshistorikk(behandlingId: BehandlingId) =
+    hentBehandlingshistorikkKall(behandlingId)
+        .expectStatus()
+        .isOk
+        .expectBody<List<BehandlingshistorikkDto>>()
+        .returnResult()
+        .responseBody!!

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/GjenopprettOppgaveKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/GjenopprettOppgaveKall.kt
@@ -1,0 +1,12 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+
+// Må kalles med utvikler-rettighet
+fun IntegrationTest.gjenopprettOppgaveKall(behandlingId: BehandlingId) =
+    webTestClient
+        .post()
+        .uri("/api/forvaltning/oppgave/gjenopprett/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/JournalpostKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/JournalpostKall.kt
@@ -1,0 +1,20 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.journalføring.dto.JournalføringRequest
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.fullførJournalpost(
+    journalpostId: String,
+    request: JournalføringRequest,
+) = webTestClient
+    .post()
+    .uri("/api/journalpost/$journalpostId/fullfor")
+    .bodyValue(request)
+    .medOnBehalfOfToken()
+    .exchange()
+    .expectStatus()
+    .isOk
+    .expectBody<String>()
+    .returnResult()
+    .responseBody!!

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/PersonKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/PersonKall.kt
@@ -1,0 +1,37 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.fagsak.søk.Søkeresultat
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.PersonIdentDto
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.søkPersonPåEksternFagsakIdKall(eksternFagsakId: Long) =
+    webTestClient
+        .get()
+        .uri("/api/sok/person/fagsak-ekstern/$eksternFagsakId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+fun IntegrationTest.søkPersonPåEksternFagsakId(eksternFagsakId: Long) =
+    søkPersonPåEksternFagsakIdKall(eksternFagsakId)
+        .expectStatus()
+        .isOk
+        .expectBody<Søkeresultat>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.søkPersonKall(personIdent: String) =
+    webTestClient
+        .post()
+        .uri("/api/sok")
+        .bodyValue(PersonIdentDto(personIdent = personIdent))
+        .medOnBehalfOfToken()
+        .exchange()
+
+fun IntegrationTest.søkPerson(personIdent: String) =
+    søkPersonKall(personIdent)
+        .expectStatus()
+        .isOk
+        .expectBody<Søkeresultat>()
+        .returnResult()
+        .responseBody!!

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/SettPåVentKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/SettPåVentKall.kt
@@ -1,0 +1,40 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.vent.KanTaAvVentDto
+import no.nav.tilleggsstonader.sak.behandling.vent.SettPåVentDto
+import no.nav.tilleggsstonader.sak.behandling.vent.StatusPåVentDto
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.settPåVentKall(
+    behandlingId: BehandlingId,
+    settPåVentDto: SettPåVentDto,
+) = webTestClient
+    .post()
+    .uri("/api/sett-pa-vent/$behandlingId")
+    .bodyValue(settPåVentDto)
+    .medOnBehalfOfToken()
+    .exchange()
+
+fun IntegrationTest.settPåVent(
+    behandlingId: BehandlingId,
+    settPåVentDto: SettPåVentDto,
+) = settPåVentKall(behandlingId, settPåVentDto)
+    .expectStatus()
+    .isOk
+    .expectBody<StatusPåVentDto>()
+    .returnResult()
+    .responseBody!!
+
+fun IntegrationTest.hentKanTaAvVent(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/sett-pa-vent/$behandlingId/kan-ta-av-vent")
+        .medOnBehalfOfToken()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<KanTaAvVentDto>()
+        .returnResult()
+        .responseBody!!

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/SimuleringKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/SimuleringKall.kt
@@ -1,0 +1,18 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.utbetaling.simulering.dto.SimuleringDto
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.simulerForBehandling(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/simulering/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<SimuleringDto>()
+        .returnResult()
+        .responseBody!!

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/StegKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/StegKall.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegController
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+
+fun IntegrationTest.resetSteg(
+    behandlingId: BehandlingId,
+    resetStegRequest: StegController.ResetStegRequest,
+) {
+    webTestClient
+        .post()
+        .uri("/api/steg/behandling/$behandlingId/reset")
+        .bodyValue(resetStegRequest)
+        .medOnBehalfOfToken()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/VedtakKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/VedtakKall.kt
@@ -1,0 +1,257 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.VedtakTilsynBarnResponse
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.InnvilgelseBoutgifterRequest
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterRequest
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.VedtakBoutgifterRequest
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.VedtakBoutgifterResponse
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.AvslagDagligReiseDto
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseRequest
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.VedtakDagligReiseRequest
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.VedtakDagligReiseResponse
+import no.nav.tilleggsstonader.sak.vedtak.dto.VedtakRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.VedtakLæremidlerRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.VedtakLæremidlerResponse
+import org.springframework.test.web.reactive.server.expectBody
+
+fun IntegrationTest.lagreVedtak(
+    behandlingId: BehandlingId,
+    vedtakRequest: VedtakRequest,
+    stønadsPath: String,
+    resultatPath: String,
+) = webTestClient
+    .post()
+    .uri("/api/vedtak/$stønadsPath/$behandlingId/$resultatPath")
+    .bodyValue(vedtakRequest)
+    .medOnBehalfOfToken()
+    .exchange()
+    .expectStatus()
+    .isOk
+
+// Tilsyn barn
+fun IntegrationTest.hentVedtakTilsynBarnKall(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/vedtak/tilsyn-barn/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+inline fun <reified T : VedtakTilsynBarnResponse> IntegrationTest.hentVedtakTilsynBarn(behandlingId: BehandlingId) =
+    hentVedtakTilsynBarnKall(behandlingId)
+        .expectStatus()
+        .isOk
+        .expectBody<T>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.lagreVedtakTilsynBarn(
+    behandlingId: BehandlingId,
+    vedtakTilsynBarnRequest: VedtakTilsynBarnRequest,
+    resultat: String,
+) = lagreVedtak(behandlingId, vedtakTilsynBarnRequest, "tilsyn-barn", resultat)
+
+fun IntegrationTest.innvilgeVedtakTilsynBarn(
+    behandlingId: BehandlingId,
+    innvilgeVedtakTilsynBarnRequest: InnvilgelseTilsynBarnRequest,
+) {
+    lagreVedtakTilsynBarn(behandlingId, innvilgeVedtakTilsynBarnRequest, "innvilgelse")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.avslåVedtakTilsynBarn(
+    behandlingId: BehandlingId,
+    innvilgeVedtakTilsynBarnRequest: AvslagTilsynBarnDto,
+) {
+    lagreVedtakTilsynBarn(behandlingId, innvilgeVedtakTilsynBarnRequest, "avslag")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.opphørVedtakTilsynBarn(
+    behandlingId: BehandlingId,
+    innvilgeVedtakTilsynBarnRequest: OpphørTilsynBarnRequest,
+) {
+    lagreVedtakTilsynBarn(behandlingId, innvilgeVedtakTilsynBarnRequest, "opphor")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+// Boutgifter
+fun IntegrationTest.hentVedtakBoutgifterKall(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/vedtak/boutgifter/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+inline fun <reified T : VedtakBoutgifterResponse> IntegrationTest.hentVedtakBoutgifter(behandlingId: BehandlingId) =
+    hentVedtakBoutgifterKall(behandlingId)
+        .expectStatus()
+        .isOk
+        .expectBody<T>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.lagreVedtakBoutgifter(
+    behandlingId: BehandlingId,
+    vedtakBoutgifterRequest: VedtakBoutgifterRequest,
+    resultat: String,
+) = lagreVedtak(behandlingId, vedtakBoutgifterRequest, "boutgifter", resultat)
+
+fun IntegrationTest.innvilgeVedtakBoutgifter(
+    behandlingId: BehandlingId,
+    innvilgeVedtakBoutgifterRequest: InnvilgelseBoutgifterRequest,
+) {
+    lagreVedtakBoutgifter(behandlingId, innvilgeVedtakBoutgifterRequest, "innvilgelse")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.avslåVedtakBoutgifter(
+    behandlingId: BehandlingId,
+    innvilgeVedtakBoutgifterRequest: AvslagBoutgifterDto,
+) {
+    lagreVedtakBoutgifter(behandlingId, innvilgeVedtakBoutgifterRequest, "avslag")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.opphørVedtakBoutgifter(
+    behandlingId: BehandlingId,
+    innvilgeVedtakBoutgifterRequest: OpphørBoutgifterRequest,
+) {
+    lagreVedtakBoutgifter(behandlingId, innvilgeVedtakBoutgifterRequest, "opphor")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+// Læremidler
+fun IntegrationTest.hentVedtakLæremidlerKall(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/vedtak/laremidler/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+inline fun <reified T : VedtakLæremidlerResponse> IntegrationTest.hentVedtakLæremidler(behandlingId: BehandlingId) =
+    hentVedtakLæremidlerKall(behandlingId)
+        .expectStatus()
+        .isOk
+        .expectBody<T>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.lagreVedtakLæremidler(
+    behandlingId: BehandlingId,
+    vedtakLæremidlerRequest: VedtakLæremidlerRequest,
+    resultat: String,
+) = lagreVedtak(behandlingId, vedtakLæremidlerRequest, "laremidler", resultat)
+
+fun IntegrationTest.innvilgeVedtakLæremidler(
+    behandlingId: BehandlingId,
+    innvilgeVedtakLæremidlerRequest: InnvilgelseLæremidlerRequest,
+) {
+    lagreVedtakLæremidler(behandlingId, innvilgeVedtakLæremidlerRequest, "innvilgelse")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.avslåVedtakLæremidler(
+    behandlingId: BehandlingId,
+    innvilgeVedtakLæremidlerRequest: AvslagLæremidlerDto,
+) {
+    lagreVedtakLæremidler(behandlingId, innvilgeVedtakLæremidlerRequest, "avslag")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+fun IntegrationTest.opphørVedtakLæremidler(
+    behandlingId: BehandlingId,
+    innvilgeVedtakLæremidlerRequest: OpphørLæremidlerRequest,
+) {
+    lagreVedtakLæremidler(behandlingId, innvilgeVedtakLæremidlerRequest, "opphor")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+// Daglig reise
+fun IntegrationTest.hentVedtakDagligReiseKall(behandlingId: BehandlingId) =
+    webTestClient
+        .get()
+        .uri("/api/vedtak/daglig-reise/$behandlingId")
+        .medOnBehalfOfToken()
+        .exchange()
+
+inline fun <reified T : VedtakDagligReiseResponse> IntegrationTest.hentVedtakDagligReise(behandlingId: BehandlingId) =
+    hentVedtakDagligReiseKall(behandlingId)
+        .expectStatus()
+        .isOk
+        .expectBody<T>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.lagreVedtakDagligReise(
+    behandlingId: BehandlingId,
+    vedtakDagligReiseRequest: VedtakDagligReiseRequest,
+    resultat: String,
+) = lagreVedtak(behandlingId, vedtakDagligReiseRequest, "daglig-reise", resultat)
+
+fun IntegrationTest.innvilgeVedtakDagligReise(
+    behandlingId: BehandlingId,
+    innvilgeVedtakDagligReiseRequest: InnvilgelseDagligReiseRequest,
+) = lagreVedtakDagligReise(behandlingId, innvilgeVedtakDagligReiseRequest, "innvilgelse")
+    .expectStatus()
+    .isOk
+    .expectBody()
+    .isEmpty
+
+fun IntegrationTest.avslåVedtakDagligReise(
+    behandlingId: BehandlingId,
+    innvilgeVedtakDagligReiseRequest: AvslagDagligReiseDto,
+) {
+    lagreVedtakDagligReise(behandlingId, innvilgeVedtakDagligReiseRequest, "avslag")
+        .expectStatus()
+        .isOk
+        .expectBody()
+        .isEmpty
+}
+
+// fun IntegrationTest.opphørVedtakDagligReise(
+//    behandlingId: BehandlingId,
+//    innvilgeVedtakDagligReiseRequest: OpphørDagligReiseRequest,
+// ) {
+//    lagreVedtakDagligReise(behandlingId, innvilgeVedtakDagligReiseRequest, "opphor")
+//        .expectStatus()
+//        .isOk
+//        .expectBody()
+//        .isEmpty
+// }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/VilkårperiodeKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/VilkårperiodeKall.kt
@@ -1,0 +1,82 @@
+package no.nav.tilleggsstonader.sak.kall
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiodeResponse
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperioderResponse
+import org.springframework.http.HttpMethod
+import org.springframework.test.web.reactive.server.expectBody
+import java.util.UUID
+
+fun IntegrationTest.hentVilkårperioder(behandling: Behandling) =
+    webTestClient
+        .get()
+        .uri("/api/vilkarperiode/behandling/${behandling.id}")
+        .medOnBehalfOfToken()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<VilkårperioderResponse>()
+        .returnResult()
+        .responseBody!!
+        .vilkårperioder
+
+fun IntegrationTest.opprettVilkårperiode(lagreVilkårperiode: LagreVilkårperiode) =
+    webTestClient
+        .post()
+        .uri("/api/vilkarperiode/v2")
+        .bodyValue(lagreVilkårperiode)
+        .medOnBehalfOfToken()
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody<LagreVilkårperiodeResponse>()
+        .returnResult()
+        .responseBody!!
+
+fun IntegrationTest.oppdaterVikårperiode(
+    lagreVilkårperiode: LagreVilkårperiode,
+    vilkårperiodeId: UUID,
+) = webTestClient
+    .post()
+    .uri("/api/vilkarperiode/v2/$vilkårperiodeId")
+    .bodyValue(lagreVilkårperiode)
+    .medOnBehalfOfToken()
+    .exchange()
+    .expectStatus()
+    .isOk
+    .expectBody<LagreVilkårperiodeResponse>()
+    .returnResult()
+    .responseBody!!
+
+fun IntegrationTest.slettVilkårperiodeKall(
+    vilkårperiodeId: UUID,
+    slettVikårperiode: SlettVikårperiode,
+) = webTestClient
+    .method(HttpMethod.DELETE) // Delete's ikke spesifisert skal ha body, så er en "hack"
+    .uri("/api/vilkarperiode/$vilkårperiodeId")
+    .bodyValue(slettVikårperiode)
+    .medOnBehalfOfToken()
+    .exchange()
+
+fun IntegrationTest.slettVilkårperiode(
+    vilkårperiodeId: UUID,
+    slettVikårperiode: SlettVikårperiode,
+) = slettVilkårperiodeKall(vilkårperiodeId, slettVikårperiode)
+    .expectStatus()
+    .isOk
+    .expectBody<LagreVilkårperiodeResponse>()
+    .returnResult()
+    .responseBody!!
+
+fun IntegrationTest.oppdaterGrunnlagKall(
+    behandlingId: BehandlingId,
+    role: String = rolleConfig.beslutterRolle,
+) = webTestClient
+    .post()
+    .uri("/api/vilkarperiode/behandling/$behandlingId/oppdater-grunnlag")
+    .medOnBehalfOfToken(role)
+    .exchange()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/VilkårperiodeKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/kall/VilkårperiodeKall.kt
@@ -72,11 +72,9 @@ fun IntegrationTest.slettVilkårperiode(
     .returnResult()
     .responseBody!!
 
-fun IntegrationTest.oppdaterGrunnlagKall(
-    behandlingId: BehandlingId,
-    role: String = rolleConfig.beslutterRolle,
-) = webTestClient
-    .post()
-    .uri("/api/vilkarperiode/behandling/$behandlingId/oppdater-grunnlag")
-    .medOnBehalfOfToken(role)
-    .exchange()
+fun IntegrationTest.oppdaterGrunnlagKall(behandlingId: BehandlingId) =
+    webTestClient
+        .post()
+        .uri("/api/vilkarperiode/behandling/$behandlingId/oppdater-grunnlag")
+        .medOnBehalfOfToken()
+        .exchange()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/EksternArenaControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/EksternArenaControllerTest.kt
@@ -1,53 +1,26 @@
 package no.nav.tilleggsstonader.sak.migrering.arena
 
 import no.nav.tilleggsstonader.kontrakter.arena.vedtak.Rettighet
-import no.nav.tilleggsstonader.libs.test.httpclient.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.IntegrationTest
-import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
+import no.nav.tilleggsstonader.sak.kall.hentStatusFraArena
+import no.nav.tilleggsstonader.sak.kall.hentStatusFraArenaKall
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod
-import org.springframework.web.client.exchange
 
 class EksternArenaControllerTest : IntegrationTest() {
-    @BeforeEach
-    fun setUp() {
-        headers.setBearerAuth(clientCredential(EksternApplikasjon.ARENA.namespaceAppNavn, true))
-    }
-
     @Test
     fun `skal kunne sende inn rettighetstype som er mappet`() {
-        val response = hentStatus("ident", Rettighet.TILSYN_BARN)
+        val response = hentStatusFraArena(ArenaFinnesPersonRequest("ident", Rettighet.TILSYN_BARN.kodeArena))
         assertThat(response.finnes).isTrue()
     }
 
     @Test
     fun `skal kaste feil hvis man sender inn rettighet som ikke er mappet`() {
-        val exception =
-            catchProblemDetailException {
-                hentStatus("ident", Rettighet.REISE)
-            }
-
-        assertThat(exception.detail.detail)
+        hentStatusFraArenaKall(ArenaFinnesPersonRequest("ident", Rettighet.REISE.kodeArena))
+            .expectStatus()
+            .is5xxServerError
+            .expectBody()
+            .jsonPath("$.detail")
             .isEqualTo("Har ikke lagt inn mapping av stønadstype for REISE")
-    }
-
-    private fun hentStatus(
-        ident: String,
-        rettighet: Rettighet,
-    ): ArenaFinnesPersonResponse {
-        val request =
-            mapOf(
-                "ident" to ident,
-                "rettighet" to rettighet.kodeArena,
-            )
-        return restTemplate
-            .exchange<ArenaFinnesPersonResponse>(
-                localhost("api/ekstern/arena/status"),
-                HttpMethod.POST,
-                HttpEntity(request, headers),
-            ).body!!
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/GjenopprettOppgaveControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/GjenopprettOppgaveControllerTest.kt
@@ -1,18 +1,13 @@
 package no.nav.tilleggsstonader.sak.opplysninger.oppgave
 
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.kall.gjenopprettOppgaveKall
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.GjenopprettOppgavePåBehandlingTask
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
-import org.springframework.web.client.HttpClientErrorException
-import org.springframework.web.client.exchange
 
 class GjenopprettOppgaveControllerTest : IntegrationTest() {
     @Autowired
@@ -22,29 +17,19 @@ class GjenopprettOppgaveControllerTest : IntegrationTest() {
     fun `gjenopprett feilregistrert på behandling, har utviklerrolle`() {
         val behandling = testoppsettService.opprettBehandlingMedFagsak()
 
-        val res =
-            restTemplate.exchange<Unit>(
-                localhost("/api/forvaltning/oppgave/gjenopprett/${behandling.id}"),
-                HttpMethod.POST,
-                HttpEntity(null, headers.apply { setBearerAuth(onBehalfOfToken(role = rolleConfig.utvikler)) }),
-            )
-
-        assertThat(res.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+        medBrukercontext(rolle = rolleConfig.utvikler) {
+            gjenopprettOppgaveKall(behandling.id)
+                .expectStatus()
+                .isNoContent
+        }
 
         assertThat(taskService.findAll().filter { it.type == GjenopprettOppgavePåBehandlingTask.TYPE }).hasSize(1)
     }
 
     @Test
     fun `gjenopprett feilregistrert på behandling, har ikke utviklerrolle, får 403`() {
-        val res =
-            catchThrowableOfType<HttpClientErrorException> {
-                restTemplate.exchange<Unit>(
-                    localhost("/api/forvaltning/oppgave/gjenopprett/${BehandlingId.random()}"),
-                    HttpMethod.POST,
-                    HttpEntity(null, headers.apply { setBearerAuth(onBehalfOfToken()) }), // får default rolle beslutter
-                )
-            }
-
-        assertThat(res.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        gjenopprettOppgaveKall(BehandlingId.random())
+            .expectStatus()
+            .isForbidden
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
@@ -1,13 +1,15 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.libs.test.httpclient.ProblemDetailUtil.catchProblemDetailException
 import no.nav.tilleggsstonader.sak.IntegrationTest
-import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.kall.avslåVedtakDagligReise
+import no.nav.tilleggsstonader.sak.kall.hentVedtakDagligReise
+import no.nav.tilleggsstonader.sak.kall.hentVedtakDagligReiseKall
+import no.nav.tilleggsstonader.sak.kall.innvilgeVedtakDagligReise
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.vilkår
@@ -20,7 +22,6 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunn
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.AvslagDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseRequest
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseResponse
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.VedtakDagligReiseResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeTestUtil.vedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
 import no.nav.tilleggsstonader.sak.vedtak.dto.LagretVedtaksperiodeDto
@@ -37,10 +38,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
-import org.springframework.web.client.exchange
 import java.time.LocalDate
 
 class DagligReiseVedtakControllerTest : IntegrationTest() {
@@ -62,7 +59,12 @@ class DagligReiseVedtakControllerTest : IntegrationTest() {
             status = BehandlingStatus.UTREDES,
         )
     val dummyOffentligTransport =
-        OffentligTransport(reisedagerPerUke = 4, prisEnkelbillett = 44, prisSyvdagersbillett = null, prisTrettidagersbillett = 750)
+        OffentligTransport(
+            reisedagerPerUke = 4,
+            prisEnkelbillett = 44,
+            prisSyvdagersbillett = null,
+            prisTrettidagersbillett = 750,
+        )
 
     val vedtaksperiode = vedtaksperiode(fom = dummyFom, tom = dummyTom)
     val aktivitet = aktivitet(dummyBehandlingId, fom = dummyFom, tom = dummyTom)
@@ -132,7 +134,6 @@ class DagligReiseVedtakControllerTest : IntegrationTest() {
 
     @BeforeEach
     fun setUp() {
-        headers.setBearerAuth(onBehalfOfToken())
         testoppsettService.opprettBehandlingMedFagsak(dummyBehandling, stønadstype = Stønadstype.DAGLIG_REISE_TSO)
         vilkårperiodeRepository.insert(aktivitet)
         vilkårperiodeRepository.insert(målgruppe)
@@ -140,35 +141,25 @@ class DagligReiseVedtakControllerTest : IntegrationTest() {
     }
 
     @Test
-    fun `skal validere token`() {
-        headers.clear()
-        val exception =
-            catchProblemDetailException { hentVedtak<InnvilgelseDagligReiseResponse>(BehandlingId.random()) }
-
-        assertThat(exception.httpStatus).isEqualTo(HttpStatus.UNAUTHORIZED)
-    }
-
-    @Test
     fun `hent vedtak skal returnere tom body når det ikke finnes noen lagrede vedtak`() {
-        val response = hentVedtak<InnvilgelseDagligReiseResponse>(dummyBehandlingId)
-
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isNull()
+        hentVedtakDagligReiseKall(dummyBehandlingId)
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .isEmpty
     }
 
     @Test
     fun `hent ut lagrede vedtak av type innvilgelse`() {
         val vedtakRequest = InnvilgelseDagligReiseRequest(listOf(vedtaksperiode.tilDto()))
-        val lagreVedtak =
-            innvilgeVedtak<InnvilgelseDagligReiseResponse>(
-                dummyBehandling,
-                vedtakRequest,
-            )
-        assertThat(lagreVedtak.statusCode).isEqualTo(HttpStatus.OK)
-        val response = hentVedtak<InnvilgelseDagligReiseResponse>(dummyBehandlingId)
 
-        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body).isEqualTo(dummyInnvilgelse)
+        innvilgeVedtakDagligReise(
+            dummyBehandling.id,
+            vedtakRequest,
+        )
+        val response = hentVedtakDagligReise<InnvilgelseDagligReiseResponse>(dummyBehandlingId)
+
+        assertThat(response).isEqualTo(dummyInnvilgelse)
     }
 
     @Nested
@@ -181,40 +172,13 @@ class DagligReiseVedtakControllerTest : IntegrationTest() {
                     begrunnelse = "begrunnelse",
                 )
 
-            avslåVedtak(dummyBehandling, avslag)
+            avslåVedtakDagligReise(dummyBehandling.id, avslag)
 
-            val lagretDto = hentVedtak<AvslagDagligReiseDto>(dummyBehandling.id).body!!
+            val lagretDto = hentVedtakDagligReise<AvslagDagligReiseDto>(dummyBehandling.id)
 
             assertThat(lagretDto.årsakerAvslag).isEqualTo(avslag.årsakerAvslag)
             assertThat(lagretDto.begrunnelse).isEqualTo(avslag.begrunnelse)
             assertThat(lagretDto.type).isEqualTo(TypeVedtak.AVSLAG)
         }
-
-        private fun avslåVedtak(
-            behandling: Behandling,
-            vedtak: AvslagDagligReiseDto,
-        ) {
-            restTemplate.exchange<Map<String, Any>?>(
-                localhost("api/vedtak/daglig-reise/${behandling.id}/avslag"),
-                HttpMethod.POST,
-                HttpEntity(vedtak, headers),
-            )
-        }
     }
-
-    private inline fun <reified T> innvilgeVedtak(
-        behandling: Behandling,
-        vedtak: InnvilgelseDagligReiseRequest,
-    ) = restTemplate.exchange<T>(
-        localhost("api/vedtak/daglig-reise/${behandling.id}/innvilgelse"),
-        HttpMethod.POST,
-        HttpEntity(vedtak, headers),
-    )
-
-    private inline fun <reified T : VedtakDagligReiseResponse> hentVedtak(behandlingId: BehandlingId) =
-        restTemplate.exchange<T>(
-            localhost("api/vedtak/daglig-reise/$behandlingId"),
-            HttpMethod.GET,
-            HttpEntity(null, headers),
-        )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeControllerTest.kt
@@ -106,14 +106,16 @@ class VilkårperiodeControllerTest : IntegrationTest() {
         fun `må ha saksbehandlerrolle for å kunne oppdatere grunnlag`() {
             val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
 
-            oppdaterGrunnlagKall(behandling.id, rolleConfig.veilederRolle)
-                .expectStatus()
-                .isForbidden
-                .expectBody()
-                .jsonPath("$.detail")
-                .value<String> {
-                    assertThat(it).startsWith("Mangler nødvendig saksbehandlerrolle for å utføre handlingen")
-                }
+            medBrukercontext(rolle = rolleConfig.veilederRolle) {
+                oppdaterGrunnlagKall(behandling.id)
+                    .expectStatus()
+                    .isForbidden
+                    .expectBody()
+                    .jsonPath("$.detail")
+                    .value<String> {
+                        assertThat(it).startsWith("Mangler nødvendig saksbehandlerrolle for å utføre handlingen")
+                    }
+            }
         }
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å rydde opp og samle hvordan vi kaller rest-endepunkt fra integrasjonstester, slik at det kanskje vil bli enklere å skrive integrasjonstester som kaller rest-endepunkt, istedenfor å kalle servicer direkte.

- Bytter ut alle rest-kall fra integrasjonstester fra RestTemplate til å bruke WebTestClient. Dette da sistnevnte er et bedre verktøy å skrive tester med.

- Organiserer alle rest-kall i en egen mappe som extension-funksjoner på IntegrationTest, slik at disse er enkle å gjenbruke mellom tester