### PR TITLE
🐛 Fix flaky test: bruk fom-dato for å finne riktig reiseId

### DIFF
--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
@@ -69,8 +69,8 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
             kall.privatBil
                 .hentRammevedtak(førstegangsBehandlingContext.ident)
 
-        reiseIdRamme1 = rammevedtak.first().reiseId
-        reiseIdRamme2 = rammevedtak.last().reiseId
+        reiseIdRamme1 = rammevedtak.single { it.fom == fomRamme1 }.reiseId
+        reiseIdRamme2 = rammevedtak.single { it.fom == fomRamme2 }.reiseId
         brukerident = førstegangsBehandlingContext.ident
 
         førstegangsbehandling = testoppsettService.hentBehandling(førstegangsBehandlingContext.behandlingId)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Erstatter posisjonell .first()/.last() med .single { it.fom == fomRamme1/2 } for å garantere deterministisk oppslag uavhengig av rekkefølgen rammevedtak returneres i.

Fikk problemer med at reiseId kunne switche så når kjøreliste ble sendt inn på et annet rammevedtak så feilet validerAtAlleDagerIKjørelistaErInnenForRammevedtaket som ruller tilbake transaksjonen og behandlingen blir aldri laget 😢