### PR TITLE
Endepunkt for å kunne matche andeler til vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
@@ -8,4 +8,6 @@ enum class EksternApplikasjon(
 
     BIDRAG_GRUNNLAG("gcp:bidrag:bidrag-grunnlag"),
     BIDRAG_GRUNNLAG_FEATURE("gcp:bidrag:bidrag-grunnlag-feature"),
+
+    TILBAKE("toodo:tilbake"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/sikkerhet/EksternApplikasjon.kt
@@ -8,6 +8,4 @@ enum class EksternApplikasjon(
 
     BIDRAG_GRUNNLAG("gcp:bidrag:bidrag-grunnlag"),
     BIDRAG_GRUNNLAG_FEATURE("gcp:bidrag:bidrag-grunnlag-feature"),
-
-    TILBAKE("toodo:tilbake"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingAndelerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingAndelerController.kt
@@ -5,9 +5,6 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingIdRepository
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
-import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingAndelerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingAndelerController.kt
@@ -1,0 +1,124 @@
+package no.nav.tilleggsstonader.sak.tilbakekreving
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingIdRepository
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.EksternApplikasjon
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørBoutgifter
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørDagligReise
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørLæremidler
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtak
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.finnPeriodeFraAndel as finnPeriodeTilsynBarnFraAndel
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.finnPeriodeFraAndel as finnPeriodeBoutgifterFraAndel
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.finnPerioderFraAndel as finnPerioderLæremidlerFraAndel
+
+@RestController
+@RequestMapping(
+    path = ["/api/ekstern/tilbakekreving/andeler"],
+)
+@ProtectedWithClaims(issuer = "azuread")
+class TilbakekrevingAndelerController(
+    private val vedtakService: VedtakService,
+    private val tilkjentYtelseService: TilkjentYtelseService,
+    private val behandlingService: BehandlingService,
+    private val eksternBehandlingIdRepository: EksternBehandlingIdRepository,
+) {
+    @GetMapping("/{eksternBehandlingId}")
+    fun hentEndringIVedtakForTilbakekreving(
+        @PathVariable("eksternBehandlingId") eksternBehandlingId: Long,
+    ): AndelerUtbetalingDto {
+        val kallendeApplikasjonErTilbakekreving = SikkerhetContext.kallKommerFra(EksternApplikasjon.TILBAKE)
+        feilHvisIkke(kallendeApplikasjonErTilbakekreving) {
+            "Kun kall fra tilbakekreving er tillatt"
+        }
+
+        val behandlingId =
+            eksternBehandlingIdRepository
+                .findById(eksternBehandlingId)
+                .orElseThrow { error("Finner ingen behandling med id $eksternBehandlingId") }
+                .behandlingId
+
+        val behandling = behandlingService.hentBehandling(behandlingId)
+
+        feilHvis(behandling.forrigeIverksatteBehandlingId == null) {
+            "Behandling med id=$behandlingId har ingen forrige iverksatte behandling"
+        }
+
+        return AndelerUtbetalingDto(
+            andelerForBehandling =
+                mapAndelerForBehandling(behandling.id)
+                    .sortedBy { it.utbetalingsperiode.fom },
+            andelerForForrigeBehandling =
+                mapAndelerForBehandling(behandling.forrigeIverksatteBehandlingId)
+                    .sortedBy { it.utbetalingsperiode.fom },
+        )
+    }
+
+    private fun mapAndelerForBehandling(behandlingId: BehandlingId): List<AndelUtbetalingMedVedtaksperiodeDto> {
+        val andeler = tilkjentYtelseService.hentForBehandling(behandlingId).andelerTilkjentYtelse
+        val vedtak = vedtakService.hentVedtak(behandlingId) ?: error("Behandling $behandlingId har ingen vedtak")
+        return andeler.map {
+            AndelUtbetalingMedVedtaksperiodeDto(
+                utbetalingsperiode =
+                    PeriodeDto(
+                        fom = it.fom,
+                        tom = it.tom,
+                    ),
+                vedtaksperiode = lagFaktiskPeriode(it, vedtak),
+                beløp = it.beløp,
+                typeAndel = it.type,
+            )
+        }
+    }
+
+    private fun lagFaktiskPeriode(
+        andelTilkjentYtelse: AndelTilkjentYtelse,
+        vedtak: Vedtak,
+    ): PeriodeDto {
+        val vedtakdata = vedtak.data
+        return when (vedtakdata) {
+            is InnvilgelseEllerOpphørBoutgifter ->
+                finnPeriodeBoutgifterFraAndel(vedtakdata.beregningsresultat, andelTilkjentYtelse)
+                    .let { PeriodeDto(it.fom, it.tom) }
+            is InnvilgelseEllerOpphørTilsynBarn ->
+                finnPeriodeTilsynBarnFraAndel(vedtakdata.beregningsresultat, andelTilkjentYtelse)
+                    .let { PeriodeDto(it.fom, it.tom) }
+            is InnvilgelseEllerOpphørLæremidler ->
+                finnPerioderLæremidlerFraAndel(vedtakdata.beregningsresultat, andelTilkjentYtelse)
+                    .let { perioder -> PeriodeDto(perioder.minOf { it.fom }, perioder.maxOf { it.tom }) }
+            is InnvilgelseEllerOpphørDagligReise -> TODO() // Vil gi mer mening å returnere flere perioder?
+            else -> error("Behandling ${vedtak.behandlingId} har ikke et iverksatt vedtak")
+        }
+    }
+}
+
+data class AndelerUtbetalingDto(
+    val andelerForBehandling: List<AndelUtbetalingMedVedtaksperiodeDto>,
+    val andelerForForrigeBehandling: List<AndelUtbetalingMedVedtaksperiodeDto>,
+)
+
+data class AndelUtbetalingMedVedtaksperiodeDto(
+    val utbetalingsperiode: PeriodeDto,
+    val vedtaksperiode: PeriodeDto,
+    val beløp: Int,
+    val typeAndel: TypeAndel,
+)
+
+data class PeriodeDto(
+    val fom: LocalDate,
+    val tom: LocalDate,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingAndelerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingAndelerController.kt
@@ -41,11 +41,6 @@ class TilbakekrevingAndelerController(
     fun hentEndringIVedtakForTilbakekreving(
         @PathVariable("eksternBehandlingId") eksternBehandlingId: Long,
     ): AndelerUtbetalingDto {
-        val kallendeApplikasjonErTilbakekreving = SikkerhetContext.kallKommerFra(EksternApplikasjon.TILBAKE)
-        feilHvisIkke(kallendeApplikasjonErTilbakekreving) {
-            "Kun kall fra tilbakekreving er tillatt"
-        }
-
         val behandlingId =
             eksternBehandlingIdRepository
                 .findById(eksternBehandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapper.kt
@@ -27,3 +27,17 @@ fun BeregningsresultatTilsynBarn.mapTilAndelTilkjentYtelse(saksbehandling: Saksb
             )
         }
     }
+
+fun finnPeriodeFraAndel(
+    beregningsresultat: BeregningsresultatTilsynBarn,
+    andelTilkjentYtelse: AndelTilkjentYtelse,
+) = beregningsresultat.perioder
+    .flatMap {
+        // Lages andel per beløpsperiode, som igjen lages fra vedtaksperiodeGrunnlag
+        it.grunnlag.vedtaksperiodeGrunnlag.mapIndexed { index, grunnlag ->
+            grunnlag to it.beløpsperioder[index]
+        }
+    }.single {
+        // Fom og tom på andel er beløpsperiode sin dato
+        it.second.dato == andelTilkjentYtelse.fom
+    }.first.vedtaksperiode

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapper.kt
@@ -6,7 +6,10 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjen
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.VedtaksperiodeGrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.domain.VedtaksperiodeBeregning
 
 fun BeregningsresultatTilsynBarn.mapTilAndelTilkjentYtelse(saksbehandling: Saksbehandling): List<AndelTilkjentYtelse> =
     perioder.flatMap {
@@ -31,13 +34,31 @@ fun BeregningsresultatTilsynBarn.mapTilAndelTilkjentYtelse(saksbehandling: Saksb
 fun finnPeriodeFraAndel(
     beregningsresultat: BeregningsresultatTilsynBarn,
     andelTilkjentYtelse: AndelTilkjentYtelse,
-) = beregningsresultat.perioder
-    .flatMap {
-        // Lages andel per beløpsperiode, som igjen lages fra vedtaksperiodeGrunnlag
-        it.grunnlag.vedtaksperiodeGrunnlag.mapIndexed { index, grunnlag ->
-            grunnlag to it.beløpsperioder[index]
-        }
-    }.single {
-        // Fom og tom på andel er beløpsperiode sin dato
-        it.second.dato == andelTilkjentYtelse.fom
-    }.first.vedtaksperiode
+): VedtaksperiodeBeregning {
+    val perioderMedBeløpsperiode: List<VedtaksperiodeGrunnlagMedBeløpsperiode> =
+        beregningsresultat.perioder
+            .flatMap {
+                // En beløpsperiode lages av vedtaksperiodeGrunnlag, så vil finnes på samme indeks
+                it.grunnlag.vedtaksperiodeGrunnlag.mapIndexed { index, grunnlag ->
+                    VedtaksperiodeGrunnlagMedBeløpsperiode(grunnlag, it.beløpsperioder[index])
+                }
+            }
+
+    val periodeMedBeløpsperiodeTilhørendeAndel =
+        perioderMedBeløpsperiode
+            .filter {
+                // Fom og tom på andel er beløpsperiode sin dato
+                it.beløpsperiode.dato == andelTilkjentYtelse.fom
+            }
+
+    if (periodeMedBeløpsperiodeTilhørendeAndel.size != 1) {
+        throw IllegalStateException("Forventet å finne nøyaktig én periode for andel, fant ${periodeMedBeløpsperiodeTilhørendeAndel.size}")
+    }
+
+    return perioderMedBeløpsperiode.single().vedtaksperiodeGrunnlag.vedtaksperiode
+}
+
+private data class VedtaksperiodeGrunnlagMedBeløpsperiode(
+    val vedtaksperiodeGrunnlag: VedtaksperiodeGrunnlag,
+    val beløpsperiode: Beløpsperiode,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
@@ -25,3 +25,11 @@ fun BeregningsresultatBoutgifter.mapTilAndelTilkjentYtelse(behandlingId: Behandl
                 utbetalingsdato = it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
             )
         }
+
+fun finnPeriodeFraAndel(
+    beregningsresultat: BeregningsresultatBoutgifter,
+    andelTilkjentYtelse: AndelTilkjentYtelse,
+) = beregningsresultat.perioder
+    .first {
+        it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag() == andelTilkjentYtelse.utbetalingsdato
+    }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapper.kt
@@ -48,3 +48,11 @@ private fun mapTilYtelse(
                 utbetalingsdato = utbetalingsdato,
             )
         }
+
+fun finnPerioderFraAndel(
+    beregningsresultat: BeregningsresultatLæremidler,
+    andelTilkjentYtelse: AndelTilkjentYtelse,
+) = beregningsresultat.perioder
+    .filter {
+        it.grunnlag.utbetalingsdato == andelTilkjentYtelse.utbetalingsdato
+    }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapperTest.kt
@@ -1,0 +1,49 @@
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
+
+import no.nav.tilleggsstonader.libs.utils.dato.september
+import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.beregningsresultatForMåned
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class TilsynBarnAndelTilkjentYtelseMapperTest {
+    @Test
+    fun `finnPeriodeFraAndel finner riktig vedtaksperiode gitt andel tilkjent ytelse`() {
+        val beregningsresultatForMåned =
+            beregningsresultatForMåned(
+                måned = YearMonth.of(2025, 9),
+                beløpsperioder =
+                    listOf(
+                        Beløpsperiode(
+                            dato = 1 september 2025,
+                            beløp = 1000,
+                            målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                        ),
+                    ),
+            )
+        val beregningsresultat = BeregningsresultatTilsynBarn(perioder = listOf(beregningsresultatForMåned))
+
+        val andeler = beregningsresultat.mapTilAndelTilkjentYtelse(saksbehandling())
+        assertThat(andeler).hasSize(1)
+
+        val periodeFraAndel = finnPeriodeFraAndel(beregningsresultat, andeler.single())
+        assertThat(
+            periodeFraAndel.fom,
+        ).isEqualTo(
+            beregningsresultatForMåned.grunnlag.vedtaksperiodeGrunnlag
+                .single()
+                .vedtaksperiode.fom,
+        )
+        assertThat(
+            periodeFraAndel.tom,
+        ).isEqualTo(
+            beregningsresultatForMåned.grunnlag.vedtaksperiodeGrunnlag
+                .single()
+                .vedtaksperiode.tom,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapperTest.kt
@@ -1,0 +1,72 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler
+
+import no.nav.tilleggsstonader.libs.utils.dato.august
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.november
+import no.nav.tilleggsstonader.libs.utils.dato.oktober
+import no.nav.tilleggsstonader.libs.utils.dato.september
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil.beregningsresultatForMåned
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatLæremidler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LæremidlerAndelTilkjentYtelseMapperTest {
+    @Test
+    fun `lag andeler fra beregningsresultat og finn perioder i beregningsresultat fra andeler`() {
+        val beregningsresultat =
+            BeregningsresultatLæremidler(
+                perioder =
+                    listOf(
+                        beregningsresultatForMåned(
+                            fom = 1 september 2025,
+                            tom = 30 september 2025,
+                            utbetalingsdato = 15 august 2025,
+                        ),
+                        beregningsresultatForMåned(
+                            fom = 1 oktober 2025,
+                            tom = 31 oktober 2025,
+                            utbetalingsdato = 15 august 2025,
+                        ),
+                        beregningsresultatForMåned(
+                            fom = 1 november 2025,
+                            tom = 30 november 2025,
+                            utbetalingsdato = 15 august 2025,
+                        ),
+                        beregningsresultatForMåned(
+                            fom = 1 januar 2026,
+                            tom = 31 januar 2026,
+                            utbetalingsdato = 1 januar 2026,
+                        ),
+                        beregningsresultatForMåned(
+                            fom = 1 februar 2026,
+                            tom = 28 februar 2026,
+                            utbetalingsdato = 1 januar 2026,
+                        ),
+                    ),
+            )
+
+        val andeler = beregningsresultat.mapTilAndelTilkjentYtelse(behandlingId = BehandlingId.random())
+
+        assertThat(andeler).hasSize(2)
+        with(andeler[0]) {
+            assertThat(fom).isEqualTo(15 august 2025)
+            assertThat(tom).isEqualTo(15 august 2025)
+            assertThat(utbetalingsdato).isEqualTo(15 august 2025)
+            val perioderFraAndel = finnPerioderFraAndel(beregningsresultat, this)
+            assertThat(perioderFraAndel).hasSize(3)
+            assertThat(perioderFraAndel.minOf { it.fom }).isEqualTo(1 september 2025)
+            assertThat(perioderFraAndel.maxOf { it.tom }).isEqualTo(30 november 2025)
+        }
+        with(andeler[1]) {
+            assertThat(fom).isEqualTo(1 januar 2026)
+            assertThat(tom).isEqualTo(1 januar 2026)
+            assertThat(utbetalingsdato).isEqualTo(1 januar 2026)
+            val perioderFraAndel = finnPerioderFraAndel(beregningsresultat, this)
+            assertThat(perioderFraAndel).hasSize(2)
+            assertThat(perioderFraAndel.minOf { it.fom }).isEqualTo(1 januar 2026)
+            assertThat(perioderFraAndel.maxOf { it.tom }).isEqualTo(28 februar 2026)
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Oppretter et endepunkt tiltenkt brukt av tilbakekreving, for at de skal kunne slå opp med perioder de får fra oppdrag/økonomi til mer meningsfulle vedtaksperioder, slik at de kan vise dette i grensesnittet sitt.

Ved en tilbakekreving får team-tilbake en xml fra oppdrag, som viser perioder som skal kreves tilbake. Denne inneholder blant annet en periode og klassekode. Perioden er en endags-periode, samme som vi sender til helved ved iverksetting (og samme som i AndelTilkjentYtelse). Klassekode er det vi kaller `TypeAndel`.

Endepunktet returnerer alle andeler fra nåværende og forrige behandling, hvilken vedtaksperiode som tilhører en gitt andel samt type andel.

Edit: selve integrasjonen blir over Kafka (et topic vi lytter på for request, og et topic hvor vi produserer svar), slik at Team Tilbake får større eierskap over integrasjonen og modellen, i og med at de skal kunne tilbakekreve fra flere andre systemer. Beholder endepunktet i PRen likevel for å kunne teste litt i dev frem til Kafka-delen er på plass.