### PR TITLE
✨ Legg til kjøreliste-ruting basert på vedtak med privat bil

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/RoutingStrategi.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/RoutingStrategi.kt
@@ -13,6 +13,8 @@ sealed interface RoutingStrategi {
         val kreverAktivtAapVedtak: Boolean,
         val kreverUgradertAdresse: Boolean,
     ) : RoutingStrategi
+
+    data object KjørelisteRouting : RoutingStrategi
 }
 
 fun bestemRoutingStrategi(skjematype: Skjematype): RoutingStrategi =
@@ -28,5 +30,5 @@ fun bestemRoutingStrategi(skjematype: Skjematype): RoutingStrategi =
                 kreverUgradertAdresse = true,
             )
 
-        Skjematype.DAGLIG_REISE_KJØRELISTE -> TODO()
+        Skjematype.DAGLIG_REISE_KJØRELISTE -> RoutingStrategi.KjørelisteRouting
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingService.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.unleash.UnleashUtil.getVariantW
 import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
+import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseService
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørDagligReise

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingService.kt
@@ -112,10 +112,11 @@ class SkjemaRoutingService(
         ident: String,
         skjematype: Skjematype,
     ): Boolean {
+        val personIdenter = personService.hentFolkeregisterIdenter(ident).identer()
         val harVedtakMedPrivatBil =
             skjematype
                 .tilStønadstyper()
-                .mapNotNull { fagsakService.finnFagsak(personIdenter = setOf(ident), stønadstype = it) }
+                .mapNotNull { fagsakService.finnFagsak(personIdenter = personIdenter, stønadstype = it) }
                 .flatMap { behandlingService.hentBehandlinger(fagsakId = it.id) }
                 .mapNotNull { vedtakService.hentVedtak(it.id) }
                 .any { (it.data as? InnvilgelseEllerOpphørDagligReise)?.rammevedtakPrivatBil != null }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingService.kt
@@ -17,6 +17,8 @@ import no.nav.tilleggsstonader.sak.opplysninger.arena.ArenaService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelseService
+import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørDagligReise
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,6 +32,7 @@ class SkjemaRoutingService(
     private val ytelseService: YtelseService,
     private val personService: PersonService,
     private val advisoryLockService: AdvisoryLockService,
+    private val vedtakService: VedtakService,
 ) {
     private fun harLagretRouting(
         ident: String,
@@ -51,6 +54,10 @@ class SkjemaRoutingService(
 
                 is RoutingStrategi.SendEnkelteBrukereTilNyLøsning -> {
                     skalBrukerRoutesTilNyLøsning(ident, skjematype, routingStrategi)
+                }
+
+                RoutingStrategi.KjørelisteRouting -> {
+                    skalBrukerRoutesTilNyKjørelisteLøsning(ident, skjematype)
                 }
             }.also { loggRoutingResultatet(skjematype, it) }
         }
@@ -84,6 +91,37 @@ class SkjemaRoutingService(
 
         lagreRouting(ident, skjematype, mapOf("skalTilNyLøsning" to true))
         return true
+    }
+
+    private fun skalBrukerRoutesTilNyKjørelisteLøsning(
+        ident: String,
+        skjematype: Skjematype,
+    ): Boolean {
+        if (harLagretRouting(ident, skjematype)) {
+            logger.info("routing - skjematype=$skjematype harLagretRouting=true")
+            return true
+        }
+        if (harVedtakMedPrivatBil(ident, skjematype)) {
+            lagreRouting(ident, skjematype, mapOf("harVedtakMedPrivatBil" to true))
+            return true
+        }
+        return false
+    }
+
+    private fun harVedtakMedPrivatBil(
+        ident: String,
+        skjematype: Skjematype,
+    ): Boolean {
+        val harVedtakMedPrivatBil =
+            skjematype
+                .tilStønadstyper()
+                .mapNotNull { fagsakService.finnFagsak(personIdenter = setOf(ident), stønadstype = it) }
+                .flatMap { behandlingService.hentBehandlinger(fagsakId = it.id) }
+                .mapNotNull { vedtakService.hentVedtak(it.id) }
+                .any { (it.data as? InnvilgelseEllerOpphørDagligReise)?.rammevedtakPrivatBil != null }
+
+        logger.info("routing - skjematype=$skjematype harVedtakMedPrivatBil=$harVedtakMedPrivatBil")
+        return harVedtakMedPrivatBil
     }
 
     private fun harFortroligEllerStrengtFortroligAdresse(ident: String): Boolean =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingIntegrationTest.kt
@@ -23,8 +23,17 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlIdenter
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelsePerioderUtil.kildeResultatAAP
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelsePerioderUtil.periodeAAP
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelsePerioderUtil.ytelsePerioderDto
+import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.DagligReiseTestUtil
+import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -37,6 +46,7 @@ import java.util.concurrent.CompletableFuture
 class SkjemaRoutingIntegrationTest(
     @Autowired private val arenaClient: ArenaClient,
     @Autowired private val pdlClient: PdlClient,
+    @Autowired private val vedtakRepository: VedtakRepository,
 ) : CleanDatabaseIntegrationTest() {
     val jonasIdent = "12345678910"
     val ernaIdent = "10987654321"
@@ -269,4 +279,95 @@ class SkjemaRoutingIntegrationTest(
         skjematype: Skjematype = Skjematype.SØKNAD_DAGLIG_REISE,
         ident: String = jonasIdent,
     ) = testoppsettService.hentSøknadRouting(ident, skjematype) != null
+
+    @Nested
+    inner class DagligReiseKjøreliste {
+        val kjørelisteRoutingRequest =
+            IdentSkjematype(
+                ident = jonasIdent,
+                skjematype = Skjematype.DAGLIG_REISE_KJØRELISTE,
+            )
+
+        @Test
+        fun `skal route til ny løsning hvis person har vedtak med privat bil`() {
+            opprettBehandlingMedVedtakForPrivatBil(Stønadstype.DAGLIG_REISE_TSO)
+
+            val routingSjekk = kall.skjemaRouting.sjekk(kjørelisteRoutingRequest)
+
+            assertThat(routingSjekk.skalBehandlesINyLøsning).isTrue()
+            assertThat(routingHarBlittLagret(Skjematype.DAGLIG_REISE_KJØRELISTE)).isTrue()
+        }
+
+        @Test
+        fun `skal route til gammel løsning hvis person ikke har vedtak`() {
+            val routingSjekk = kall.skjemaRouting.sjekk(kjørelisteRoutingRequest)
+
+            assertThat(routingSjekk.skalBehandlesINyLøsning).isFalse()
+            assertThat(routingHarBlittLagret(Skjematype.DAGLIG_REISE_KJØRELISTE)).isFalse()
+        }
+
+        @Test
+        fun `skal route til gammel løsning hvis person har vedtak uten privat bil`() {
+            opprettBehandlingMedVedtakUtenPrivatBil(Stønadstype.DAGLIG_REISE_TSO)
+
+            val routingSjekk = kall.skjemaRouting.sjekk(kjørelisteRoutingRequest)
+
+            assertThat(routingSjekk.skalBehandlesINyLøsning).isFalse()
+            assertThat(routingHarBlittLagret(Skjematype.DAGLIG_REISE_KJØRELISTE)).isFalse()
+        }
+
+        @Test
+        fun `skal alltid svare ja hvis personen har blitt routet til ny løsning tidligere`() {
+            testoppsettService.lagreSøknadRouting(
+                SkjemaRouting(
+                    ident = jonasIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                    detaljer = JsonWrapper("{}"),
+                ),
+            )
+
+            val routingSjekk = kall.skjemaRouting.sjekk(kjørelisteRoutingRequest)
+
+            assertThat(routingSjekk.skalBehandlesINyLøsning).isTrue()
+        }
+
+        private fun opprettBehandlingMedVedtakForPrivatBil(stønadstype: Stønadstype) {
+            val fagsak = fagsak(identer = setOf(PersonIdent(jonasIdent)), stønadstype = stønadstype)
+            val dagligReiseBehandling = behandling(fagsak)
+
+            testoppsettService.lagreFagsak(fagsak)
+            testoppsettService.lagre(behandling = dagligReiseBehandling, opprettGrunnlagsdata = false)
+
+            val vedtak =
+                GeneriskVedtak(
+                    behandlingId = dagligReiseBehandling.id,
+                    type = TypeVedtak.INNVILGELSE,
+                    data =
+                        InnvilgelseDagligReise(
+                            vedtaksperioder = DagligReiseTestUtil.defaultVedtaksperioder,
+                            beregningsresultat = DagligReiseTestUtil.defaultBeregningsresultat,
+                            rammevedtakPrivatBil = RammevedtakPrivatBilUtil.rammevedtakPrivatBil(),
+                            beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
+                        ),
+                    gitVersjon = Applikasjonsversjon.versjon,
+                    tidligsteEndring = null,
+                    opphørsdato = null,
+                )
+            vedtakRepository.insert(vedtak)
+        }
+
+        private fun opprettBehandlingMedVedtakUtenPrivatBil(stønadstype: Stønadstype) {
+            val fagsak = fagsak(identer = setOf(PersonIdent(jonasIdent)), stønadstype = stønadstype)
+            val dagligReiseBehandling = behandling(fagsak)
+
+            testoppsettService.lagreFagsak(fagsak)
+            testoppsettService.lagre(behandling = dagligReiseBehandling, opprettGrunnlagsdata = false)
+
+            val vedtak =
+                DagligReiseTestUtil.innvilgelse(
+                    behandlingId = dagligReiseBehandling.id,
+                )
+            vedtakRepository.insert(vedtak)
+        }
+    }
 }


### PR DESCRIPTION
## Endringer

Legger til ruting for `DAGLIG_REISE_KJØRELISTE` i `SkjemaRoutingService`.

Brukere med daglig reise-vedtak som har rammevedtak for privat bil routes til ny løsning (vår SPA). Andre brukere sendes til gammel FyllUt-løsning (`nav111224b`).

### Detaljer
- Ny `KjørelisteRouting`-strategi i `RoutingStrategi.kt`
- Sjekker om bruker har vedtak med `rammevedtakPrivatBil != null` på tvers av `DAGLIG_REISE_TSO` og `DAGLIG_REISE_TSR`
- Lagrer routing i `skjema_routing`-tabellen for caching
- 4 integrasjonstester i `SkjemaRoutingIntegrationTest`

### Testing
⚠️ Ikke testet lokalt end-to-end. Express-backenden (routes.ts med redirect-logikken) kjører ikke lokalt med `yarn start:dev` — den kjører bare i produksjon/nais. Lokal utvikling bruker webpack-dev-server som serverer React-appen direkte uten å gå gjennom Express-rutene. Backend-logikken (denne PR-en) er verifisert med integrasjonstester.

Se også: tilhørende frontend-PR i tilleggsstonader-soknad