### PR TITLE
Kjøreliste - desimaler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.util.iDagHvisMandagEllerForrigeMandag
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatPrivatBil
@@ -77,7 +78,7 @@ fun BeregningsresultatPrivatBil.mapTilAndelTilkjentYtelse(
                     lagAndelForDagligReise(
                         saksbehandling = saksbehandling,
                         fomUkedag = fom.iDagHvisMandagEllerForrigeMandag(),
-                        beløp = periode.stønadsbeløp.toInt(),
+                        beløp = periode.stønadsbeløp.avrundetStønadsbeløp().toInt(),
                         målgruppe = vedtaksperiode.målgruppe,
                         typeAktivitet = rammevedtakForReise.typeAktivitet,
                         brukersNavKontor = periode.brukersNavKontor,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/FellesBeregningUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/FellesBeregningUtil.kt
@@ -4,6 +4,8 @@ import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.periode.beregnSnitt
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.LocalDate
 
 fun antallHverdagerIPeriodeInklusiv(
@@ -49,3 +51,5 @@ fun <P> finnSnittMellomReiseOgVedtaksperioder(
             ),
     )
 }
+
+fun BigDecimal.avrundetStønadsbeløp(): BigDecimal = setScale(0, RoundingMode.HALF_UP)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
@@ -145,13 +145,13 @@ class PrivatBilBeregningService(
                                                 bompengerPerDag = delperiode.bompengerPerDag,
                                                 fergekostnadPerDag = delperiode.fergekostnadPerDag,
                                             ),
-                                        kilometersats = sats.beløp,
+                                        kilometersats = sats.beløp.setScale(2),
                                     )
 
                                 RammeForReiseMedPrivatBilSatsForDelperiode(
                                     fom = snitt.fom,
                                     tom = snitt.tom,
-                                    kilometersats = sats.beløp,
+                                    kilometersats = sats.beløp.setScale(2),
                                     dagsatsUtenParkering = dagsatsUtenParkering,
                                     satsBekreftetVedVedtakstidspunkt = sats.bekreftet,
                                 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatService.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilDag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilGrunnlag
@@ -14,7 +15,6 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPri
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import org.springframework.stereotype.Service
-import java.math.RoundingMode
 
 @Service
 class PrivatBilBeregningsresultatService {
@@ -99,7 +99,7 @@ class PrivatBilBeregningsresultatService {
                                 stønadsbeløpForDag =
                                     dagsatsUtenParkering
                                         .plus(parkeringsutgift.toBigDecimal())
-                                        .setScale(0, RoundingMode.HALF_UP),
+                                        .setScale(2),
                             )
                         }
 
@@ -110,7 +110,7 @@ class PrivatBilBeregningsresultatService {
                         BeregningsresultatForReisePrivatBilGrunnlag(
                             dager = beregnedeDager,
                         ),
-                    stønadsbeløp = beregnedeDager.sumOf { it.stønadsbeløpForDag },
+                    stønadsbeløp = beregnedeDager.sumOf { it.stønadsbeløpForDag }.avrundetStønadsbeløp(),
                     brukersNavKontor = brukersNavKontor,
                 )
             }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatService.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPri
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import org.springframework.stereotype.Service
+import java.math.RoundingMode
 
 @Service
 class PrivatBilBeregningsresultatService {
@@ -94,8 +95,11 @@ class PrivatBilBeregningsresultatService {
                             BeregningsresultatForReisePrivatBilDag(
                                 dato = dag.dato,
                                 parkeringskostnad = parkeringsutgift,
-                                dagsatsUtenParkering = dagsatsUtenParkering,
-                                stønadsbeløpForDag = dagsatsUtenParkering.plus(parkeringsutgift.toBigDecimal()),
+                                dagsatsUtenParkering = dagsatsUtenParkering.setScale(2),
+                                stønadsbeløpForDag =
+                                    dagsatsUtenParkering
+                                        .plus(parkeringsutgift.toBigDecimal())
+                                        .setScale(0, RoundingMode.HALF_UP),
                             )
                         }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -30,6 +30,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.LocalDate
 
 class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
@@ -261,5 +262,6 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
                 .multiply(reiseavstandEnVei)
                 .multiply(2.toBigDecimal())
                 .plus(parkeringskostnader.toBigDecimal())
+                .setScale(0, RoundingMode.HALF_UP)
         }.toInt()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -49,7 +49,7 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
 
         val fom = 2 februar 2026
         val tom = 22 februar 2026
