### PR TITLE
Lagre "uke i år" i databasen på avklart_kjort_uke istedenfor kun ukenummer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 val javaVersion = JavaLanguageVersion.of(21)
 val tomcatVersion = "11.0.21"
 val familieProsesseringVersion = "2.20260331095424_89d92d2"
-val tilleggsstønaderLibsVersion = "2026.03.03-10.23.f286f5829acc"
+val tilleggsstønaderLibsVersion = "2026.04.16-14.35.49734215fe02"
 val tilleggsstønaderKontrakterVersion = "2026.04.15-21.48.778bd4a8f583"
 val avroVersion = "1.12.1"
 val confluentVersion = "8.0.1"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/database/DatabaseConfiguration.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.infrastruktur.database
 import no.nav.familie.prosessering.PropertiesWrapperTilStringConverter
 import no.nav.familie.prosessering.StringTilPropertiesWrapperConverter
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
+import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.sak.behandling.vent.SettPåVent
 import no.nav.tilleggsstonader.sak.infrastruktur.database.IdConverters.alleValueClassConverters
 import no.nav.tilleggsstonader.sak.oppfølging.OppfølgingData
@@ -128,6 +129,8 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
             TilbakekrevingJsonDataWriter(),
             InnsendtKjørelisteReader(),
             InnsendtKjørelisteWriter(),
+            TilUkeIÅrConverter(),
+            UkeIÅrTilStringConverter(),
         ) + alleVedtaksstatistikkJsonConverters +
             alleValueClassConverters
 
