### PR TITLE
Håndter at det kommer inn flere kjørelister før en kjørelistebehandling er ferdig

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteService.kt
@@ -7,10 +7,13 @@ import no.nav.tilleggsstonader.sak.behandling.OpprettBehandling
 import no.nav.tilleggsstonader.sak.behandling.OpprettBehandlingOppgaveMetadata
 import no.nav.tilleggsstonader.sak.behandling.OpprettBehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -19,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class BehandleMottattKjørelisteService(
     private val opprettBehandlingService: OpprettBehandlingService,
+    private val behandlingRepository: BehandlingRepository,
+    private val oppgaveService: OppgaveService,
     private val gjenbrukDataRevurderingService: GjenbrukDataRevurderingService,
     private val avklartKjørelisteService: AvklartKjørelisteService,
     private val taskService: TaskService,
@@ -27,39 +32,66 @@ class BehandleMottattKjørelisteService(
 
     @Transactional
     fun behandleMottattKjøreliste(kjøreliste: Kjøreliste) {
-        val behandling = opprettKjørelisteBehandling(kjøreliste)
-
-        gjenbrukData(behandling)
+        val behandling = finnKjørelistebehandlingSomKanGjenbrukes(kjøreliste) ?: opprettKjørelisteBehandling(kjøreliste)
 
         avklartKjørelisteService.avklarUkerFraKjøreliste(
             behandling = behandling,
             kjøreliste = kjøreliste,
         )
+    }
 
-        taskService.save(
-            OpprettOppgaveForOpprettetBehandlingTask.opprettTask(
-                OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData(
-                    behandlingId = behandling.id,
-                    beskrivelse = "Skal behandles i TS-Sak",
-                    prioritet = OppgavePrioritet.NORM,
-                ),
-            ),
-        )
+    private fun finnKjørelistebehandlingSomKanGjenbrukes(kjøreliste: Kjøreliste): Behandling? {
+        val sisteKjørelistebehandlingSomIkkeErPåbegynt =
+            behandlingRepository
+                .findByFagsakId(kjøreliste.fagsakId)
+                .filter { it.type == BehandlingType.KJØRELISTE && it.status == BehandlingStatus.OPPRETTET }
+                .sortedByDescending { it.sporbar.opprettetTid }
+                .firstOrNull { !erPåbegynt(it) }
+
+        sisteKjørelistebehandlingSomIkkeErPåbegynt?.let {
+            logger.info("Gjenbruker eksisterende kjørelistebehandling=${it.id} for fagsak=${kjøreliste.fagsakId}")
+        }
+
+        return sisteKjørelistebehandlingSomIkkeErPåbegynt
+    }
+
+    private fun erPåbegynt(behandling: Behandling): Boolean {
+        if (behandling.status != BehandlingStatus.OPPRETTET) {
+            return true
+        }
+
+        val åpenBehandlingsoppgave = oppgaveService.hentÅpenBehandlingsoppgave(behandling.id) ?: return true
+
+        return åpenBehandlingsoppgave.tilordnetSaksbehandler != null
     }
 
     private fun opprettKjørelisteBehandling(kjøreliste: Kjøreliste): Behandling {
         logger.info("Oppretter kjørelistebehandling for fagsak=${kjøreliste.fagsakId}")
 
-        return opprettBehandlingService.opprettBehandling(
-            OpprettBehandling(
-                fagsakId = kjøreliste.fagsakId,
-                status = BehandlingStatus.OPPRETTET,
-                stegType = StegType.KJØRELISTE,
-                behandlingsårsak = BehandlingÅrsak.KJØRELISTE,
-                kravMottatt = kjøreliste.datoMottatt.toLocalDate(),
-                oppgaveMetadata = OpprettBehandlingOppgaveMetadata.UtenOppgave,
+        val kjørelistebehandling =
+            opprettBehandlingService.opprettBehandling(
+                OpprettBehandling(
+                    fagsakId = kjøreliste.fagsakId,
+                    status = BehandlingStatus.OPPRETTET,
+                    stegType = StegType.KJØRELISTE,
+                    behandlingsårsak = BehandlingÅrsak.KJØRELISTE,
+                    kravMottatt = kjøreliste.datoMottatt.toLocalDate(),
+                    oppgaveMetadata = OpprettBehandlingOppgaveMetadata.UtenOppgave,
+                ),
+            )
+
+        gjenbrukData(kjørelistebehandling)
+        taskService.save(
+            OpprettOppgaveForOpprettetBehandlingTask.opprettTask(
+                OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData(
+                    behandlingId = kjørelistebehandling.id,
+                    beskrivelse = "Skal behandles i TS-Sak",
+                    prioritet = OppgavePrioritet.NORM,
+                ),
             ),
         )
+
+        return kjørelistebehandling
     }
 
     private fun gjenbrukData(behandling: Behandling) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/KjørelistePåVentIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/KjørelistePåVentIntegrationTest.kt
@@ -77,6 +77,9 @@ class KjørelistePåVentIntegrationTest : IntegrationTest() {
                 .hentBehandlinger(førstegangsbehandling.fagsakId)
                 .single { it.type == BehandlingType.KJØRELISTE }
 
+        // Påbegynt behandling skal ikke gjenbrukes når ny kjøreliste kommer inn.
+        tilordneÅpenBehandlingOppgaveForBehandling(kjørelisteBehandling1.id)
+
         // Sender inn en ny kjøreliste hvor behandlingen blir satt på vent
         sendInnKjøreliste(
             kjørelisteSkjema(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaKjørelisteIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaKjørelisteIntegrationTest.kt
@@ -6,16 +6,23 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.fjernTilordningPåÅpenBehandlingOppgaveForBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteRepository
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -78,6 +85,194 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
         val oppgaver = oppgaveRepository.findByBehandlingId(kjørelisteBehandling.id)
         assertThat(oppgaver).hasSize(1)
         assertThat(oppgaver.single().type).isEqualTo(Oppgavetype.BehandleKjøreliste)
+    }
+
+    @Test
+    fun `skal kun opprettes en kjørelistebehandling om det kommer inn to kjørelister etter hverandre`() {
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+
+        val fom = 2 mars 2026
+        val tom = 15 mars 2026
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
+
+                sendInnKjøreliste {
+                    periode = Datoperiode(fom, 8 mars 2026)
+                    kjørteDager = listOf(fom to 50)
+                }
+            }
+
+        val rammevedtak = kall.privatBil.hentRammevedtak(behandlingContext.ident)
+        val reiseId = rammevedtak.single().reiseId
+
+        assertThat(
+            testoppsettService.hentBehandlinger(fagsakId = behandlingContext.fagsakId).filter {
+                it.type == BehandlingType.KJØRELISTE
+            },
+        ).hasSize(1)
+
+        sendInnKjøreliste(
+            kjøreliste =
+                kjørelisteSkjema(
+                    reiseId = reiseId,
+                    periode = Datoperiode(9 mars 2026, tom),
+                    dagerKjørt =
+                        listOf(
+                            KjørtDag(9 mars 2026, 50),
+                        ),
+                ),
+            ident = behandlingContext.ident,
+        )
+
+        val kjørelistebehandlinger =
+            testoppsettService.hentBehandlinger(fagsakId = behandlingContext.fagsakId).filter {
+                it.type ==
+                    BehandlingType.KJØRELISTE
+            }
+        assertThat(kjørelistebehandlinger).hasSize(1)
+        val kjørelistebehandling = kjørelistebehandlinger.single()
+
+        val reisevurderingForReise =
+            kall.privatBil.hentReisevurderingForBehandling(kjørelistebehandling.id).single {
+                it.reiseId ==
+                    ReiseId.fromString(reiseId)
+            }
+        assertThat(reisevurderingForReise.uker).allMatch { it.kjørelisteInnsendtDato != null }
+    }
+
+    @Test
+    fun `skal opprette to kjørelistebehandlinger om den første ikke er ferdigstilt men er påbegynt`() {
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+
+        val fom = 2 mars 2026
+        val tom = 15 mars 2026
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
+
+                sendInnKjøreliste {
+                    periode = Datoperiode(fom, 8 mars 2026)
+                    kjørteDager = listOf(fom to 50)
+                }
+            }
+
+        val rammevedtak = kall.privatBil.hentRammevedtak(behandlingContext.ident)
+        val reiseId = rammevedtak.single().reiseId
+
+        val kjørelistebehandling =
+            testoppsettService.hentBehandlinger(fagsakId = behandlingContext.fagsakId).single {
+                it.type ==
+                    BehandlingType.KJØRELISTE
+            }
+
+        tilordneÅpenBehandlingOppgaveForBehandling(kjørelistebehandling.id)
+
+        sendInnKjøreliste(
+            kjøreliste =
+                kjørelisteSkjema(
+                    reiseId = reiseId,
+                    periode = Datoperiode(9 mars 2026, tom),
+                    dagerKjørt =
+                        listOf(
+                            KjørtDag(9 mars 2026, 50),
+                        ),
+                ),
+            ident = behandlingContext.ident,
+        )
+
+        assertThat(
+            testoppsettService.hentBehandlinger(fagsakId = behandlingContext.fagsakId).filter {
+                it.type == BehandlingType.KJØRELISTE
+            },
+        ).hasSize(2)
+    }
+
+    @Test
+    fun `skal opprette ny kjørelistebehandling når første er manuelt endret og ikke lenger tilordnet`() {
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+
+        val fom = 2 mars 2026
+        val tom = 15 mars 2026
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
+
+                sendInnKjøreliste {
+                    periode = Datoperiode(fom, 8 mars 2026)
+                    kjørteDager = listOf(fom to 50)
+                }
+            }
+
+        val rammevedtak = kall.privatBil.hentRammevedtak(behandlingContext.ident)
+        val reiseId = rammevedtak.single().reiseId
+
+        val førsteKjørelistebehandling =
+            testoppsettService.hentBehandlinger(fagsakId = behandlingContext.fagsakId).single { it.type == BehandlingType.KJØRELISTE }
+
+        tilordneÅpenBehandlingOppgaveForBehandling(førsteKjørelistebehandling.id)
+
+        val ukeForManuellEndring =
+            kall.privatBil
+                .hentReisevurderingForBehandling(førsteKjørelistebehandling.id)
+                .single { it.reiseId == ReiseId.fromString(reiseId) }
+                .uker
+                .first { it.avklartUkeId != null }
+        val dagerSomKanOppdateres = ukeForManuellEndring.dager.filter { it.avklartDag != null }
+        val dagForManuellEndring = dagerSomKanOppdateres.first { it.kjørelisteDag?.harKjørt == true }
+
+        val oppdaterteDager =
+            dagerSomKanOppdateres.map { dag ->
+                val avklartDag = dag.avklartDag!!
+                if (dag.dato == dagForManuellEndring.dato) {
+                    EndreAvklartDagRequest(
+                        dato = dag.dato,
+                        godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
+                        begrunnelse = "Manuelt vurdert",
+                        parkeringsutgift = null,
+                    )
+                } else {
+                    EndreAvklartDagRequest(
+                        dato = dag.dato,
+                        godkjentGjennomførtKjøring = avklartDag.godkjentGjennomførtKjøring,
+                        begrunnelse = avklartDag.begrunnelse,
+                        parkeringsutgift = avklartDag.parkeringsutgift,
+                    )
+                }
+            }
+
+        kall.privatBil.oppdaterUke(
+            behandlingId = førsteKjørelistebehandling.id,
+            avklartUkeId = ukeForManuellEndring.avklartUkeId!!,
+            avklarteDager = oppdaterteDager,
+        )
+
+        fjernTilordningPåÅpenBehandlingOppgaveForBehandling(førsteKjørelistebehandling.id)
+
+        sendInnKjøreliste(
+            kjøreliste =
+                kjørelisteSkjema(
+                    reiseId = reiseId,
+                    periode = Datoperiode(9 mars 2026, tom),
+                    dagerKjørt =
+                        listOf(
+                            KjørtDag(9 mars 2026, 50),
+                        ),
+                ),
+            ident = behandlingContext.ident,
+        )
+
+        assertThat(
+            testoppsettService.hentBehandlinger(fagsakId = behandlingContext.fagsakId).filter {
+                it.type == BehandlingType.KJØRELISTE
+            },
+        ).hasSize(2)
     }
 
     private fun assertLagretKjørelisteInneholderDager(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/OppgaveExtensions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/OppgaveExtensions.kt
@@ -42,6 +42,10 @@ fun IntegrationTest.tilordneÅpenBehandlingOppgaveForBehandling(
     mockClients.oppgaveClient.fordelOppgave(oppgave.id, tilordneTilSaksbehandler, oppgave.versjon, null)
 }
 
+fun IntegrationTest.fjernTilordningPåÅpenBehandlingOppgaveForBehandling(behandlingId: BehandlingId) {
+    tilordneÅpenBehandlingOppgaveForBehandling(behandlingId, null)
+}
+
 fun IntegrationTest.opprettJournalføringsoppgave(
     tema: Tema = Tema.TSO,
     behandlingstema: String = "ab0300",

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
@@ -147,7 +147,7 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
     @Test
     fun `skal håndtere innsending av flere kjørelister på samme rammevedtak`() {
         // Sender inn kjøreliste for første uke
-        val kjørelistebehandling1 =
+        val kjørelistebehandling =
             sendInnKjøreliste(
                 indeksKjørelistebehandling = 0,
                 kjøreliste =
@@ -162,9 +162,9 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
             )
 
         // sender inn kjøreliste for andre og tredje uke før første kjørelistebehandling er ferdigbehandlet
-        val kjørelistebehandling2 =
+        val kjørelistebehandlinEtterAndreInnsending =
             sendInnKjøreliste(
-                indeksKjørelistebehandling = 1,
+                indeksKjørelistebehandling = 0,
                 kjøreliste =
                     kjørelisteSkjema(
                         reiseId = reiseIdRamme1,
@@ -177,31 +177,20 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
                     ),
             )
 
+        // Skal kun opprettes en behandling, som tar for seg begge kjørelister
+        assertThat(kjørelistebehandling).isEqualTo(kjørelistebehandlinEtterAndreInnsending)
+
         // Henter reisevurderinger for begge behandlingene
-        val reisevurderingBehandling1 = finnReisevurderinger(kjørelistebehandling1.id).ramme1!!
-        val reisevurderingerBehandling2 = finnReisevurderinger(kjørelistebehandling2.id).ramme1!!
+        val (ramme1, ramme2) = finnReisevurderinger(kjørelistebehandling.id)
+        assertThat(ramme1).isNotNull
+        assertThat(ramme2).isNotNull
 
-        // Kun første uken skal ha en kjøreliste og avklart uke i den første kjørelistebehandlingen
-        val (uke1Behandling1, resterendeUkerBehandling1) = reisevurderingBehandling1.uker.first() to reisevurderingBehandling1.uker.drop(1)
-        assertThat(uke1Behandling1.kjørelisteInnsendtDato).isNotNull
-        assertThat(uke1Behandling1.avklartUkeId).isNotNull
+        // Verifiser at begge uker finnes på ramme1 for behandlingen
+        val ukerHvorDetFinnesAvklarteUker = ramme1!!.uker.filter { it.kjørelisteInnsendtDato != null && it.avklartUkeId != null }
+        assertThat(ukerHvorDetFinnesAvklarteUker).hasSameSizeAs(ramme1.uker)
 
-        resterendeUkerBehandling1.forEach {
-            assertThat(it.kjørelisteInnsendtDato).isNull()
-            assertThat(it.avklartUkeId).isNull()
-        }
-
-        // Kun andre og tredje uken skal ha en kjøreliste og avklart uke i den andre kjørelistebehandlingen
-        val (uke1Behandling2, resterendeUkerBehandling2) =
-            reisevurderingerBehandling2.uker.first() to
-                reisevurderingerBehandling2.uker.drop(1)
-        assertThat(uke1Behandling2.kjørelisteInnsendtDato).isNull()
-        assertThat(uke1Behandling2.avklartUkeId).isNull()
-
-        resterendeUkerBehandling2.forEach {
-            assertThat(it.kjørelisteInnsendtDato).isNotNull
-            assertThat(it.avklartUkeId).isNotNull()
-        }
+        // Verifiser ingen uker på ramme2
+        assertThat(ramme2!!.uker.filter { it.kjørelisteInnsendtDato != null && it.avklartUkeId != null }).isEmpty()
     }
 
     private fun sendInnKjøreliste(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Forslag til løsning på https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-27661 - "Hvordan håndtere at det kommer flere kjørelister før behandling er ferdig?"

Om bruker i dag sender inn en-og-en uke (ikke mange uker på en gang), så vil det opprettes en ny behandling for hver innsending, og vi vil da potensielt får svært mange kjørelistebehandlinger.

Løser dette ved:
Hvis vi mottar en kjøreliste og det allerede finnes en kjørelistebehandling som ikke er påbegynt/endret/plukket (behandlingsstatus OPPRETTET og ingen saksbehandler tilordnet tilhørende oppgave) skal vi legge til kjørelisten i eksisterende kjørelistebehandling.



