### PR TITLE
Sorter vedtaksperioder konsekvent nyest til eldst i beregnings resultat

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/detaljerteVedtaksperioder/DetaljertVedtaksperioderTilsynBarnMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/detaljerteVedtaksperioder/DetaljertVedtaksperioderTilsynBarnMapper.kt
@@ -8,7 +8,7 @@ object DetaljertVedtaksperioderTilsynBarnMapper {
         val vedtaksperioderFraBeregningsresultat =
             finnVedtaksperioderFraBeregningsresultatTilsynBarn(this.beregningsresultat)
 
-        return vedtaksperioderFraBeregningsresultat.sorterOgMergeSammenhengende()
+        return vedtaksperioderFraBeregningsresultat.sorterOgMergeSammenhengende().sortedByDescending { it.fom }
     }
 
     private fun finnVedtaksperioderFraBeregningsresultatTilsynBarn(beregningsresultatTilsynBarn: BeregningsresultatTilsynBarn) =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
@@ -109,7 +109,7 @@ object DetaljertVedtaksperioderBoutgifterMapper {
         var alleredeSummerteUtgifter = sumLøpendeUtgifter
 
         return utgifterOvernatting
-            .sorted()
+            .sortedByDescending { it.fom }
             .map { utgift ->
                 val beløpSomDekkes = minOf(utgift.utgift, makssats - alleredeSummerteUtgifter)
                 alleredeSummerteUtgifter += beløpSomDekkes

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
@@ -109,7 +109,7 @@ object DetaljertVedtaksperioderBoutgifterMapper {
         var alleredeSummerteUtgifter = sumLøpendeUtgifter
 
         return utgifterOvernatting
-            .sortedByDescending { it.fom }
+            .sorted()
             .map { utgift ->
                 val beløpSomDekkes = minOf(utgift.utgift, makssats - alleredeSummerteUtgifter)
                 alleredeSummerteUtgifter += beløpSomDekkes
@@ -120,7 +120,7 @@ object DetaljertVedtaksperioderBoutgifterMapper {
                     utgift = utgift.utgift,
                     beløpSomDekkes = beløpSomDekkes,
                 )
-            }
+            }.sortedByDescending { it.fom }
     }
 
     private fun summerLøpendeUtgifterBo(utgifter: BoutgifterPerUtgiftstype): Int =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapper.kt
@@ -10,7 +10,7 @@ object DetaljertVedtaksperioderBoutgifterMapper {
         val overnatting = finnVedtaksperioderMedOvernattingUtgifter(this)
         val løpende = finnVedtaksperioderMedLøpendeUtgifter(this)
 
-        return (overnatting + løpende).sorted()
+        return (overnatting + løpende).sortedByDescending { it.fom }
     }
 
     private fun finnVedtaksperioderMedOvernattingUtgifter(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/detaljerteVedtaksperioder/DetaljertVedtaksperioderLæremidlerMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/detaljerteVedtaksperioder/DetaljertVedtaksperioderLæremidlerMapper.kt
@@ -18,6 +18,6 @@ object DetaljertVedtaksperioderLæremidlerMapper {
                 )
             }
 
-        return vedtaksperioderFraBeregningsresultat.sorterOgMergeSammenhengende()
+        return vedtaksperioderFraBeregningsresultat.sorterOgMergeSammenhengende().sortedByDescending { it.fom }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
@@ -79,7 +79,7 @@ class VedtaksperioderOversiktService(
         return when (vedtaksdata) {
             is InnvilgelseEllerOpphørTilsynBarn -> vedtaksdata.finnDetaljerteVedtaksperioder()
             is InnvilgelseEllerOpphørLæremidler -> vedtaksdata.finnDetaljerteVedtaksperioder()
-            is InnvilgelseEllerOpphørBoutgifter -> vedtaksdata.finnDetaljerteVedtaksperioder()
+            is InnvilgelseEllerOpphørBoutgifter -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
             null -> emptyList()
             else -> error("Vi støtter ikke å hente detaljertevedtaksperioder innenfor samme enhet for ${vedtaksdata::class.java}")
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
@@ -77,8 +77,8 @@ class VedtaksperioderOversiktService(
     private fun finnDetaljerteVedtaksperioderInnenforSammeEnhet(behandling: Saksbehandling?): List<DetaljertVedtaksperiode> {
         val vedtaksdata = behandling?.forrigeIverksatteBehandlingId?.let { vedtakService.hentVedtak(it)?.data }
         return when (vedtaksdata) {
-            is InnvilgelseEllerOpphørTilsynBarn -> vedtaksdata.finnDetaljerteVedtaksperioder()
-            is InnvilgelseEllerOpphørLæremidler -> vedtaksdata.finnDetaljerteVedtaksperioder()
+            is InnvilgelseEllerOpphørTilsynBarn -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
+            is InnvilgelseEllerOpphørLæremidler -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
             is InnvilgelseEllerOpphørBoutgifter -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
             null -> emptyList()
             else -> error("Vi støtter ikke å hente detaljertevedtaksperioder innenfor samme enhet for ${vedtaksdata::class.java}")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
@@ -77,9 +77,9 @@ class VedtaksperioderOversiktService(
     private fun finnDetaljerteVedtaksperioderInnenforSammeEnhet(behandling: Saksbehandling?): List<DetaljertVedtaksperiode> {
         val vedtaksdata = behandling?.forrigeIverksatteBehandlingId?.let { vedtakService.hentVedtak(it)?.data }
         return when (vedtaksdata) {
-            is InnvilgelseEllerOpphørTilsynBarn -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
-            is InnvilgelseEllerOpphørLæremidler -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
-            is InnvilgelseEllerOpphørBoutgifter -> vedtaksdata.finnDetaljerteVedtaksperioder().sortedByDescending { it.fom }
+            is InnvilgelseEllerOpphørTilsynBarn -> vedtaksdata.finnDetaljerteVedtaksperioder()
+            is InnvilgelseEllerOpphørLæremidler -> vedtaksdata.finnDetaljerteVedtaksperioder()
+            is InnvilgelseEllerOpphørBoutgifter -> vedtaksdata.finnDetaljerteVedtaksperioder()
             null -> emptyList()
             else -> error("Vi støtter ikke å hente detaljertevedtaksperioder innenfor samme enhet for ${vedtaksdata::class.java}")
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapperTest.kt
@@ -143,8 +143,8 @@ class DetaljertVedtaksperioderBoutgifterMapperTest {
 
             assertThat(res).hasSize(2)
 
-            val resJan = res.first()
-            val resFeb = res.last()
+            val resFeb = res.first()
+            val resJan = res.last()
 
             assertThat(resJan.fom).isEqualTo(førsteJan)
             assertThat(resJan.tom).isEqualTo(sisteJan)
@@ -160,7 +160,7 @@ class DetaljertVedtaksperioderBoutgifterMapperTest {
         }
 
         @Test
-        fun `skal sortere utgifter til overnatting kronologisk`() {
+        fun `skal sortere utgifter til overnatting nyest til eldst`() {
             val beregningsresultatJan =
                 BoutgifterTestUtil.lagBeregningsresultatMåned(
                     fom = førsteJan,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapperTest.kt
@@ -71,22 +71,22 @@ class DetaljertVedtaksperioderBoutgifterMapperTest {
             val forventetUtgiftRes =
                 listOf(
                     UtgiftTilOvernatting(
-                        fom = LocalDate.of(2024, 1, 3),
-                        tom = LocalDate.of(2024, 1, 4),
-                        utgift = 4000,
-                        beløpSomDekkes = 4000,
+                        fom = LocalDate.of(2024, 1, 10),
+                        tom = LocalDate.of(2024, 1, 11),
+                        utgift = 1000,
+                        beløpSomDekkes = 1000,
                     ),
                     UtgiftTilOvernatting(
                         fom = LocalDate.of(2024, 1, 7),
                         tom = LocalDate.of(2024, 1, 8),
                         utgift = 1000,
-                        beløpSomDekkes = 809,
+                        beløpSomDekkes = 1000,
                     ),
                     UtgiftTilOvernatting(
-                        fom = LocalDate.of(2024, 1, 10),
-                        tom = LocalDate.of(2024, 1, 11),
-                        utgift = 1000,
-                        beløpSomDekkes = 0,
+                        fom = LocalDate.of(2024, 1, 3),
+                        tom = LocalDate.of(2024, 1, 4),
+                        utgift = 4000,
+                        beløpSomDekkes = 2809,
                     ),
                 )
 
@@ -190,8 +190,8 @@ class DetaljertVedtaksperioderBoutgifterMapperTest {
 
             val utgifter = res.first().utgifterTilOvernatting!!
 
-            assertThat(utgifter[0].fom).isEqualTo(LocalDate.of(2024, 1, 3))
-            assertThat(utgifter[1].fom).isEqualTo(LocalDate.of(2024, 1, 7))
+            assertThat(utgifter[0].fom).isEqualTo(LocalDate.of(2024, 1, 7))
+            assertThat(utgifter[1].fom).isEqualTo(LocalDate.of(2024, 1, 3))
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/detaljerteVedtaksperioder/DetaljertVedtaksperioderBoutgifterMapperTest.kt
@@ -74,19 +74,19 @@ class DetaljertVedtaksperioderBoutgifterMapperTest {
                         fom = LocalDate.of(2024, 1, 10),
                         tom = LocalDate.of(2024, 1, 11),
                         utgift = 1000,
-                        beløpSomDekkes = 1000,
+                        beløpSomDekkes = 0,
                     ),
                     UtgiftTilOvernatting(
                         fom = LocalDate.of(2024, 1, 7),
                         tom = LocalDate.of(2024, 1, 8),
                         utgift = 1000,
-                        beløpSomDekkes = 1000,
+                        beløpSomDekkes = 809,
                     ),
                     UtgiftTilOvernatting(
                         fom = LocalDate.of(2024, 1, 3),
                         tom = LocalDate.of(2024, 1, 4),
                         utgift = 4000,
-                        beløpSomDekkes = 2809,
+                        beløpSomDekkes = 4000,
                     ),
                 )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/detaljerteVedtaksperioder/DetaljertVedtaksperioderLæremidlerMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/detaljerteVedtaksperioder/DetaljertVedtaksperioderLæremidlerMapperTest.kt
@@ -59,8 +59,8 @@ class DetaljertVedtaksperioderLæremidlerMapperTest {
 
         val forventetRes =
             listOf(
-                detaljertVedtaksperiodeLæremidler(fom = førsteFeb, tom = sisteFeb),
                 detaljertVedtaksperiodeLæremidler(fom = førsteApril, tom = sisteApril),
+                detaljertVedtaksperiodeLæremidler(fom = førsteFeb, tom = sisteFeb),
             )
 
         assertThat(res).isEqualTo(forventetRes)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Favro- https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-28497

<img width="974" height="490" alt="Screenshot 2026-04-23 at 09 04 19" src="https://github.com/user-attachments/assets/96dfa76b-0078-4705-9f1b-06000b3de310" />
<img width="1215" height="511" alt="Screenshot 2026-04-23 at 09 03 56" src="https://github.com/user-attachments/assets/184cfaae-8c41-4034-bbe9-75440e187502" />

