### PR TITLE
Skal være lov å gå videre fra vilkår uten å legge til noen vilkår dersom det blir avslag uansett

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/VilkårSteg.kt
@@ -31,11 +31,6 @@ class VilkårSteg(
 
         validerIkkeOverlappendeVilkår(vilkår)
 
-        val manglerVilkår = vilkår.isEmpty()
-        brukerfeilHvis(manglerVilkår) {
-            "Mangler vilkår, vennligst legg til et vilkår for reiseperioden."
-        }
-
         val manglerVerdierPåOppfylteVilkår =
             vilkår
                 .filter { it.resultat == Vilkårsresultat.OPPFYLT }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler kommer ikke videre fra stønadsvilkårsteget uten å legge inn minst et vilkår. Dette er ikke noe de trenger å gjøre dersom de kan gi avslag på inngangsvilkår. Har laget en favrooppgave på å evt. fikse dette på en annen måte om vi vil ha validering av at de eksisterer