@@ -194,6 +197,16 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
     @WritingConverter
     class VilkårperiodeTypeTilStringConverter : Converter<VilkårperiodeType, String> {
         override fun convert(data: VilkårperiodeType): String = data.tilDbType()
+    }
+
+    @ReadingConverter
+    class TilUkeIÅrConverter : Converter<String, UkeIÅr> {
+        override fun convert(type: String): UkeIÅr = UkeIÅr.fraString(type)
+    }
+
+    @WritingConverter
+    class UkeIÅrTilStringConverter : Converter<UkeIÅr, String> {
+        override fun convert(data: UkeIÅr): String = data.toString()
     }
 
     class SimuleringResponseWriter : JsonWriter<SimuleringJson>()

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/Kjøreliste.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/Kjøreliste.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
-import no.nav.tilleggsstonader.libs.utils.dato.ukenummer
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
@@ -22,6 +21,4 @@ data class Kjøreliste(
     val sporbar: Sporbar = Sporbar(),
     @Column("data")
     val data: InnsendtKjøreliste,
-) {
-    fun inneholderUkenummer(ukenummer: Int): Boolean = data.reisedager.any { it.dato.ukenummer() == ukenummer }
-}
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/PrivatBilController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/PrivatBilController.kt
@@ -4,7 +4,6 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
-import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.ekstern.stønad.DagligReisePrivatBilService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
@@ -65,7 +64,7 @@ class PrivatBilController(
                         .alleDatoerGruppertPåUke()
                         .map { (uke, datoer) ->
                             val avklartUke =
-                                avklarteUker.singleOrNull { it.reiseId == reise.reiseId && it.fom.tilUkeIÅr() == uke }
+                                avklarteUker.singleOrNull { it.reiseId == reise.reiseId && it.uke == uke }
 
                             val kjørelisteForUke =
                                 avklartUke?.let {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/PrivatBilController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/PrivatBilController.kt
@@ -96,14 +96,8 @@ class PrivatBilController(
         val oppdatertAvklartUke = avklartKjørelisteService.oppdaterAvklartUke(behandlingId, ukeId, avklarteDager)
         val kjøreliste = kjørelisteService.hentKjøreliste(oppdatertAvklartUke.kjørelisteId)
 
-        val uke =
-            UkeIÅr(
-                ukenummer = oppdatertAvklartUke.ukenummer,
-                år = oppdatertAvklartUke.fom.year,
-            )
-
         return lagUke(
-            uke = uke,
+            uke = oppdatertAvklartUke.uke,
             datoer = oppdatertAvklartUke.alleDatoer(),
             kjørelisteForUke = kjøreliste,
             avklartUke = oppdatertAvklartUke,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -137,7 +137,7 @@ class AvklartKjørelisteService(
             reiseId = rammevedtak.reiseId,
             fom = reisedager.minOf { it.dato },
             tom = reisedager.maxOf { it.dato },
-            ukenummer = ukeIÅr.ukenummer,
+            uke = ukeIÅr,
             // Trengs denne? Kan lages i visningslogikk
             // Rart at den er avhengig av både ukeavvik og dagavvik
             status = utledAutomatiskStatusForUke(avklarteDager, avvikUke),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -69,7 +69,7 @@ class AvklartKjørelisteService(
 
         validerOppdatertAvklartKjørtUke(
             oppdaterteDager = oppdaterteDager,
-            ukeSomSkalOppdateres = eksisterendeUke.fom.tilUkeIÅr(),
+            ukeSomSkalOppdateres = eksisterendeUke.uke,
             rammevedtak = rammevedtak,
             innsendteKjørelisteDager = innsendteKjørelisteDager,
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.ukenummer
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
@@ -25,7 +26,8 @@ data class AvklartKjørtUke(
     val reiseId: ReiseId,
     override val fom: LocalDate,
     override val tom: LocalDate,
-    val ukenummer: Int,
+    @Column("uke")
+    val uke: UkeIÅr,
     val status: UkeStatus,
     val typeAvvik: TypeAvvikUke? = null,
     val behandletDato: LocalDate? = null,
@@ -37,7 +39,7 @@ data class AvklartKjørtUke(
     init {
         require(dager.all { inneholder(it.dato) }) { "Alle dager må være innenfor perioden til uken" }
         require(fom.ukenummer() == tom.ukenummer()) { "Fom og tom må være i samme uke" }
-        require(fom.ukenummer() == ukenummer) { "Ukenummer $ukenummer stemmer ikke med perioden" }
+        require(fom.ukenummer() == uke.ukenummer) { "Ukenummer $uke stemmer ikke med perioden" }
     }
 
     fun kopierTilNyBehandling(nyBehandlingId: BehandlingId): AvklartKjørtUke =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
-import no.nav.tilleggsstonader.libs.utils.dato.ukenummer
+import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteId
@@ -38,8 +38,8 @@ data class AvklartKjørtUke(
 ) : Periode<LocalDate> {
     init {
         require(dager.all { inneholder(it.dato) }) { "Alle dager må være innenfor perioden til uken" }
-        require(fom.ukenummer() == tom.ukenummer()) { "Fom og tom må være i samme uke" }
-        require(fom.ukenummer() == uke.ukenummer) { "Ukenummer $uke stemmer ikke med perioden" }
+        require(fom.tilUkeIÅr() == tom.tilUkeIÅr()) { "Fom og tom må være i samme uke" }
+        require(fom.tilUkeIÅr() == uke) { "Ukenummer $uke stemmer ikke med perioden" }
     }
 
     fun kopierTilNyBehandling(nyBehandlingId: BehandlingId): AvklartKjørtUke =

--- a/src/main/resources/db/migration/V126__uke_kolonne_avklart_kjort_uke.sql
+++ b/src/main/resources/db/migration/V126__uke_kolonne_avklart_kjort_uke.sql
@@ -4,4 +4,4 @@ ALTER TABLE avklart_kjort_uke
     RENAME COLUMN ukenummer TO uke;
 
 UPDATE avklart_kjort_uke
-SET uke = EXTRACT(YEAR FROM tom)::TEXT || '-' || uke;
+SET uke = to_char(tom, 'IYYY') || '-' || to_char(tom, 'IW');

--- a/src/main/resources/db/migration/V126__uke_kolonne_avklart_kjort_uke.sql
+++ b/src/main/resources/db/migration/V126__uke_kolonne_avklart_kjort_uke.sql
@@ -1,0 +1,7 @@
+ALTER TABLE avklart_kjort_uke
+    ALTER COLUMN ukenummer TYPE VARCHAR;
+ALTER TABLE avklart_kjort_uke
+    RENAME COLUMN ukenummer TO uke;
+
+UPDATE avklart_kjort_uke
+SET uke = EXTRACT(YEAR FROM tom)::TEXT || '-' || uke;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.behandling
 
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
-import no.nav.tilleggsstonader.libs.utils.dato.ukenummer
+import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
@@ -353,7 +353,7 @@ class NullstillBehandlingServiceTest : CleanDatabaseIntegrationTest() {
                 reiseId = ReiseId.random(),
                 fom = LocalDate.now(),
                 tom = LocalDate.now(),
-                ukenummer = LocalDate.now().ukenummer(),
+                uke = LocalDate.now().tilUkeIÅr(),
                 status = UkeStatus.OK_AUTOMATISK,
                 dager =
                     setOf(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteStegTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.libs.utils.dato.januar
-import no.nav.tilleggsstonader.libs.utils.dato.ukenummer
+import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
@@ -106,7 +106,7 @@ class KjørelisteStegTest {
             reiseId = dummyReiseId,
             fom = fom,
             tom = tom,
-            ukenummer = fom.ukenummer(),
+            uke = fom.tilUkeIÅr(),
             status = status,
             dager = emptySet(),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -591,7 +591,7 @@ class PrivatBilBeregningsresultatServiceTest {
                     reiseId = kjøreliste.data.reiseId,
                     fom = dager.minOf { it.dato },
                     tom = dager.maxOf { it.dato },
-                    ukenummer = uke.ukenummer,
+                    uke = uke,
                     status = UkeStatus.OK_AUTOMATISK,
                     behandletDato = LocalDate.now(),
                     dager =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vi lagrer i dag ukenummer i tabellen `avklart_kjort_uke`. Det kan være litt misvisende da man ikke vet hvilket år man snakker om. Er også lett å begynne å sammenligne uker på kun ukenummer, selv om ukene egentlig er i forskjellige år.

Endrer `avklart_kjort_uke`-tabellen til å holde på en string, som i Kotlin representeres av objektet `UkeIÅr` (inneholder både ukenummer og år). Migrerer også eksisterende data.