### PR TITLE
integrasjonstest for mottak av søknad boutgifter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaConsumer.kt
@@ -1,0 +1,26 @@
+package no.nav.tilleggsstonader.sak.hendelser.journalføring
+
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.support.Acknowledgment
+import org.springframework.stereotype.Service
+
+@Service
+@Profile("!local & !integrasjonstest")
+class JournalhendelseKafkaConsumer(
+    private val journalhendelseKafkaListener: JournalhendelseKafkaListener,
+) {
+    @KafkaListener(
+        groupId = "tilleggsstonader-sak",
+        topics = ["\${topics.journalhendelser}"],
+        containerFactory = "journalhendelserListenerContainerFactory",
+    )
+    fun listen(
+        consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>,
+        ack: Acknowledgment,
+    ) {
+        journalhendelseKafkaListener.listen(consumerRecord, ack)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaListener.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaListener.kt
@@ -13,8 +13,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
-import org.springframework.context.annotation.Profile
-import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.support.Acknowledgment
 import org.springframework.stereotype.Service
 
@@ -25,7 +23,6 @@ import org.springframework.stereotype.Service
  * https://confluence.adeo.no/display/BOA/Joarkhendelser
  */
 @Service
-@Profile("!local & !integrasjonstest")
 class JournalhendelseKafkaListener(
     private val hendelseRepository: HendelseRepository,
     private val transactionHandler: TransactionHandler,
@@ -33,11 +30,6 @@ class JournalhendelseKafkaListener(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @KafkaListener(
-        groupId = "tilleggsstonader-sak",
-        topics = ["\${topics.journalhendelser}"],
-        containerFactory = "journalhendelserListenerContainerFactory",
-    )
     fun listen(
         consumerRecord: ConsumerRecord<String, JournalfoeringHendelseRecord>,
         ack: Acknowledgment,
@@ -81,7 +73,7 @@ class JournalhendelseKafkaListener(
         hendelseRecord.kanalReferanseId?.takeIf { it.isNotBlank() } ?: IdUtils.generateId()
 }
 
-private enum class JournalpostHendelseType {
+enum class JournalpostHendelseType {
     JournalpostMottatt,
     TemaEndret,
     EndeligJournalført,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaSøknadTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaSøknadTest.kt
@@ -1,0 +1,111 @@
+package no.nav.tilleggsstonader.sak.ekstern.journalføring
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.joarkjournalfoeringhendelser.JournalfoeringHendelseRecord
+import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
+import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.kontrakter.journalpost.Bruker
+import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
+import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakRepository
+import no.nav.tilleggsstonader.sak.hendelser.ConsumerRecordUtil
+import no.nav.tilleggsstonader.sak.hendelser.HendelseRepository
+import no.nav.tilleggsstonader.sak.hendelser.TypeHendelse
+import no.nav.tilleggsstonader.sak.hendelser.journalføring.JournalhendelseKafkaListener
+import no.nav.tilleggsstonader.sak.hendelser.journalføring.JournalpostHendelseType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksKlareForProsessering
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.util.SøknadBoutgifterUtil.søknadBoutgifter
+import no.nav.tilleggsstonader.sak.util.dokumentInfo
+import no.nav.tilleggsstonader.sak.util.dokumentvariant
+import no.nav.tilleggsstonader.sak.util.journalpost
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.kafka.support.Acknowledgment
+import java.util.UUID
+
+class MottaSøknadTest : IntegrationTest() {
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var fagsakRepository: FagsakRepository
+
+    @Autowired
+    private lateinit var journalpostClient: JournalpostClient
+
+    @Autowired
+    lateinit var journalhendelseKafkaListener: JournalhendelseKafkaListener
+
+    @Autowired
+    lateinit var hendelseRepository: HendelseRepository
+
+    val journalpostId = 123321L
+    val ident = "12345678901"
+
+    @Test
+    fun `mottar boutgifter-søknad fra kafka, journalføres og oppretter sak`() {
+        val hendelse = JournalfoeringHendelseRecord()
+        hendelse.journalpostId = journalpostId
+        hendelse.mottaksKanal = "NAV_NO"
+        hendelse.hendelsesType = JournalpostHendelseType.JournalpostMottatt.name
+        hendelse.temaNytt = Tema.TSO.name
+        hendelse.hendelsesId = UUID.randomUUID().toString()
+
+        journalhendelseKafkaListener.listen(
+            ConsumerRecordUtil.lagConsumerRecord("key", hendelse),
+            mockk<Acknowledgment>(relaxed = true),
+        )
+
+        assertThat(hendelseRepository.findByTypeAndId(TypeHendelse.JOURNALPOST, hendelse.hendelsesId)).isNotNull
+
+        mockJournalpost(brevkode = DokumentBrevkode.BOUTGIFTER, søknad = søknadBoutgifter(ident = ident))
+        kjørTasksKlareForProsessering()
+
+        val fagsakerPåBruker = fagsakRepository.findBySøkerIdent(setOf(ident))
+        assertThat(fagsakerPåBruker).hasSize(1)
+        val fagsak = fagsakerPåBruker.single()
+        assertThat(fagsak.stønadstype).isEqualTo(Stønadstype.BOUTGIFTER)
+
+        val behandlinger = behandlingRepository.findByFagsakId(fagsak.id)
+        assertThat(behandlinger).hasSize(1)
+        val behandling = behandlinger.single()
+        assertThat(behandling.årsak).isEqualTo(BehandlingÅrsak.SØKNAD)
+    }
+
+    private fun mockJournalpost(
+        brevkode: DokumentBrevkode,
+        søknad: Any,
+    ) {
+        val søknaddookumentInfo =
+            dokumentInfo(
+                brevkode = brevkode.verdi,
+                dokumentvarianter = listOf(dokumentvariant(variantformat = Dokumentvariantformat.ORIGINAL)),
+            )
+        val journalpost =
+            journalpost(
+                journalpostId = journalpostId.toString(),
+                journalposttype = Journalposttype.I,
+                dokumenter = listOf(søknaddookumentInfo),
+                kanal = "NAV_NO",
+                bruker = Bruker(ident, BrukerIdType.FNR),
+                journalstatus = Journalstatus.MOTTATT,
+            )
+
+        every { journalpostClient.hentJournalpost(journalpostId.toString()) } returns journalpost
+
+        every {
+            journalpostClient.hentDokument(journalpostId.toString(), søknaddookumentInfo.dokumentInfoId, Dokumentvariantformat.ORIGINAL)
+        } returns
+            objectMapper.writeValueAsBytes(søknad)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -387,6 +387,7 @@ fun journalpost(
     tema: String = Tema.TSO.toString(),
     dokumenter: List<DokumentInfo>? = null,
     bruker: Bruker? = null,
+    kanal: String? = null,
 ) = Journalpost(
     journalpostId = journalpostId,
     journalposttype = journalposttype,
@@ -394,14 +395,17 @@ fun journalpost(
     tema = tema,
     dokumenter = dokumenter,
     bruker = bruker,
+    kanal = kanal,
 )
 
 fun dokumentInfo(
     dokumentInfoId: String = UUID.randomUUID().toString(),
     dokumentvarianter: List<Dokumentvariant>? = null,
+    brevkode: String? = null,
 ) = DokumentInfo(
     dokumentInfoId = dokumentInfoId,
     dokumentvarianter = dokumentvarianter,
+    brevkode = brevkode,
 )
 
 fun dokumentvariant(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadBoutgifterUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/SøknadBoutgifterUtil.kt
@@ -25,10 +25,10 @@ import no.nav.tilleggsstonader.kontrakter.søknad.boutgifter.fyllutsendinn.Utgif
 import java.time.LocalDate
 
 object SøknadBoutgifterUtil {
-    fun søknadBoutgifter(): SøknadsskjemaBoutgifterFyllUtSendInn {
+    fun søknadBoutgifter(ident: String = "11111122222"): SøknadsskjemaBoutgifterFyllUtSendInn {
         val skjemaBoutgifter =
             SkjemaBoutgifter(
-                dineOpplysninger = dineOpplysninger(),
+                dineOpplysninger = dineOpplysninger(ident),
                 hovedytelse = mapOf(HovedytelseType.arbeidsavklaringspenger to true),
                 harNedsattArbeidsevne = JaNeiType.ja,
                 arbeidOgOpphold = null,
@@ -81,13 +81,13 @@ object SøknadBoutgifterUtil {
                 ),
         )
 
-    private fun dineOpplysninger(): DineOpplysninger =
+    private fun dineOpplysninger(ident: String): DineOpplysninger =
         DineOpplysninger(
             fornavn = "Fornavn",
             etternavn = "Etternavn",
             identitet =
                 Identitet(
-                    identitetsnummer = "11111122222",
+                    identitetsnummer = ident,
                 ),
             adresse =
                 NavAdresse(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Selve mottak av søknad som skal føre til opprettelse av sak/behandling er en prosess hvor det skjer ganske mye forskjellig, og jeg så det ikke var noe særlige tester på dette. Oppretter derfor en integrasjonstest på dette, som tester hele løypa fra vi mottar hendelse på Kafka og hele veien til det opprettes fagsak. Bør være fint mulig å bygge videre på.

Testen i seg selv er litt tidkrevende, så vi trenger ikke mange av disse. Men jeg mener det ville vært en fordel om vi hadde en per søknad/stønadstype som skal opprettes 🤷 

Tester kun mottak av boutgifter-søknad. Kan også utvides for daglig reise.