### PR TITLE
Tilpass beregning for dalig reise slik at den kan returnere ulike res…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -9,8 +9,8 @@ import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakDtoMapper
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.OffentligTransportBeregningService
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.DagligReiseBeregningService
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.AvslagDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseRequest
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.VedtakDagligReiseRequest
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController
 @ProtectedWithClaims(issuer = "azuread")
 class DagligReiseVedtakController(
     private val behandlingService: BehandlingService,
-    private val beregningService: OffentligTransportBeregningService,
+    private val beregningService: DagligReiseBeregningService,
     private val tilgangService: TilgangService,
     private val stegService: StegService,
     private val steg: DagligReiseBeregnYtelseSteg,
@@ -76,7 +76,7 @@ class DagligReiseVedtakController(
     fun beregn(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseDagligReiseRequest,
-    ): Beregningsresultat {
+    ): BeregningsresultatDagligReise {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         return beregningService

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
@@ -1,0 +1,61 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning
+
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
+import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vedtak.validering.VedtaksperiodeValideringService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import org.springframework.stereotype.Service
+
+@Service
+class DagligReiseBeregningService(
+    private val vilkårService: VilkårService,
+    private val vedtaksperiodeValideringService: VedtaksperiodeValideringService,
+    private val offentligTransportBeregningService: OffentligTransportBeregningService,
+) {
+    fun beregn(
+        behandlingId: BehandlingId,
+        vedtaksperioder: List<Vedtaksperiode>,
+        behandling: Saksbehandling,
+        typeVedtak: TypeVedtak,
+    ): BeregningsresultatDagligReise {
+        vedtaksperiodeValideringService.validerVedtaksperioder(
+            vedtaksperioder = vedtaksperioder,
+            behandling = behandling,
+            typeVedtak = typeVedtak,
+        )
+
+        val oppfylteVilkår = vilkårService.hentOppfylteDagligReiseVilkår(behandlingId)
+        validerUtgifter(oppfylteVilkår)
+
+        val oppfylteVilkårGruppertPåType = oppfylteVilkår.groupBy { it.type }
+
+        return BeregningsresultatDagligReise(
+            offentligTransport = beregnOffentligTransport(oppfylteVilkårGruppertPåType, vedtaksperioder),
+        )
+    }
+
+    private fun beregnOffentligTransport(
+        vilkår: Map<VilkårType, List<Vilkår>>,
+        vedtaksperioder: List<Vedtaksperiode>,
+    ): Beregningsresultat? {
+        val vilkårOffentligTransport = vilkår[VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT] ?: return null
+
+        return offentligTransportBeregningService.beregn(
+            vedtaksperioder = vedtaksperioder,
+            oppfylteVilkår = vilkårOffentligTransport,
+        )
+    }
+
+    private fun validerUtgifter(vilkår: List<Vilkår>) {
+        brukerfeilHvis(vilkår.isEmpty()) {
+            "Innvilgelse er ikke et gyldig vedtaksresultat når det ikke er lagt inn perioder med reise"
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/OffentligTransportBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/OffentligTransportBeregningService.kt
@@ -1,9 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning
 
-import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
-import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
@@ -11,36 +7,15 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatF
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.UtgiftOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
-import no.nav.tilleggsstonader.sak.vedtak.validering.VedtaksperiodeValideringService
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import org.springframework.stereotype.Service
 
 @Service
-class OffentligTransportBeregningService(
-    private val vilkårService: VilkårService,
-    private val vedtaksperiodeValideringService: VedtaksperiodeValideringService,
-) {
+class OffentligTransportBeregningService {
     fun beregn(
-        behandlingId: BehandlingId,
         vedtaksperioder: List<Vedtaksperiode>,
-        behandling: Saksbehandling,
-        typeVedtak: TypeVedtak,
+        oppfylteVilkår: List<Vilkår>,
     ): Beregningsresultat {
-        val oppfylteVilkår = vilkårService.hentOppfylteDagligReiseVilkår(behandlingId)
-
-        val vilkårOffentligTransport = oppfylteVilkår.filter { it.type == VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT }
-
-        brukerfeilHvis(vilkårOffentligTransport.isEmpty()) {
-            "Innvilgelse er ikke et gyldig vedtaksresultat når det ikke er lagt inn perioder med reise"
-        }
-
-        vedtaksperiodeValideringService.validerVedtaksperioder(
-            vedtaksperioder = vedtaksperioder,
-            behandling = behandling,
-            typeVedtak = typeVedtak,
-        )
-
         val utgifter =
             oppfylteVilkår
                 .filter { it.offentligTransport != null }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/BeregningsresultatDagligReise.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/BeregningsresultatDagligReise.kt
@@ -1,0 +1,6 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain
+
+data class BeregningsresultatDagligReise(
+    val offentligTransport: Beregningsresultat?,
+    // val privatBil: BeregningsresultatPrivatBil?,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/BeregningsresultatOffentligTransport.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/BeregningsresultatOffentligTransport.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import java.time.LocalDate
 import java.util.UUID
 
+// TODO: Rename til BeregningsresultatOffentligTransport i egen PR
 data class Beregningsresultat(
     val reiser: List<BeregningsresultatForReise>,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/InnvilgelseDagligReiseDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/InnvilgelseDagligReiseDto.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto
 
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dto.LagretVedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 import java.time.LocalDate
@@ -11,7 +11,7 @@ import java.time.LocalDate
  */
 data class InnvilgelseDagligReiseResponse(
     val vedtaksperioder: List<LagretVedtaksperiodeDto>?,
-    val beregningsresultat: Beregningsresultat,
+    val beregningsresultat: BeregningsresultatDagligReise,
     val gjelderFraOgMed: LocalDate?,
     val gjelderTilOgMed: LocalDate?,
     val begrunnelse: String? = null,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakDagligReise.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/domain/VedtakDagligReise.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.domain
 
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 
 enum class TypeVedtakDagligReise(
@@ -31,7 +31,7 @@ enum class TypeDagligReise {
                 VilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT -> OFFENTLIG_TRANSPORT
                 VilkårType.DAGLIG_REISE_KJØRELISTE -> KJØRELISTE
                 VilkårType.DAGLIG_REISE_TAXI -> TAXI
-                else -> error("$vilkårType er ikke en gyldig utgiftstype for boutgifter")
+                else -> error("$vilkårType er ikke et gyldig vilkår for daglig reise")
             }
     }
 }
@@ -39,12 +39,12 @@ enum class TypeDagligReise {
 sealed interface VedtakDagligReise : Vedtaksdata
 
 sealed interface InnvilgelseEllerOpphørDagligReise : VedtakDagligReise {
-    val beregningsresultat: Beregningsresultat
+    val beregningsresultat: BeregningsresultatDagligReise
     val vedtaksperioder: List<Vedtaksperiode>
 }
 
 data class InnvilgelseDagligReise(
-    override val beregningsresultat: Beregningsresultat,
+    override val beregningsresultat: BeregningsresultatDagligReise,
     override val vedtaksperioder: List<Vedtaksperiode>,
     val begrunnelse: String? = null,
 ) : InnvilgelseEllerOpphørDagligReise,
@@ -70,7 +70,7 @@ data class AvslagDagligReise(
 
 data class OpphørDagligReise(
     override val vedtaksperioder: List<Vedtaksperiode>,
-    override val beregningsresultat: Beregningsresultat,
+    override val beregningsresultat: BeregningsresultatDagligReise,
     override val årsaker: List<ÅrsakOpphør>,
     override val begrunnelse: String,
 ) : InnvilgelseEllerOpphørDagligReise,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsgrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.Beregningsresultat
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunnlag
@@ -84,38 +85,41 @@ class DagligReiseVedtakControllerTest : IntegrationTest() {
                     ),
                 ),
             beregningsresultat =
-                Beregningsresultat(
-                    reiser =
-                        listOf(
-                            BeregningsresultatForReise(
-                                perioder =
-                                    listOf(
-                                        BeregningsresultatForPeriode(
-                                            grunnlag =
-                                                Beregningsgrunnlag(
-                                                    fom = dummyFom,
-                                                    tom = dummyTom,
-                                                    prisEnkeltbillett = 44,
-                                                    prisSyvdagersbillett = null,
-                                                    pris30dagersbillett = 750,
-                                                    antallReisedagerPerUke = 4,
-                                                    vedtaksperioder =
-                                                        listOf(
-                                                            VedtaksperiodeGrunnlag(
-                                                                id = vedtaksperiode.id,
-                                                                fom = dummyFom,
-                                                                tom = dummyTom,
-                                                                målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
-                                                                aktivitet = AktivitetType.TILTAK,
-                                                                antallReisedagerIVedtaksperioden = 19,
-                                                            ),
+                BeregningsresultatDagligReise(
+                    offentligTransport =
+                        Beregningsresultat(
+                            reiser =
+                                listOf(
+                                    BeregningsresultatForReise(
+                                        perioder =
+                                            listOf(
+                                                BeregningsresultatForPeriode(
+                                                    grunnlag =
+                                                        Beregningsgrunnlag(
+                                                            fom = dummyFom,
+                                                            tom = dummyTom,
+                                                            prisEnkeltbillett = 44,
+                                                            prisSyvdagersbillett = null,
+                                                            pris30dagersbillett = 750,
+                                                            antallReisedagerPerUke = 4,
+                                                            vedtaksperioder =
+                                                                listOf(
+                                                                    VedtaksperiodeGrunnlag(
+                                                                        id = vedtaksperiode.id,
+                                                                        fom = dummyFom,
+                                                                        tom = dummyTom,
+                                                                        målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+                                                                        aktivitet = AktivitetType.TILTAK,
+                                                                        antallReisedagerIVedtaksperioden = 19,
+                                                                    ),
+                                                                ),
+                                                            antallReisedager = 19,
                                                         ),
-                                                    antallReisedager = 19,
+                                                    beløp = 750,
                                                 ),
-                                            beløp = 750,
-                                        ),
+                                            ),
                                     ),
-                            ),
+                                ),
                         ),
                 ),
             gjelderFraOgMed = dummyFom,

--- a/src/test/resources/vedtak/DAGLIG_REISE/INNVILGELSE_DAGLIG_REISE.json
+++ b/src/test/resources/vedtak/DAGLIG_REISE/INNVILGELSE_DAGLIG_REISE.json
@@ -1,34 +1,36 @@
 {
   "begrunnelse": "En begrunnelse",
   "beregningsresultat": {
-    "reiser": [
-      {
-        "perioder": [
-          {
-            "grunnlag": {
-              "fom": "2025-08-21",
-              "tom": "2025-08-31",
-              "prisEnkeltbillett": 44,
-              "prisSyvdagersbillett" : null,
-              "pris30dagersbillett": 750,
-              "antallReisedagerPerUke": 4,
-              "vedtaksperioder": [
-                {
-                  "id": "d4c1944d-3ee5-435e-9618-8ae667b965a7",
-                  "fom": "2025-08-21",
-                  "tom": "2025-08-31",
-                  "målgruppe": "NEDSATT_ARBEIDSEVNE",
-                  "aktivitet": "TILTAK",
-                  "antallReisedagerIVedtaksperioden": 6
-                }
-              ],
-              "antallReisedager": 6
-            },
-            "beløp": 528
-          }
-        ]
-      }
-    ]
+    "offentligTransport": {
+      "reiser": [
+        {
+          "perioder": [
+            {
+              "grunnlag": {
+                "fom": "2025-08-21",
+                "tom": "2025-08-31",
+                "prisEnkeltbillett": 44,
+                "prisSyvdagersbillett": null,
+                "pris30dagersbillett": 750,
+                "antallReisedagerPerUke": 4,
+                "vedtaksperioder": [
+                  {
+                    "id": "d4c1944d-3ee5-435e-9618-8ae667b965a7",
+                    "fom": "2025-08-21",
+                    "tom": "2025-08-31",
+                    "målgruppe": "NEDSATT_ARBEIDSEVNE",
+                    "aktivitet": "TILTAK",
+                    "antallReisedagerIVedtaksperioden": 6
+                  }
+                ],
+                "antallReisedager": 6
+              },
+              "beløp": 528
+            }
+          ]
+        }
+      ]
+    }
   },
   "type": "INNVILGELSE_DAGLIG_REISE",
   "vedtaksperioder": [

--- a/src/test/resources/vedtak/DAGLIG_REISE/OPPHØR_DAGLIG_REISE.json
+++ b/src/test/resources/vedtak/DAGLIG_REISE/OPPHØR_DAGLIG_REISE.json
@@ -4,34 +4,36 @@
   ],
   "begrunnelse": "En begrunnelse",
   "beregningsresultat": {
-    "reiser": [
-      {
-        "perioder": [
-          {
-            "grunnlag": {
-              "fom": "2025-08-21",
-              "tom": "2025-08-31",
-              "prisEnkeltbillett": 44,
-              "prisSyvdagersbillett": null,
-              "pris30dagersbillett": 750,
-              "antallReisedagerPerUke": 4,
-              "vedtaksperioder": [
-                {
-                  "id": "d4c1944d-3ee5-435e-9618-8ae667b965a7",
-                  "fom": "2025-08-21",
-                  "tom": "2025-08-31",
-                  "målgruppe": "NEDSATT_ARBEIDSEVNE",
-                  "aktivitet": "TILTAK",
-                  "antallReisedagerIVedtaksperioden": 6
-                }
-              ],
-              "antallReisedager": 6
-            },
-            "beløp": 528
-          }
-        ]
-      }
-    ]
+    "offentligTransport": {
+      "reiser": [
+        {
+          "perioder": [
+            {
+              "grunnlag": {
+                "fom": "2025-08-21",
+                "tom": "2025-08-31",
+                "prisEnkeltbillett": 44,
+                "prisSyvdagersbillett": null,
+                "pris30dagersbillett": 750,
+                "antallReisedagerPerUke": 4,
+                "vedtaksperioder": [
+                  {
+                    "id": "d4c1944d-3ee5-435e-9618-8ae667b965a7",
+                    "fom": "2025-08-21",
+                    "tom": "2025-08-31",
+                    "målgruppe": "NEDSATT_ARBEIDSEVNE",
+                    "aktivitet": "TILTAK",
+                    "antallReisedagerIVedtaksperioden": 6
+                  }
+                ],
+                "antallReisedager": 6
+              },
+              "beløp": 528
+            }
+          ]
+        }
+      ]
+    }
   },
   "type": "OPPHØR_DAGLIG_REISE",
   "vedtaksperioder": [


### PR DESCRIPTION
…ultater for ulike typer reise

### Hvorfor er denne endringen nødvendig? ✨
Lager en ekstra BeregningService utenfor beregning av offentlig transport som tar ansvar for å validere ting som er felles og sende nødvendig informasjon til beregningene som skal kjøres.

PS: Vi tenkte å endre navn på `Beregningsresultat` til `BeregningsresultatOffentligTransport` men vil gjøre det utenfor dette fordi det ble endring i mange filer