### PR TITLE
Endepunkt for å kjøre vedtaksstatistikk på nytt for spesifikk behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/FerdigstillBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/FerdigstillBehandlingSteg.kt
@@ -46,7 +46,6 @@ class FerdigstillBehandlingSteg(
         taskService.save(
             VedtaksstatistikkTask.opprettVedtaksstatistikkTask(
                 behandlingId = saksbehandling.id,
-                fagsakId = saksbehandling.fagsakId,
                 stønadstype = saksbehandling.stønadstype,
             ),
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkForvaltningController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkForvaltningController.kt
@@ -1,0 +1,29 @@
+package no.nav.tilleggsstonader.sak.statistikk.vedtak
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.libs.log.logger
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Forvaltning")
+@RestController
+@RequestMapping("/api/forvaltning/vedtaksstatistikk")
+@ProtectedWithClaims(issuer = "azuread")
+class VedtaksstatistikkForvaltningController(
+    private val tilgangService: TilgangService,
+    private val vedtaksstatistikkService: VedtaksstatistikkService,
+) {
+    @PostMapping("/oppdater/{behandlingId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun oppdaterVedtaksstatistikk(behandlingId: BehandlingId) {
+        tilgangService.validerHarUtviklerrolle()
+        logger.info("Oppdaterer vedtaksstatistikk for behandling $behandlingId")
+        vedtaksstatistikkService.oppdaterVedtaksstatistikkV2(behandlingId)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkForvaltningController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkForvaltningController.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.libs.log.logger
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -21,7 +22,9 @@ class VedtaksstatistikkForvaltningController(
 ) {
     @PostMapping("/oppdater/{behandlingId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun oppdaterVedtaksstatistikk(behandlingId: BehandlingId) {
+    fun oppdaterVedtaksstatistikk(
+        @PathVariable behandlingId: BehandlingId,
+    ) {
         tilgangService.validerHarUtviklerrolle()
         logger.info("Oppdaterer vedtaksstatistikk for behandling $behandlingId")
         vedtaksstatistikkService.oppdaterVedtaksstatistikkV2(behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkService.kt
@@ -4,7 +4,6 @@ import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.barn.BarnRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gradering
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.AdressebeskyttelseDvh
@@ -32,10 +31,17 @@ class VedtaksstatistikkService(
     private val vedtakService: VedtakService,
     private val barnRepository: BarnRepository,
 ) {
-    fun lagreVedtaksstatistikkV2(
-        behandlingId: BehandlingId,
-        fagsakId: FagsakId,
-    ) {
+    fun lagreVedtaksstatistikkV2(behandlingId: BehandlingId) {
+        val vedtaksstatistikkV2 = mapTilVedtaksstatistikkV2(behandlingId)
+        vedtaksstatistikkRepositoryV2.insert(vedtaksstatistikkV2)
+    }
+
+    fun oppdaterVedtaksstatistikkV2(behandlingId: BehandlingId) {
+        val vedtaksstatistikkV2 = mapTilVedtaksstatistikkV2(behandlingId)
+        vedtaksstatistikkRepositoryV2.update(vedtaksstatistikkV2)
+    }
+
+    private fun mapTilVedtaksstatistikkV2(behandlingId: BehandlingId): VedtaksstatistikkV2 {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val vedtak =
             vedtakService.hentVedtak(behandlingId)
@@ -47,25 +53,23 @@ class VedtaksstatistikkService(
         val andelTilkjentYtelse = iverksettService.hentAndelTilkjentYtelse(behandlingId)
         val barn = barnRepository.findByBehandlingId(behandlingId)
 
-        vedtaksstatistikkRepositoryV2.insert(
-            VedtaksstatistikkV2(
-                fagsakId = fagsakId,
-                stønadstype = StønadstypeDvh.fraDomene(behandling.stønadstype),
-                behandlingId = behandlingId,
-                eksternFagsakId = behandling.eksternFagsakId,
-                eksternBehandlingId = behandling.eksternId,
-                relatertBehandlingId = hentRelatertBehandlingId(behandling),
-                adressebeskyttelse = hentAdressebeskyttelse(søkerIdent),
-                tidspunktVedtak = vedtakstidspunkt,
-                søkerIdent = søkerIdent,
-                behandlingType = BehandlingTypeDvh.fraDomene(behandling.type),
-                behandlingÅrsak = BehandlingÅrsakDvh.fraDomene(behandling.årsak),
-                vedtakResultat = VedtakResultatDvh.fraDomene(behandling.resultat),
-                vedtaksperioder = VedtaksperioderDvh.fraDomene(vedtak, barn),
-                utbetalinger = UtbetalingerDvh.fraDomene(andelTilkjentYtelse, vedtak),
-                årsakerAvslag = ÅrsakAvslagDvh.fraDomene(vedtak.takeIfType<Avslag>()?.data?.årsaker),
-                årsakerOpphør = ÅrsakOpphørDvh.fraDomene(vedtak.takeIfType<Opphør>()?.data?.årsaker),
-            ),
+        return VedtaksstatistikkV2(
+            fagsakId = behandling.fagsakId,
+            stønadstype = StønadstypeDvh.fraDomene(behandling.stønadstype),
+            behandlingId = behandlingId,
+            eksternFagsakId = behandling.eksternFagsakId,
+            eksternBehandlingId = behandling.eksternId,
+            relatertBehandlingId = hentRelatertBehandlingId(behandling),
+            adressebeskyttelse = hentAdressebeskyttelse(søkerIdent),
+            tidspunktVedtak = vedtakstidspunkt,
+            søkerIdent = søkerIdent,
+            behandlingType = BehandlingTypeDvh.fraDomene(behandling.type),
+            behandlingÅrsak = BehandlingÅrsakDvh.fraDomene(behandling.årsak),
+            vedtakResultat = VedtakResultatDvh.fraDomene(behandling.resultat),
+            vedtaksperioder = VedtaksperioderDvh.fraDomene(vedtak, barn),
+            utbetalinger = UtbetalingerDvh.fraDomene(andelTilkjentYtelse, vedtak),
+            årsakerAvslag = ÅrsakAvslagDvh.fraDomene(vedtak.takeIfType<Avslag>()?.data?.årsaker),
+            årsakerOpphør = ÅrsakOpphørDvh.fraDomene(vedtak.takeIfType<Opphør>()?.data?.årsaker),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkTask.kt
@@ -6,7 +6,6 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import org.springframework.stereotype.Service
 import tools.jackson.module.kotlin.readValue
 import java.time.LocalDateTime
@@ -21,18 +20,14 @@ class VedtaksstatistikkTask(
     private val vedtaksstatistikkService: VedtaksstatistikkService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        val (behandlingId, fagsakId) = jsonMapper.readValue<VedtaksstatistikkTaskPayload>(task.payload)
+        val (behandlingId) = jsonMapper.readValue<VedtaksstatistikkTaskPayload>(task.payload)
 
-        vedtaksstatistikkService.lagreVedtaksstatistikkV2(
-            behandlingId,
-            fagsakId,
-        )
+        vedtaksstatistikkService.lagreVedtaksstatistikkV2(behandlingId)
     }
 
     companion object {
         fun opprettVedtaksstatistikkTask(
             behandlingId: BehandlingId,
-            fagsakId: FagsakId,
             hendelseTidspunkt: LocalDateTime = LocalDateTime.now(),
             stønadstype: Stønadstype,
         ): Task =
@@ -42,13 +37,11 @@ class VedtaksstatistikkTask(
                     jsonMapper.writeValueAsString(
                         VedtaksstatistikkTaskPayload(
                             behandlingId = behandlingId,
-                            fagsakId = fagsakId,
                         ),
                     ),
                 properties =
                     Properties().apply {
                         this["behandlingId"] = behandlingId.toString()
-                        this["fagsakId"] = fagsakId.toString()
                         this["hendelseTidspunkt"] = hendelseTidspunkt.toString()
                         this["stønadstype"] = stønadstype.toString()
                     },
@@ -59,6 +52,5 @@ class VedtaksstatistikkTask(
 
     data class VedtaksstatistikkTaskPayload(
         val behandlingId: BehandlingId,
-        val fagsakId: FagsakId,
     )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2.kt
@@ -11,6 +11,7 @@ import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.VedtakResultatDvh
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.VedtaksperioderDvh
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.ÅrsakAvslagDvh
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.ÅrsakOpphørDvh
+import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.relational.core.mapping.Column
@@ -43,6 +44,7 @@ data class VedtaksstatistikkV2(
     val årsakerAvslag: ÅrsakAvslagDvh.JsonWrapper?,
     @Column("arsaker_opphor")
     val årsakerOpphør: ÅrsakOpphørDvh.JsonWrapper?,
+    @CreatedDate
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
     @LastModifiedDate
     val endretTid: LocalDateTime = opprettetTid,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2.kt
@@ -11,10 +11,9 @@ import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.VedtakResultatDvh
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.VedtaksperioderDvh
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.ÅrsakAvslagDvh
 import no.nav.tilleggsstonader.sak.statistikk.vedtak.domene.ÅrsakOpphørDvh
-import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.Id
-import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.InsertOnlyProperty
 import java.time.LocalDateTime
 
 /**
@@ -44,8 +43,7 @@ data class VedtaksstatistikkV2(
     val årsakerAvslag: ÅrsakAvslagDvh.JsonWrapper?,
     @Column("arsaker_opphor")
     val årsakerOpphør: ÅrsakOpphørDvh.JsonWrapper?,
-    @CreatedDate
+    @InsertOnlyProperty
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
-    @LastModifiedDate
     val endretTid: LocalDateTime = opprettetTid,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2MigreringController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/VedtaksstatistikkV2MigreringController.kt
@@ -70,7 +70,7 @@ class VedtaksstatistikkV2MigreringController(
         behandinger
             .sortertEtterVedtakstidspunkt()
             .forEach { behandling ->
-                vedtaksstatistikkService.lagreVedtaksstatistikkV2(behandling.id, behandling.fagsakId)
+                vedtaksstatistikkService.lagreVedtaksstatistikkV2(behandling.id)
             }
 
         logger.info("vedtaksstatistikk-migrasjon ferdig 🚀")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/UtbetalingerDvh.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/UtbetalingerDvh.kt
@@ -20,10 +20,16 @@ data class UtbetalingerDvh(
 
     companion object {
         fun fraDomene(
-            ytelser: List<AndelTilkjentYtelse>,
+            andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
             vedtak: Vedtak,
         ): JsonWrapper {
-            val gyldigeAndeler = ytelser.filterNot { it.type == TypeAndel.UGYLDIG }
+            val gyldigeAndeler =
+                andelerTilkjentYtelse
+                    .filterNot { it.type == TypeAndel.UGYLDIG }
+                    // Finnes andeler med 0 i beløp som ikke har type UGYLDIG. Disse sender vi uansett ikke til økonomi så filtreres vekk her
+                    .filterNot { it.beløp == 0 }
+                    .sortedBy { it.fom }
+
             return JsonWrapper(
                 utbetalinger =
                     gyldigeAndeler.map {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/UtbetalingerDvhTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/UtbetalingerDvhTest.kt
@@ -163,4 +163,20 @@ class UtbetalingerDvhTest {
 
         assertThat(resultat).isEqualTo(forventetResultat)
     }
+
+    // Se kommentar i UtbetalingerDvh.fraDomene
+    @Test
+    fun `gyldige andeler med beløp 0 blir fjernet`() {
+        val innvilgelse = LæremidlerTestUtil.innvilgelse()
+        val andlelerTilkjentYtelse = listOf(andelTilkjentYtelse(fom = 1 januar 2024, beløp = 0))
+
+        val resultat = UtbetalingerDvh.fraDomene(andlelerTilkjentYtelse, innvilgelse)
+
+        val forventetResultat =
+            UtbetalingerDvh.JsonWrapper(
+                utbetalinger = emptyList(),
+            )
+
+        assertThat(resultat).isEqualTo(forventetResultat)
+    }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ref https://nav-it.slack.com/archives/C069SPX84FL/p1768479991246479:
- Finnes flere behandlinger med duplikate utbetalingsdatoer hvor en av dem har beløp 0. Andeler med beløp 0 sender vi uansett ikke til økonomi, så er OK å fjerne disse fra vedtaksstatistikk-grensesnittet da bruksområde også er å finne det som finnes i UR (utbetalingsregister)
- Finnes også noen innslag av vedtaksstatiskk hvor alle utbetalinger er duplisert (ifølge Sara var dette pga en feil ved migrering, se tråd over)

Oppretter endepunkt som kan kalles ved å sende inn en behandlingid. Oppdaterer da eksisterende innslag i tabellen.