-        val reiseavstandEnVei = BigDecimal(10)
+        val reiseavstandEnVei = BigDecimal(7.9)
         val kjørteDager =
             listOf(
                 2 februar 2026 to 50,
@@ -147,6 +147,9 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
         assertThat(gjeldendeIverksatteBehandlinger.map { it.id })
             .contains(kjørelisteBehandling.id)
             .doesNotContain(førstegangsBehandling.id)
+
+        val andelsBeløp = tilkjentYtelseRepository.findByBehandlingId(kjørelisteBehandling.id)!!.andelerTilkjentYtelse.sumOf { it.beløp }
+        assertThat(andelsBeløp).isEqualTo(forventetBeløp)
     }
 
     @Test
@@ -262,7 +265,6 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
                 .multiply(reiseavstandEnVei)
                 .multiply(2.toBigDecimal())
                 .plus(parkeringskostnader.toBigDecimal())
-                .setScale(2)
         }.avrundetStønadsbeløp()
             .toInt()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -24,13 +24,13 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjen
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.privatBil.SatsDagligReisePrivatBilProvider
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.LocalDate
 
 class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
@@ -262,6 +262,7 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
                 .multiply(reiseavstandEnVei)
                 .multiply(2.toBigDecimal())
                 .plus(parkeringskostnader.toBigDecimal())
-                .setScale(0, RoundingMode.HALF_UP)
-        }.toInt()
+                .setScale(2)
+        }.avrundetStønadsbeløp()
+            .toInt()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
@@ -293,7 +293,7 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
                         satserSize = 2,
                         totalParkeringskostnad = 150,
                         ukenummer = 1,
-                        stønadsbeløp = BigDecimal("367"),
+                        stønadsbeløp = BigDecimal("366"),
                     ),
             )
 
@@ -325,7 +325,7 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
                         satserSize = 1,
                         totalParkeringskostnad = 60,
                         ukenummer = 3,
-                        stønadsbeløp = BigDecimal("537"),
+                        stønadsbeløp = BigDecimal("536"),
                     ),
             )
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
@@ -293,7 +293,7 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
                         satserSize = 2,
                         totalParkeringskostnad = 150,
                         ukenummer = 1,
-                        stønadsbeløp = BigDecimal("366.40"),
+                        stønadsbeløp = BigDecimal("367"),
                     ),
             )
 
@@ -309,7 +309,7 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
                         satserSize = 1,
                         totalParkeringskostnad = 0,
                         ukenummer = 2,
-                        stønadsbeløp = BigDecimal("217.60"),
+                        stønadsbeløp = BigDecimal("218"),
                     ),
             )
 
@@ -325,7 +325,7 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
                         satserSize = 1,
                         totalParkeringskostnad = 60,
                         ukenummer = 3,
-                        stønadsbeløp = BigDecimal("536.40"),
+                        stønadsbeløp = BigDecimal("537"),
                     ),
             )
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -110,7 +110,10 @@ class PrivatBilBeregningsresultatServiceTest {
         ).isEqualTo(
             beregningsresultatUke.grunnlag.dager
                 .first()
-                .dagsatsUtenParkering * 3.toBigDecimal() + totaleParkeringsutgifter.avrundetStønadsbeløp(),
+                .dagsatsUtenParkering
+                .multiply(3.toBigDecimal())
+                .add(totaleParkeringsutgifter)
+                .avrundetStønadsbeløp(),
         )
 
         assertThat(beregningsresultatUke.grunnlag.dager).hasSize(reisedager.size)
