### PR TITLE
Refaktorerer VedtaksperioderOversikt til å returnere et objekt med detaljerte og overordnede/faktiske vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperiodeDagligReiseTsr.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperiodeDagligReiseTsr.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise.detaljerteVedtaksperioder
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.vedtak.domain.DetaljertVedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import java.time.LocalDate
 
@@ -10,4 +11,5 @@ class DetaljertVedtaksperiodeDagligReiseTsr(
     override val tom: LocalDate,
     val aktivitet: AktivitetType,
     val målgruppe: FaktiskMålgruppe,
-) : Periode<LocalDate>
+) : Periode<LocalDate>,
+    DetaljertVedtaksperiode

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversikt.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversikt.kt
@@ -1,15 +1,22 @@
 package no.nav.tilleggsstonader.sak.vedtak.vedtaksperioderOversikt
 
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.detaljerteVedtaksperioder.DetaljertVedtaksperiodeTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.detaljerteVedtaksperioder.DetaljertVedtaksperiodeBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.detaljerteVedtaksperioder.DetaljertVedtaksperiodeDagligReiseTso
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.detaljerteVedtaksperioder.DetaljertVedtaksperiodeDagligReiseTsr
+import no.nav.tilleggsstonader.sak.vedtak.domain.DetaljertVedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.detaljerteVedtaksperioder.DetaljertVedtaksperiodeLæremidler
 
 data class VedtaksperioderOversikt(
-    val tilsynBarn: List<DetaljertVedtaksperiodeTilsynBarn>,
-    val læremidler: List<DetaljertVedtaksperiodeLæremidler>,
-    val boutgifter: List<DetaljertVedtaksperiodeBoutgifter>,
-    val dagligReiseTso: List<DetaljertVedtaksperiodeDagligReiseTso>,
-    val dagligReiseTsr: List<DetaljertVedtaksperiodeDagligReiseTsr>,
+    val tilsynBarn: VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeTilsynBarn>?,
+    val læremidler: VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeLæremidler>?,
+    val boutgifter: VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeBoutgifter>?,
+    val dagligReiseTso: VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeDagligReiseTso>?,
+    val dagligReiseTsr: VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeDagligReiseTsr>?,
+)
+
+data class VedtaksperiodeOversiktForBehandling<T : DetaljertVedtaksperiode>(
+    val detaljerteVedtaksperioder: List<T>,
+    val vedtaksperioder: List<Datoperiode>,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktController.kt
@@ -29,7 +29,7 @@ class VedtaksperioderOversiktController(
     @GetMapping("/detaljerte-vedtaksperioder/{behandlingId}")
     fun hentDetaljerteVedtaksperioderForBehandling(
         @PathVariable behandlingId: BehandlingId,
-    ): List<DetaljertVedtaksperiode> {
+    ): VedtaksperiodeOversiktForBehandling<out DetaljertVedtaksperiode> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return vedtakOversiktService.hentDetaljerteVedtaksperioderForBehandling(behandlingId)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
@@ -1,10 +1,12 @@
 package no.nav.tilleggsstonader.sak.vedtak.vedtaksperioderOversikt
 
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.detaljerteVedtaksperioder.DetaljertVedtaksperiodeTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.detaljerteVedtaksperioder.DetaljertVedtaksperioderTilsynBarnMapper.finnDetaljerteVedtaksperioder
@@ -38,59 +40,106 @@ class VedtaksperioderOversiktService(
         val fagsaker = fagsakService.finnFagsakerForFagsakPersonId(fagsakPersonId)
 
         return VedtaksperioderOversikt(
-            tilsynBarn = fagsaker.barnetilsyn?.let { oppsummerVedtaksperioderTilsynBarn(it.id) } ?: emptyList(),
-            læremidler = fagsaker.læremidler?.let { oppsummerVedtaksperioderLæremidler(it.id) } ?: emptyList(),
-            boutgifter = fagsaker.boutgifter?.let { oppsummerVedtaksperioderBoutgifter(it.id) } ?: emptyList(),
-            dagligReiseTso = fagsaker.dagligReiseTso?.let { oppsummerVedtaksperioderDagligReiseTso(it.id) } ?: emptyList(),
-            dagligReiseTsr = fagsaker.dagligReiseTsr?.let { oppsummerVedtaksperioderDagligReiseTsr(it.id) } ?: emptyList(),
+            tilsynBarn = fagsaker.barnetilsyn?.let { oppsummerVedtaksperioderTilsynBarn(it.id) },
+            læremidler = fagsaker.læremidler?.let { oppsummerVedtaksperioderLæremidler(it.id) },
+            boutgifter = fagsaker.boutgifter?.let { oppsummerVedtaksperioderBoutgifter(it.id) },
+            dagligReiseTso = fagsaker.dagligReiseTso?.let { oppsummerVedtaksperioderDagligReiseTso(it.id) },
+            dagligReiseTsr = fagsaker.dagligReiseTsr?.let { oppsummerVedtaksperioderDagligReiseTsr(it.id) },
         )
     }
 
-    fun hentDetaljerteVedtaksperioderForBehandling(behandlingId: BehandlingId): List<DetaljertVedtaksperiode> {
+    fun hentDetaljerteVedtaksperioderForBehandling(
+        behandlingId: BehandlingId,
+    ): VedtaksperiodeOversiktForBehandling<out DetaljertVedtaksperiode> {
         val vedtaksdata = vedtakService.hentVedtak(behandlingId)?.data
+        feilHvis(vedtaksdata == null) {
+            "Behandling med id $behandlingId har ikke vedtak"
+        }
         return when (vedtaksdata) {
-            is InnvilgelseEllerOpphørTilsynBarn -> vedtaksdata.finnDetaljerteVedtaksperioder()
-            is InnvilgelseEllerOpphørLæremidler -> vedtaksdata.finnDetaljerteVedtaksperioder()
-            is InnvilgelseEllerOpphørBoutgifter -> vedtaksdata.finnDetaljerteVedtaksperioder()
-            is InnvilgelseEllerOpphørDagligReise -> vedtaksdata.finnDetaljerteVedtaksperioderTso()
-            null -> emptyList()
+            is InnvilgelseEllerOpphørTilsynBarn -> lagVedtaksperiodeOversiktForBehandling(vedtaksdata)
+            is InnvilgelseEllerOpphørLæremidler -> lagVedtaksperiodeOversiktForBehandling(vedtaksdata)
+            is InnvilgelseEllerOpphørBoutgifter -> lagVedtaksperiodeOversiktForBehandling(vedtaksdata)
+            is InnvilgelseEllerOpphørDagligReise -> lagVedtaksperiodeOversiktForBehandling(vedtaksdata)
             else -> error("Vi støtter ikke å hente detaljertevedtaksperioder for denne stønadstypen enda")
         }
     }
 
-    private fun oppsummerVedtaksperioderTilsynBarn(fagsakId: FagsakId): List<DetaljertVedtaksperiodeTilsynBarn> {
+    private fun oppsummerVedtaksperioderTilsynBarn(
+        fagsakId: FagsakId,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeTilsynBarn>? {
         val vedtakForSisteIverksatteBehandling =
             hentVedtaksdataForSisteIverksatteBehandling<InnvilgelseEllerOpphørTilsynBarn>(fagsakId)
-                ?: return emptyList()
+                ?: return null
 
-        return vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioder()
+        return lagVedtaksperiodeOversiktForBehandling(vedtakForSisteIverksatteBehandling)
     }
 
-    private fun oppsummerVedtaksperioderLæremidler(fagsakId: FagsakId): List<DetaljertVedtaksperiodeLæremidler> {
+    private fun lagVedtaksperiodeOversiktForBehandling(
+        vedtakForSisteIverksatteBehandling: InnvilgelseEllerOpphørTilsynBarn,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeTilsynBarn> =
+        VedtaksperiodeOversiktForBehandling(
+            detaljerteVedtaksperioder = vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioder(),
+            vedtaksperioder = vedtakForSisteIverksatteBehandling.vedtaksperioder.map { Datoperiode(it.fom, it.tom) },
+        )
+
+    private fun oppsummerVedtaksperioderLæremidler(
+        fagsakId: FagsakId,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeLæremidler>? {
         val vedtakForSisteIverksatteBehandling =
             hentVedtaksdataForSisteIverksatteBehandling<InnvilgelseEllerOpphørLæremidler>(fagsakId)
-                ?: return emptyList()
+                ?: return null
 
-        return vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioder()
+        return lagVedtaksperiodeOversiktForBehandling(vedtakForSisteIverksatteBehandling)
     }
 
-    private fun oppsummerVedtaksperioderBoutgifter(fagsakId: FagsakId): List<DetaljertVedtaksperiodeBoutgifter> {
+    private fun lagVedtaksperiodeOversiktForBehandling(
+        vedtakForSisteIverksatteBehandling: InnvilgelseEllerOpphørLæremidler,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeLæremidler> =
+        VedtaksperiodeOversiktForBehandling(
+            detaljerteVedtaksperioder = vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioder(),
+            vedtaksperioder = vedtakForSisteIverksatteBehandling.vedtaksperioder.map { Datoperiode(it.fom, it.tom) },
+        )
+
+    private fun oppsummerVedtaksperioderBoutgifter(
+        fagsakId: FagsakId,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeBoutgifter>? {
         val vedtakForSisteIverksatteBehandling =
             hentVedtaksdataForSisteIverksatteBehandling<InnvilgelseEllerOpphørBoutgifter>(fagsakId)
-                ?: return emptyList()
+                ?: return null
 
-        return vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioder()
+        return lagVedtaksperiodeOversiktForBehandling(vedtakForSisteIverksatteBehandling)
     }
 
-    private fun oppsummerVedtaksperioderDagligReiseTso(fagsakId: FagsakId): List<DetaljertVedtaksperiodeDagligReiseTso> {
+    private fun lagVedtaksperiodeOversiktForBehandling(
+        vedtakForSisteIverksatteBehandling: InnvilgelseEllerOpphørBoutgifter,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeBoutgifter> =
+        VedtaksperiodeOversiktForBehandling(
+            detaljerteVedtaksperioder = vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioder(),
+            vedtaksperioder = vedtakForSisteIverksatteBehandling.vedtaksperioder.map { Datoperiode(it.fom, it.tom) },
+        )
+
+    private fun oppsummerVedtaksperioderDagligReiseTso(
+        fagsakId: FagsakId,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeDagligReiseTso>? {
         val vedtakForSisteIverksatteBehandling =
             hentVedtaksdataForSisteIverksatteBehandling<InnvilgelseEllerOpphørDagligReise>(fagsakId)
-                ?: return emptyList()
+                ?: return null
 
-        return vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioderTso()
+        return lagVedtaksperiodeOversiktForBehandling(vedtakForSisteIverksatteBehandling)
     }
 
-    private fun oppsummerVedtaksperioderDagligReiseTsr(fagsakId: FagsakId): List<DetaljertVedtaksperiodeDagligReiseTsr> = emptyList()
+    private fun lagVedtaksperiodeOversiktForBehandling(
+        vedtakForSisteIverksatteBehandling: InnvilgelseEllerOpphørDagligReise,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeDagligReiseTso> =
+        VedtaksperiodeOversiktForBehandling(
+            detaljerteVedtaksperioder = vedtakForSisteIverksatteBehandling.finnDetaljerteVedtaksperioderTso(),
+            vedtaksperioder = vedtakForSisteIverksatteBehandling.vedtaksperioder.map { Datoperiode(it.fom, it.tom) },
+        )
+
+    private fun oppsummerVedtaksperioderDagligReiseTsr(
+        fagsakId: FagsakId,
+    ): VedtaksperiodeOversiktForBehandling<DetaljertVedtaksperiodeDagligReiseTsr> =
+        VedtaksperiodeOversiktForBehandling(emptyList(), emptyList())
 
     private inline fun <reified T : Vedtaksdata> hentVedtaksdataForSisteIverksatteBehandling(fagsakId: FagsakId): T? {
         val sisteIverksatteBehandling = behandlingService.finnSisteIverksatteBehandling(fagsakId) ?: return null

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktServiceTest.kt
@@ -35,9 +35,9 @@ class VedtaksperioderOversiktServiceTest : CleanDatabaseIntegrationTest() {
 
         val res = vedtaksperioderOversiktService.hentVedtaksperioderOversikt(fagsakPersonId = fagsakPerson.id)
 
-        assertThat(res.tilsynBarn).isNotEmpty()
-        assertThat(res.læremidler).isNotEmpty()
-        assertThat(res.boutgifter).isNotEmpty()
+        assertThat(res.tilsynBarn?.detaljerteVedtaksperioder).isNotEmpty()
+        assertThat(res.læremidler?.detaljerteVedtaksperioder).isNotEmpty()
+        assertThat(res.boutgifter?.detaljerteVedtaksperioder).isNotEmpty()
     }
 
     private fun opprettBehandlingOgVedtakTilsynBarn(fagsakPerson: FagsakPerson) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Detaljerte vedtkasperioder hentes ut fra vedtaksperioder i beregningsresultatet. I beregningsresultatet for boutgifter vil vedtaksperiodene alltid være en hel måned, og det blir feil i visningen frontend hvor det står eks `Søker har vedtak i TS-sak til og med 31.12.25`, selv om søker egentlig kun har en vedtaksperiode `01.12.25 - 31.12.25`.

Legger opp et forslag på hvordan det kan løses, ved å heller returnere et objekt med både detaljerte vedtaksperioder, og de faktiske vedtaksperioder. Slik at man kan hente ut `tom` fra de faktiske vedtaksperiodene for å fortelle saksbehandler hvor lenge søker har vedtak til.

Slenger opp forslaget her for å få tilbakemeldinger på løsning før jeg fikser i frontend 🙃 