### PR TITLE
👔 Skal behandle alle boutgifter i TS-Sak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
-import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.migrering.routing.SøknadRoutingService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
@@ -41,10 +40,6 @@ class ArenaStatusService(
         )
 
         val logPrefix = "Sjekker om person finnes i ny løsning stønadstype=${request.stønadstype}"
-        if (skalKunneOppretteSakIArenaForPerson(fagsak)) {
-            logger.info("$logPrefix unntakFagsakSjekk")
-            return false
-        }
         if (harBehandling(fagsak)) {
             logger.info("$logPrefix finnes=true harRouting harBehandling")
             return true
@@ -60,11 +55,6 @@ class ArenaStatusService(
         return false
     }
 
-    private fun skalKunneOppretteSakIArenaForPerson(fagsak: Fagsak?): Boolean {
-        val fagsakId = fagsak?.id
-        return fagsakId in setOf<FagsakId>()
-    }
-
     /**
      * Denne håndterer at gitt stønadstype alltid svarer med at personen finnes i ny løsning.
      * Eks for Barnetilsyn er det ønskelig at personen skal håndteres i ny løsning og at det ikke fattes nye vedtak i Arena
@@ -73,9 +63,9 @@ class ArenaStatusService(
         when (stønadstype) {
             Stønadstype.BARNETILSYN -> true
             Stønadstype.LÆREMIDLER -> true
-            Stønadstype.BOUTGIFTER -> false
-            Stønadstype.DAGLIG_REISE_TSO -> TODO("Daglig reise er ikke implementert enda")
-            Stønadstype.DAGLIG_REISE_TSR -> TODO("Daglig reise er ikke implementert enda")
+            Stønadstype.BOUTGIFTER -> true
+            Stønadstype.DAGLIG_REISE_TSO -> false
+            Stønadstype.DAGLIG_REISE_TSR -> false
         }
 
     private fun harBehandling(fagsak: Fagsak?): Boolean =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusServiceTest.kt
@@ -33,9 +33,9 @@ class ArenaStatusServiceTest {
         )
 
     val ident = "ident"
-    val fagsak = fagsak(stønadstype = Stønadstype.LÆREMIDLER, identer = setOf(PersonIdent(ident)))
+    val fagsak = fagsak(stønadstype = Stønadstype.DAGLIG_REISE_TSO, identer = setOf(PersonIdent(ident)))
 
-    val request = ArenaFinnesPersonRequest(ident, Rettighet.BOUTGIFTER.kodeArena)
+    val request = ArenaFinnesPersonRequest(ident, Rettighet.DAGLIG_REISE.kodeArena)
 
     @BeforeEach
     fun setUp() {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Alle søknader på boutgifter er satt opp til å rutes til vår løsning.
 
Da er det litt merkelig at vi sier til Arena at ikke alle boutgift-saker skal behandles hos oss.

Jeg mistenker at dette bare er teknisk gjeld.  

Det er generelt også litt uheldig å bruke `TODO()` i et eksternt endepunkt 🥴 