### PR TITLE
Håndter dødsbo uten adresse ved distribusjon av frittstående brev

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/DistribuerBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/DistribuerBrevService.kt
@@ -12,7 +12,7 @@ import org.springframework.web.client.HttpClientErrorException
 
 @Service
 class DistribuerBrevService(
-    val journalpostClient: JournalpostClient,
+    private val journalpostClient: JournalpostClient,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/DistribuerBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/DistribuerBrevService.kt
@@ -5,7 +5,7 @@ import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
 import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
 import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.client.HttpClientErrorException
@@ -14,6 +14,8 @@ import org.springframework.web.client.HttpClientErrorException
 class DistribuerBrevService(
     val journalpostClient: JournalpostClient,
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     @Transactional
     fun distribuerOgHåndterDødsbo(
         journalpostId: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/DistribuerBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/DistribuerBrevService.kt
@@ -1,0 +1,46 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
+import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.logger
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException
+
+@Service
+class DistribuerBrevService(
+    val journalpostClient: JournalpostClient,
+) {
+    @Transactional
+    fun distribuerOgHåndterDødsbo(
+        journalpostId: String,
+        distribusjonstype: Distribusjonstype,
+        brevtype: String,
+        lagreDistribusjon: (bestillingId: String) -> Unit,
+    ): ResultatDistribusjon =
+        try {
+            val bestillingId =
+                journalpostClient.distribuerJournalpost(
+                    DistribuerJournalpostRequest(
+                        journalpostId = journalpostId,
+                        bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
+                        dokumentProdApp = "TILLEGGSSTONADER-SAK",
+                        distribusjonstype = distribusjonstype,
+                    ),
+                )
+            lagreDistribusjon(bestillingId)
+            logger.info("Distribuert $brevtype (journalpost=$journalpostId) med bestillingId=$bestillingId")
+            ResultatDistribusjon.Distribuert
+        } catch (ex: ProblemDetailException) {
+            logger.warn("Distribusjon av $brevtype for journalpost $journalpostId feilet: ${ex.message}")
+            if (ex.responseException is HttpClientErrorException.Gone) {
+                logger.warn("Kan ikke sende $brevtype da personen er død og mangler adresse.")
+                ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse(ex.message)
+            } else {
+                throw ex
+            }
+        }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/ResultatDistribusjon.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/ResultatDistribusjon.kt
@@ -1,0 +1,9 @@
+package no.nav.tilleggsstonader.sak.brev
+
+sealed interface ResultatDistribusjon {
+    data object Distribuert : ResultatDistribusjon
+
+    data class FeiletFordiMottakerErDødOgManglerAdresse(
+        val feilmelding: String?,
+    ) : ResultatDistribusjon
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevService.kt
@@ -1,65 +1,25 @@
 package no.nav.tilleggsstonader.sak.brev.frittstående
 
-import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
-import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
-import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.DistribuerBrevService
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.client.HttpClientErrorException
 
 @Service
 class DistribuerFrittståendeBrevService(
-    private val journalpostClient: JournalpostClient,
     private val brevmottakerFrittståendeBrevRepository: BrevmottakerFrittståendeBrevRepository,
     private val transactionHandler: TransactionHandler,
+    private val distribuerBrevService: DistribuerBrevService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    interface ResultatDistribusjon {
-        data object BrevDistribuert : ResultatDistribusjon
-
-        data class FeiletFordiMottakerErDødOgManglerAdresse(
-            val feilmelding: String?,
-        ) : ResultatDistribusjon
-    }
-
-    @Transactional
-    fun distribuerBrev(mottaker: BrevmottakerFrittståendeBrev): ResultatDistribusjon {
-        try {
-            return distribuerBrevOgOppdaterMottakerHvisSuksess(mottaker)
-        } catch (ex: ProblemDetailException) {
-            logger.warn("Distribusjon av frittstående brev for journalpost ${mottaker.journalpostId} feilet: ${ex.message}")
-            if (ex.responseException is HttpClientErrorException.Gone) {
-                logger.warn("Kan ikke sende frittstående brev da personen er død og mangler adresse.")
-                return ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("${ex.message}")
-            } else {
-                throw ex
-            }
-        }
-    }
-
-    private fun distribuerBrevOgOppdaterMottakerHvisSuksess(mottaker: BrevmottakerFrittståendeBrev): ResultatDistribusjon {
-        val bestillingId =
-            journalpostClient.distribuerJournalpost(
-                DistribuerJournalpostRequest(
-                    journalpostId = mottaker.journalpostId ?: error("journalpostId er påkrevd"),
-                    bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
-                    dokumentProdApp = "TILLEGGSSTONADER-SAK",
-                    distribusjonstype = Distribusjonstype.VIKTIG,
-                ),
-            )
-        mottaker.lagreDistribusjonGjennomført(bestillingId)
-        logger.info(
-            "Distribuert frittstående brev (journalpost=${mottaker.journalpostId}) med bestillingId=$bestillingId",
-        )
-        return ResultatDistribusjon.BrevDistribuert
-    }
+    fun distribuerBrev(mottaker: BrevmottakerFrittståendeBrev): ResultatDistribusjon =
+        distribuerBrevService.distribuerOgHåndterDødsbo(
+            journalpostId = mottaker.journalpostId ?: error("journalpostId er påkrevd"),
+            distribusjonstype = Distribusjonstype.VIKTIG,
+            brevtype = "frittstående brev",
+        ) { bestillingId -> mottaker.lagreDistribusjonGjennomført(bestillingId) }
 
     private fun BrevmottakerFrittståendeBrev.lagreDistribusjonGjennomført(bestillingId: String) {
         transactionHandler.runInNewTransaction {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevService.kt
@@ -1,0 +1,69 @@
+package no.nav.tilleggsstonader.sak.brev.frittstående
+
+import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
+import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.client.HttpClientErrorException
+
+@Service
+class DistribuerFrittståendeBrevService(
+    private val journalpostClient: JournalpostClient,
+    private val brevmottakerFrittståendeBrevRepository: BrevmottakerFrittståendeBrevRepository,
+    private val transactionHandler: TransactionHandler,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    interface ResultatDistribusjon {
+        data object BrevDistribuert : ResultatDistribusjon
+
+        data class FeiletFordiMottakerErDødOgManglerAdresse(
+            val feilmelding: String?,
+        ) : ResultatDistribusjon
+    }
+
+    @Transactional
+    fun distribuerBrev(mottaker: BrevmottakerFrittståendeBrev): ResultatDistribusjon {
+        try {
+            return distribuerBrevOgOppdaterMottakerHvisSuksess(mottaker)
+        } catch (ex: ProblemDetailException) {
+            logger.warn("Distribusjon av frittstående brev for journalpost ${mottaker.journalpostId} feilet: ${ex.message}")
+            if (ex.responseException is HttpClientErrorException.Gone) {
+                logger.warn("Kan ikke sende frittstående brev da personen er død og mangler adresse.")
+                return ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("${ex.message}")
+            } else {
+                throw ex
+            }
+        }
+    }
+
+    private fun distribuerBrevOgOppdaterMottakerHvisSuksess(mottaker: BrevmottakerFrittståendeBrev): ResultatDistribusjon {
+        val bestillingId =
+            journalpostClient.distribuerJournalpost(
+                DistribuerJournalpostRequest(
+                    journalpostId = mottaker.journalpostId ?: error("journalpostId er påkrevd"),
+                    bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
+                    dokumentProdApp = "TILLEGGSSTONADER-SAK",
+                    distribusjonstype = Distribusjonstype.VIKTIG,
+                ),
+            )
+        mottaker.lagreDistribusjonGjennomført(bestillingId)
+        logger.info(
+            "Distribuert frittstående brev (journalpost=${mottaker.journalpostId}) med bestillingId=$bestillingId",
+        )
+        return ResultatDistribusjon.BrevDistribuert
+    }
+
+    private fun BrevmottakerFrittståendeBrev.lagreDistribusjonGjennomført(bestillingId: String) {
+        transactionHandler.runInNewTransaction {
+            brevmottakerFrittståendeBrevRepository.update(this.copy(bestillingId = bestillingId))
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevService.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.brev.DistribuerBrevService
 import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import org.springframework.stereotype.Service
 
@@ -16,7 +17,7 @@ class DistribuerFrittståendeBrevService(
 ) {
     fun distribuerBrev(mottaker: BrevmottakerFrittståendeBrev): ResultatDistribusjon =
         distribuerBrevService.distribuerOgHåndterDødsbo(
-            journalpostId = mottaker.journalpostId ?: error("journalpostId er påkrevd"),
+            journalpostId = mottaker.journalpostId ?: feil("journalpostId er påkrevd"),
             distribusjonstype = Distribusjonstype.VIKTIG,
             brevtype = "frittstående brev",
         ) { bestillingId -> mottaker.lagreDistribusjonGjennomført(bestillingId) }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
@@ -5,8 +5,8 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
-import no.nav.tilleggsstonader.sak.brev.frittstående.DistribuerFrittståendeBrevService.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.util.stoppTaskOgRekjørSenere

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTask.kt
@@ -3,13 +3,13 @@ package no.nav.tilleggsstonader.sak.brev.frittstående
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
-import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
-import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereFrittståendeBrevService
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.brev.frittstående.DistribuerFrittståendeBrevService.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.util.stoppTaskOgRekjørSenere
 import org.springframework.stereotype.Service
 import java.util.Properties
 import java.util.UUID
@@ -23,25 +23,24 @@ import java.util.UUID
     beskrivelse = "Distribuerer frittstående brev etter journalføring",
 )
 class DistribuerFrittståendeBrevTask(
-    private val journalpostClient: JournalpostClient,
-    private val brevmottakereFrittståendeBrevService: BrevmottakereFrittståendeBrevService,
+    private val brevmottakerFrittståendeBrevRepository: BrevmottakerFrittståendeBrevRepository,
+    private val distribuerFrittståendeBrevService: DistribuerFrittståendeBrevService,
+    private val taskService: TaskService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
         val payload = jsonMapper.readValue(task.payload, DistribuerFrittståendeBrevPayload::class.java)
 
-        val bestillingId =
-            journalpostClient.distribuerJournalpost(
-                DistribuerJournalpostRequest(
-                    journalpostId = payload.journalpostId,
-                    bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
-                    dokumentProdApp = "TILLEGGSSTONADER-SAK",
-                    distribusjonstype = Distribusjonstype.VIKTIG,
-                ),
-            )
-        brevmottakereFrittståendeBrevService
-            .hentBrevmottakere(payload.mottakerId)
-            .copy(bestillingId = bestillingId)
-            .let { brevmottakereFrittståendeBrevService.oppdaterBrevmottaker(it) }
+        val mottaker = brevmottakerFrittståendeBrevRepository.findByIdOrThrow(payload.mottakerId)
+
+        distribuerFrittståendeBrevService
+            .distribuerBrev(mottaker)
+            .håndterRekjøringSenereHvisMottakerErDød(task)
+    }
+
+    private fun ResultatDistribusjon.håndterRekjøringSenereHvisMottakerErDød(task: Task) {
+        if (this is ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse) {
+            taskService.stoppTaskOgRekjørSenere(task, årsak = "Mottaker er død", melding = feilmelding)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevService.kt
@@ -1,65 +1,26 @@
 package no.nav.tilleggsstonader.sak.brev.vedtaksbrev
 
-import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
-import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
-import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.DistribuerBrevService
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.client.HttpClientErrorException
 
 @Service
 class DistribuerVedtaksbrevService(
-    private val journalpostClient: JournalpostClient,
     private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
     private val transactionHandler: TransactionHandler,
+    private val distribuerBrevService: DistribuerBrevService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    interface ResultatBrevutsendelse {
-        data object BrevDistribuert : ResultatBrevutsendelse
-
-        data class FeiletFordiMottakerErDødOgManglerAdresse(
-            val feilmelding: String?,
-        ) : ResultatBrevutsendelse
-    }
-
-    @Transactional
-    fun distribuerVedtaksbrev(mottaker: BrevmottakerVedtaksbrev): ResultatBrevutsendelse {
-        try {
-            return distribuerVedtaksbrevOgOppdaterMottakerHvisSuksess(mottaker)
-        } catch (ex: ProblemDetailException) {
-            logger.warn("Distribusjon av vedtaksbrev for journalpost ${mottaker.journalpostId} feilet: ${ex.message}")
-            if (ex.responseException is HttpClientErrorException.Gone) {
-                logger.warn("Kan ikke sende vedtaksbrev da personen er død og mangler adresse.")
-                return ResultatBrevutsendelse.FeiletFordiMottakerErDødOgManglerAdresse("${ex.message}")
-            } else {
-                throw ex
-            }
-        }
-    }
-
-    private fun distribuerVedtaksbrevOgOppdaterMottakerHvisSuksess(mottaker: BrevmottakerVedtaksbrev): ResultatBrevutsendelse {
-        val bestillingsId =
-            journalpostClient.distribuerJournalpost(
-                DistribuerJournalpostRequest(
-                    journalpostId = mottaker.journalpostId ?: error("journalpostId er påkrevd"),
-                    bestillendeFagsystem = Fagsystem.TILLEGGSSTONADER,
-                    dokumentProdApp = "TILLEGGSSTONADER-SAK",
-                    distribusjonstype = Distribusjonstype.VEDTAK,
-                ),
-            )
-        mottaker.lagreDistribusjonGjennomført(bestillingsId)
-        logger.info(
-            "Distribuert vedtaksbrev (journalpost=${mottaker.journalpostId}) med bestillingId=$bestillingsId",
-        )
-        return ResultatBrevutsendelse.BrevDistribuert
-    }
+    fun distribuerVedtaksbrev(mottaker: BrevmottakerVedtaksbrev): ResultatDistribusjon =
+        distribuerBrevService.distribuerOgHåndterDødsbo(
+            journalpostId = mottaker.journalpostId ?: feil("journalpostId er påkrevd"),
+            distribusjonstype = Distribusjonstype.VEDTAK,
+            brevtype = "vedtaksbrev",
+        ) { bestillingId -> mottaker.lagreDistribusjonGjennomført(bestillingId) }
 
     private fun BrevmottakerVedtaksbrev.lagreDistribusjonGjennomført(bestillingId: String) {
         transactionHandler.runInNewTransaction {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTask.kt
@@ -4,8 +4,8 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.DistribuerVedtaksbrevService.ResultatBrevutsendelse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.util.stoppTaskOgRekjørSenere
@@ -46,8 +46,8 @@ class DistribuerVedtaksbrevTask(
             .håndterRekjøringSenereHvisMottakerErDød(task)
     }
 
-    private fun List<ResultatBrevutsendelse>.håndterRekjøringSenereHvisMottakerErDød(task: Task) {
-        filterIsInstance<ResultatBrevutsendelse.FeiletFordiMottakerErDødOgManglerAdresse>()
+    private fun List<ResultatDistribusjon>.håndterRekjøringSenereHvisMottakerErDød(task: Task) {
+        filterIsInstance<ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse>()
             .firstOrNull()
             ?.let { taskService.stoppTaskOgRekjørSenere(task, årsak = "Mottaker er død", melding = it.feilmelding) }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevServiceTest.kt
@@ -1,0 +1,107 @@
+package no.nav.tilleggsstonader.sak.brev.frittstående
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
+import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
+import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.web.client.HttpClientErrorException
+
+class DistribuerFrittståendeBrevServiceTest {
+    private val journalpostClient = mockk<JournalpostClient>()
+    private val brevmottakerFrittståendeBrevRepository = mockk<BrevmottakerFrittståendeBrevRepository>()
+
+    private val service =
+        DistribuerFrittståendeBrevService(
+            journalpostClient = journalpostClient,
+            brevmottakerFrittståendeBrevRepository = brevmottakerFrittståendeBrevRepository,
+            transactionHandler = TransactionHandler(),
+        )
+
+    private val journalpostId = "journalpostId123"
+    private val bestillingId = "bestillingId123"
+    private val mottaker =
+        BrevmottakerFrittståendeBrev(
+            fagsakId = FagsakId.random(),
+            mottaker = mottakerPerson(ident = "12345678901"),
+            journalpostId = journalpostId,
+            bestillingId = null,
+        )
+
+    private val utførteDistribusjoner = mutableListOf<DistribuerJournalpostRequest>()
+    private val oppdaterteBrevmottakere = mutableListOf<BrevmottakerFrittståendeBrev>()
+
+    @BeforeEach
+    fun setUp() {
+        utførteDistribusjoner.clear()
+        oppdaterteBrevmottakere.clear()
+
+        every { brevmottakerFrittståendeBrevRepository.update(capture(oppdaterteBrevmottakere)) } answers { firstArg() }
+    }
+
+    @Test
+    fun `skal distribuere frittstående brev og returnere BrevDistribuert`() {
+        every {
+            journalpostClient.distribuerJournalpost(capture(utførteDistribusjoner))
+        } returns bestillingId
+
+        val resultat = service.distribuerBrev(mottaker)
+
+        assertThat(resultat).isEqualTo(DistribuerFrittståendeBrevService.ResultatDistribusjon.BrevDistribuert)
+
+        assertThat(utførteDistribusjoner).hasSize(1)
+        with(utførteDistribusjoner[0]) {
+            assertThat(this.journalpostId).isEqualTo(journalpostId)
+            assertThat(bestillendeFagsystem).isEqualTo(Fagsystem.TILLEGGSSTONADER)
+            assertThat(dokumentProdApp).isEqualTo("TILLEGGSSTONADER-SAK")
+            assertThat(distribusjonstype).isEqualTo(Distribusjonstype.VIKTIG)
+        }
+
+        assertThat(oppdaterteBrevmottakere).hasSize(1)
+        assertThat(oppdaterteBrevmottakere[0].bestillingId).isEqualTo(bestillingId)
+    }
+
+    @Test
+    fun `skal returnere FeiletFordiMottakerErDødOgManglerAdresse ved 410 Gone`() {
+        every {
+            journalpostClient.distribuerJournalpost(any())
+        } throws HttpStatus.GONE.problemDetailException()
+
+        val resultat = service.distribuerBrev(mottaker)
+
+        assertThat(resultat).isInstanceOf(
+            DistribuerFrittståendeBrevService.ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse::class.java,
+        )
+    }
+
+    @Test
+    fun `skal kaste videre andre ProblemDetailException-feil`() {
+        every {
+            journalpostClient.distribuerJournalpost(any())
+        } throws HttpStatus.BAD_REQUEST.problemDetailException()
+
+        assertThatThrownBy { service.distribuerBrev(mottaker) }
+            .isInstanceOf(ProblemDetailException::class.java)
+    }
+
+    private fun HttpStatus.problemDetailException() =
+        ProblemDetailException(
+            detail = ProblemDetail.forStatus(this),
+            responseException = HttpClientErrorException.create(this, "", HttpHeaders(), byteArrayOf(), null),
+            httpStatus = this,
+        )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevServiceTest.kt
@@ -6,6 +6,8 @@ import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
 import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
 import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.DistribuerBrevService
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
@@ -27,9 +29,9 @@ class DistribuerFrittståendeBrevServiceTest {
 
     private val service =
         DistribuerFrittståendeBrevService(
-            journalpostClient = journalpostClient,
             brevmottakerFrittståendeBrevRepository = brevmottakerFrittståendeBrevRepository,
             transactionHandler = TransactionHandler(),
+            distribuerBrevService = DistribuerBrevService(journalpostClient),
         )
 
     private val journalpostId = "journalpostId123"
@@ -61,7 +63,7 @@ class DistribuerFrittståendeBrevServiceTest {
 
         val resultat = service.distribuerBrev(mottaker)
 
-        assertThat(resultat).isEqualTo(DistribuerFrittståendeBrevService.ResultatDistribusjon.BrevDistribuert)
+        assertThat(resultat).isEqualTo(ResultatDistribusjon.Distribuert)
 
         assertThat(utførteDistribusjoner).hasSize(1)
         with(utførteDistribusjoner[0]) {
@@ -84,7 +86,7 @@ class DistribuerFrittståendeBrevServiceTest {
         val resultat = service.distribuerBrev(mottaker)
 
         assertThat(resultat).isInstanceOf(
-            DistribuerFrittståendeBrevService.ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse::class.java,
+            ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse::class.java,
         )
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTaskTest.kt
@@ -1,0 +1,109 @@
+package no.nav.tilleggsstonader.sak.brev.frittstående
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.prosessering.domene.Loggtype
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskLogg
+import no.nav.familie.prosessering.error.RekjørSenereException
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
+import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.Optional
+import java.util.UUID
+
+class DistribuerFrittståendeBrevTaskTest {
+    private val brevmottakerFrittståendeBrevRepository = mockk<BrevmottakerFrittståendeBrevRepository>()
+    private val distribuerFrittståendeBrevService = mockk<DistribuerFrittståendeBrevService>()
+    private val taskService = mockk<TaskService>(relaxed = true)
+
+    private val distribuerFrittståendeBrevTask =
+        DistribuerFrittståendeBrevTask(
+            brevmottakerFrittståendeBrevRepository = brevmottakerFrittståendeBrevRepository,
+            distribuerFrittståendeBrevService = distribuerFrittståendeBrevService,
+            taskService = taskService,
+        )
+
+    private val fagsakId = FagsakId.random()
+    private val journalpostId = "journalpostId123"
+    private val mottakerId = UUID.randomUUID()
+
+    private val payload =
+        DistribuerFrittståendeBrevPayload(
+            fagsakId = fagsakId,
+            journalpostId = journalpostId,
+            mottakerId = mottakerId,
+        )
+
+    private val task =
+        Task(
+            type = DistribuerFrittståendeBrevTask.TYPE,
+            payload = jsonMapper.writeValueAsString(payload),
+        )
+
+    private val brevmottaker =
+        BrevmottakerFrittståendeBrev(
+            id = mottakerId,
+            fagsakId = fagsakId,
+            mottaker = mottakerPerson(ident = "12345678901"),
+            journalpostId = journalpostId,
+            bestillingId = null,
+        )
+
+    @BeforeEach
+    fun setUp() {
+        every { brevmottakerFrittståendeBrevRepository.findById(mottakerId) } returns Optional.of(brevmottaker)
+    }
+
+    @Test
+    fun `skal distribuere brev via service`() {
+        every {
+            distribuerFrittståendeBrevService.distribuerBrev(brevmottaker)
+        } returns DistribuerFrittståendeBrevService.ResultatDistribusjon.BrevDistribuert
+
+        distribuerFrittståendeBrevTask.doTask(task)
+    }
+
+    @Nested
+    inner class `Rekjøring senere` {
+        @Test
+        fun `skal rekjøre senere hvis mottaker er død og mangler adresse`() {
+            every {
+                distribuerFrittståendeBrevService.distribuerBrev(brevmottaker)
+            } returns DistribuerFrittståendeBrevService.ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("Gone")
+
+            val rekjørSenereException =
+                catchThrowableOfType<RekjørSenereException> { distribuerFrittståendeBrevTask.doTask(task) }
+
+            assertThat(rekjørSenereException.triggerTid)
+                .isBetween(LocalDateTime.now().plusDays(6), LocalDateTime.now().plusDays(8))
+            assertThat(rekjørSenereException.årsak).startsWith("Mottaker er død")
+        }
+
+        @Test
+        fun `skal feile hvis tasken har kjørt over 26 ganger`() {
+            every {
+                distribuerFrittståendeBrevService.distribuerBrev(brevmottaker)
+            } returns DistribuerFrittståendeBrevService.ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("Gone")
+
+            val taskLogg =
+                (1..27).map { TaskLogg(taskId = task.id, type = Loggtype.KLAR_TIL_PLUKK, melding = "Mottaker er død") }
+            every { taskService.findTaskLoggByTaskId(any()) } returns taskLogg
+
+            val taskException =
+                catchThrowableOfType<TaskExceptionUtenStackTrace> { distribuerFrittståendeBrevTask.doTask(task) }
+
+            assertThat(taskException).hasMessageStartingWith("Nådd max antall rekjøringer - 26")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/frittstående/DistribuerFrittståendeBrevTaskTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerFrittståendeBrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
@@ -69,7 +70,7 @@ class DistribuerFrittståendeBrevTaskTest {
     fun `skal distribuere brev via service`() {
         every {
             distribuerFrittståendeBrevService.distribuerBrev(brevmottaker)
-        } returns DistribuerFrittståendeBrevService.ResultatDistribusjon.BrevDistribuert
+        } returns ResultatDistribusjon.Distribuert
 
         distribuerFrittståendeBrevTask.doTask(task)
     }
@@ -80,7 +81,7 @@ class DistribuerFrittståendeBrevTaskTest {
         fun `skal rekjøre senere hvis mottaker er død og mangler adresse`() {
             every {
                 distribuerFrittståendeBrevService.distribuerBrev(brevmottaker)
-            } returns DistribuerFrittståendeBrevService.ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("Gone")
+            } returns ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("Gone")
 
             val rekjørSenereException =
                 catchThrowableOfType<RekjørSenereException> { distribuerFrittståendeBrevTask.doTask(task) }
@@ -94,7 +95,7 @@ class DistribuerFrittståendeBrevTaskTest {
         fun `skal feile hvis tasken har kjørt over 26 ganger`() {
             every {
                 distribuerFrittståendeBrevService.distribuerBrev(brevmottaker)
-            } returns DistribuerFrittståendeBrevService.ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("Gone")
+            } returns ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse("Gone")
 
             val taskLogg =
                 (1..27).map { TaskLogg(taskId = task.id, type = Loggtype.KLAR_TIL_PLUKK, melding = "Mottaker er død") }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevServiceTest.kt
@@ -5,6 +5,9 @@ import io.mockk.mockk
 import no.nav.tilleggsstonader.kontrakter.dokdist.DistribuerJournalpostRequest
 import no.nav.tilleggsstonader.kontrakter.dokdist.Distribusjonstype
 import no.nav.tilleggsstonader.kontrakter.felles.Fagsystem
+import no.nav.tilleggsstonader.libs.http.client.ProblemDetailException
+import no.nav.tilleggsstonader.sak.brev.DistribuerBrevService
+import no.nav.tilleggsstonader.sak.brev.ResultatDistribusjon
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
@@ -14,8 +17,13 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.util.PdlTestdataHelper
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.web.client.HttpClientErrorException
 
 class DistribuerVedtaksbrevServiceTest {
     private val journalpostClient = mockk<JournalpostClient>()
@@ -24,9 +32,9 @@ class DistribuerVedtaksbrevServiceTest {
 
     private val service =
         DistribuerVedtaksbrevService(
-            journalpostClient = journalpostClient,
             brevmottakerVedtaksbrevRepository = brevmottakerVedtaksbrevRepository,
             transactionHandler = TransactionHandler(),
+            distribuerBrevService = DistribuerBrevService(journalpostClient),
         )
 
     private val saksbehandling = saksbehandling()
@@ -63,7 +71,7 @@ class DistribuerVedtaksbrevServiceTest {
 
         val resultat = service.distribuerVedtaksbrev(mottaker)
 
-        assertThat(resultat).isEqualTo(DistribuerVedtaksbrevService.ResultatBrevutsendelse.BrevDistribuert)
+        assertThat(resultat).isEqualTo(ResultatDistribusjon.Distribuert)
 
         assertThat(utførteDistribusjoner).hasSize(1)
         with(utførteDistribusjoner[0]) {
@@ -77,4 +85,34 @@ class DistribuerVedtaksbrevServiceTest {
         assertThat(oppdaterteBrevmottakere).hasSize(1)
         assertThat(oppdaterteBrevmottakere[0].bestillingId).isEqualTo(bestillingId)
     }
+
+    @Test
+    fun `skal returnere FeiletFordiMottakerErDødOgManglerAdresse ved 410 Gone`() {
+        every {
+            journalpostClient.distribuerJournalpost(any())
+        } throws HttpStatus.GONE.problemDetailException()
+
+        val resultat = service.distribuerVedtaksbrev(mottaker)
+
+        assertThat(resultat).isInstanceOf(
+            ResultatDistribusjon.FeiletFordiMottakerErDødOgManglerAdresse::class.java,
+        )
+    }
+
+    @Test
+    fun `skal kaste videre andre ProblemDetailException-feil`() {
+        every {
+            journalpostClient.distribuerJournalpost(any())
+        } throws HttpStatus.BAD_REQUEST.problemDetailException()
+
+        assertThatThrownBy { service.distribuerVedtaksbrev(mottaker) }
+            .isInstanceOf(ProblemDetailException::class.java)
+    }
+
+    private fun HttpStatus.problemDetailException() =
+        ProblemDetailException(
+            detail = ProblemDetail.forStatus(this),
+            responseException = HttpClientErrorException.create(this, "", HttpHeaders(), byteArrayOf(), null),
+            httpStatus = this,
+        )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/DistribuerVedtaksbrevTaskTest.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.DistribuerBrevService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
@@ -46,9 +47,9 @@ class DistribuerVedtaksbrevTaskTest {
 
     val distribuerVedtaksbrevService =
         DistribuerVedtaksbrevService(
-            journalpostClient = journalpostClient,
             brevmottakerVedtaksbrevRepository = brevmottakerVedtaksbrevRepository,
             transactionHandler = TransactionHandler(),
+            distribuerBrevService = DistribuerBrevService(journalpostClient),
         )
 
     val saksbehandling = saksbehandling(steg = StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en mottaker er død og dødsboet ikke har fått adresse ennå, returnerer dokdist HTTP 410 Gone. For frittstående brev førte dette til at tasken feilet og gikk til manuell oppfølging. For vedtaksbrev er dette allerede løst i PR #827.

### Hva er endret?
Speiler mønsteret fra vedtaksbrev over til frittstående brev:
- Ny `DistribuerFrittståendeBrevService` som wrapper distribusjon og fanger 410 Gone
- Oppdatert `DistribuerFrittståendeBrevTask` til å bruke ny service og kalle `stoppTaskOgRekjørSenere()` ved 410 Gone (rekjøring ukentlig i opptil 26 uker)

Vi har prøvd å gjøre koden så lik som mulig til vedtaksbrev-implementasjonen, men siden frittstående brev kun sendes til én mottaker per task (i motsetning til vedtaksbrev som prosesserer alle mottakere i én task), er det noen forskjeller. For eksempel opererer `håndterRekjøringSenereHvisMottakerErDød` på et enkelt resultat i stedet for en liste.