### PR TITLE
Henter ut oppfølgingskontor fra veilarboppfolging ifbm sending av utbetalinger for TSR

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -113,6 +113,8 @@ spec:
           namespace: helved
         - application: logging
           namespace: nais-system
+        - application: veilarboppfolging
+          namespace: poao
       external:
         - host: pdl-api.dev-fss-pub.nais.io
         - host: tilleggsstonader-arena.dev-fss-pub.nais.io

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -119,6 +119,8 @@ spec:
           namespace: team-rocket
         - application: logging
           namespace: nais-system
+        - application: veilarboppfolging
+          namespace: poao
       external:
         - host: pdl-api.prod-fss-pub.nais.io
         - host: tilleggsstonader-arena.prod-fss-pub.nais.io

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -7,7 +7,9 @@ import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningDto
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningType
 import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.libs.spring.cache.getValue
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.felles.domain.gjelderBarn
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.opplysninger.egenansatt.EgenAnsattService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.domain.AdressebeskyttelseForPerson
@@ -23,8 +25,10 @@ class ArbeidsfordelingService(
     @Qualifier("shortCache")
     private val cacheManager: CacheManager,
     private val arbeidsfordelingClient: ArbeidsfordelingClient,
+    private val oppfolgingsenhetClient: OppfolgingsenhetClient,
     private val personService: PersonService,
     private val egenAnsattService: EgenAnsattService,
+    private val unleashService: UnleashService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -84,6 +88,11 @@ class ArbeidsfordelingService(
         personIdent: String,
         stønadstype: Stønadstype,
     ): String {
+        if (unleashService.isEnabled(Toggle.BRUK_OPPFOLGINGSENHET_FOR_UTBETALING)) {
+            return oppfolgingsenhetClient.hentOppfølgingsenhet(personIdent)
+                ?: error("Finner ikke oppfølgingsenhet for person")
+        }
+
         val adressebeskyttelseForPerson = hentAdressebeskyttelse(personIdent, stønadstype)
         // TODO - OK med default til Oslo her og?
         val geografiskTilknytning =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
@@ -17,6 +17,16 @@ class OppfolgingsenhetClient(
     private val navConsumerId: String,
     @Qualifier("restClientAzure") private val restClient: RestClient,
 ) {
+    /**
+     * Henter ut oppfølgingsenhet fra https://github.com/navikt/veilarboppfolging
+     * veilarboppfolging gir oss hvilket kontor som har oppfølging for en bruker.
+     * Om en bruker går på et tiltaks vil de som oftest også ha et NAV-kontor.
+     *
+     * Vil som oftest returnere NAV-kontor til bruker sin geografiske tilknytning.
+     * Kontoret kan også overstyres (i Arena?), noe som kan være nødvendig om bruker har utenlandsk adresse
+     *
+     * Bruker oppfølgingsenhet til å knytte utbetalinger til et NAV-kontor for tiltaksenheten.
+     */
     fun hentOppfølgingsenhet(fnr: String): String? {
         val request =
             OppfolgingsenhetRequest(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
@@ -1,0 +1,91 @@
+package no.nav.tilleggsstonader.sak.arbeidsfordeling
+
+import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
+import org.apache.commons.lang3.StringUtils
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+
+@Component
+class OppfolgingsenhetClient(
+    @Value("\${clients.veilarboppfolging.uri}")
+    private val veilarboppfolgingUri: String,
+    @Value("\${NAIS_APP_NAME}")
+    private val navConsumerId: String,
+    @Qualifier("restClientAzure") private val restClient: RestClient,
+) {
+    fun hentOppfølgingsenhet(fnr: String): String? {
+        val request =
+            OppfolgingsenhetRequest(
+                variables = OppfolgingsenhetRequestVariables(fnr = fnr),
+                query = OppfolgingsenhetConfig.oppfolgingsenhetQuery,
+            )
+
+        val response =
+            restClient
+                .post()
+                .uri("$veilarboppfolgingUri/veilarboppfolging/api/graphql")
+                .body(request)
+                .headers { it["Nav-Consumer-Id"] = navConsumerId }
+                .retrieve()
+                .body<OppfolgingsenhetResponse>()
+
+        if (response == null) {
+            error("Fikk tom respons ved oppslag av oppfølgingsenhet")
+        }
+
+        if (!response.errors.isNullOrEmpty()) {
+            secureLogger.error("Feil ved henting av oppfolgingsenhet: ${response.errors.joinToString { it.message }}")
+            error("Feil ved henting av oppfolgingsenhet")
+        }
+
+        val data = response.data ?: error("Data er null fra oppfolgingsenhet")
+        return data.oppfolgingsEnhet?.enhet?.id
+    }
+}
+
+private object OppfolgingsenhetConfig {
+    val oppfolgingsenhetQuery = graphqlQuery()
+
+    private fun graphqlQuery() =
+        OppfolgingsenhetConfig::class.java
+            .getResource("/arbeidsfordeling/oppfolgingsenhet.graphql")!!
+            .readText()
+            .graphqlCompatible()
+
+    private fun String.graphqlCompatible(): String = StringUtils.normalizeSpace(this.replace("\n", ""))
+}
+
+data class OppfolgingsenhetRequest(
+    val variables: OppfolgingsenhetRequestVariables,
+    val query: String,
+)
+
+data class OppfolgingsenhetRequestVariables(
+    val fnr: String,
+)
+
+data class OppfolgingsenhetResponse(
+    val data: OppfolgingsenhetData?,
+    val errors: List<OppfolgingsenhetError>?,
+)
+
+data class OppfolgingsenhetError(
+    val message: String,
+)
+
+data class OppfolgingsenhetData(
+    val oppfolgingsEnhet: OppfolgingsenhetResultat?,
+)
+
+data class OppfolgingsenhetResultat(
+    val enhet: Oppfolgingsenhet?,
+)
+
+data class Oppfolgingsenhet(
+    val id: String?,
+    val navn: String,
+    val kilde: String,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
@@ -7,11 +7,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
+import java.net.URI
 
 @Component
 class OppfolgingsenhetClient(
     @Value("\${clients.veilarboppfolging.uri}")
-    private val veilarboppfolgingUri: String,
+    private val veilarboppfolgingUri: URI,
     @Value("\${NAIS_APP_NAME}")
     private val navConsumerId: String,
     @Qualifier("restClientAzure") private val restClient: RestClient,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/config/ApplicationConfig.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.infrastruktur.config
 import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import no.nav.tilleggsstonader.libs.http.config.RestTemplateConfiguration
+import no.nav.tilleggsstonader.libs.http.config.RestclientConfiguration
 import no.nav.tilleggsstonader.libs.log.filter.LogFilterConfiguration
 import no.nav.tilleggsstonader.libs.unleash.UnleashConfiguration
 import no.nav.tilleggsstonader.sak.infrastruktur.filter.NAVIdentFilter
@@ -20,6 +21,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @EnableOAuth2Client(cacheEnabled = true)
 @Import(
     RestTemplateConfiguration::class,
+    RestclientConfiguration::class,
     LogFilterConfiguration::class,
     UnleashConfiguration::class,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -21,5 +21,7 @@ enum class Toggle(
 
     KAN_BEHANDLE_PRIVAT_BIL("sak.daglig-reise-privat-bil"),
 
+    BRUK_OPPFOLGINGSENHET_FOR_UTBETALING("sak.bruk-oppfolgingsenhet-for-utbetaling"),
+
     SØKNAD_ROUTING_REISE_TIL_SAMLING("sak.soknad-routing.reise-til-samling"),
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -216,6 +216,24 @@ no.nav.security.jwt:
         client-id: ${AZURE_APP_CLIENT_ID}
         client-secret: ${AZURE_APP_CLIENT_SECRET}
         client-auth-method: client_secret_basic
+    veilarboppfolging:
+      resource-url: ${clients.veilarboppfolging.uri}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+      scope: ${clients.veilarboppfolging.scope}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
+    veilarboppfolging-client_credentials:
+      resource-url: ${clients.veilarboppfolging.uri}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: client_credentials
+      scope: ${clients.veilarboppfolging.scope}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
 
 google:
   api-key: ${GOOGLE_MAPS_API_KEY}
@@ -257,6 +275,9 @@ clients:
     scope: api://${CLIENT_ENV}-gcp.tilleggsstonader.tilleggsstonader-klage/.default
   norg2:
     uri: https://norg2.${CLIENT_ENV}-fss-pub.nais.io/norg2
+  veilarboppfolging:
+    uri: http://veilarboppfolging.poao
+    scope: api://${CLIENT_ENV}-gcp.poao.veilarboppfolging/.default
   ereg:
     uri: https://ereg-services.${CLIENT_ENV}-fss-pub.nais.io
     scope: api://${CLIENT_ENV}-fss.arbeidsforhold.ereg-services/.default

--- a/src/main/resources/arbeidsfordeling/oppfolgingsenhet.graphql
+++ b/src/main/resources/arbeidsfordeling/oppfolgingsenhet.graphql
@@ -1,0 +1,10 @@
+query($fnr: String!){
+  oppfolgingsEnhet(fnr: $fnr) {
+    enhet {
+      id
+      navn
+      kilde
+    }
+  }
+}
+

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -8,6 +8,8 @@ import no.nav.tilleggsstonader.kontrakter.felles.Enhet
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningDto
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningType
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.opplysninger.egenansatt.EgenAnsatt
 import no.nav.tilleggsstonader.sak.opplysninger.egenansatt.EgenAnsattService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
@@ -28,13 +30,17 @@ class ArbeidsfordelingServiceTest {
     val personService = mockk<PersonService>()
     val egenAnsattService = mockk<EgenAnsattService>()
     val arbeidsfordelingClient = mockk<ArbeidsfordelingClient>()
+    val oppfolgingsenhetClient = mockk<OppfolgingsenhetClient>()
+    val unleashService = mockk<UnleashService>()
 
     val service =
         ArbeidsfordelingService(
             cacheManager = cacheManager,
             arbeidsfordelingClient = arbeidsfordelingClient,
+            oppfolgingsenhetClient = oppfolgingsenhetClient,
             personService = personService,
             egenAnsattService = egenAnsattService,
+            unleashService = unleashService,
         )
 
     val søkerIdent = "søker"
@@ -64,6 +70,7 @@ class ArbeidsfordelingServiceTest {
         every { egenAnsattService.erEgenAnsatt(capture(slotEgenAnsatt)) } answers {
             firstArg<Set<String>>().associateWith { EgenAnsatt(it, false) }
         }
+        every { unleashService.isEnabled(Toggle.BRUK_OPPFOLGINGSENHET_FOR_UTBETALING) } returns false
     }
 
     @AfterEach
@@ -164,6 +171,31 @@ class ArbeidsfordelingServiceTest {
 
             assertThat(slotEgenAnsatt.captured)
                 .containsExactlyInAnyOrder(søkerIdent, annenForeldreIdent)
+        }
+    }
+
+    @Nested
+    inner class HentBrukersNavKontor {
+        @Test
+        fun `skal bruke oppfolgingsenhet nar toggle er pa`() {
+            every { unleashService.isEnabled(Toggle.BRUK_OPPFOLGINGSENHET_FOR_UTBETALING) } returns true
+            every { oppfolgingsenhetClient.hentOppfølgingsenhet(søkerIdent) } returns "9999"
+
+            val navKontor = service.hentBrukersNavKontor(søkerIdent, Stønadstype.LÆREMIDLER)
+
+            assertThat(navKontor).isEqualTo("9999")
+            verify(exactly = 0) { arbeidsfordelingClient.finnNavKontorForGeografiskOmråde(any(), any(), any()) }
+        }
+
+        @Test
+        fun `skal bruke eksisterende arbeidsfordeling nar toggle er av`() {
+            every { personService.hentAdressebeskyttelse(søkerIdent) } returns lagPersonUtenRelasjoner()
+            every { arbeidsfordelingClient.finnNavKontorForGeografiskOmråde(any(), any(), any()) } returns NavKontor("1010")
+
+            val navKontor = service.hentBrukersNavKontor(søkerIdent, Stønadstype.LÆREMIDLER)
+
+            assertThat(navKontor).isEqualTo("1010")
+            verify(exactly = 0) { oppfolgingsenhetClient.hentOppfølgingsenhet(any()) }
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClientTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClientTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.web.client.RestClient
+import java.net.URI
 
 class OppfolgingsenhetClientTest {
     companion object {
@@ -29,7 +30,7 @@ class OppfolgingsenhetClientTest {
         fun initClass() {
             wiremockServerItem = WireMockServer(wireMockConfig().dynamicPort())
             wiremockServerItem.start()
-            client = OppfolgingsenhetClient(wiremockServerItem.baseUrl(), "tilleggsstonader-sak", restClient)
+            client = OppfolgingsenhetClient(URI(wiremockServerItem.baseUrl()), "tilleggsstonader-sak", restClient)
         }
 
         @AfterAll

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClientTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClientTest.kt
@@ -1,0 +1,95 @@
+package no.nav.tilleggsstonader.sak.arbeidsfordeling
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import no.nav.tilleggsstonader.sak.util.FileUtil.readFile
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.web.client.RestClient
+
+class OppfolgingsenhetClientTest {
+    companion object {
+        private val restClient: RestClient = RestClient.builder().build()
+
+        lateinit var client: OppfolgingsenhetClient
+        lateinit var wiremockServerItem: WireMockServer
+
+        val forventetUrl = "/veilarboppfolging/api/graphql"
+
+        @BeforeAll
+        @JvmStatic
+        fun initClass() {
+            wiremockServerItem = WireMockServer(wireMockConfig().dynamicPort())
+            wiremockServerItem.start()
+            client = OppfolgingsenhetClient(wiremockServerItem.baseUrl(), "tilleggsstonader-sak", restClient)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            wiremockServerItem.stop()
+        }
+    }
+
+    @AfterEach
+    fun tearDownEachTest() {
+        wiremockServerItem.resetAll()
+    }
+
+    @Test
+    fun `henter nav-kontor fra oppfolgingsenhet`() {
+        wiremockServerItem.stubFor(
+            post(urlEqualTo(forventetUrl))
+                .withHeader("Nav-Consumer-Id", equalTo("tilleggsstonader-sak"))
+                .willReturn(okJson(readFile("arbeidsfordeling/oppfolgingsenhet_ok.json"))),
+        )
+
+        val navKontor = client.hentOppfølgingsenhet("12345678901")
+
+        assertThat(navKontor).isEqualTo("1234")
+    }
+
+    @Test
+    fun `returnerer null nar enhet er null`() {
+        wiremockServerItem.stubFor(
+            post(urlEqualTo(forventetUrl))
+                .willReturn(okJson(readFile("arbeidsfordeling/oppfolgingsenhet_null_enhet.json"))),
+        )
+
+        val navKontor = client.hentOppfølgingsenhet("12345678901")
+
+        assertThat(navKontor).isNull()
+    }
+
+    @Test
+    fun `kaster feil ved errors i respons`() {
+        wiremockServerItem.stubFor(
+            post(urlEqualTo(forventetUrl))
+                .willReturn(okJson(readFile("arbeidsfordeling/oppfolgingsenhet_errors.json"))),
+        )
+
+        assertThat(Assertions.catchThrowable { client.hentOppfølgingsenhet("12345678901") })
+            .hasMessageStartingWith("Feil ved henting av oppfolgingsenhet")
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `kaster feil nar data er null`() {
+        wiremockServerItem.stubFor(
+            post(urlEqualTo(forventetUrl))
+                .willReturn(okJson(readFile("arbeidsfordeling/oppfolgingsenhet_null_data.json"))),
+        )
+
+        assertThat(Assertions.catchThrowable { client.hentOppfølgingsenhet("12345678901") })
+            .hasMessageStartingWith("Data er null fra oppfolgingsenhet")
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/ArbeidsfordelingClientMockConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/ArbeidsfordelingClientMockConfig.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingClient
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.NavKontor
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.OppfolgingsenhetClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -18,11 +19,20 @@ class ArbeidsfordelingClientMockConfig {
     @Primary
     fun arbedisfordelingClient() = mockk<ArbeidsfordelingClient>().apply { resetTilDefault(this) }
 
+    @Bean
+    @Primary
+    fun oppfolgingsenhetClient() = mockk<OppfolgingsenhetClient>().apply { resetTilDefault(this) }
+
     companion object {
         fun resetTilDefault(client: ArbeidsfordelingClient) {
             clearMocks(client)
             every { client.finnArbeidsfordelingsenhet(any()) } returns listOf(Arbeidsfordelingsenhet("4462", "NAY Nasjonal"))
             every { client.finnNavKontorForGeografiskOmråde(any(), any(), any()) } returns NavKontor("1014") // Nav Midt-Agder
+        }
+
+        fun resetTilDefault(client: OppfolgingsenhetClient) {
+            clearMocks(client)
+            every { client.hentOppfølgingsenhet(any()) } returns "1014"
         }
     }
 }

--- a/src/test/resources/arbeidsfordeling/oppfolgingsenhet_errors.json
+++ b/src/test/resources/arbeidsfordeling/oppfolgingsenhet_errors.json
@@ -1,0 +1,9 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Noe gikk galt"
+    }
+  ]
+}
+

--- a/src/test/resources/arbeidsfordeling/oppfolgingsenhet_null_data.json
+++ b/src/test/resources/arbeidsfordeling/oppfolgingsenhet_null_data.json
@@ -1,0 +1,5 @@
+{
+  "data": null,
+  "errors": []
+}
+

--- a/src/test/resources/arbeidsfordeling/oppfolgingsenhet_null_enhet.json
+++ b/src/test/resources/arbeidsfordeling/oppfolgingsenhet_null_enhet.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "oppfolgingsEnhet": {
+      "enhet": null
+    }
+  }
+}
+

--- a/src/test/resources/arbeidsfordeling/oppfolgingsenhet_ok.json
+++ b/src/test/resources/arbeidsfordeling/oppfolgingsenhet_ok.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "oppfolgingsEnhet": {
+      "enhet": {
+        "id": "1234",
+        "navn": "NAV Test",
+        "kilde": "NORG"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når vi sender utbetalinger for en TSR-sak, så legger vi med bruker sitt NAV-kontor, slik at utbetalinger kommer inn i tiltaksregnskapet. Vi henter i dag ut NAV-kontoret ved å slå opp bruker sin geografiske tilknytning i PDL, og henter deretter ut tilknyttet NAV-kontor fra Norg.

Dette er riktig i de aller fleste tilfeller, men det finnes tilfeller hvor bruker sitt NAV-kontor har blitt overstyrt (i Arena?).
Vi har også et case i prod hvor bruker har utenlandsk adresse (i på vente av at en adresseendring skal gå gjennom), og har da ikke geografisk tilknytning. Her er nok også bruker sitt NAV-kontor overstyrt, siden bruker også har tiltakspenger.

Tiltakspenger sin saksbehandlingsløsnig henter ut NAV-kontor fra https://github.com/navikt/veilarboppfolging. Den sjekker om bruker har fått overstyrt NAV-kontor, eller så faller den til slutt tilbake på kontor gjennom geografisk tilknytning. Er nok også en fordel at vi bruker den samme kilden som tiltakspenger sin løsning her.

Integrerer da her mot veilarboppfolging sitt graphql-grensensitt for å hente ut NAV-kontor. Legger det og bak en feature-toggle for å få testet ut integrasjonen før gammel kode fjernes.