### PR TITLE
Filtrerer overnatting og lopende perioder

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
@@ -20,7 +20,9 @@ object DetaljertVedtaksperioderBoutgifterMapper {
             vedtak.beregningsresultat.perioder
                 .filter { it.grunnlag.utgifter.containsKey(TypeBoutgift.UTGIFTER_OVERNATTING) }
 
-        return relevantePerioder.map { it.mapBeregningsresultatMndOvernatting() }
+        return relevantePerioder
+            .map { it.mapBeregningsresultatMndOvernatting() }
+            .filter { it.totalUtgiftMåned > 0 || it.stønadsbeløpMnd > 0 }
     }
 
     private fun finnVedtaksperioderMedLøpendeUtgifter(vedtak: InnvilgelseEllerOpphørBoutgifter): List<DetaljertVedtaksperiodeBoutgifter> {
@@ -35,6 +37,7 @@ object DetaljertVedtaksperioderBoutgifterMapper {
 
         return relevantePerioder
             .map { it.mapBeregningsresultatMndLøpendeUtgift() }
+            .filter { it.totalUtgiftMåned > 0 || it.stønadsbeløpMnd > 0 }
             .sorterOgMergeSammenhengende()
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
@@ -26,7 +26,12 @@ object DetaljertVedtaksperioderBoutgifterMapper {
     private fun finnVedtaksperioderMedLøpendeUtgifter(vedtak: InnvilgelseEllerOpphørBoutgifter): List<DetaljertVedtaksperiodeBoutgifter> {
         val relevantePerioder =
             vedtak.beregningsresultat.perioder
-                .filter { it.grunnlag.utgifter.containsKey(TypeBoutgift.LØPENDE_UTGIFTER_EN_BOLIG) }
+                .filter {
+                    it.grunnlag.utgifter.keys.any { key ->
+                        key == TypeBoutgift.LØPENDE_UTGIFTER_EN_BOLIG ||
+                            key == TypeBoutgift.LØPENDE_UTGIFTER_TO_BOLIGER
+                    }
+                }
 
         return relevantePerioder
             .map { it.mapBeregningsresultatMndLøpendeUtgift() }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å filtrere vekk innslag av 0  når man finner detaljer for vedtaksperioder for både løpende og faste utgifter.
[Oppgave i Favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-26485)

**FØR:**
<img width="910" height="588" alt="image" src="https://github.com/user-attachments/assets/fc7074ed-7d16-4ca4-bbfa-98ac9556aed2" />

**ETTER:**
<img width="1247" height="335" alt="Screenshot 2025-10-08 at 13 40 42" src="https://github.com/user-attachments/assets/2038b104-b077-43f2-9a04-2bb2ee304183" />
<img width="1215" height="338" alt="Screenshot 2025-10-08 at 13 40 58" src="https://github.com/user-attachments/assets/b375e99b-65de-4756-a392-87c31f183223" />


