### PR TITLE
Fiks for når det opprettes FaktaGrunnlagBarnAndreForeldreSaksinformasjon med barn som har flere barnid i vedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnRepository.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.behandling.barn
 
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
@@ -24,4 +25,12 @@ interface BarnRepository :
     """,
     )
     fun finnIdenterTilFagsakPersonId(fagsakPersonId: FagsakPersonId): Set<String>
+
+    @Query(
+        """
+        select * from behandling_barn 
+        where behandling_id in (select id from behandling where fagsak_id=:fagsakId)
+    """,
+    )
+    fun finnAlleBarnPåFagsakId(fagsakId: FagsakId): List<BehandlingBarn>
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/barn/BarnService.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.behandling.barn
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.stereotype.Service
@@ -16,6 +17,8 @@ class BarnService(
     fun opprettBarn(barn: List<BehandlingBarn>): List<BehandlingBarn> = barnRepository.insertAll(barn)
 
     fun finnBarnPåBehandling(behandlingId: BehandlingId): List<BehandlingBarn> = barnRepository.findByBehandlingId(behandlingId)
+
+    fun finnBarnPåFagsak(fagsakId: FagsakId): List<BehandlingBarn> = barnRepository.finnAlleBarnPåFagsakId(fagsakId)
 
     fun finnIdenterTilFagsakPersonId(fagsakPersonId: FagsakPersonId) = barnRepository.finnIdenterTilFagsakPersonId(fagsakPersonId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/FaktaGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/FaktaGrunnlagService.kt
@@ -196,7 +196,7 @@ class FaktaGrunnlagService(
                 .findByIdOrThrow(this.id)
                 .withTypeOrThrow<InnvilgelseEllerOpphørTilsynBarn>()
         return BehandlingsinformasjonAnnenForelder.IverksattBehandlingForelder(
-            barnFraTidligereVedtak = barnService.finnBarnPåBehandling(id).associate { it.id to it.ident },
+            barnFraTidligereVedtak = barnService.finnBarnPåFagsak(fagsakId).associate { it.id to it.ident },
             tidligereVedtak = vedtak.data,
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/FaktaGrunnlagBarnAndreForeldreSaksinformasjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/FaktaGrunnlagBarnAndreForeldreSaksinformasjon.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.opplysninger.grunnlag.faktagrunnlag
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
-import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.GeneriskFaktaGrunnlag
@@ -62,9 +61,6 @@ data class BehandlingsinformasjonAnnenForelder(
                         }
                     }
                 }
-            secureLogger.info("Barn fra tidligere vedtak: {}", barnFraTidligereVedtak)
-            secureLogger.info("perioderForBarn: {}", perioderForBarn)
-            secureLogger.info("tidligereVedtak: {}", tidligereVedtak)
 
             /*
             perioderForBarn inneholder alle perioder for barn som har hatt utgifter i tidligere vedtak.

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/FaktaGrunnlagBarnAndreForeldreSaksinformasjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/FaktaGrunnlagBarnAndreForeldreSaksinformasjon.kt
@@ -66,9 +66,20 @@ data class BehandlingsinformasjonAnnenForelder(
             secureLogger.info("perioderForBarn: {}", perioderForBarn)
             secureLogger.info("tidligereVedtak: {}", tidligereVedtak)
 
+            /*
+            perioderForBarn inneholder alle perioder for barn som har hatt utgifter i tidligere vedtak.
+            Hvis forrige vedtak er en revurdering, kan det være at det er flere barnId som peker på samme barnIdent,
+            da man ved en revurdering kopierer fra forrige vedtak.
+             */
             perioderForBarn
-                .mapKeys { barnFraTidligereVedtak[it.key]!! }
-                .mapValues { it.value.sorted().mergeSammenhengende { d1, d2 -> d1.overlapperEllerPåfølgesAv(d2) } }
+                .map { barnFraTidligereVedtak.getValue(it.key) to it.value }
+                .groupBy { it.first }
+                .mapValues { (_, pairs: List<Pair<IdentBarn, MutableList<Datoperiode>>>) ->
+                    pairs
+                        .flatMap { it.second }
+                        .sorted()
+                        .mergeSammenhengende { d1, d2 -> d1.overlapperEllerPåfølgesAv(d2) }
+                }
         }
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gitt case:
**Forelder 1** har:
- Fått innvilget vedtak barnetilsyn med ett barn
- Gjort revurdering, innvilgelse, samme barn som førstegangsbehandling
  - Dette fører til at gamle perioder i vedtaket refererer til barnId i førstegangsbehandling, mens nye perioder refererer til barnId i revurdering

Etter dette søker **Forelder 2** for samme barn. Fører til at det kastes en feil i `src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/grunnlag/faktagrunnlag/FaktaGrunnlagBarnAndreForeldreSaksinformasjon.kt`: `perioderForBarn.mapKeys { barnFraTidligereVedtak[it.key]!! }` - da `barnFraTidligereVedtak` kun inneholder barnId fra siste iverksatte behandling på **Forelder 1**.

Må da:
- Henter ut alle barnId fra fagsak på annen forelder (se endring i FaktaGrunnlagService)
- Gjøre at `FaktaGrunnlagBarnAndreForeldreSaksinformasjon` håndterer at property `barnFraTidligereVedtak` inneholder flere `BarnId` som peker på samme ident.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-26258