### PR TITLE
Legger til ny task for å opprette vedtaksbrev for kjørelistebehandling, som opprettes når en kjørelistebehandling ferdigstilles

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/JournalførVedtaksbrevService.kt
@@ -1,0 +1,97 @@
+package no.nav.tilleggsstonader.sak.brev
+
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.dokumenttyper
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.journalføring.ArkiverDokumentConflictException
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class JournalførVedtaksbrevService(
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val journalpostService: JournalpostService,
+    private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
+    private val transactionHandler: TransactionHandler,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun journalførForAlleMottakere(
+        pdfBytes: ByteArray,
+        saksbehandling: Saksbehandling,
+        brevmottakere: List<BrevmottakerVedtaksbrev>,
+        brevtittel: String,
+    ) {
+        brevmottakere
+            .filter { it.journalpostId == null }
+            .forEach { brevmottaker ->
+                transactionHandler.runInNewTransaction {
+                    journalførForEnMottaker(pdfBytes, saksbehandling, brevmottaker, brevtittel)
+                }
+            }
+    }
+
+    private fun journalførForEnMottaker(
+        pdfBytes: ByteArray,
+        saksbehandling: Saksbehandling,
+        brevmottaker: BrevmottakerVedtaksbrev,
+        brevtittel: String,
+    ) {
+        val dokument =
+            Dokument(
+                dokument = pdfBytes,
+                filtype = Filtype.PDFA,
+                dokumenttype = saksbehandling.stønadstype.dokumenttyper.vedtaksbrev,
+                tittel = brevtittel,
+            )
+
+        val eksternReferanseId = "${saksbehandling.eksternId}-vedtaksbrev-${brevmottaker.id}"
+
+        val arkiverDokumentRequest =
+            ArkiverDokumentRequest(
+                fnr = saksbehandling.ident,
+                forsøkFerdigstill = true,
+                hoveddokumentvarianter = listOf(dokument),
+                fagsakId = saksbehandling.eksternFagsakId.toString(),
+                journalførendeEnhet =
+                    arbeidsfordelingService.hentNavEnhet(saksbehandling.ident, saksbehandling.stønadstype)?.enhetNr
+                        ?: error("Fant ikke arbeidsfordelingsenhet"),
+                eksternReferanseId = eksternReferanseId,
+                avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),
+            )
+
+        val response = opprettJournalpost(arkiverDokumentRequest, saksbehandling, eksternReferanseId)
+        brevmottakerVedtaksbrevRepository.update(brevmottaker.copy(journalpostId = response.journalpostId))
+    }
+
+    private fun opprettJournalpost(
+        arkiverDokumentRequest: ArkiverDokumentRequest,
+        saksbehandling: Saksbehandling,
+        eksternReferanseId: String,
+    ): ArkiverDokumentResponse {
+        val response =
+            try {
+                journalpostService.opprettJournalpost(arkiverDokumentRequest)
+            } catch (e: ArkiverDokumentConflictException) {
+                logger.warn(
+                    "Konflikt ved arkivering av dokument. Brevet har sannsynligvis allerede blitt arkivert" +
+                        " for behandlingId=${saksbehandling.id} med eksternReferanseId=$eksternReferanseId",
+                )
+                e.response
+            }
+        feilHvisIkke(response.ferdigstilt) {
+            "Journalposten ble ikke ferdigstilt og kan derfor ikke distribueres"
+        }
+        return response
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
@@ -27,7 +27,7 @@ class BrevmottakereController(
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerLesetilgangTilBehandling(behandlingId)
 
-        return brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId)
+        return brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId).tilBrevmottakereDto()
     }
 
     @PostMapping("/{behandlingId}")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereService.kt
@@ -34,15 +34,15 @@ class BrevmottakereService(
     }
 
     @Transactional