@@ -188,7 +191,9 @@ class PrivatBilBeregningsresultatServiceTest {
         ).isEqualTo(
             beregningsresultatUke.grunnlag.dager
                 .first()
-                .dagsatsUtenParkering * 2.toBigDecimal().avrundetStønadsbeløp(),
+                .dagsatsUtenParkering
+                .multiply(2.toBigDecimal())
+                .avrundetStønadsbeløp(),
         )
 
         assertThat(beregningsresultatUke.grunnlag.dager).hasSize(2).allMatch { it.parkeringskostnad == 0 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UtfyltDagAutomatiskVu
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilSatsForDelperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatEkstrakostnader
@@ -24,8 +25,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatException
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Test
-import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
@@ -272,13 +271,15 @@ class PrivatBilBeregningsresultatServiceTest {
         val dagI2026 = beregningsresultatUke.grunnlag.dager.first { it.dato.year == 2026 }
 
         assertThat(dagI2025.parkeringskostnad).isZero
-        assertThat(dagI2025.stønadsbeløpForDag).isEqualTo(dagI2025.dagsatsUtenParkering.avrundetStønadsbeløp())
+        assertThat(dagI2025.stønadsbeløpForDag).isEqualTo(dagI2025.dagsatsUtenParkering)
         assertThat(dagI2026.parkeringskostnad).isZero
-        assertThat(dagI2026.stønadsbeløpForDag).isEqualTo(dagI2026.dagsatsUtenParkering.avrundetStønadsbeløp())
+        assertThat(dagI2026.stønadsbeløpForDag).isEqualTo(dagI2026.dagsatsUtenParkering)
 
         assertThat(dagI2025.stønadsbeløpForDag).isNotEqualTo(dagI2026.stønadsbeløpForDag)
 
-        assertThat(beregningsresultatUke.stønadsbeløp).isEqualTo(beregningsresultatUke.grunnlag.dager.sumOf { it.stønadsbeløpForDag })
+        assertThat(
+            beregningsresultatUke.stønadsbeløp.setScale(2),
+        ).isEqualTo(beregningsresultatUke.grunnlag.dager.sumOf { it.stønadsbeløpForDag })
     }
 
     @Test
@@ -628,6 +629,4 @@ class PrivatBilBeregningsresultatServiceTest {
                             }.toSet(),
                 )
             }
-
-    private fun BigDecimal.avrundetStønadsbeløp(): BigDecimal = setScale(0, RoundingMode.HALF_UP)
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -24,6 +24,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatException
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
@@ -108,7 +110,7 @@ class PrivatBilBeregningsresultatServiceTest {
         ).isEqualTo(
             beregningsresultatUke.grunnlag.dager
                 .first()
-                .dagsatsUtenParkering * 3.toBigDecimal() + totaleParkeringsutgifter,
+                .dagsatsUtenParkering * 3.toBigDecimal() + totaleParkeringsutgifter.avrundetStønadsbeløp(),
         )
 
         assertThat(beregningsresultatUke.grunnlag.dager).hasSize(reisedager.size)
@@ -186,7 +188,7 @@ class PrivatBilBeregningsresultatServiceTest {
         ).isEqualTo(
             beregningsresultatUke.grunnlag.dager
                 .first()
-                .dagsatsUtenParkering * 2.toBigDecimal(),
+                .dagsatsUtenParkering * 2.toBigDecimal().avrundetStønadsbeløp(),
         )
 
         assertThat(beregningsresultatUke.grunnlag.dager).hasSize(2).allMatch { it.parkeringskostnad == 0 }
