### PR TITLE
Skal være mulig å rekjøre en OppfølgingTask uten å være avhengig av a…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
@@ -78,30 +78,63 @@ class OppfølgingOpprettKontrollerService(
     }
 
     /**
-     * Oppretter oppfølging for behandlingId
+     * Oppretter oppfølging for behandlingId.
      *
-     * Hvis siste kontroll har utfall ignoreres og ny oppfølging er lik som sist opprettes ikke ny oppfølging
+     * Oppretter ikke ny oppfølging hvis:
+     * - sisteForFagsak ble ignorert og ny data er lik gammel data
+     * - det finnes en aktiv oppfølging på behandlingen med utfall UNDER_ARBEID eller UTSETTES
+     * - det finnes en aktiv oppfølging på behandlingen og data er uendret
+     *
+     * En aktiv oppfølging deaktiveres (erstattes) hvis den ikke er påstartet (kontrollert == null)
+     * eller har utfall HÅNDTERT eller IGNORERES.
+     *
+     * UTSETTES er inkludert som aktiv fordi saksbehandler kan ha oppdaget avviket og utsatt i påvente
+     * av svar fra bruker eller andre.
      */
+    @Transactional
     fun opprettOppfølging(behandlingId: BehandlingId): Oppfølging? {
         val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
         val fagsakMetadata = fagsakService.hentMetadata(listOf(behandling.fagsakId)).values.single()
 
         val perioderForKontroll = hentPerioderForKontroll(behandling, fagsakMetadata)
-        if (perioderForKontroll.isNotEmpty()) {
-            val data = OppfølgingData(perioderTilKontroll = perioderForKontroll)
-            val sisteForFagsak = oppfølgingRepository.finnSisteForFagsak(behandlingId)
-            if (sisteForFagsak?.kontrollert?.utfall != KontrollertUtfall.IGNORERES || sisteForFagsak.data != data) {
-                return oppfølgingRepository.insert(
-                    Oppfølging(behandlingId = behandlingId, data = data, tema = fagsakMetadata.stønadstype.tilTema()),
-                )
-            } else {
-                logger.warn(
-                    "Ingen endring for behandling=$behandlingId siden oppfølging=${sisteForFagsak.id} " +
-                        "ble kontrollert forrige gang, oppretter ikke ny oppfølging",
-                )
-            }
+        if (perioderForKontroll.isEmpty()) return null
+
+        val data = OppfølgingData(perioderTilKontroll = perioderForKontroll)
+
+        val sisteForFagsak = oppfølgingRepository.finnSisteForFagsak(behandlingId)
+
+        if (sisteForFagsak?.kontrollert?.utfall == KontrollertUtfall.IGNORERES && sisteForFagsak.data == data) {
+            logger.warn(
+                "Ingen endring for behandling=$behandlingId siden oppfølging=${sisteForFagsak.id} " +
+                    "ble kontrollert forrige gang, oppretter ikke ny oppfølging",
+            )
+            return null
         }
-        return null
+
+        val aktivOppfølging = oppfølgingRepository.finnAktivForBehandling(behandlingId)
+
+        if (aktivOppfølging != null) {
+            val aktivUtfall = aktivOppfølging.kontrollert?.utfall
+            if (aktivUtfall == KontrollertUtfall.UNDER_ARBEID || aktivUtfall == KontrollertUtfall.UTSETTES) {
+                logger.warn(
+                    "Aktiv oppfølging=${aktivOppfølging.id} for behandling=$behandlingId er under arbeid " +
+                        "(utfall=$aktivUtfall), oppretter ikke ny oppfølging",
+                )
+                return null
+            }
+            if (aktivOppfølging.data == data) {
+                logger.warn(
+                    "Aktiv oppfølging=${aktivOppfølging.id} for behandling=$behandlingId har uendret data, " +
+                        "oppretter ikke ny oppfølging",
+                )
+                return null
+            }
+            oppfølgingRepository.markerAktivSomIkkeAktiv(behandlingId)
+        }
+
+        return oppfølgingRepository.insert(
+            Oppfølging(behandlingId = behandlingId, data = data, tema = fagsakMetadata.stønadstype.tilTema()),
+        )
     }
 
     private fun hentPerioderForKontroll(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerService.kt
@@ -104,7 +104,7 @@ class OppfølgingOpprettKontrollerService(
         val sisteForFagsak = oppfølgingRepository.finnSisteForFagsak(behandlingId)
 
         if (sisteForFagsak?.kontrollert?.utfall == KontrollertUtfall.IGNORERES && sisteForFagsak.data == data) {
-            logger.warn(
+            logger.info(
                 "Ingen endring for behandling=$behandlingId siden oppfølging=${sisteForFagsak.id} " +
                     "ble kontrollert forrige gang, oppretter ikke ny oppfølging",
             )
@@ -116,14 +116,14 @@ class OppfølgingOpprettKontrollerService(
         if (aktivOppfølging != null) {
             val aktivUtfall = aktivOppfølging.kontrollert?.utfall
             if (aktivUtfall == KontrollertUtfall.UNDER_ARBEID || aktivUtfall == KontrollertUtfall.UTSETTES) {
-                logger.warn(
+                logger.info(
                     "Aktiv oppfølging=${aktivOppfølging.id} for behandling=$behandlingId er under arbeid " +
                         "(utfall=$aktivUtfall), oppretter ikke ny oppfølging",
                 )
                 return null
             }
             if (aktivOppfølging.data == data) {
-                logger.warn(
+                logger.info(
                     "Aktiv oppfølging=${aktivOppfølging.id} for behandling=$behandlingId har uendret data, " +
                         "oppretter ikke ny oppfølging",
                 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingRepository.kt
@@ -29,6 +29,13 @@ interface OppfølgingRepository :
     @Query("update oppfolging SET aktiv = false, version=version + 1 WHERE aktiv = true AND tema = :tema")
     fun markerAlleAktiveSomIkkeAktive(tema: Tema)
 
+    @Query("SELECT * FROM oppfolging WHERE aktiv = true AND behandling_id = :behandlingId")
+    fun finnAktivForBehandling(behandlingId: BehandlingId): Oppfølging?
+
+    @Modifying
+    @Query("UPDATE oppfolging SET aktiv = false, version = version + 1 WHERE aktiv = true AND behandling_id = :behandlingId")
+    fun markerAktivSomIkkeAktiv(behandlingId: BehandlingId)
+
     @Query(
         """
         SELECT o.* 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/OppfølgingRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/repository/OppfølgingRepositoryFake.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.Tema
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.oppfølging.Behandlingsdetaljer
 import no.nav.tilleggsstonader.sak.oppfølging.Oppfølging
 import no.nav.tilleggsstonader.sak.oppfølging.OppfølgingMedDetaljer
@@ -14,8 +15,22 @@ import java.util.UUID
 class OppfølgingRepositoryFake :
     DummyRepository<Oppfølging, UUID>({ it.id }),
     OppfølgingRepository {
+    override fun insert(t: Oppfølging): Oppfølging {
+        feilHvis(findAll().any { it.behandlingId == t.behandlingId && it.aktiv }) {
+            "Kan bare ha en aktiv oppfølging per behandling"
+        }
+        return super.insert(t)
+    }
+
     override fun markerAlleAktiveSomIkkeAktive(tema: Tema) {
         updateAll(findAll().filter { it.tema == tema }.map { it.copy(aktiv = false) })
+    }
+
+    override fun finnAktivForBehandling(behandlingId: BehandlingId): Oppfølging? =
+        findAll().singleOrNull { it.behandlingId == behandlingId && it.aktiv }
+
+    override fun markerAktivSomIkkeAktiv(behandlingId: BehandlingId) {
+        update(findAll().single { it.behandlingId == behandlingId && it.aktiv }.copy(aktiv = false))
     }
 
     /**

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerServiceTest.kt
@@ -466,8 +466,34 @@ class OppfølgingOpprettKontrollerServiceTest {
 
     @Nested
     inner class HarLagretOppfølgingFraFør {
-        val ignoreres =
-            Kontrollert(saksbehandler = "saksbehandler", utfall = KontrollertUtfall.IGNORERES, kommentar = "")
+        @Test
+        fun `skal lagre på nytt hvis dataen endret seg og aktiv oppfølging ikke er kontrollert`() {
+            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
+            assertThat(førsteOppfølging).isNotNull
+
+            førsteOppfølging!!.fjernPerioderTilKontroll()
+
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNotNull
+        }
+
+        @EnumSource(
+            value = KontrollertUtfall::class,
+            names = ["HÅNDTERT", "IGNORERES"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal lagre ny oppfølging dersom aktiv oppfølging er håndtert eller ignorert om data er endret`(utfall: KontrollertUtfall) {
+            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
+            assertThat(førsteOppfølging).isNotNull
+
+            // Skal ikke opprette dersom data er lik
+            førsteOppfølging!!.kontroller(utfall)
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
+
+            // Skal opprette dersom data er ulik
+            førsteOppfølging.fjernPerioderTilKontroll()
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNotNull()
+        }
 
         @EnumSource(
             value = KontrollertUtfall::class,
@@ -482,55 +508,8 @@ class OppfølgingOpprettKontrollerServiceTest {
             førsteOppfølging!!.kontroller(utfall)
 
             assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
-        }
 
-        @Test
-        fun `skal lagre på nytt hvis dataen endret seg`() {
-            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
-            assertThat(førsteOppfølging).isNotNull
-            val oppfølgingMedFjernedePerioder =
-                førsteOppfølging!!.copy(data = førsteOppfølging.data.copy(perioderTilKontroll = emptyList()))
-            oppfølgingRepository.update(oppfølgingMedFjernedePerioder)
-
-            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNotNull
-        }
-
-        @Test
-        fun `skal lagre på nytt hvis forrige ble håndtert og dataen endret seg`() {
-            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
-            assertThat(førsteOppfølging).isNotNull
-            val oppfølgingMedFjernedePerioder =
-                førsteOppfølging!!.copy(
-                    kontrollert = ignoreres.copy(utfall = KontrollertUtfall.HÅNDTERT),
-                    data = førsteOppfølging.data.copy(perioderTilKontroll = emptyList()),
-                )
-            oppfølgingRepository.update(oppfølgingMedFjernedePerioder)
-
-            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNotNull()
-        }
-
-        @Test
-        fun `skal lagre på nytt hvis forrige skal ignoreres og dataen endret seg`() {
-            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
-            assertThat(førsteOppfølging).isNotNull
-            val oppfølgingMedFjernedePerioder =
-                førsteOppfølging!!.copy(
-                    kontrollert = ignoreres,
-                    data = førsteOppfølging.data.copy(perioderTilKontroll = emptyList()),
-                )
-            oppfølgingRepository.update(oppfølgingMedFjernedePerioder)
-
-            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNotNull()
-        }
-
-        @Test
-        fun `skal ikke lagre på nytt hvis forrige skal ignoreres og dataen ikke endret seg`() {
-            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
-            assertThat(førsteOppfølging).isNotNull
-
-            førsteOppfølging!!.kontroller(KontrollertUtfall.IGNORERES)
-
-            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
+            oppfølgingRepository.update(førsteOppfølging.copy(data = førsteOppfølging.data.copy(perioderTilKontroll = emptyList())))
         }
 
         @EnumSource(
@@ -543,7 +522,23 @@ class OppfølgingOpprettKontrollerServiceTest {
             val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
             assertThat(førsteOppfølging).isNotNull
 
-            førsteOppfølging!!.kontroller(utfall)
+            // Skal ikke opprette dersom data er lik
+            val kontrollertOppfølging = førsteOppfølging!!.kontroller(utfall)
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
+
+            // Skal ikke opprette dersom data er ulik
+            kontrollertOppfølging.fjernPerioderTilKontroll()
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
+        }
+
+        @Test
+        fun `skal ikke lagre på nytt hvis forrige skal ignoreres og dataen ikke endret seg`() {
+            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
+
+            assertThat(førsteOppfølging).isNotNull
+
+            førsteOppfølging!!.kontroller(KontrollertUtfall.IGNORERES)
+            oppfølgingRepository.markerAktivSomIkkeAktiv(behandling.id)
 
             assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
         }
@@ -673,7 +668,7 @@ class OppfølgingOpprettKontrollerServiceTest {
         } returns perioder.toList()
     }
 
-    private fun Oppfølging.kontroller(utfall: KontrollertUtfall) {
+    private fun Oppfølging.kontroller(utfall: KontrollertUtfall) =
         oppfølgingRepository.update(
             this.copy(
                 kontrollert =
@@ -682,6 +677,13 @@ class OppfølgingOpprettKontrollerServiceTest {
                         utfall = utfall,
                         kommentar = "Kommentar",
                     ),
+            ),
+        )
+
+    private fun Oppfølging.fjernPerioderTilKontroll() {
+        oppfølgingRepository.update(
+            this.copy(
+                data = this.data.copy(perioderTilKontroll = emptyList()),
             ),
         )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/oppfølging/OppfølgingOpprettKontrollerServiceTest.kt
@@ -37,6 +37,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -467,12 +469,19 @@ class OppfølgingOpprettKontrollerServiceTest {
         val ignoreres =
             Kontrollert(saksbehandler = "saksbehandler", utfall = KontrollertUtfall.IGNORERES, kommentar = "")
 
-        @Test
-        fun `skal lagre ny hvis det finnes en fra før men som ikke er kontrollert`() {
+        @EnumSource(
+            value = KontrollertUtfall::class,
+        )
+        @ParameterizedTest
+        fun `skal ikke lagre ny hvis det finnes en aktiv fra før med samme data om behandling ikke er kontrollert`(
+            utfall: KontrollertUtfall,
+        ) {
             val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
             assertThat(førsteOppfølging).isNotNull
 
-            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNotNull
+            førsteOppfølging!!.kontroller(utfall)
+
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
         }
 
         @Test
@@ -518,8 +527,23 @@ class OppfølgingOpprettKontrollerServiceTest {
         fun `skal ikke lagre på nytt hvis forrige skal ignoreres og dataen ikke endret seg`() {
             val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
             assertThat(førsteOppfølging).isNotNull
-            val oppfølgingMedFjernedePerioder = førsteOppfølging!!.copy(kontrollert = ignoreres)
-            oppfølgingRepository.update(oppfølgingMedFjernedePerioder)
+
+            førsteOppfølging!!.kontroller(KontrollertUtfall.IGNORERES)
+
+            assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
+        }
+
+        @EnumSource(
+            value = KontrollertUtfall::class,
+            names = ["UNDER_ARBEID", "UTSETTES"],
+            mode = EnumSource.Mode.INCLUDE,
+        )
+        @ParameterizedTest
+        fun `skal ikke lagre ny oppfølging dersom utfall er under arbeid eller utsatt selv om data er endret`(utfall: KontrollertUtfall) {
+            val førsteOppfølging = oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)
+            assertThat(førsteOppfølging).isNotNull
+
+            førsteOppfølging!!.kontroller(utfall)
 
             assertThat(oppfølgingOpprettKontrollerService.opprettOppfølging(behandling.id)).isNull()
         }
@@ -647,5 +671,18 @@ class OppfølgingOpprettKontrollerServiceTest {
         every {
             registerAktivitetService.hentAktiviteterForGrunnlagsdata(any(), any(), any())
         } returns perioder.toList()
+    }
+
+    private fun Oppfølging.kontroller(utfall: KontrollertUtfall) {
+        oppfølgingRepository.update(
+            this.copy(
+                kontrollert =
+                    Kontrollert(
+                        saksbehandler = "saksbehandler",
+                        utfall = utfall,
+                        kommentar = "Kommentar",
+                    ),
+            ),
+        )
     }
 }


### PR DESCRIPTION
…t alle oppfølginger settes til ikke aktiv utenfor

### Hvorfor er denne endringen nødvendig? ✨
Har nesten 500 feilede tasker etter jeg klarte å kjøre oppfølgingslista 2 ganger på rad 😢
Alternativet er å slette alle taskene fra databasen.

Problemet kommer av at 1 behandling kun kan ha 1 aktiv oppfølging, så har endret det slik at hvis den ikke er under arbeid som markes den som ikke aktiv slik at funksjonen kan fortsette. Kunne nok her godt for en update, men det bryter litt mer hvordan resten gjøres. Slettes aldri noe her