-    fun hentEllerOpprettBrevmottakere(behandlingId: BehandlingId): BrevmottakereDto =
+    fun hentEllerOpprettBrevmottakere(behandlingId: BehandlingId): List<BrevmottakerVedtaksbrev> =
         if (brevmottakereRepository.existsByBehandlingId(behandlingId)) {
-            brevmottakereRepository.findByBehandlingId(behandlingId).tilBrevmottakereDto()
+            brevmottakereRepository.findByBehandlingId(behandlingId)
         } else {
             validerBehandlingKanRedigeres(behandlingId)
 
             val brevmottaker = opprettInitiellBrevmottakerForBehandling(behandlingId)
 
-            listOf(brevmottaker).tilBrevmottakereDto()
+            listOf(brevmottaker)
         }
 
     private fun fjernMottakereIkkeIDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
@@ -13,7 +13,6 @@ import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
@@ -119,7 +118,7 @@ class JournalførKjørelisteBehandlingBrevTask(
         return response
     }
 
-    // TODO - hva skal tittel være? Bør være forskjellig
+    // TODO - hva skal tittel være? Bør være forskjellig fra rammevedtak-brev
     private fun utledBrevtittel(saksbehandling: Saksbehandling) = "Vedtak om ${saksbehandling.stønadstype.visningsnavn}"
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
@@ -1,0 +1,142 @@
+package no.nav.tilleggsstonader.sak.brev.kjørelistebrev
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
+import no.nav.tilleggsstonader.kontrakter.dokarkiv.dokumenttyper
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereService
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
+import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.DistribuerVedtaksbrevTask
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.journalføring.ArkiverDokumentConflictException
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.Properties
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = JournalførKjørelisteBehandlingBrevTask.TYPE,
+    maxAntallFeil = 50,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 31L,
+    beskrivelse = "Journalfører vedtaksbrev for kjørelistebehandling",
+)
+class JournalførKjørelisteBehandlingBrevTask(
+    private val taskService: TaskService,
+    private val behandlingService: BehandlingService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
+    private val journalpostService: JournalpostService,
+    private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
+    private val transactionHandler: TransactionHandler,
+    private val kjørelisteBehandlingBrevService: KjørelisteBehandlingBrevService,
+    private val brevmottakereService: BrevmottakereService,
+) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        val behandlingId = BehandlingId.fromString(task.payload)
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+        feilHvisIkke(saksbehandling.type == BehandlingType.KJØRELISTE) {
+            "Forventer at behandlingstype skal være ${BehandlingType.KJØRELISTE}"
+        }
+
+        val kjørelisteBrev = kjørelisteBehandlingBrevService.hentBrev(behandlingId)
+
+        val ikkeJournalførteBrevmottakere =
+            brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId).filter { it.journalpostId == null }
+        ikkeJournalførteBrevmottakere.forEach { brevmottaker ->
+            transactionHandler.runInNewTransaction {
+                journalførVedtaksbrevForEnMottaker(kjørelisteBrev, saksbehandling, brevmottaker)
+            }
+        }
+    }
+
+    private fun journalførVedtaksbrevForEnMottaker(
+        kjørelisteBehandlingBrev: KjørelisteBehandlingBrev,
+        saksbehandling: Saksbehandling,
+        brevmottaker: BrevmottakerVedtaksbrev,
+    ) {
+        val dokument =
+            Dokument(
+                dokument = kjørelisteBehandlingBrev.pdf.bytes,
+                filtype = Filtype.PDFA,
+                dokumenttype = saksbehandling.stønadstype.dokumenttyper.vedtaksbrev,
+                tittel = utledBrevtittel(saksbehandling),
+            )
+
+        val eksternReferanseId = "${saksbehandling.eksternId}-vedtaksbrev-${brevmottaker.id}"
+
+        val arkviverDokumentRequest =
+            ArkiverDokumentRequest(
+                fnr = saksbehandling.ident,
+                forsøkFerdigstill = true,
+                hoveddokumentvarianter = listOf(dokument),
+                fagsakId = saksbehandling.eksternFagsakId.toString(),
+                journalførendeEnhet =
+                    arbeidsfordelingService.hentNavEnhet(saksbehandling.ident, saksbehandling.stønadstype)?.enhetNr
+                        ?: error("Fant ikke arbeidsfordelingsenhet"),
+                eksternReferanseId = eksternReferanseId,
+                avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),
+            )
+
+        val arkiverDokumentResponse = opprettJournalpost(arkviverDokumentRequest, saksbehandling, eksternReferanseId)
+        brevmottakerVedtaksbrevRepository.update(brevmottaker.copy(journalpostId = arkiverDokumentResponse.journalpostId))
+    }
+
+    private fun opprettJournalpost(
+        arkviverDokumentRequest: ArkiverDokumentRequest,
+        saksbehandling: Saksbehandling,
+        eksternReferanseId: String,
+    ): ArkiverDokumentResponse {
+        val response =
+            try {
+                journalpostService.opprettJournalpost(arkviverDokumentRequest)
+            } catch (e: ArkiverDokumentConflictException) {
+                logger.warn(
+                    "Konflikt ved arkivering av dokument. Kjøreliste-brev har sannsynligvis allerede blitt arkivert" +
+                        " for behandlingId=${saksbehandling.id} med eksternReferanseId=$eksternReferanseId",
+                )
+                e.response
+            }
+        feilHvisIkke(response.ferdigstilt) {
+            "Journalposten ble ikke ferdigstilt og kan derfor ikke distribueres"
+        }
+        return response
+    }
+
+    // TODO - hva skal tittel være? Bør være forskjellig
+    private fun utledBrevtittel(saksbehandling: Saksbehandling) = "Vedtak om ${saksbehandling.stønadstype.visningsnavn}"
+
+    override fun onCompletion(task: Task) {
+        taskService.save(DistribuerVedtaksbrevTask.opprettTask(BehandlingId.fromString(task.payload)))
+    }
+
+    companion object {
+        fun opprettTask(behandlingId: BehandlingId): Task =
+            Task(
+                type = TYPE,
+                payload = behandlingId.toString(),
+                properties =
+                    Properties().apply {
+                        setProperty("behandlingId", behandlingId.toString())
+                    },
+            )
+
+        const val TYPE = "journalførKjørelisteBehandlingBrev"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
@@ -4,26 +4,15 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.dokumenttyper
-import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.brev.JournalførVedtaksbrevService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereService
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.DistribuerVedtaksbrevTask
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
-import no.nav.tilleggsstonader.sak.journalføring.ArkiverDokumentConflictException
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
 
@@ -38,15 +27,10 @@ import java.util.Properties
 class JournalførKjørelisteBehandlingBrevTask(
     private val taskService: TaskService,
     private val behandlingService: BehandlingService,
-    private val arbeidsfordelingService: ArbeidsfordelingService,
-    private val journalpostService: JournalpostService,
-    private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
-    private val transactionHandler: TransactionHandler,
     private val kjørelisteBehandlingBrevService: KjørelisteBehandlingBrevService,
     private val brevmottakereService: BrevmottakereService,
+    private val journalførVedtaksbrevService: JournalførVedtaksbrevService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
     override fun doTask(task: Task) {
         val behandlingId = BehandlingId.fromString(task.payload)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
@@ -54,72 +38,16 @@ class JournalførKjørelisteBehandlingBrevTask(
             "Forventer at behandlingstype skal være ${BehandlingType.KJØRELISTE}"
         }
 
-        val kjørelisteBrev = kjørelisteBehandlingBrevService.hentBrev(behandlingId)
+        val brev = kjørelisteBehandlingBrevService.hentBrev(behandlingId)
 
-        val ikkeJournalførteBrevmottakere =
-            brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId).filter { it.journalpostId == null }
-        ikkeJournalførteBrevmottakere.forEach { brevmottaker ->
-            transactionHandler.runInNewTransaction {
-                journalførVedtaksbrevForEnMottaker(kjørelisteBrev, saksbehandling, brevmottaker)
-            }
-        }
+        journalførVedtaksbrevService.journalførForAlleMottakere(
+            pdfBytes = brev.pdf.bytes,
+            saksbehandling = saksbehandling,
+            brevmottakere = brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId),
+            // TODO - hva skal tittel være? Bør være forskjellig fra rammevedtak-brev
+            brevtittel = "Vedtak om ${saksbehandling.stønadstype.visningsnavn}",
+        )
     }
