### PR TITLE
✨ Legg til sporbar-kolonner på avklart_kjort_dag og avklart_kjort_uke

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
 import java.util.UUID
@@ -17,6 +19,8 @@ data class AvklartKjørtDag(
     val avvik: List<TypeAvvikDag>,
     val begrunnelse: String? = null,
     val parkeringsutgift: Int? = null,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar(),
 )
 
 enum class GodkjentGjennomførtKjøring {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
@@ -3,9 +3,11 @@ package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.libs.utils.dato.ukenummer
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.MappedCollection
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
@@ -28,6 +30,8 @@ data class AvklartKjørtUke(
     val behandletDato: LocalDate? = null,
     @MappedCollection(idColumn = "avklart_kjort_uke_id")
     val dager: Set<AvklartKjørtDag>,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
+    val sporbar: Sporbar = Sporbar(),
 ) : Periode<LocalDate> {
     init {
         require(dager.all { inneholder(it.dato) }) { "Alle dager må være innenfor perioden til uken" }

--- a/src/main/resources/db/migration/V124__sporbar_avklart_kjørt_dag_og_uke.sql
+++ b/src/main/resources/db/migration/V124__sporbar_avklart_kjørt_dag_og_uke.sql
@@ -1,0 +1,23 @@
+ALTER TABLE avklart_kjort_dag
+    ADD COLUMN opprettet_av  VARCHAR      NOT NULL DEFAULT 'VL',
+    ADD COLUMN opprettet_tid TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(3),
+    ADD COLUMN endret_av     VARCHAR      NOT NULL DEFAULT 'VL',
+    ADD COLUMN endret_tid    TIMESTAMP    NOT NULL DEFAULT current_timestamp;
+
+ALTER TABLE avklart_kjort_dag
+    ALTER COLUMN opprettet_av DROP DEFAULT,
+    ALTER COLUMN opprettet_tid DROP DEFAULT,
+    ALTER COLUMN endret_av DROP DEFAULT,
+    ALTER COLUMN endret_tid DROP DEFAULT;
+
+ALTER TABLE avklart_kjort_uke
+    ADD COLUMN opprettet_av  VARCHAR      NOT NULL DEFAULT 'VL',
+    ADD COLUMN opprettet_tid TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(3),
+    ADD COLUMN endret_av     VARCHAR      NOT NULL DEFAULT 'VL',
+    ADD COLUMN endret_tid    TIMESTAMP    NOT NULL DEFAULT current_timestamp;
+
+ALTER TABLE avklart_kjort_uke
+    ALTER COLUMN opprettet_av DROP DEFAULT,
+    ALTER COLUMN opprettet_tid DROP DEFAULT,
+    ALTER COLUMN endret_av DROP DEFAULT,
+    ALTER COLUMN endret_tid DROP DEFAULT;


### PR DESCRIPTION
## Hva er gjort?

Legger til sporbar-felter (`opprettet_av`, `opprettet_tid`, `endret_av`, `endret_tid`) på tabellene `avklart_kjort_dag` og `avklart_kjort_uke`.

## Migrering

Migreringsskriptet (`V124`) legger til kolonnene som `NOT NULL`, men bruker midlertidige `DEFAULT`-verdier for å fylle ut eksisterende rader i dev uten å brekke databasen:

- `opprettet_av` / `endret_av` → `'VL'`
- `opprettet_tid` / `endret_tid` → `current_timestamp`

Etter at eksisterende rader er fylt ut, fjernes `DEFAULT`-verdiene slik at fremtidige inserts må oppgi verdiene eksplisitt.

❗Migreringen gjøres så vi ikke brekker saker i dev, vet at dataen vi fyller inn ikke gir mening. (Vi har ikke data i prod).