### PR TITLE
Returner tom liste når bruker ikke har rammevedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/DagligReisePrivatBilController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/DagligReisePrivatBilController.kt
@@ -2,15 +2,9 @@ package no.nav.tilleggsstonader.sak.ekstern.stønad
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.søknad.RammevedtakDto
-import no.nav.tilleggsstonader.kontrakter.søknad.RammevedtakUkeDto
 import no.nav.tilleggsstonader.libs.sikkerhet.EksternBrukerUtils
-import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteService
-import no.nav.tilleggsstonader.sak.util.erFørNåværendeUke
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -37,33 +31,8 @@ class DagligReisePrivatBilController(
                 .flatMap { kjørelisteService.hentForFagsakId(it.id) }
 
         val rammevedtak = dagligReisePrivatBilService.hentRammevedtaksPrivatBil(ident)
-        val kjøreliste = kjørelister.associateBy { it.data.reiseId }
+        val kjøreliste = kjørelister.groupBy { it.data.reiseId }
 
         return rammevedtak.flatMap { it.tilDto(kjøreliste) }
     }
 }
-
-private fun RammevedtakPrivatBil.tilDto(kjøreliste: Map<ReiseId, Kjøreliste>): List<RammevedtakDto> =
-    reiser.map { reise ->
-        val kjøreliste = kjøreliste[reise.reiseId]
-        RammevedtakDto(
-            reiseId = reise.reiseId.toString(),
-            fom = reise.grunnlag.fom,
-            tom = reise.grunnlag.tom,
-            reisedagerPerUke = reise.grunnlag.reisedagerPerUke,
-            aktivitetsadresse = reise.aktivitetsadresse ?: "Ukjent adresse",
-            aktivitetsnavn = "Ukjent aktivitet",
-            uker =
-                reise.grunnlag
-                    .alleDatoerGruppertPåUke()
-                    .map { (uke, datoer) ->
-                        RammevedtakUkeDto(
-                            fom = datoer.min(),
-                            tom = datoer.max(),
-                            ukeNummer = uke.ukenummer,
-                            innsendtDato = kjøreliste?.datoMottatt?.toLocalDate(),
-                            kanSendeInnKjøreliste = uke.erFørNåværendeUke(),
-                        )
-                    },
-        )
-    }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/DagligReisePrivatBilService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/DagligReisePrivatBilService.kt
@@ -25,11 +25,11 @@ class DagligReisePrivatBilService(
 
     fun hentRammevedtakPåIdent(ident: String): List<GeneriskVedtak<InnvilgelseEllerOpphørDagligReise>> {
         val alleIdenterPåPerson = hentAlleIdenterPåPerson(ident)
-        val fagsakPerson = fagsakPersonService.finnPerson(alleIdenterPåPerson)
+        val fagsakPerson = fagsakPersonService.finnPerson(alleIdenterPåPerson) ?: return emptyList()
 
         val iverksatteBehandlingIder =
             behandlingRepository.finnSisteIverksatteBehandlingerForFagsakPersonId(
-                fagsakPersonId = fagsakPerson?.id!!,
+                fagsakPersonId = fagsakPerson.id,
                 stønadstyper = listOf(Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR),
             )
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapper.kt
@@ -1,0 +1,41 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad
+
+import no.nav.tilleggsstonader.kontrakter.søknad.RammevedtakDto
+import no.nav.tilleggsstonader.kontrakter.søknad.RammevedtakUkeDto
+import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
+import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
+import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
+import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
+import no.nav.tilleggsstonader.sak.util.erFørNåværendeUke
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
+
+fun RammevedtakPrivatBil.tilDto(kjørelister: Map<ReiseId, List<Kjøreliste>>): List<RammevedtakDto> =
+    reiser.map { reise ->
+        val kjørelisterForReise = kjørelister[reise.reiseId] ?: emptyList()
+        RammevedtakDto(
+            reiseId = reise.reiseId.toString(),
+            fom = reise.grunnlag.fom,
+            tom = reise.grunnlag.tom,
+            reisedagerPerUke = reise.grunnlag.reisedagerPerUke,
+            aktivitetsadresse = reise.aktivitetsadresse ?: "Ukjent adresse",
+            aktivitetsnavn = "Ukjent aktivitet",
+            uker =
+                reise.grunnlag
+                    .alleDatoerGruppertPåUke()
+                    .map { (uke, datoer) ->
+                        val kjørelisteForUke = kjørelisterForReise.finnForUke(uke)
+                        RammevedtakUkeDto(
+                            fom = datoer.min(),
+                            tom = datoer.max(),
+                            ukeNummer = uke.ukenummer,
+                            innsendtDato = kjørelisteForUke?.datoMottatt?.toLocalDate(),
+                            kanSendeInnKjøreliste = uke.erFørNåværendeUke(),
+                        )
+                    },
+        )
+    }
+
+fun List<Kjøreliste>.finnForUke(uke: UkeIÅr): Kjøreliste? = firstOrNull { it.inneholderUke(uke) }
+
+private fun Kjøreliste.inneholderUke(uke: UkeIÅr): Boolean = data.reisedager.any { it.dato.tilUkeIÅr() == uke }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/DagligReisePrivatBilServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/DagligReisePrivatBilServiceTest.kt
@@ -1,0 +1,56 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
+import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdent
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
+import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DagligReisePrivatBilServiceTest {
+    private val fagsakPersonService = mockk<FagsakPersonService>()
+    private val personService = mockk<PersonService>()
+    private val behandlingRepository = mockk<BehandlingRepository>()
+    private val vedtakService = mockk<VedtakService>()
+
+    private val service =
+        DagligReisePrivatBilService(
+            fagsakPersonService = fagsakPersonService,
+            personService = personService,
+            behandlingRepository = behandlingRepository,
+            vedtakService = vedtakService,
+        )
+
+    private val ident = "12345678901"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.erTokenMedIssuerTokenX() } returns false
+        every { personService.hentFolkeregisterIdenter(any()) } returns
+            PdlIdenter(listOf(PdlIdent(ident, false, "FOLKEREGISTERIDENT")))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Test
+    fun `skal returnere tom liste når fagsakPerson ikke finnes`() {
+        every { fagsakPersonService.finnPerson(any()) } returns null
+
+        val result = service.hentRammevedtaksPrivatBil(ident)
+
+        assertThat(result).isEmpty()
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapperTest.kt
@@ -1,0 +1,92 @@
+package no.nav.tilleggsstonader.sak.ekstern.stønad
+
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.kjøreliste
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class RammevedtakPrivatBilDtoMapperTest {
+
+    @Test
+    fun `innsendtDato settes kun for uker som har kjørelistedata`() {
+        val reiseId = ReiseId.random()
+
+        val rammevedtak = rammevedtakPrivatBil(
+            reiseId = reiseId,
+            fom = 6 januar 2025, // uke 2
+            tom = 19 januar 2025, // uke 3
+        )
+
+        val datoMottatt = LocalDateTime.of(2025, 1, 15, 10, 0)
+        val kjøreliste = kjøreliste(
+            reiseId = reiseId,
+            datoMottatt = datoMottatt,
+            periode = Datoperiode(6 januar 2025, 12 januar 2025), // kun uke 2
+            kjørteDager = listOf(KjørtDag(6 januar 2025)),
+        )
+
+        val kjørelister = listOf(kjøreliste).groupBy { it.data.reiseId }
+        val result = rammevedtak.tilDto(kjørelister).single()
+
+        val uke2 = result.uker.single { it.ukeNummer == 2 }
+        val uke3 = result.uker.single { it.ukeNummer == 3 }
+
+        assertThat(uke2.innsendtDato).isEqualTo(datoMottatt.toLocalDate())
+        assertThat(uke3.innsendtDato).isNull()
+    }
+
+    @Test
+    fun `flere kjørelister for samme reise gir riktig innsendtDato per uke`() {
+        val reiseId = ReiseId.random()
+
+        val rammevedtak = rammevedtakPrivatBil(
+            reiseId = reiseId,
+            fom = 6 januar 2025, // uke 2
+            tom = 19 januar 2025, // uke 3
+        )
+
+        val datoMottattUke2 = LocalDateTime.of(2025, 1, 13, 9, 0)
+        val datoMottattUke3 = LocalDateTime.of(2025, 1, 20, 14, 30)
+
+        val kjørelisteUke2 = kjøreliste(
+            reiseId = reiseId,
+            datoMottatt = datoMottattUke2,
+            periode = Datoperiode(6 januar 2025, 12 januar 2025),
+            kjørteDager = listOf(KjørtDag(6 januar 2025)),
+        )
+        val kjørelisteUke3 = kjøreliste(
+            reiseId = reiseId,
+            datoMottatt = datoMottattUke3,
+            periode = Datoperiode(13 januar 2025, 19 januar 2025),
+            kjørteDager = listOf(KjørtDag(13 januar 2025)),
+        )
+
+        val kjørelister = listOf(kjørelisteUke2, kjørelisteUke3).groupBy { it.data.reiseId }
+        val result = rammevedtak.tilDto(kjørelister).single()
+
+        val uke2 = result.uker.single { it.ukeNummer == 2 }
+        val uke3 = result.uker.single { it.ukeNummer == 3 }
+
+        assertThat(uke2.innsendtDato).isEqualTo(datoMottattUke2.toLocalDate())
+        assertThat(uke3.innsendtDato).isEqualTo(datoMottattUke3.toLocalDate())
+    }
+
+    @Test
+    fun `ingen kjøreliste gir null innsendtDato for alle uker`() {
+        val rammevedtak = rammevedtakPrivatBil(
+            fom = 6 januar 2025,
+            tom = 19 januar 2025,
+        )
+
+        val result = rammevedtak.tilDto(emptyMap()).single()
+
+        assertThat(result.uker).allSatisfy {
+            assertThat(it.innsendtDato).isNull()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapperTest.kt
@@ -11,24 +11,25 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class RammevedtakPrivatBilDtoMapperTest {
-
     @Test
     fun `innsendtDato settes kun for uker som har kjørelistedata`() {
         val reiseId = ReiseId.random()
 
-        val rammevedtak = rammevedtakPrivatBil(
-            reiseId = reiseId,
-            fom = 6 januar 2025, // uke 2
-            tom = 19 januar 2025, // uke 3
-        )
+        val rammevedtak =
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025, // uke 2
+                tom = 19 januar 2025, // uke 3
+            )
 
         val datoMottatt = LocalDateTime.of(2025, 1, 15, 10, 0)
-        val kjøreliste = kjøreliste(
-            reiseId = reiseId,
-            datoMottatt = datoMottatt,
-            periode = Datoperiode(6 januar 2025, 12 januar 2025), // kun uke 2
-            kjørteDager = listOf(KjørtDag(6 januar 2025)),
-        )
+        val kjøreliste =
+            kjøreliste(
+                reiseId = reiseId,
+                datoMottatt = datoMottatt,
+                periode = Datoperiode(6 januar 2025, 12 januar 2025), // kun uke 2
+                kjørteDager = listOf(KjørtDag(6 januar 2025)),
+            )
 
         val kjørelister = listOf(kjøreliste).groupBy { it.data.reiseId }
         val result = rammevedtak.tilDto(kjørelister).single()
@@ -44,27 +45,30 @@ class RammevedtakPrivatBilDtoMapperTest {
     fun `flere kjørelister for samme reise gir riktig innsendtDato per uke`() {
         val reiseId = ReiseId.random()
 
-        val rammevedtak = rammevedtakPrivatBil(
-            reiseId = reiseId,
-            fom = 6 januar 2025, // uke 2
-            tom = 19 januar 2025, // uke 3
-        )
+        val rammevedtak =
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025, // uke 2
+                tom = 19 januar 2025, // uke 3
+            )
 
         val datoMottattUke2 = LocalDateTime.of(2025, 1, 13, 9, 0)
         val datoMottattUke3 = LocalDateTime.of(2025, 1, 20, 14, 30)
 
-        val kjørelisteUke2 = kjøreliste(
-            reiseId = reiseId,
-            datoMottatt = datoMottattUke2,
-            periode = Datoperiode(6 januar 2025, 12 januar 2025),
-            kjørteDager = listOf(KjørtDag(6 januar 2025)),
-        )
-        val kjørelisteUke3 = kjøreliste(
-            reiseId = reiseId,
-            datoMottatt = datoMottattUke3,
-            periode = Datoperiode(13 januar 2025, 19 januar 2025),
-            kjørteDager = listOf(KjørtDag(13 januar 2025)),
-        )
+        val kjørelisteUke2 =
+            kjøreliste(
+                reiseId = reiseId,
+                datoMottatt = datoMottattUke2,
+                periode = Datoperiode(6 januar 2025, 12 januar 2025),
+                kjørteDager = listOf(KjørtDag(6 januar 2025)),
+            )
+        val kjørelisteUke3 =
+            kjøreliste(
+                reiseId = reiseId,
+                datoMottatt = datoMottattUke3,
+                periode = Datoperiode(13 januar 2025, 19 januar 2025),
+                kjørteDager = listOf(KjørtDag(13 januar 2025)),
+            )
 
         val kjørelister = listOf(kjørelisteUke2, kjørelisteUke3).groupBy { it.data.reiseId }
         val result = rammevedtak.tilDto(kjørelister).single()
@@ -78,10 +82,11 @@ class RammevedtakPrivatBilDtoMapperTest {
 
     @Test
     fun `ingen kjøreliste gir null innsendtDato for alle uker`() {
-        val rammevedtak = rammevedtakPrivatBil(
-            fom = 6 januar 2025,
-            tom = 19 januar 2025,
-        )
+        val rammevedtak =
+            rammevedtakPrivatBil(
+                fom = 6 januar 2025,
+                tom = 19 januar 2025,
+            )
 
         val result = rammevedtak.tilDto(emptyMap()).single()
 


### PR DESCRIPTION
## Endring
Fikser NPE i `DagligReisePrivatBilService.hentRammevedtakPåIdent()` når brukeren ikke har noen `fagsakPerson`.

**Før:** `fagsakPerson?.id            {                 echo ___BEGIN___COMMAND_OUTPUT_MARKER___;                 PS1=;PS2=;unset HISTFILE;                 EC=0;                 echo ___BEGIN___COMMAND_DONE_MARKER___0;             }` kastet `NullPointerException` → HTTP 500
**Etter:** `?: return emptyList()` → returnerer tom liste

## Filer endret
- `DagligReisePrivatBilService.kt` — Early return med tom liste
- `DagligReisePrivatBilServiceTest.kt` — Ny test