### PR TITLE
Forslag til hvordan tillate innvilgelse uten endringer

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -68,7 +68,7 @@ class TilsynBarnBeregnYtelseSteg(
         vedtak: InnvilgelseTilsynBarnRequest,
     ) {
         val tidligsteEndring =
-            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+            utledTidligsteEndringService.utledTidligsteEndringV2(
                 saksbehandling.id,
                 vedtak.vedtaksperioder.tilDomene(),
             )
@@ -78,7 +78,7 @@ class TilsynBarnBeregnYtelseSteg(
                 vedtaksperioder = vedtak.vedtaksperioder.tilDomene(),
                 behandling = saksbehandling,
                 typeVedtak = TypeVedtak.INNVILGELSE,
-                tidligsteEndring = tidligsteEndring,
+                tidligsteEndring = tidligsteEndring.tidligsteEndringEllerLocalDateMaxHvisIngenEndring(),
             )
         vedtakRepository.insert(
             lagInnvilgetVedtak(
@@ -86,7 +86,7 @@ class TilsynBarnBeregnYtelseSteg(
                 beregningsresultat = beregningsresultat,
                 vedtaksperioder = vedtak.vedtaksperioder.tilDomene().sorted(),
                 begrunnelse = vedtak.begrunnelse,
-                tidligsteEndring = tidligsteEndring,
+                tidligsteEndring = tidligsteEndring.tidligsteEndringEllerLocalDateMaxHvisIngenEndring(),
             ),
         )
         lagreAndeler(saksbehandling, beregningsresultat)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Alternativt forslag til løsning av: https://github.com/navikt/tilleggsstonader-sak/pull/1042

Lar tidligste endring returnere et objekt istedenfor kun en nullable `LocalDate`, som beskriver konsekvensen av endringen. Mulige konsekvenser sketchet opp er `INGEN_ENDRING`, `ENDRING_PÅVIRKER_BEREGNING` eller `ENDRING_PÅVIRKER_IKKE_BEREGNING`.

Dette objektet har og en funksjon `tidligsteEndringEllerLocalDateMaxHvisIngenEndring()`, som returnerer `LocalDate.MAX_VALUE`. Denne kan brukes steder der vi beregner, se endring i `TilsynBarnBeregnYtelseSteg.kt`.

---

Er litt videre utviklingsjobb som må til her. Tenker at vi også bør kjøre en migrering for å endre kolonne `vedtak.tidligste_endring` til å inneholde en json, og ikke bare en nullable dato som den holder på i dag.