### PR TITLE
Bygger opp en ruter reiseurl basert på google maps søket

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/googlemaps/Reisedata.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/googlemaps/Reisedata.kt
@@ -35,7 +35,9 @@ data class Strekning(
 
 data class KollektivDetaljer(
     val startHoldeplass: String,
+    val startHoldeplassLokasjon: Lokasjon,
     val sluttHoldeplass: String,
+    val sluttHoldeplassLokasjon: Lokasjon,
     val linjeNavn: String?,
     val linjeType: LinjeType,
     val operatør: List<Operatør>,
@@ -96,7 +98,9 @@ fun List<Leg>.tilDomene(): List<Strekning> {
 private fun TransitDetails.tilDomene(): KollektivDetaljer =
     KollektivDetaljer(
         startHoldeplass = stopDetails.departureStop.name,
+        startHoldeplassLokasjon = stopDetails.departureStop.location.tilDomene(),
         sluttHoldeplass = stopDetails.arrivalStop.name,
+        sluttHoldeplassLokasjon = stopDetails.arrivalStop.location.tilDomene(),
         linjeNavn = transitLine.name,
         linjeType = transitLine.vehicle.type,
         operatør = transitLine.agencies.map { it.tilDomene() },

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/googlemaps/dto/ReisedataDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/googlemaps/dto/ReisedataDto.kt
@@ -92,7 +92,7 @@ fun KollektivDetaljer.tilDto() =
         operatør = operatør.map { it.tilDto(startHoldeplass, startHoldeplassLokasjon, sluttHoldeplass, sluttHoldeplassLokasjon) },
     )
 
-fun Operatør.tilDto(
+private fun Operatør.tilDto(
     startHoldeplass: String,
     startLokasjon: Lokasjon,
     sluttHoldeplass: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/googlemaps/dto/ReisedataDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/googlemaps/dto/ReisedataDto.kt
@@ -55,6 +55,11 @@ data class KollektivDetaljerDto(
     val operatør: List<OperatørDto>,
 )
 
+private const val RUTER_NAVN = "Ruter"
+private const val RUTER_BASE_URL = "https://reise.ruter.no/"
+private const val RUTER_STOP_TYPE = "STOP_PLACE"
+private const val RUTER_MAP_ZOOM = 13
+
 data class OperatørDto(
     val navn: String,
     val url: String,
@@ -84,11 +89,41 @@ fun KollektivDetaljer.tilDto() =
         sluttHoldeplass = sluttHoldeplass,
         linjeNavn = linjeNavn,
         linjeType = linjeType,
-        operatør = operatør.map { it.tilDto() },
+        operatør = operatør.map { it.tilDto(startHoldeplass, startHoldeplassLokasjon, sluttHoldeplass, sluttHoldeplassLokasjon) },
     )
 
-fun `Operatør`.tilDto() =
-    OperatørDto(
-        navn = navn,
-        url = url,
-    )
+fun Operatør.tilDto(
+    startHoldeplass: String,
+    startLokasjon: Lokasjon,
+    sluttHoldeplass: String,
+    sluttLokasjon: Lokasjon,
+) = OperatørDto(
+    navn = navn,
+    url = if (navn == RUTER_NAVN) byggRuterUrl(startHoldeplass, startLokasjon, sluttHoldeplass, sluttLokasjon) else url,
+)
+
+private fun byggRuterUrl(
+    startHoldeplass: String,
+    startLokasjon: Lokasjon,
+    sluttHoldeplass: String,
+    sluttLokasjon: Lokasjon,
+): String {
+    val mapLat = (startLokasjon.lat + sluttLokasjon.lat) / 2
+    val mapLng = (startLokasjon.lng + sluttLokasjon.lng) / 2
+    return buildString {
+        append(RUTER_BASE_URL)
+        append("?fromName=__").append(startHoldeplass.urlEncode()).append("__")
+        append("&fromLatitude=").append(startLokasjon.lat)
+        append("&fromLongitude=").append(startLokasjon.lng)
+        append("&toName=__").append(sluttHoldeplass.urlEncode()).append("__")
+        append("&toLatitude=").append(sluttLokasjon.lat)
+        append("&toLongitude=").append(sluttLokasjon.lng)
+        append("&mapLatitude=").append(mapLat)
+        append("&mapLongitude=").append(mapLng)
+        append("&fromType=__").append(RUTER_STOP_TYPE).append("__")
+        append("&toType=__").append(RUTER_STOP_TYPE).append("__")
+        append("&mapZoom=").append(RUTER_MAP_ZOOM)
+    }
+}
+
+private fun String.urlEncode(): String = java.net.URLEncoder.encode(this, Charsets.UTF_8)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/googlemaps/dto/ReisedataDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/googlemaps/dto/ReisedataDtoTest.kt
@@ -1,0 +1,181 @@
+package no.nav.tilleggsstonader.sak.googlemaps.dto
+
+import no.nav.tilleggsstonader.sak.googlemaps.KollektivDetaljer
+import no.nav.tilleggsstonader.sak.googlemaps.Lokasjon
+import no.nav.tilleggsstonader.sak.googlemaps.Operatør
+import no.nav.tilleggsstonader.sak.googlemaps.routesApi.LinjeType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+class ReisedataDtoTest {
+    private val startLokasjon = Lokasjon(lat = 59.9139, lng = 10.7522)
+    private val sluttLokasjon = Lokasjon(lat = 59.9200, lng = 10.7600)
+
+    private fun kollektivDetaljer(
+        operatørNavn: String,
+        operatørUrl: String = "https://ruter.no/fa-hjelp-og-kontakt/kontakt-oss",
+    ) = KollektivDetaljer(
+        startHoldeplass = "Jernbanetorget",
+        startHoldeplassLokasjon = startLokasjon,
+        sluttHoldeplass = "Nationaltheatret",
+        sluttHoldeplassLokasjon = sluttLokasjon,
+        linjeNavn = "T1",
+        linjeType = LinjeType.SUBWAY,
+        operatør = listOf(Operatør(navn = operatørNavn, url = operatørUrl)),
+    )
+
+    @Nested
+    inner class OperatørUrlForRuter {
+        @Test
+        fun `Ruter-operatør får overstyrt default Ruter-url med reise-url`() {
+            val detaljer = kollektivDetaljer("Ruter")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            assertThat(url).startsWith("https://reise.ruter.no/")
+            assertThat(url).isNotEqualTo("https://ruter.no/fa-hjelp-og-kontakt/kontakt-oss")
+        }
+
+        @Test
+        fun `Ruter-url inneholder forventet fromName med holdeplassnavn`() {
+            val detaljer = kollektivDetaljer("Ruter")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            val dekodetUrl = URLDecoder.decode(url, StandardCharsets.UTF_8)
+            assertThat(dekodetUrl).contains("fromName=__Jernbanetorget__")
+        }
+
+        @Test
+        fun `Ruter-url inneholder forventet toName med holdeplassnavn`() {
+            val detaljer = kollektivDetaljer("Ruter")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            val dekodetUrl = URLDecoder.decode(url, StandardCharsets.UTF_8)
+            assertThat(dekodetUrl).contains("toName=__Nationaltheatret__")
+        }
+
+        @Test
+        fun `Ruter-url inneholder koordinater for start- og sluttlokasjon`() {
+            val detaljer = kollektivDetaljer("Ruter")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            assertThat(url).contains("fromLatitude=${startLokasjon.lat}")
+            assertThat(url).contains("fromLongitude=${startLokasjon.lng}")
+            assertThat(url).contains("toLatitude=${sluttLokasjon.lat}")
+            assertThat(url).contains("toLongitude=${sluttLokasjon.lng}")
+        }
+
+        @Test
+        fun `Ruter-url inneholder midtpunkt-koordinater mellom start og slutt`() {
+            val detaljer = kollektivDetaljer("Ruter")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            val forventetMapLat = (startLokasjon.lat + sluttLokasjon.lat) / 2
+            val forventetMapLng = (startLokasjon.lng + sluttLokasjon.lng) / 2
+            assertThat(url).contains("mapLatitude=$forventetMapLat")
+            assertThat(url).contains("mapLongitude=$forventetMapLng")
+        }
+
+        @Test
+        fun `Ruter-url inneholder forventet stoptype og zoom`() {
+            val detaljer = kollektivDetaljer("Ruter")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            val dekodetUrl = URLDecoder.decode(url, StandardCharsets.UTF_8)
+            assertThat(dekodetUrl).contains("fromType=__STOP_PLACE__")
+            assertThat(dekodetUrl).contains("toType=__STOP_PLACE__")
+            assertThat(url).contains("mapZoom=13")
+        }
+
+        @Test
+        fun `holdeplassnavn med spesialtegn blir URL-enkodet i Ruter-url`() {
+            val detaljer =
+                KollektivDetaljer(
+                    startHoldeplass = "Ås stasjon",
+                    startHoldeplassLokasjon = startLokasjon,
+                    sluttHoldeplass = "Østerås",
+                    sluttHoldeplassLokasjon = sluttLokasjon,
+                    linjeNavn = "L1",
+                    linjeType = LinjeType.SUBWAY,
+                    operatør = listOf(Operatør(navn = "Ruter", url = "")),
+                )
+
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            // Rå URL skal inneholde enkodede tegn
+            assertThat(url).doesNotContain("Ås stasjon")
+            assertThat(url).doesNotContain("Østerås")
+            // Dekoded skal inneholde originale verdier
+            val dekodetUrl = URLDecoder.decode(url, StandardCharsets.UTF_8)
+            assertThat(dekodetUrl).contains("Ås stasjon")
+            assertThat(dekodetUrl).contains("Østerås")
+        }
+    }
+
+    @Nested
+    inner class OperatørUrlForAndreOperatører {
+        @Test
+        fun `ikke-Ruter-operatør beholder sin originale url`() {
+            val originalUrl = "https://www.vy.no/tog"
+            val detaljer = kollektivDetaljer("Vy", operatørUrl = originalUrl)
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            assertThat(url).isEqualTo(originalUrl)
+        }
+
+        @Test
+        fun `ikke-Ruter-operatør url peker ikke til reise ruter no`() {
+            val detaljer = kollektivDetaljer("Vy", operatørUrl = "https://www.vy.no")
+            val url =
+                detaljer
+                    .tilDto()
+                    .operatør
+                    .single()
+                    .url
+
+            assertThat(url).doesNotStartWith("https://reise.ruter.no/")
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å gjøre oppslag mot ruter med brukervennlig når SB skal finne billettpriser for ruterreise. [Oppgave i Favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-28244)

NB: Dette er overkillversjonen - alt i denne PR-en kan erstattes med:
```fun Operatør.tilDto() = 
OperatørDto(
    navn = navn,
    url = if (navn == "Ruter") "https://reise.ruter.no/" else url,
)```