-
-    private fun journalførVedtaksbrevForEnMottaker(
-        kjørelisteBehandlingBrev: KjørelisteBehandlingBrev,
-        saksbehandling: Saksbehandling,
-        brevmottaker: BrevmottakerVedtaksbrev,
-    ) {
-        val dokument =
-            Dokument(
-                dokument = kjørelisteBehandlingBrev.pdf.bytes,
-                filtype = Filtype.PDFA,
-                dokumenttype = saksbehandling.stønadstype.dokumenttyper.vedtaksbrev,
-                tittel = utledBrevtittel(saksbehandling),
-            )
-
-        val eksternReferanseId = "${saksbehandling.eksternId}-vedtaksbrev-${brevmottaker.id}"
-
-        val arkviverDokumentRequest =
-            ArkiverDokumentRequest(
-                fnr = saksbehandling.ident,
-                forsøkFerdigstill = true,
-                hoveddokumentvarianter = listOf(dokument),
-                fagsakId = saksbehandling.eksternFagsakId.toString(),
-                journalførendeEnhet =
-                    arbeidsfordelingService.hentNavEnhet(saksbehandling.ident, saksbehandling.stønadstype)?.enhetNr
-                        ?: error("Fant ikke arbeidsfordelingsenhet"),
-                eksternReferanseId = eksternReferanseId,
-                avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),
-            )
-
-        val arkiverDokumentResponse = opprettJournalpost(arkviverDokumentRequest, saksbehandling, eksternReferanseId)
-        brevmottakerVedtaksbrevRepository.update(brevmottaker.copy(journalpostId = arkiverDokumentResponse.journalpostId))
-    }
-
-    private fun opprettJournalpost(
-        arkviverDokumentRequest: ArkiverDokumentRequest,
-        saksbehandling: Saksbehandling,
-        eksternReferanseId: String,
-    ): ArkiverDokumentResponse {
-        val response =
-            try {
-                journalpostService.opprettJournalpost(arkviverDokumentRequest)
-            } catch (e: ArkiverDokumentConflictException) {
-                logger.warn(
-                    "Konflikt ved arkivering av dokument. Kjøreliste-brev har sannsynligvis allerede blitt arkivert" +
-                        " for behandlingId=${saksbehandling.id} med eksternReferanseId=$eksternReferanseId",
-                )
-                e.response
-            }
-        feilHvisIkke(response.ferdigstilt) {
-            "Journalposten ble ikke ferdigstilt og kan derfor ikke distribueres"
-        }
-        return response
-    }
-
-    // TODO - hva skal tittel være? Bør være forskjellig fra rammevedtak-brev
-    private fun utledBrevtittel(saksbehandling: Saksbehandling) = "Vedtak om ${saksbehandling.stønadstype.visningsnavn}"
 
     override fun onCompletion(task: Task) {
         taskService.save(DistribuerVedtaksbrevTask.opprettTask(BehandlingId.fromString(task.payload)))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/JournalførKjørelisteBehandlingBrevTask.kt
@@ -7,8 +7,6 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.brev.JournalførVedtaksbrevService
-import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereService
 import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.DistribuerVedtaksbrevTask
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/KjørelisteBehandlingBrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/KjørelisteBehandlingBrevController.kt
@@ -26,7 +26,7 @@ class KjørelisteBehandlingBrevController(
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
-        return Base64.getEncoder().encode(kjørelisteBehandlingBrevService.genererOgLagreBrev(behandlingId))
+        return Base64.getEncoder().encode(kjørelisteBehandlingBrevService.genererOgLagreBrev(behandlingId).pdf.bytes)
     }
 
     @GetMapping("/{behandlingId}")
@@ -36,6 +36,6 @@ class KjørelisteBehandlingBrevController(
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerLesetilgangTilBehandling(behandlingId)
 
-        return Base64.getEncoder().encode(kjørelisteBehandlingBrevService.hentBrev(behandlingId))
+        return Base64.getEncoder().encode(kjørelisteBehandlingBrevService.hentBrev(behandlingId).pdf.bytes)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/KjørelisteBehandlingBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/KjørelisteBehandlingBrevService.kt
@@ -25,26 +25,24 @@ class KjørelisteBehandlingBrevService(
     private val vedtakService: VedtakService,
     private val behandlingService: BehandlingService,
 ) {
-    fun genererOgLagreBrev(behandlingId: BehandlingId): ByteArray {
+    fun genererOgLagreBrev(behandlingId: BehandlingId): KjørelisteBehandlingBrev {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         saksbehandling.status.validerKanBehandlingRedigeres()
 
         val html = genererHtml(saksbehandling)
         val pdf = familieDokumentClient.genererPdf(html)
 
-        lagreEllerOppdaterBrev(saksbehandling, html, pdf)
-
-        return pdf
+        return lagreEllerOppdaterBrev(saksbehandling, html, pdf)
     }
 
-    fun hentBrev(behandlingId: BehandlingId): ByteArray {
+    fun hentBrev(behandlingId: BehandlingId): KjørelisteBehandlingBrev {
         val brev = kjørelisteBehandlingBrevRepository.findByBehandlingId(behandlingId)
 
         brukerfeilHvis(brev == null) {
             "Finner ikke kjørelistebrev for behandlingId=$behandlingId. Det er nok fordi et brev ikke har blitt laget enda."
         }
 
-        return brev.pdf.bytes
+        return brev
     }
 
     private fun genererHtml(saksbehandling: Saksbehandling): String {
@@ -82,7 +80,7 @@ class KjørelisteBehandlingBrevService(
         saksbehandling: Saksbehandling,
         html: String,
         pdf: ByteArray,
-    ) {
+    ): KjørelisteBehandlingBrev {
         val brev =
             KjørelisteBehandlingBrev(
                 behandlingId = saksbehandling.id,
@@ -96,5 +94,7 @@ class KjørelisteBehandlingBrevService(
         } else {
             kjørelisteBehandlingBrevRepository.insert(brev)
         }
+
+        return brev
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTask.kt
@@ -4,25 +4,12 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.Dokument
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.Filtype
-import no.nav.tilleggsstonader.kontrakter.dokarkiv.dokumenttyper
-import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.JournalførVedtaksbrevService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerUtil.tilAvsenderMottaker
-import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
-import no.nav.tilleggsstonader.sak.journalføring.ArkiverDokumentConflictException
-import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
 
@@ -38,84 +25,23 @@ class JournalførVedtaksbrevTask(
     private val taskService: TaskService,
     private val behandlingService: BehandlingService,
     private val brevService: BrevService,
-    private val arbeidsfordelingService: ArbeidsfordelingService,
-    private val journalpostService: JournalpostService,
     private val brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository,
     private val stegService: StegService,
-    private val transactionHandler: TransactionHandler,
+    private val journalførVedtaksbrevService: JournalførVedtaksbrevService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
     override fun doTask(task: Task) {
         val behandlingId = BehandlingId.fromString(task.payload)
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
-
         val vedtaksbrev = brevService.hentBesluttetBrev(saksbehandling.id)
 
-        val ikkeJournalførteBrevmottakere =
-            brevmottakerVedtaksbrevRepository.findByBehandlingId(behandlingId).filter { it.journalpostId == null }
-        ikkeJournalførteBrevmottakere.forEach { brevmottaker ->
-            transactionHandler.runInNewTransaction {
-                journalførVedtaksbrevForEnMottaker(vedtaksbrev, saksbehandling, brevmottaker)
-            }
-        }
+        journalførVedtaksbrevService.journalførForAlleMottakere(
+            pdfBytes = vedtaksbrev.beslutterPdf?.bytes ?: error("Mangler beslutterpdf"),
+            saksbehandling = saksbehandling,
+            brevmottakere = brevmottakerVedtaksbrevRepository.findByBehandlingId(behandlingId),
+            brevtittel = "Vedtak om ${saksbehandling.stønadstype.visningsnavn}",
+        )
         stegService.håndterSteg(behandlingId, StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV)
     }
-
-    private fun journalførVedtaksbrevForEnMottaker(
-        vedtaksbrev: Vedtaksbrev,
-        saksbehandling: Saksbehandling,
-        brevmottaker: BrevmottakerVedtaksbrev,
-    ) {
-        val dokument =
-            Dokument(
-                dokument = vedtaksbrev.beslutterPdf?.bytes ?: error("Mangler beslutterpdf"),
-                filtype = Filtype.PDFA,
-                dokumenttype = saksbehandling.stønadstype.dokumenttyper.vedtaksbrev,
-                tittel = utledBrevtittel(saksbehandling),
-            )
-
-        val eksternReferanseId = "${saksbehandling.eksternId}-vedtaksbrev-${brevmottaker.id}"
-
-        val arkviverDokumentRequest =
-            ArkiverDokumentRequest(
-                fnr = saksbehandling.ident,
-                forsøkFerdigstill = true,
-                hoveddokumentvarianter = listOf(dokument),
-                fagsakId = saksbehandling.eksternFagsakId.toString(),
-                journalførendeEnhet =
-                    arbeidsfordelingService.hentNavEnhet(saksbehandling.ident, saksbehandling.stønadstype)?.enhetNr
-                        ?: error("Fant ikke arbeidsfordelingsenhet"),
-                eksternReferanseId = eksternReferanseId,
-                avsenderMottaker = brevmottaker.mottaker.tilAvsenderMottaker(),
-            )
-
-        val arkiverDokumentResponse = opprettJournalpost(arkviverDokumentRequest, saksbehandling, eksternReferanseId)
-        brevmottakerVedtaksbrevRepository.update(brevmottaker.copy(journalpostId = arkiverDokumentResponse.journalpostId))
-    }
-
-    private fun opprettJournalpost(
-        arkviverDokumentRequest: ArkiverDokumentRequest,
-        saksbehandling: Saksbehandling,
-        eksternReferanseId: String,
-    ): ArkiverDokumentResponse {
-        val response =
-            try {
-                journalpostService.opprettJournalpost(arkviverDokumentRequest)
-            } catch (e: ArkiverDokumentConflictException) {
-                logger.warn(
-                    "Konflikt ved arkivering av dokument. Vedtaksbrevet har sannsynligvis allerede blitt arkivert" +
-                        " for behandlingId=${saksbehandling.id} med eksternReferanseId=$eksternReferanseId",
-                )
-                e.response
-            }
-        feilHvisIkke(response.ferdigstilt) {
-            "Journalposten ble ikke ferdigstilt og kan derfor ikke distribueres"
-        }
-        return response
-    }
-
-    private fun utledBrevtittel(saksbehandling: Saksbehandling) = "Vedtak om ${saksbehandling.stønadstype.visningsnavn}"
 
     override fun onCompletion(task: Task) {
         taskService.save(DistribuerVedtaksbrevTask.opprettTask(BehandlingId.fromString(task.payload)))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/migrering/arena/ArenaStatusService.kt
@@ -98,5 +98,6 @@ class ArenaStatusService(
             10458,
             10329,
             13151,
+            10818,
         )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/FullførKjørelistebehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/FullførKjørelistebehandlingSteg.kt
@@ -10,6 +10,9 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.FerdigstillBehandlingTask
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakereService
+import no.nav.tilleggsstonader.sak.brev.kjørelistebrev.JournalførKjørelisteBehandlingBrevTask
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.FerdigstillOppgaveTask
@@ -22,6 +25,7 @@ class FullførKjørelistebehandlingSteg(
     private val iverksettService: IverksettService,
     private val taskService: TaskService,
     private val oppgaveService: OppgaveService,
+    private val brevmottakereService: BrevmottakereService,
 ) : BehandlingSteg<Void?> {
     override fun utførSteg(
         saksbehandling: Saksbehandling,
@@ -34,11 +38,19 @@ class FullførKjørelistebehandlingSteg(
             "Kan ikke fullføre behandling=${saksbehandling.id} fordi den ikke er en kjørelistebehandling."
         }
 
+        opprettTaskForSendingAvVedtaksbrev(behandlingId = saksbehandling.id)
         behandlingService.oppdaterResultatPåBehandling(saksbehandling.id, BehandlingResultat.INNVILGET)
         behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.IVERKSETTER_VEDTAK)
         taskService.save(FerdigstillBehandlingTask.opprettTask(saksbehandling))
+
         ferdigstillOppgave(saksbehandling)
         iverksettService.iverksettBehandlingFørsteGang(saksbehandling.id)
+    }
+
+    private fun opprettTaskForSendingAvVedtaksbrev(behandlingId: BehandlingId) {
+        // For å opprette brevmottakere for kjøreliste-brev da det ikke gjøres fra frontend
+        brevmottakereService.hentEllerOpprettBrevmottakere(behandlingId)
+        taskService.save(JournalførKjørelisteBehandlingBrevTask.opprettTask(behandlingId))
     }
 
     private fun ferdigstillOppgave(saksbehandling: Saksbehandling): Long? {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/CleanDatabaseIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/CleanDatabaseIntegrationTest.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.behandling.vent.SettPåVent
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerFrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
 import no.nav.tilleggsstonader.sak.brev.frittstående.FrittståendeBrev
+import no.nav.tilleggsstonader.sak.brev.kjørelistebrev.KjørelisteBehandlingBrev
 import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretBrev
 import no.nav.tilleggsstonader.sak.brev.mellomlager.MellomlagretFrittståendeBrev
 import no.nav.tilleggsstonader.sak.brev.vedtaksbrev.Vedtaksbrev
@@ -83,6 +84,7 @@ abstract class CleanDatabaseIntegrationTest : IntegrationTest() {
             AvklartKjørtDag::class,
             AvklartKjørtUke::class,
             Kjøreliste::class,
+            KjørelisteBehandlingBrev::class,
             Behandling::class,
             EksternFagsakId::class,
             FagsakDomain::class,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereServiceTest.kt
@@ -211,7 +211,7 @@ class BrevmottakereServiceTest {
         every { brevmottakereRepository.existsByBehandlingId(behandlingID) } returns true
         every { brevmottakereRepository.findByBehandlingId(behandlingID) } returns listOf(brevmottakerTestObjekt)
 
-        val brevmottakere: BrevmottakereDto = brevmottakereService.hentEllerOpprettBrevmottakere(behandlingID)
+        val brevmottakere: BrevmottakereDto = brevmottakereService.hentEllerOpprettBrevmottakere(behandlingID).tilBrevmottakereDto()
 
         assertThat(brevmottakere).isEqualTo(brevmottakereDtoFasit)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/JournalførVedtaksbrevTaskTest.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingTestUtil
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.brev.JournalførVedtaksbrevService
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.MottakerTestUtil.mottakerPerson
 import no.nav.tilleggsstonader.sak.brev.brevmottaker.domain.BrevmottakerVedtaksbrev
@@ -42,16 +43,22 @@ class JournalførVedtaksbrevTaskTest {
     val brevmottakerVedtaksbrevRepository = mockk<BrevmottakerVedtaksbrevRepository>()
     val stegService = mockk<StegService>(relaxed = true)
 
+    private val journalførVedtaksbrevService =
+        JournalførVedtaksbrevService(
+            arbeidsfordelingService,
+            journalpostService,
+            brevmottakerVedtaksbrevRepository,
+            TransactionHandler(),
+        )
+
     private val journalførVedtaksbrevTask =
         JournalførVedtaksbrevTask(
             taskService,
             behandlingService,
             brevService,
-            arbeidsfordelingService,
-            journalpostService,
             brevmottakerVedtaksbrevRepository,
             stegService,
-            TransactionHandler(),
+            journalførVedtaksbrevService,
         )
 
     val saksbehandling = saksbehandling()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførKjørelistebehandling.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførKjørelistebehandling.kt
@@ -28,6 +28,7 @@ fun IntegrationTest.gjennomførKjørelisteBehandling(
 
     if (tilSteg == StegType.SIMULERING) return
     gjennomførSimuleringSteg(behandling.id)
+    kall.privatBil.genererKjørelisteVedtaksbrev(behandling.id)
     kall.privatBil.fullførKjørelisteBehandling(behandling.id)
 
     if (tilSteg in setOf(StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV, StegType.FERDIGSTILLE_BEHANDLING)) return

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/PrivatBilKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/PrivatBilKall.kt
@@ -28,6 +28,9 @@ class PrivatBilKall(
     fun hentOppsummertBeregning(behandlingId: BehandlingId) =
         apiRespons.hentOppsummertBeregning(behandlingId).expectOkWithBody<PrivatBilOppsummertBeregningDto>()
 
+    fun genererKjørelisteVedtaksbrev(behandlingId: BehandlingId) =
+        apiRespons.genererKjørelisteVedtaksbrev(behandlingId).expectOkWithBody<ByteArray>()
+
     // Gir tilgang til "rå"-endepunktene slik at tester kan skrive egne assertions på responsen.
     val apiRespons = PrivatBilApi()
 
@@ -77,6 +80,15 @@ class PrivatBilKall(
                 restTestClient
                     .get()
                     .uri("/api/vedtak/daglig-reise/$behandlingId/privat-bil/oppsummer-beregning")
+                    .medOnBehalfOfToken()
+                    .exchange()
+            }
+
+        fun genererKjørelisteVedtaksbrev(behandlingId: BehandlingId) =
+            with(testklient.testkontekst) {
+                restTestClient
+                    .post()
+                    .uri("/api/kjorelistebrev/$behandlingId")
                     .medOnBehalfOfToken()
                     .exchange()
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilStatistikkIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilStatistikkIntegrationTest.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.kontrakter.saksstatistikk.BehandlingDVH
 import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.brev.brevmottaker.BrevmottakerVedtaksbrevRepository
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.JournalpostClientMockConfig
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KafkaFake
@@ -17,10 +18,14 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehand
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
 
 // Bruker for å teste litt "side-effekter" som kommer ut av behandlingsløp. Behandlingsstatistikk, vedtaksstatistikk og internt vedtak
 class DagligReisePrivatBilStatistikkIntegrationTest : IntegrationTest() {
+    @Autowired
+    lateinit var brevmottakerVedtaksbrevRepository: BrevmottakerVedtaksbrevRepository
+
     @Test
     fun `blir produsert vedtaksstatistikk for rammevedtakbehandling og kjørelistebehandling`() {
         every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
@@ -68,8 +73,15 @@ class DagligReisePrivatBilStatistikkIntegrationTest : IntegrationTest() {
         verifiserVedtaksstatistikkFinnesForBehandling(kjørelisteBehandling.id)
         verifiserFinnesBehandlingstatistikkForBehandling(kjørelisteBehandling.id)
         verifiserHarBlittProdusertInterntVedtakForBehandling(kjørelisteBehandling.id)
+        verifiserHarBlittProdusertVedtaksbrevForKjørelistebehandling(kjørelisteBehandling.id)
 
         // TODO - også verifisere at statistikk og internt vedtak blir produsert av en automatisk kjørelistebehandling
+    }
+
+    private fun verifiserHarBlittProdusertVedtaksbrevForKjørelistebehandling(behandlingId: BehandlingId) {
+        val brevmottakereVedtaksbrev = brevmottakerVedtaksbrevRepository.findByBehandlingId(behandlingId)
+        assertThat(brevmottakereVedtaksbrev).hasSize(1)
+        assertThat(brevmottakereVedtaksbrev.single().bestillingId).isNotNull
     }
 
     private fun verifiserFinnesBehandlingstatistikkForBehandling(behandlingId: BehandlingId) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Bygger videre fra https://github.com/navikt/tilleggsstonader-sak/pull/1172, hvor det legges opp til å opprette en pdf for vedtaksbrev som går til bruker etter en kjørelistebehandling. Legger til her at vi oppretter en journalpost og distribuerer denne. I første omgang går denne kun til bruker (kom på nå vi kan hente dette fra rammevedtak-behandlingen, da vi også må støtte at dette går automatisk)