### PR TITLE
Eksponerer navn og ident på bruker tilknyttet sak til oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/KontrollerOppfølgingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/KontrollerOppfølgingDto.kt
@@ -1,6 +1,8 @@
 package no.nav.tilleggsstonader.sak.oppfølging
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -18,16 +20,15 @@ data class KontrollerOppfølgingResponse(
     val opprettetTidspunkt: LocalDateTime,
     val perioderTilKontroll: List<PeriodeForKontroll>,
     val kontrollert: Kontrollert?,
-    val behandlingsdetaljer: Behandlingsdetaljer,
+    val behandlingsdetaljer: OppfølgingBehandlingDetaljerDto,
 )
 
-fun OppfølgingMedDetaljer.tilDto(): KontrollerOppfølgingResponse =
-    KontrollerOppfølgingResponse(
-        id = id,
-        behandlingId = behandlingId,
-        version = version,
-        opprettetTidspunkt = opprettetTidspunkt,
-        perioderTilKontroll = data.perioderTilKontroll,
-        kontrollert = kontrollert,
-        behandlingsdetaljer = behandlingsdetaljer,
-    )
+data class OppfølgingBehandlingDetaljerDto(
+    val saksnummer: Long,
+    val fagsakPersonId: FagsakPersonId,
+    val fagsakPersonIdent: String,
+    val fagsakPersonNavn: String,
+    val stønadstype: Stønadstype,
+    val vedtakstidspunkt: LocalDateTime,
+    val harNyereBehandling: Boolean,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingRepository.kt
@@ -47,12 +47,14 @@ interface OppfølgingRepository :
         fe.id AS saksnummer,
         f.stonadstype,
         f.fagsak_person_id,
+        pid.ident AS fagsak_person_ident,
         b.vedtakstidspunkt,
         (select count(*) > 0 from behandling b where b.forrige_iverksatte_behandling_id = o.behandling_id) har_nyere_behandling
         FROM oppfolging o
         JOIN behandling b ON b.id = o.behandling_id
         JOIN fagsak f ON f.id = b.fagsak_id
         JOIN fagsak_ekstern fe ON fe.fagsak_id = f.id
+        JOIN person_ident pid on f.fagsak_person_id = pid.fagsak_person_id
         WHERE o.aktiv=true
     """,
     )
@@ -65,12 +67,14 @@ interface OppfølgingRepository :
         fe.id AS saksnummer,
         f.stonadstype,
         f.fagsak_person_id,
+        pid.ident AS fagsak_person_ident,
         b.vedtakstidspunkt,
         (select count(*) > 0 from behandling b where b.forrige_iverksatte_behandling_id = o.behandling_id) har_nyere_behandling
         FROM oppfolging o 
         JOIN behandling b ON b.id = o.behandling_id
         JOIN fagsak f ON f.id = b.fagsak_id
         JOIN fagsak_ekstern fe ON fe.fagsak_id = f.id
+        JOIN person_ident pid on f.fagsak_person_id = pid.fagsak_person_id
         WHERE o.aktiv=true
         AND o.behandling_id = :behandlingId
     """,
@@ -154,6 +158,7 @@ data class OppfølgingMedDetaljer(
 data class Behandlingsdetaljer(
     val saksnummer: Long,
     val fagsakPersonId: FagsakPersonId,
+    val fagsakPersonIdent: String,
     @Column("stonadstype")
     val stønadstype: Stønadstype,
     val vedtakstidspunkt: LocalDateTime,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/OppfølgingRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/OppfølgingRepositoryFake.kt
@@ -35,6 +35,7 @@ class OppfølgingRepositoryFake :
             Behandlingsdetaljer(
                 saksnummer = 1,
                 fagsakPersonId = FagsakPersonId.random(),
+                fagsakPersonIdent = "12345678901",
                 stønadstype = Stønadstype.BARNETILSYN,
                 vedtakstidspunkt = LocalDateTime.now(),
                 harNyereBehandling = true,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Eksponerer navn og ident for å gi bedre oversikt til den som behandler oppfølgingslista. Favro https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-26306