### PR TITLE
Grupper utbetalinger på reise for privat bil

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepository.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdat
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.utbetaling.UtbetalingId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.data.annotation.Id
 import org.springframework.stereotype.Repository
 
@@ -12,9 +13,10 @@ import org.springframework.stereotype.Repository
 interface FagsakUtbetalingIdRepository :
     RepositoryInterface<FagsakUtbetalingId, UtbetalingId>,
     InsertUpdateRepository<FagsakUtbetalingId> {
-    fun findByFagsakIdAndTypeAndel(
+    fun findByFagsakIdAndTypeAndelAndReiseId(
         fagsakId: FagsakId,
         typeAndel: TypeAndel,
+        reiseId: ReiseId?,
     ): FagsakUtbetalingId?
 
     fun findByFagsakId(fagsakId: FagsakId): List<FagsakUtbetalingId>
@@ -25,4 +27,5 @@ data class FagsakUtbetalingId(
     val utbetalingId: UtbetalingId = UtbetalingId.random(),
     val fagsakId: FagsakId,
     val typeAndel: TypeAndel,
+    val reiseId: ReiseId?,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepository.kt
@@ -20,6 +20,8 @@ interface FagsakUtbetalingIdRepository :
     ): FagsakUtbetalingId?
 
     fun findByFagsakId(fagsakId: FagsakId): List<FagsakUtbetalingId>
+
+    fun deleteByFagsakId(fagsakId: FagsakId)
 }
 
 data class FagsakUtbetalingId(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdService.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.utbetaling.id
 
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.stereotype.Service
 
 @Service
@@ -11,8 +12,9 @@ class FagsakUtbetalingIdService(
     fun hentEllerOpprettUtbetalingId(
         fagsakId: FagsakId,
         typeAndel: TypeAndel,
+        reiseId: ReiseId?,
     ): FagsakUtbetalingId {
-        val eksisterende = fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndel(fagsakId, typeAndel)
+        val eksisterende = fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndelAndReiseId(fagsakId, typeAndel, reiseId)
         if (eksisterende != null) {
             return eksisterende
         }
@@ -21,6 +23,7 @@ class FagsakUtbetalingIdService(
             FagsakUtbetalingId(
                 fagsakId = fagsakId,
                 typeAndel = typeAndel,
+                reiseId = reiseId,
             ),
         )
     }
@@ -28,7 +31,8 @@ class FagsakUtbetalingIdService(
     fun finnesUtbetalingsId(
         fagsakId: FagsakId,
         typeAndel: TypeAndel,
-    ): Boolean = fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndel(fagsakId, typeAndel) != null
+        reiseId: ReiseId?,
+    ): Boolean = fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndelAndReiseId(fagsakId, typeAndel, reiseId) != null
 
     fun hentUtbetalingIderForFagsakId(fagsakId: FagsakId): List<FagsakUtbetalingId> = fagsakUtbetalingIdRepository.findByFagsakId(fagsakId)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.util.erFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.util.erLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.util.erSisteDagIMåneden
 import no.nav.tilleggsstonader.sak.util.toYearMonth
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.annotation.Version
@@ -51,6 +52,7 @@ data class AndelTilkjentYtelse(
     val endretTid: LocalDateTime = SporbarUtils.now(),
     val utbetalingsdato: LocalDate,
     val brukersNavKontor: String? = null,
+    val reiseId: ReiseId? = null,
 ) : Periode<LocalDate> {
     init {
         feilHvis(YearMonth.from(fom) != YearMonth.from(tom)) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.utbetaling.id.FagsakUtbetalingIdService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -64,8 +65,8 @@ class UtbetalingV3Mapper(
     ): List<UtbetalingDto> =
         andelerTilkjentYtelse
             .filterNot { it.erNullandel() }
-            .groupBy { it.type }
-            .map { (type, andelerAvType) -> lagUtbetaling(behandling, type, andelerAvType) }
+            .groupBy { TypeAndelOgReiseId(it.type, it.reiseId) }
+            .map { (typeAndelOgReiseId, andelerAvType) -> lagUtbetaling(behandling, typeAndelOgReiseId, andelerAvType) }
             .let { utbetalinger ->
                 if (erFørsteIverksettingForBehandling) {
                     utbetalinger + lagUtbetalingDtoForAnnulering(behandling, andelerTilkjentYtelse)
@@ -79,13 +80,18 @@ class UtbetalingV3Mapper(
 
     private fun lagUtbetaling(
         behandling: Saksbehandling,
-        type: TypeAndel,
+        typeAndelOgReiseId: TypeAndelOgReiseId,
         andeler: Collection<AndelTilkjentYtelse>,
     ): UtbetalingDto {
-        val utbetalingId = fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(behandling.fagsakId, type)
+        val utbetalingId =
+            fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(
+                fagsakId = behandling.fagsakId,
+                typeAndel = typeAndelOgReiseId.typeAndel,
+                reiseId = typeAndelOgReiseId.reiseId,
+            )
         return UtbetalingDto(
             id = utbetalingId.utbetalingId,
-            stønad = mapTilStønadUtbetaling(type),
+            stønad = mapTilStønadUtbetaling(typeAndelOgReiseId.typeAndel),
             perioder = grupperPåDagOgMapTilPerioder(andeler),
             brukFagområdeTillst = behandling.stønadstype.skalBrukeGamleFagområder(),
         )
@@ -99,7 +105,7 @@ class UtbetalingV3Mapper(
             .map { typeAndel ->
                 lagUtbetaling(
                     behandling = behandling,
-                    type = typeAndel,
+                    typeAndelOgReiseId = typeAndel,
                     andeler = emptyList(), // periodene skal annuleres 💥
                 )
             }
@@ -122,6 +128,11 @@ class UtbetalingV3Mapper(
     private data class UtbetalingsDatoOgEnhet(
         val utbetalingsperiodeFom: LocalDate,
         val betalendeEnhet: String?,
+    )
+
+    private data class TypeAndelOgReiseId(
+        val typeAndel: TypeAndel,
+        val reiseId: ReiseId?,
     )
 
     private fun mapTilStønadUtbetaling(typeAndel: TypeAndel): StønadUtbetaling =
@@ -170,7 +181,7 @@ class UtbetalingV3Mapper(
     private fun finnTypeAndelerSomSkalAnnulleres(
         behandling: Saksbehandling,
         andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
-    ): Set<TypeAndel> {
+    ): Set<TypeAndelOgReiseId> {
         if (behandling.forrigeIverksatteBehandlingId == null) {
             return emptySet()
         }
@@ -179,11 +190,11 @@ class UtbetalingV3Mapper(
                 .hentForBehandling(behandling.forrigeIverksatteBehandlingId)
                 .andelerTilkjentYtelse
 
-        val typeAndelerNåværendeBehandling = andelerTilkjentYtelse.map { it.type }
+        val typeAndelerOgReiseIdNåværendeBehandling = andelerTilkjentYtelse.map { TypeAndelOgReiseId(it.type, it.reiseId) }
         return andelerForrigeBehandling
-            .filter { it.type !in typeAndelerNåværendeBehandling }
-            .map { it.type }
-            .filter { it != TypeAndel.UGYLDIG }
+            .filter { it.type != TypeAndel.UGYLDIG }
+            .map { TypeAndelOgReiseId(it.type, it.reiseId) }
+            .filter { it !in typeAndelerOgReiseIdNåværendeBehandling }
             .toSet()
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
@@ -190,7 +190,11 @@ class UtbetalingV3Mapper(
                 .hentForBehandling(behandling.forrigeIverksatteBehandlingId)
                 .andelerTilkjentYtelse
 
-        val typeAndelerOgReiseIdNåværendeBehandling = andelerTilkjentYtelse.map { TypeAndelOgReiseId(it.type, it.reiseId) }
+        val typeAndelerOgReiseIdNåværendeBehandling =
+            andelerTilkjentYtelse
+                .map { TypeAndelOgReiseId(it.type, it.reiseId) }
+                .toSet()
+
         return andelerForrigeBehandling
             .filter { it.type != TypeAndel.UGYLDIG }
             .map { TypeAndelOgReiseId(it.type, it.reiseId) }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatD
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import java.time.LocalDate
 
 fun BeregningsresultatOffentligTransport.mapTilAndelTilkjentYtelse(saksbehandling: Saksbehandling): List<AndelTilkjentYtelse> =
@@ -47,6 +48,7 @@ fun BeregningsresultatOffentligTransport.mapTilAndelTilkjentYtelse(saksbehandlin
                         målgruppe = målgrupper.first(),
                         typeAktivitet = typeAktivitet.firstOrNull(),
                         brukersNavKontor = brukersNavKontor,
+                        reiseId = null, // Skal kun opprette andeler for privat-bil med reiseId
                     )
                 }
         }
@@ -87,6 +89,7 @@ fun BeregningsresultatPrivatBil.mapTilAndelTilkjentYtelse(
                         målgruppe = vedtaksperiode.målgruppe,
                         typeAktivitet = vedtaksperiode.typeAktivitet,
                         brukersNavKontor = periode.brukersNavKontor,
+                        reiseId = reise.reiseId, // Skal kun opprette andeler for privat-bil med reiseId
                     )
                 }
         }.filterNot { it.beløp == 0 }
@@ -98,6 +101,7 @@ private fun lagAndelForDagligReise(
     målgruppe: FaktiskMålgruppe,
     typeAktivitet: TypeAktivitet?,
     brukersNavKontor: String?,
+    reiseId: ReiseId?,
 ): AndelTilkjentYtelse {
     val typeAndel =
         when (saksbehandling.stønadstype) {
@@ -128,6 +132,7 @@ private fun lagAndelForDagligReise(
         kildeBehandlingId = saksbehandling.id,
         utbetalingsdato = fomUkedag,
         brukersNavKontor = brukersNavKontor,
+        reiseId = reiseId,
     )
 }
 

--- a/src/main/resources/db/migration/V124__fagsak_utbetaling_id_reise_id.sql
+++ b/src/main/resources/db/migration/V124__fagsak_utbetaling_id_reise_id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE fagsak_utbetaling_id ADD COLUMN reise_id UUID;
+ALTER TABLE andel_tilkjent_ytelse ADD COLUMN reise_id UUID;
+
+DROP INDEX fagsak_utbetaling_id_fagsak_id_type_andel_idx;
+CREATE UNIQUE INDEX ON FAGSAK_UTBETALING_ID (fagsak_id, type_andel, reise_id);

--- a/src/main/resources/db/migration/V124__fagsak_utbetaling_id_reise_id.sql
+++ b/src/main/resources/db/migration/V124__fagsak_utbetaling_id_reise_id.sql
@@ -2,4 +2,11 @@ ALTER TABLE fagsak_utbetaling_id ADD COLUMN reise_id UUID;
 ALTER TABLE andel_tilkjent_ytelse ADD COLUMN reise_id UUID;
 
 DROP INDEX fagsak_utbetaling_id_fagsak_id_type_andel_idx;
-CREATE UNIQUE INDEX ON FAGSAK_UTBETALING_ID (fagsak_id, type_andel, reise_id);
+
+CREATE UNIQUE INDEX fagsak_utbetaling_id_uq_fagsak_type_when_reise_null
+    ON fagsak_utbetaling_id (fagsak_id, type_andel)
+    WHERE reise_id IS NULL;
+
+CREATE UNIQUE INDEX fagsak_utbetaling_id_uq_fagsak_type_reise_when_reise_not_null
+    ON fagsak_utbetaling_id (fagsak_id, type_andel, reise_id)
+    WHERE reise_id IS NOT NULL;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.brev.GenererPdfRequest
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientMockConfig
 import no.nav.tilleggsstonader.sak.integrasjonstest.dsl.BehandlingTestdataDsl
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksKlareForProsessering
@@ -56,6 +57,7 @@ import java.util.UUID
 
 data class BehandlingContext(
     val behandlingId: BehandlingId,
+    val fagsakId: FagsakId,
     val ident: String,
 )
 
@@ -77,14 +79,19 @@ fun IntegrationTest.opprettBehandlingOgGjennomførBehandlingsløp(
 ): BehandlingContext {
     val journalpostSøknadForStønadstype = journalpostSøknadForStønadstype(stønadstype, ident)
     mockStrukturertSøknadForJournalpost(journalpostSøknadForStønadstype, stønadstype)
-    val behandlingId = håndterSøknadService.håndterSøknad(journalpostSøknadForStønadstype)!!.id
+    val behandling = håndterSøknadService.håndterSøknad(journalpostSøknadForStønadstype)!!
     gjennomførBehandlingsløp(
-        behandlingId = behandlingId,
+        behandlingId = behandling.id,
         ident = ident,
         tilSteg = tilSteg,
         testdataProvider = testdataProvider,
     )
-    return BehandlingContext(behandlingId, ident)
+
+    return BehandlingContext(
+        behandlingId = behandling.id,
+        fagsakId = behandling.fagsakId,
+        ident = ident,
+    )
 }
 
 private fun IntegrationTest.mockStrukturertSøknadForJournalpost(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.AfterEach
@@ -62,6 +63,36 @@ class FagsakUtbetalingIdRepositoryTest : IntegrationTest() {
                 FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = null),
             )
         }
+    }
+
+    @Test
+    fun `finner ikke utbetalingid med reiseid når reiseid er lagret med null`() {
+        fagsakUtbetalingIdRepository.insert(
+            FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = null),
+        )
+
+        assertThat(
+            fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndelAndReiseId(
+                fagsakId = behandling.fagsakId,
+                typeAndel = TypeAndel.DAGLIG_REISE_AAP,
+                reiseId = ReiseId.random(),
+            ),
+        ).isNull()
+    }
+
+    @Test
+    fun `finner ikke utbetalingid uten reiseid når reiseid er lagret med verdi`() {
+        fagsakUtbetalingIdRepository.insert(
+            FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = ReiseId.random()),
+        )
+
+        assertThat(
+            fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndelAndReiseId(
+                fagsakId = behandling.fagsakId,
+                typeAndel = TypeAndel.DAGLIG_REISE_AAP,
+                reiseId = null,
+            ),
+        ).isNull()
     }
 
     @AfterEach

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepositoryTest.kt
@@ -1,0 +1,69 @@
+package no.nav.tilleggsstonader.sak.utbetaling.id
+
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.assertj.core.api.Assertions.assertThatNoException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.DuplicateKeyException
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FagsakUtbetalingIdRepositoryTest : IntegrationTest() {
+    @Autowired
+    lateinit var fagsakUtbetalingIdRepository: FagsakUtbetalingIdRepository
+
+    lateinit var behandling: Behandling
+
+    @BeforeAll
+    fun opprettFagsak() {
+        behandling = testoppsettService.opprettBehandlingMedFagsak()
+    }
+
+    @Test
+    fun `kan ikke opprette utbetalingid med samme fagsakid og typeAndel`() {
+        fagsakUtbetalingIdRepository.insert(
+            FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = null),
+        )
+        assertThatExceptionOfType(DuplicateKeyException::class.java).isThrownBy {
+            fagsakUtbetalingIdRepository.insert(
+                FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = null),
+            )
+        }
+    }
+
+    @Test
+    fun `kan ikke opprette utbetalingid med samme fagsakid og typeAndel og reiseId`() {
+        val reiseId = ReiseId.random()
+        fagsakUtbetalingIdRepository.insert(
+            FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = reiseId),
+        )
+        assertThatExceptionOfType(DuplicateKeyException::class.java).isThrownBy {
+            fagsakUtbetalingIdRepository.insert(
+                FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = reiseId),
+            )
+        }
+    }
+
+    @Test
+    fun `kan opprette en utbetalingid med samme fagsakid og typeAndel med og uten reiseid`() {
+        fagsakUtbetalingIdRepository.insert(
+            FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = ReiseId.random()),
+        )
+        assertThatNoException().isThrownBy {
+            fagsakUtbetalingIdRepository.insert(
+                FagsakUtbetalingId(fagsakId = behandling.fagsakId, typeAndel = TypeAndel.DAGLIG_REISE_AAP, reiseId = null),
+            )
+        }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        fagsakUtbetalingIdRepository.deleteByFagsakId(behandling.fagsakId)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/FagsakUtbetalingIdRepositoryTest.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.utbetaling.id
 
+import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -22,7 +24,7 @@ class FagsakUtbetalingIdRepositoryTest : IntegrationTest() {
 
     @BeforeAll
     fun opprettFagsak() {
-        behandling = testoppsettService.opprettBehandlingMedFagsak()
+        behandling = testoppsettService.opprettBehandlingMedFagsak(identer = setOf(PersonIdent(FnrGenerator.generer())))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/UtbetalingIdServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/id/UtbetalingIdServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -14,22 +15,23 @@ class UtbetalingIdServiceTest {
 
     val fagsakId = FagsakId.random()
     val typeAndel = TypeAndel.DAGLIG_REISE_AAP
+    val reiseId = ReiseId.random()
 
     @Test
-    fun `utbetalingId finnes ikke for gitt fagsakId og typeAndel, opprettes`() {
-        every { fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndel(fagsakId, typeAndel) } returns null
+    fun `utbetalingId finnes ikke for gitt fagsakId, typeAndel og reiseId, opprettes`() {
+        every { fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndelAndReiseId(fagsakId, typeAndel, reiseId) } returns null
         every { fagsakUtbetalingIdRepository.insert(any()) } answers { firstArg() }
-        val utbetalingId = fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(fagsakId, typeAndel)
+        val utbetalingId = fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(fagsakId, typeAndel, reiseId)
 
         verify { fagsakUtbetalingIdRepository.insert(utbetalingId) }
     }
 
     @Test
-    fun `utbetalingId finnes for gitt fagsakId og typeAndel, hentes`() {
-        val fagsakUtbetalingId = FagsakUtbetalingId(fagsakId = fagsakId, typeAndel = typeAndel)
-        every { fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndel(fagsakId, typeAndel) } returns fagsakUtbetalingId
+    fun `utbetalingId finnes for gitt fagsakId, typeAndel og reiseId, hentes`() {
+        val fagsakUtbetalingId = FagsakUtbetalingId(fagsakId = fagsakId, typeAndel = typeAndel, reiseId = reiseId)
+        every { fagsakUtbetalingIdRepository.findByFagsakIdAndTypeAndelAndReiseId(fagsakId, typeAndel, reiseId) } returns fagsakUtbetalingId
 
-        assertThat(fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(fagsakId, typeAndel)).isEqualTo(fagsakUtbetalingId)
+        assertThat(fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(fagsakId, typeAndel, reiseId)).isEqualTo(fagsakUtbetalingId)
         verify(exactly = 0) { fagsakUtbetalingIdRepository.insert(any()) }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -69,8 +69,8 @@ internal class SimuleringServiceTest {
         every { fagsakService.fagsakMedOppdatertPersonIdent(any()) } returns fagsak
         every { tilgangService.validerHarSaksbehandlerrolle() } just Runs
         every { tilgangService.harTilgangTilRolle(any()) } returns true
-        every { fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(any(), any()) } answers {
-            FagsakUtbetalingId(fagsakId = FagsakId(firstArg()), typeAndel = secondArg())
+        every { fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(any(), any(), any()) } answers {
+            FagsakUtbetalingId(fagsakId = FagsakId(firstArg()), typeAndel = secondArg(), reiseId = thirdArg())
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReiseOffentligTransportIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReiseOffentligTransportIntegrationTest.kt
@@ -5,18 +5,24 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.august
 import no.nav.tilleggsstonader.libs.utils.dato.oktober
 import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KafkaFake
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.finnPåTopic
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.forventAntallMeldingerPåTopic
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.verdiEllerFeil
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.utbetaling.id.FagsakUtbetalingIdRepository
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.YearMonth
 
 class UtbetalingDagligReiseOffentligTransportIntegrationTest : IntegrationTest() {
+    @Autowired
+    lateinit var fagsakUtbetalingIdRepository: FagsakUtbetalingIdRepository
+
     private val nå = LocalDate.now()
     private val fom = nå.minusMonths(3)
     private val tom = nå.plusMonths(3)
@@ -68,6 +74,8 @@ class UtbetalingDagligReiseOffentligTransportIntegrationTest : IntegrationTest()
                 assertThat(fom).isEqualTo(tom).isEqualTo(reiseperiode2.fom.datoEllerNesteMandagHvisLørdagEllerSøndag())
             }
         }
+
+        assertUtbetalingIderErUtenReiseId(behandlingContext.fagsakId)
     }
 
     @Test
@@ -75,26 +83,27 @@ class UtbetalingDagligReiseOffentligTransportIntegrationTest : IntegrationTest()
         val reiseperiode1 = Datoperiode(nå.minusDays(5), tom = nå)
         val reiseperiode2 = Datoperiode(nå.plusWeeks(1), tom = nå.plusWeeks(2))
 
-        opprettBehandlingOgGjennomførBehandlingsløp(
-            stønadstype = Stønadstype.DAGLIG_REISE_TSO,
-        ) {
-            aktivitet {
-                opprett {
-                    aktivitetTiltakTso(fom = fom, tom = tom)
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTso(fom = fom, tom = tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom = fom, tom = tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        offentligTransport(reiseperiode1.fom, reiseperiode1.tom)
+                        offentligTransport(reiseperiode2.fom, reiseperiode2.tom)
+                    }
                 }
             }
-            målgruppe {
-                opprett {
-                    målgruppeAAP(fom = fom, tom = tom)
-                }
-            }
-            vilkår {
-                opprett {
-                    offentligTransport(reiseperiode1.fom, reiseperiode1.tom)
-                    offentligTransport(reiseperiode2.fom, reiseperiode2.tom)
-                }
-            }
-        }
 
         val utbetaling =
             KafkaFake
@@ -116,6 +125,8 @@ class UtbetalingDagligReiseOffentligTransportIntegrationTest : IntegrationTest()
         ) {
             assertThat(fom).isEqualTo(tom).isEqualTo(forventetUtbetalingsdato)
         }
+
+        assertUtbetalingIderErUtenReiseId(behandlingContext.fagsakId)
     }
 
     @Test
@@ -174,5 +185,15 @@ class UtbetalingDagligReiseOffentligTransportIntegrationTest : IntegrationTest()
                 .isEqualTo(perioder.single().fom)
                 .isEqualTo(reiseperiode2.fom.datoEllerNesteMandagHvisLørdagEllerSøndag())
         }
+
+        assertUtbetalingIderErUtenReiseId(behandlingContext.fagsakId)
+    }
+
+    private fun assertUtbetalingIderErUtenReiseId(fagsakId: FagsakId) {
+        fagsakUtbetalingIdRepository
+            .findByFagsakId(fagsakId)
+            .forEach {
+                assertThat(it.reiseId).isNull()
+            }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
@@ -16,11 +17,13 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.forventAntallMeld
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.verdiEllerFeil
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.Oppgavestatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.privatBil.SatsDagligReisePrivatBilProvider
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
 import org.assertj.core.api.Assertions.assertThat
@@ -145,6 +148,88 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
             .doesNotContain(førstegangsBehandling.id)
     }
 
+    @Test
+    fun `sak med to overlappende reiser, begge utbetales med samme typeAndel, grupperes på reise til økonomi`() {
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+
+        val fom = 2 mars 2026
+        val tom = 15 mars 2026
+
+        val førstegangsBehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTso(fom, tom)
+                    }
+                }
+
+                vilkår {
+                    opprett {
+                        privatBil(fom, tom, reiseavstandEnVei = 10.toBigDecimal())
+                        privatBil(fom, tom, reiseavstandEnVei = 100.toBigDecimal())
+                    }
+                }
+            }
+
+        val alleRammevedtak = kall.privatBil.hentRammevedtak(førstegangsBehandlingContext.ident)
+        assertThat(alleRammevedtak).hasSize(2)
+        val rammevedtak1 = alleRammevedtak[0]
+        val rammevedtak2 = alleRammevedtak[1]
+
+        // Sender inn kjøreliste for første rammevedtak
+        sendInnKjøreliste(
+            kjøreliste =
+                KjørelisteSkjemaUtil.kjørelisteSkjema(
+                    rammevedtak1.reiseId,
+                    periode = Datoperiode(fom, tom),
+                    dagerKjørt = listOf(KjørelisteSkjemaUtil.KjørtDag(fom)),
+                ),
+            ident = førstegangsBehandlingContext.ident,
+        )
+
+        val førsteKjørelistebehandling =
+            testoppsettService
+                .hentBehandlinger(førstegangsBehandlingContext.fagsakId)
+                .single { it.type == BehandlingType.KJØRELISTE }
+
+        gjennomførKjørelisteBehandling(førsteKjørelistebehandling)
+        testoppsettService.settAndelerTilOkForBehandling(førsteKjørelistebehandling)
+
+        // Sender inn kjøreliste for andre rammevedtak
+        sendInnKjøreliste(
+            kjøreliste =
+                KjørelisteSkjemaUtil.kjørelisteSkjema(
+                    rammevedtak2.reiseId,
+                    periode = Datoperiode(fom, tom),
+                    dagerKjørt = listOf(KjørelisteSkjemaUtil.KjørtDag(fom)),
+                ),
+            ident = førstegangsBehandlingContext.ident,
+        )
+
+        val andreKjørelistebehandling =
+            testoppsettService
+                .hentBehandlinger(førstegangsBehandlingContext.fagsakId)
+                .single { it.type == BehandlingType.KJØRELISTE && it.id != førsteKjørelistebehandling.id }
+
+        gjennomførKjørelisteBehandling(andreKjørelistebehandling)
+
+        val sendteUtbetalinger =
+            KafkaFake
+                .sendteMeldinger()
+                .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 2)
+                .map { it.verdiEllerFeil<IverksettingDto>() }
+
+        println(sendteUtbetalinger)
+    }
+
     private fun assertAndelOpprettet(
         andelerForKjørelistebehandling: Set<AndelTilkjentYtelse>?,
         forventetBeløp: Int,
@@ -155,6 +240,7 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
         val andel = andelerForKjørelistebehandling!!.single()
         assertThat(andel.type).isEqualTo(forventetTypeAndel)
         assertThat(andel.beløp).isEqualTo(forventetBeløp)
+        assertThat(andel.reiseId).isNotNull
     }
 
     private fun List<Pair<LocalDate, Int>>.kalkulerForventetBeløp(reiseavstandEnVei: BigDecimal): Int =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -221,13 +221,23 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
 
         gjennomførKjørelisteBehandling(andreKjørelistebehandling)
 
-        val sendteUtbetalinger =
+        val sendteIverksettinger =
             KafkaFake
                 .sendteMeldinger()
                 .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 2)
                 .map { it.verdiEllerFeil<IverksettingDto>() }
 
-        println(sendteUtbetalinger)
+        assertThat(sendteIverksettinger).hasSize(2)
+        val iverksettingFørsteKjørelistebehandling = sendteIverksettinger.minBy { it.vedtakstidspunkt }
+        val iverksettingAndreKjørelistebehandling = sendteIverksettinger.maxBy { it.vedtakstidspunkt }
+
+        assertThat(iverksettingFørsteKjørelistebehandling.utbetalinger).hasSize(1)
+        assertThat(iverksettingAndreKjørelistebehandling.utbetalinger).hasSize(2)
+
+        // Verifiserer at utbetalingen fra første behandling er med i iverksetting for den andre behandlingen
+        assertThat(
+            iverksettingAndreKjørelistebehandling.utbetalinger,
+        ).contains(iverksettingFørsteKjørelistebehandling.utbetalinger.single())
     }
 
     private fun assertAndelOpprettet(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingIntegrationTest.kt
@@ -67,7 +67,7 @@ class UtbetalingIntegrationTest : IntegrationTest() {
 
         val førstegangsbehandling = behandlingService.hentBehandling(førstegangsbehandlingContext.behandlingId)
         val finnesUtbetalingIdEtterFørstegangsbehandling =
-            fagsakUtbetalingIdService.finnesUtbetalingsId(førstegangsbehandling.fagsakId, TypeAndel.LÆREMIDLER_AAP)
+            fagsakUtbetalingIdService.finnesUtbetalingsId(førstegangsbehandling.fagsakId, TypeAndel.LÆREMIDLER_AAP, null)
 
         Assertions.assertThat(finnesUtbetalingIdEtterFørstegangsbehandling).isTrue
         verify(exactly = 1) { simuleringClient.simuler(any()) }
@@ -98,7 +98,7 @@ class UtbetalingIntegrationTest : IntegrationTest() {
 
         val revurdering = behandlingService.hentBehandling(revurderingId)
         val finnesUtbetalingIdEtterRevurdering =
-            fagsakUtbetalingIdService.finnesUtbetalingsId(revurdering.fagsakId, TypeAndel.LÆREMIDLER_AAP)
+            fagsakUtbetalingIdService.finnesUtbetalingsId(revurdering.fagsakId, TypeAndel.LÆREMIDLER_AAP, null)
 
         Assertions.assertThat(finnesUtbetalingIdEtterRevurdering).isTrue
         verify(exactly = 2) { simuleringClient.simuler(any()) }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
@@ -26,6 +26,8 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.migrering.routing.SkjemaRouting
 import no.nav.tilleggsstonader.sak.migrering.routing.SkjemaRoutingRepository
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.FaktaGrunnlagService
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgetVedtak
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.vedtakBeregningsresultat
@@ -57,6 +59,7 @@ class TestoppsettService(
     private val vedtakRepository: VedtakRepository,
     private val skjemaRoutingRepository: SkjemaRoutingRepository,
     private val totrinnskontrollRepository: TotrinnskontrollRepository,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
 ) {
     fun hentFagsak(fagsakId: FagsakId) = fagsakService.hentFagsak(fagsakId)
 
@@ -234,4 +237,17 @@ class TestoppsettService(
         )
 
     fun hentPersonidentForBehandlingId(behandlingId: BehandlingId) = behandlingRepository.finnAktivIdent(behandlingId)
+
+    fun settAndelerTilOkForBehandling(behandling: Behandling) {
+        val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingId(behandling.id)!!
+        tilkjentYtelseRepository.update(
+            tilkjentYtelse.copy(
+                andelerTilkjentYtelse =
+                    tilkjentYtelse.andelerTilkjentYtelse
+                        .map {
+                            it.copy(statusIverksetting = StatusIverksetting.OK)
+                        }.toSet(),
+            ),
+        )
+    }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Problemstillingen: 
I dag grupperer vi utbetalinger på typeAndel (klassekode). Til helved sender vi en liste med utbetalinger, hvor en utbetaling har én typeAndel (klassekode), og en liste med perioder (hver enkelt utbetaling/AndelTilkjentYtelse, med beløp). En utbetaling vi sender til helved blir da til en kjede i OS (oppdragssystemet) hos økonomi. 

Når vi gjør en endring på en periode i en utbetaling vil alle senere perioder i samme utbetaling/kjede ogs måtte endres eller "legges inn på nytt igjen" om man vil (logikken her ligger hos helved). Dette fører til ganske rotete kjeder i OS om vi gjør endringer tilbake i tid og er problematisk om det må gjøres manuelle endringer på våre saker i OS. 

Et skjermbilde som viser en liten endring på en kjede i OS (er opprinnelig egentlig bare to AndelTilkjentYtelse som har byttet om på dato mellom behandlinger og blir da til 8 linjer i OS istedenfor 2):
https://nav-it.slack.com/archives/C069SPX84FL/p1773065823988089?thread_ts=1772803003.568869&cid=C069SPX84FL 

Hvis vi fortsetter å gruppere på typeAndel, så vil vi potensielt få mange endringer i kjeden, spesielt om brukere har overlappende rammevedtak.

---

Innfører her at vi grupperer utbetalinger for privat bil, slik at alle utbetalinger for én reise blir sendt sammen til helved. Dette fører videre til at en reise vil svare til én kjede hos økonomi, og vi sannsynligvis ikke vil gjøre mange endringer på denne kjeden. Som igjen vil si at det er mindre sjanse for store, rotete kjeder med mange endringer.

To små obs: 
- For tiltaksenheten vil alltid en reise med privat bil bli sendt sammen til helved. Dette fordi en reise er knyttet til en aktivitet, og vi finner typeAndel/klassekode fra aktiviteten.
- For NAY så vil en reise være en eller flere utbetalinger/kjeder hos OS. Dette fordi man i teorien kan bytte målgruppe midt i en reise, som da vil føre til to forskjellige typeAndel/klassekoder det skal utbetales på. I hel-ved sitt grensesnitt så har én utbetaling/kjede én typeAndel/klassekode.