@@ -265,9 +267,9 @@ class PrivatBilBeregningsresultatServiceTest {
         val dagI2026 = beregningsresultatUke.grunnlag.dager.first { it.dato.year == 2026 }
 
         assertThat(dagI2025.parkeringskostnad).isZero
-        assertThat(dagI2025.dagsatsUtenParkering).isEqualTo(dagI2025.stønadsbeløpForDag)
+        assertThat(dagI2025.stønadsbeløpForDag).isEqualTo(dagI2025.dagsatsUtenParkering.avrundetStønadsbeløp())
         assertThat(dagI2026.parkeringskostnad).isZero
-        assertThat(dagI2026.dagsatsUtenParkering).isEqualTo(dagI2026.stønadsbeløpForDag)
+        assertThat(dagI2026.stønadsbeløpForDag).isEqualTo(dagI2026.dagsatsUtenParkering.avrundetStønadsbeløp())
 
         assertThat(dagI2025.stønadsbeløpForDag).isNotEqualTo(dagI2026.stønadsbeløpForDag)
 
@@ -354,7 +356,8 @@ class PrivatBilBeregningsresultatServiceTest {
         assertThat(beregningsresultatUke1.stønadsbeløp).isEqualTo(
             beregningsresultatUke1.grunnlag.dager
                 .single()
-                .dagsatsUtenParkering,
+                .dagsatsUtenParkering
+                .avrundetStønadsbeløp(),
         )
         assertThat(beregningsresultatUke1.grunnlag.dager).hasSize(1).allMatch { it.parkeringskostnad == 0 }
 
@@ -364,7 +367,8 @@ class PrivatBilBeregningsresultatServiceTest {
         assertThat(beregningsresultatUke2.stønadsbeløp).isEqualTo(
             beregningsresultatUke2.grunnlag.dager
                 .single()
-                .dagsatsUtenParkering,
+                .dagsatsUtenParkering
+                .avrundetStønadsbeløp(),
         )
         assertThat(beregningsresultatUke2.grunnlag.dager).hasSize(1).allMatch { it.parkeringskostnad == 0 }
     }
@@ -464,7 +468,14 @@ class PrivatBilBeregningsresultatServiceTest {
             val beregningsresultatUke1 = beregningsresultatForReise.perioder.single()
             assertThat(beregningsresultatUke1.fom).isEqualTo(fomRammevedtak)
             assertThat(beregningsresultatUke1.tom).isEqualTo(tomRammevedtak)
-            assertThat(beregningsresultatUke1.stønadsbeløp).isEqualTo(delperiode.satser.single().dagsatsUtenParkering)
+            assertThat(
+                beregningsresultatUke1.stønadsbeløp,
+            ).isEqualTo(
+                delperiode.satser
+                    .single()
+                    .dagsatsUtenParkering
+                    .avrundetStønadsbeløp(),
+            )
             assertThat(beregningsresultatUke1.grunnlag.dager).hasSize(1).allMatch { it.parkeringskostnad == 0 }
         }
     }
@@ -612,4 +623,6 @@ class PrivatBilBeregningsresultatServiceTest {
                             }.toSet(),
                 )
             }
+
+    private fun BigDecimal.avrundetStønadsbeløp(): BigDecimal = setScale(0, RoundingMode.HALF_UP)
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Stønadsbeløp rundes opp og vises som heltall
- Dagsats uten parkering skal ha to desimaler
- Kilometersats skal ha to desimaler

Vurderte å endre stønadsbeløp til Int men det var en del endringer som skal til, totalt stønadsbeløp blir konvertert til Int når vi lager andeler.


Stønadsbeløp på vedtak og beregning i en kjørelistebehandling:
<img width="1139" height="82" alt="Screenshot 2026-04-20 at 13 18 14" src="https://github.com/user-attachments/assets/ed36619a-679a-4bdc-a96f-cecc0bf862d1" />
<img width="1203" height="104" alt="Screenshot 2026-04-20 at 13 18 19" src="https://github.com/user-attachments/assets/ea6a1ebc-9983-4baf-bf25-2a6887791d78" />

