### PR TITLE
🐛 Kjørelistebehandlinger skal forbli kjørelistebehandlinger når de tas av vent

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -276,7 +276,7 @@ class BehandlingService(
         }
     }
 
-    fun gjørOmTilRevurdering(
+    fun oppdaterReferanseTilForrigeIverksatteBehandlingOgOppdaterType(
         behandling: Behandling,
         forrigeIverksatteBehandlingId: BehandlingId?,
     ): Behandling {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingService.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.behandling
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.sortertEtterVedtakstidspunkt
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingKategori
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
@@ -12,7 +13,6 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus.FERDIGSTIL
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus.OPPRETTET
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus.SATT_PÅ_VENT
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus.UTREDES
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandlingsjournalpost
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingsjournalpostRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.EksternBehandlingIdRepository
@@ -285,10 +285,10 @@ class BehandlingService(
         ) {
             "Kan ikke gjøre om behandling til revurdering når den har status ${behandling.status.visningsnavn()}."
         }
+
         return behandlingRepository.update(
             behandling.copy(
-                type = BehandlingType.REVURDERING,
-                steg = StegType.INNGANGSVILKÅR,
+                type = utledBehandlingType(skalVæreRevurdering = true, behandlingÅrsak = behandling.årsak),
                 forrigeIverksatteBehandlingId = forrigeIverksatteBehandlingId,
             ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
@@ -9,7 +9,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 
 object BehandlingUtil {
-    fun utledBehandlingTypeV2(
+    fun utledBehandlingType(
         tidligereBehandlinger: List<Behandling>,
         behandlingÅrsak: BehandlingÅrsak,
     ): BehandlingType {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingUtil.kt
@@ -19,7 +19,14 @@ object BehandlingUtil {
                 val ikkeHenlagt = it.resultat != BehandlingResultat.HENLAGT
                 erFerdigstilt && ikkeHenlagt
             }
-        return if (skalVæreRevurdering) {
+        return utledBehandlingType(skalVæreRevurdering, behandlingÅrsak)
+    }
+
+    fun utledBehandlingType(
+        skalVæreRevurdering: Boolean,
+        behandlingÅrsak: BehandlingÅrsak,
+    ): BehandlingType =
+        if (skalVæreRevurdering) {
             if (behandlingÅrsak == BehandlingÅrsak.KJØRELISTE) {
                 BehandlingType.KJØRELISTE
             } else {
@@ -28,7 +35,6 @@ object BehandlingUtil {
         } else {
             BehandlingType.FØRSTEGANGSBEHANDLING
         }
-    }
 
     fun validerBehandlingIdErLik(
         behandlingIdParam: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettBehandlingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettBehandlingService.kt
@@ -3,7 +3,7 @@ package no.nav.tilleggsstonader.sak.behandling
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgavePrioritet
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
-import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingTypeV2
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingType
 import no.nav.tilleggsstonader.sak.behandling.OpprettBehandlingUtil.validerKanOppretteNyBehandling
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingKategori
@@ -56,7 +56,7 @@ class OpprettBehandlingService(
         val tidligereBehandlinger = behandlingRepository.findByFagsakId(request.fagsakId)
         val sisteIverksatteBehandlinger = behandlingRepository.finnSisteIverksatteBehandling(request.fagsakId)
         val forrigeBehandling = behandlingRepository.finnSisteIverksatteBehandling(request.fagsakId)
-        val behandlingType = utledBehandlingTypeV2(tidligereBehandlinger, behandlingÅrsak = request.behandlingsårsak)
+        val behandlingType = utledBehandlingType(tidligereBehandlinger, behandlingÅrsak = request.behandlingsårsak)
         val fagsak = fagsakService.hentFagsak(request.fagsakId)
 
         validerKanOppretteNyBehandling(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/TaAvVentService.kt
@@ -117,7 +117,10 @@ class TaAvVentService(
         val sisteIverksatteBehandlingId = behandlingService.finnSisteIverksatteBehandling(behandlingSomTasAvVent.fagsakId)
 
         nullstillBehandlingService.nullstillBehandling(behandlingSomTasAvVent)
-        behandlingService.gjørOmTilRevurdering(behandlingSomTasAvVent, sisteIverksatteBehandlingId?.id)
+        behandlingService.oppdaterReferanseTilForrigeIverksatteBehandlingOgOppdaterType(
+            behandlingSomTasAvVent,
+            sisteIverksatteBehandlingId?.id,
+        )
     }
 
     private fun opprettHistorikkInnslagTaAvVent(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
@@ -234,7 +234,7 @@ internal class BehandlingServiceTest {
                     ),
                 )
 
-            assertThat(behandlingService.utledNesteBehandlingstypeV2(fagsak.id)).isEqualTo(BehandlingType.REVURDERING)
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.REVURDERING)
         }
 
         @Test
@@ -244,7 +244,7 @@ internal class BehandlingServiceTest {
                 behandlingRepository.findByFagsakId(fagsak.id)
             } returns emptyList()
 
-            assertThat(behandlingService.utledNesteBehandlingstypeV2(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
         }
 
         @Test
@@ -254,7 +254,7 @@ internal class BehandlingServiceTest {
                 behandlingRepository.findByFagsakId(fagsak.id)
             } returns listOf(henlagtBehandling(fagsak))
 
-            assertThat(behandlingService.utledNesteBehandlingstypeV2(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
         }
 
         @Test
@@ -272,7 +272,7 @@ internal class BehandlingServiceTest {
                     ),
                 )
 
-            assertThat(behandlingService.utledNesteBehandlingstypeV2(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
+            assertThat(behandlingService.utledNesteBehandlingstype(fagsak.id)).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING)
         }
 
         @Test
@@ -291,13 +291,13 @@ internal class BehandlingServiceTest {
                 )
 
             assertThat(
-                behandlingService.utledNesteBehandlingstypeV2(fagsak.id, behandlingÅrsak = BehandlingÅrsak.KJØRELISTE),
+                behandlingService.utledNesteBehandlingstype(fagsak.id, behandlingÅrsak = BehandlingÅrsak.KJØRELISTE),
             ).isEqualTo(BehandlingType.KJØRELISTE)
         }
     }
 }
 
-fun BehandlingService.utledNesteBehandlingstypeV2(
+fun BehandlingService.utledNesteBehandlingstype(
     fagsakId: FagsakId,
     behandlingÅrsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
 ): BehandlingType {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingServiceTest.kt
@@ -7,7 +7,7 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingTypeV2
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
@@ -302,5 +302,5 @@ fun BehandlingService.utledNesteBehandlingstypeV2(
     behandlingÅrsak: BehandlingÅrsak = BehandlingÅrsak.SØKNAD,
 ): BehandlingType {
     val behandlinger = hentBehandlinger(fagsakId)
-    return utledBehandlingTypeV2(behandlinger, behandlingÅrsak)
+    return utledBehandlingType(behandlinger, behandlingÅrsak)
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettBehandlingUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/OpprettBehandlingUtilTest.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.behandling
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingTypeV2
+import no.nav.tilleggsstonader.sak.behandling.BehandlingUtil.utledBehandlingType
 import no.nav.tilleggsstonader.sak.behandling.OpprettBehandlingUtil.validerKanOppretteNyBehandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
@@ -27,7 +27,7 @@ internal class OpprettBehandlingUtilTest {
     inner class UtledBehandlingType {
         @Test
         fun `hvis man kun har henlagte så skal neste type være førstegangsbehandling`() {
-            assertThat(utledBehandlingTypeV2(listOf(henlagtBehandling()), BehandlingÅrsak.SØKNAD)).isEqualTo(
+            assertThat(utledBehandlingType(listOf(henlagtBehandling()), BehandlingÅrsak.SØKNAD)).isEqualTo(
                 BehandlingType.FØRSTEGANGSBEHANDLING,
             )
 
@@ -37,7 +37,7 @@ internal class OpprettBehandlingUtilTest {
                     henlagtBehandling(),
                 )
             assertThat(
-                utledBehandlingTypeV2(
+                utledBehandlingType(
                     henlangteBehandlinger,
                     BehandlingÅrsak.SØKNAD,
                 ),
@@ -47,7 +47,7 @@ internal class OpprettBehandlingUtilTest {
         @Test
         fun `hvis man har en ferdigstilt behandling som ikke er henlagt så blir neste behandling revurdering`() {
             assertThat(
-                utledBehandlingTypeV2(
+                utledBehandlingType(
                     tidligereBehandlinger =
                         listOf(
                             behandling(
@@ -59,7 +59,7 @@ internal class OpprettBehandlingUtilTest {
                 ),
             ).isEqualTo(BehandlingType.REVURDERING)
             assertThat(
-                utledBehandlingTypeV2(
+                utledBehandlingType(
                     tidligereBehandlinger =
                         listOf(
                             behandling(
@@ -71,7 +71,7 @@ internal class OpprettBehandlingUtilTest {
                 ),
             ).isEqualTo(BehandlingType.REVURDERING)
             assertThat(
-                utledBehandlingTypeV2(
+                utledBehandlingType(
                     listOf(
                         behandling(
                             resultat = BehandlingResultat.OPPHØRT,
@@ -86,7 +86,7 @@ internal class OpprettBehandlingUtilTest {
         @Test
         fun `hvis man har en innvilget og senere en henlagt behandling er det fortsatt revurdering`() {
             assertThat(
-                utledBehandlingTypeV2(
+                utledBehandlingType(
                     listOf(
                         behandling(
                             resultat = BehandlingResultat.INNVILGET,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/KjørelistePåVentIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/KjørelistePåVentIntegrationTest.kt
@@ -1,0 +1,114 @@
+package no.nav.tilleggsstonader.sak.behandling.vent
+
+import io.mockk.every
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
+import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
+import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class KjørelistePåVentIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var taAvVentService: TaAvVentService
+
+    private val fomUke1 = 5 januar 2026
+    private val tomUke1 = 11 januar 2026
+    private val fomUke2 = 12 januar 2026
+    private val tomUke2 = 18 januar 2026
+
+    lateinit var brukerident: String
+    lateinit var reiseId: String
+    lateinit var førstegangsbehandling: Behandling
+
+    @BeforeEach
+    fun `opprett daglig-reise sak med to rammevedtak`() {
+        testBrukerkontekst =
+            TestBrukerKontekst(
+                defaultBruker = "julenissen",
+                defaultRoller = listOf(rolleConfig.beslutterRolle),
+            )
+
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+
+        val førstegangsBehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(fomUke1, tomUke2)
+
+                sendInnKjøreliste {
+                    periode = Datoperiode(fomUke1, tomUke1)
+                    kjørteDager =
+                        listOf(
+                            5 januar 2026 to 50,
+                        )
+                }
+            }
+
+        val rammevedtak =
+            kall.privatBil
+                .hentRammevedtak(førstegangsBehandlingContext.ident)
+
+        reiseId = rammevedtak.first().reiseId
+        brukerident = førstegangsBehandlingContext.ident
+
+        // TODO: Bare lagre denne som fagsakId?
+        førstegangsbehandling = testoppsettService.hentBehandling(førstegangsBehandlingContext.behandlingId)
+    }
+
+    @Test
+    fun `skal sette nye kjørelistebehandlinger på vent om det finnes åpen kjørelistebehandling`() {
+        val kjørelisteBehandling1 =
+            testoppsettService
+                .hentBehandlinger(førstegangsbehandling.fagsakId)
+                .single { it.type == BehandlingType.KJØRELISTE }
+
+        // Sender inn en ny kjøreliste hvor behandlingen blir satt på vent
+        sendInnKjøreliste(
+            kjørelisteSkjema(
+                reiseId = reiseId,
+                periode = Datoperiode(fomUke2, tomUke2),
+                dagerKjørt =
+                    listOf(
+                        KjørtDag(12 januar 2026, 50),
+                    ),
+            ),
+            ident = brukerident,
+        )
+
+        val kjørelisteBehandling2 =
+            testoppsettService
+                .hentBehandlinger(førstegangsbehandling.fagsakId)
+                .last { it.type == BehandlingType.KJØRELISTE }
+
+        assertThat(kjørelisteBehandling2.status).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
+
+        // Fullfører første kjørelistebehandling
+        gjennomførKjørelisteBehandling(kjørelisteBehandling1)
+
+        // Ny kjørelistebehandling tas av vent og skal nullstilles
+        tilordneÅpenBehandlingOppgaveForBehandling(kjørelisteBehandling2.id)
+        kall.settPaVent.taAvVent(kjørelisteBehandling2.id, TaAvVentDto())
+
+        val nullstiltBehandling = testoppsettService.hentBehandling(kjørelisteBehandling2.id)
+
+        assertThat(nullstiltBehandling.forrigeIverksatteBehandlingId).isEqualTo(kjørelisteBehandling1.id)
+        assertThat(nullstiltBehandling.type).isEqualTo(BehandlingType.KJØRELISTE)
+        assertThat(nullstiltBehandling.steg).isEqualTo(StegType.KJØRELISTE)
+        assertThat(nullstiltBehandling.status).isEqualTo(BehandlingStatus.UTREDES)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/SettPåVentKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/SettPåVentKall.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall
 import no.nav.tilleggsstonader.sak.behandling.vent.KanTaAvVentDto
 import no.nav.tilleggsstonader.sak.behandling.vent.SettPåVentDto
 import no.nav.tilleggsstonader.sak.behandling.vent.StatusPåVentDto
+import no.nav.tilleggsstonader.sak.behandling.vent.TaAvVentDto
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.integrasjonstest.Testklient
 
@@ -16,6 +17,11 @@ class SettPåVentKall(
 
     fun kanTaAvVent(behandlingId: BehandlingId): KanTaAvVentDto = apiRespons.kanTaAvVent(behandlingId).expectOkWithBody()
 
+    fun taAvVent(
+        behandlingId: BehandlingId,
+        taAvVentDto: TaAvVentDto,
+    ) = apiRespons.taAvVent(behandlingId, taAvVentDto).expectOkEmpty()
+
     // Gir tilgang til "rå"-endepunktene slik at tester kan skrive egne assertions på responsen.
     val apiRespons = SettPåVentApi()
 
@@ -26,5 +32,10 @@ class SettPåVentKall(
         ) = testklient.post("/api/sett-pa-vent/$behandlingId", settPåVentDto)
 
         fun kanTaAvVent(behandlingId: BehandlingId) = testklient.get("/api/sett-pa-vent/$behandlingId/kan-ta-av-vent")
+
+        fun taAvVent(
+            behandlingId: BehandlingId,
+            taAvVentDto: TaAvVentDto,
+        ) = testklient.delete("/api/sett-pa-vent/$behandlingId", taAvVentDto)
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Om man tar en kjørelistebehandling av vent nå så får den type = REVURDERING som gir den feil steg/faner i frontend