### PR TITLE
♻️ Slå sammen duplikater av KjørtDag til én klasse i KjørelisteUtil og ta i bruk denne i DSL

### DIFF
--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/SendInnKjørelisteTestController.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/SendInnKjørelisteTestController.kt
@@ -23,8 +23,8 @@ import no.nav.tilleggsstonader.sak.hendelser.journalføring.JournalhendelseKafka
 import no.nav.tilleggsstonader.sak.hendelser.journalføring.JournalpostHendelseType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.opprettJournalpost
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostClient
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.dokumentInfo
 import no.nav.tilleggsstonader.sak.util.dokumentvariant
 import no.nav.tilleggsstonader.sak.util.journalpost
@@ -61,7 +61,7 @@ class SendInnKjørelisteTestController(
             kjørelisteSkjema(
                 reiseId = sendInnKjøreliste.reiseId.toString(),
                 periode = Datoperiode(sendInnKjøreliste.fom, sendInnKjøreliste.tom),
-                dagerKjørt = sendInnKjøreliste.kjørteDager.map { KjørtDag(it.dato, it.parkeringsutgift) },
+                dagerKjørt = sendInnKjøreliste.kjørteDager.map { KjørtDag(dato = it.dato, parkeringsutgift = it.parkeringsutgift) },
             )
 
         val fagsak = fagsakService.hentFagsakPåEksternId(sendInnKjøreliste.fagsakEksternId)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/KjørelistePåVentIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/KjørelistePåVentIntegrationTest.kt
@@ -14,8 +14,8 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBeha
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -54,7 +54,7 @@ class KjørelistePåVentIntegrationTest : IntegrationTest() {
                     periode = Datoperiode(fomUke1, tomUke1)
                     kjørteDager =
                         listOf(
-                            5 januar 2026 to 50,
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }
@@ -87,7 +87,7 @@ class KjørelistePåVentIntegrationTest : IntegrationTest() {
                 periode = Datoperiode(fomUke2, tomUke2),
                 dagerKjørt =
                     listOf(
-                        KjørtDag(12 januar 2026, 50),
+                        KjørtDag(dato = 12 januar 2026, parkeringsutgift = 50),
                     ),
             ),
             ident = brukerident,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebehandling/GenererKjørelistebehandlingBrevTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebehandling/GenererKjørelistebehandlingBrevTest.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehand
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.interntVedtak.HtmlifyClient
 import no.nav.tilleggsstonader.sak.util.FileUtil
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.DagligReiseVedtakService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.finnSatserBruktIBeregning
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.oppsummerBeregningPrivatBil
@@ -111,13 +112,13 @@ class GenererKjørelistebehandlingBrevTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(fom, tom)
                     kjørteDager =
                         listOf(
-                            29 desember 2025 to 50,
-                            30 desember 2025 to 50,
-                            2 januar 2026 to 50,
-                            5 januar 2026 to 80,
-                            6 januar 2026 to 80,
-                            12 januar 2026 to 20,
-                            13 januar 2026 to 20,
+                            KjørtDag(dato = 29 desember 2025, parkeringsutgift = 50),
+                            KjørtDag(dato = 30 desember 2025, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 80),
+                            KjørtDag(dato = 6 januar 2026, parkeringsutgift = 80),
+                            KjørtDag(dato = 12 januar 2026, parkeringsutgift = 20),
+                            KjørtDag(dato = 13 januar 2026, parkeringsutgift = 20),
                         )
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaKjørelisteIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaKjørelisteIntegrationTest.kt
@@ -20,8 +20,8 @@ import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteRepository
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -58,10 +58,10 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
 
         val dagerKjørt =
             listOf(
-                KjørtDag(1 januar 2026, 50),
-                KjørtDag(4 januar 2026, 70),
-                KjørtDag(9 januar 2026, 40),
-                KjørtDag(11 januar 2026, 90),
+                KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
+                KjørtDag(dato = 4 januar 2026, parkeringsutgift = 70),
+                KjørtDag(dato = 9 januar 2026, parkeringsutgift = 40),
+                KjørtDag(dato = 11 januar 2026, parkeringsutgift = 90),
             )
         val kjøreliste =
             kjørelisteSkjema(
@@ -101,7 +101,7 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
 
                 sendInnKjøreliste {
                     periode = Datoperiode(fom, 8 mars 2026)
-                    kjørteDager = listOf(fom to 50)
+                    kjørteDager = listOf(KjørtDag(dato = fom, parkeringsutgift = 50))
                 }
             }
 
@@ -121,7 +121,7 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
                     periode = Datoperiode(9 mars 2026, tom),
                     dagerKjørt =
                         listOf(
-                            KjørtDag(9 mars 2026, 50),
+                            KjørtDag(dato = 9 mars 2026, parkeringsutgift = 50),
                         ),
                 ),
             ident = behandlingContext.ident,
@@ -157,7 +157,7 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
 
                 sendInnKjøreliste {
                     periode = Datoperiode(fom, 8 mars 2026)
-                    kjørteDager = listOf(fom to 50)
+                    kjørteDager = listOf(KjørtDag(dato = fom, parkeringsutgift = 50))
                 }
             }
 
@@ -179,7 +179,7 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
                     periode = Datoperiode(9 mars 2026, tom),
                     dagerKjørt =
                         listOf(
-                            KjørtDag(9 mars 2026, 50),
+                            KjørtDag(dato = 9 mars 2026, parkeringsutgift = 50),
                         ),
                 ),
             ident = behandlingContext.ident,
@@ -206,7 +206,7 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
 
                 sendInnKjøreliste {
                     periode = Datoperiode(fom, 8 mars 2026)
-                    kjørteDager = listOf(fom to 50)
+                    kjørteDager = listOf(KjørtDag(dato = fom, parkeringsutgift = 50))
                 }
             }
 
@@ -262,7 +262,7 @@ class MottaKjørelisteIntegrationTest : IntegrationTest() {
                     periode = Datoperiode(9 mars 2026, tom),
                     dagerKjørt =
                         listOf(
-                            KjørtDag(9 mars 2026, 50),
+                            KjørtDag(dato = 9 mars 2026, parkeringsutgift = 50),
                         ),
                 ),
             ident = behandlingContext.ident,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/stønad/RammevedtakPrivatBilDtoMapperTest.kt
@@ -28,7 +28,7 @@ class RammevedtakPrivatBilDtoMapperTest {
                 reiseId = reiseId,
                 datoMottatt = datoMottatt,
                 periode = Datoperiode(6 januar 2025, 12 januar 2025), // kun uke 2
-                kjørteDager = listOf(KjørtDag(6 januar 2025)),
+                kjørteDager = listOf(KjørtDag(dato = 6 januar 2025)),
             )
 
         val kjørelister = listOf(kjøreliste).groupBy { it.data.reiseId }
@@ -60,14 +60,14 @@ class RammevedtakPrivatBilDtoMapperTest {
                 reiseId = reiseId,
                 datoMottatt = datoMottattUke2,
                 periode = Datoperiode(6 januar 2025, 12 januar 2025),
-                kjørteDager = listOf(KjørtDag(6 januar 2025)),
+                kjørteDager = listOf(KjørtDag(dato = 6 januar 2025)),
             )
         val kjørelisteUke3 =
             kjøreliste(
                 reiseId = reiseId,
                 datoMottatt = datoMottattUke3,
                 periode = Datoperiode(13 januar 2025, 19 januar 2025),
-                kjørteDager = listOf(KjørtDag(13 januar 2025)),
+                kjørteDager = listOf(KjørtDag(dato = 13 januar 2025)),
             )
 
         val kjørelister = listOf(kjørelisteUke2, kjørelisteUke3).groupBy { it.data.reiseId }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/KjørelisteTestdataDsl.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/KjørelisteTestdataDsl.kt
@@ -4,14 +4,14 @@ import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.VilkårDagligReiseDto
-import java.time.LocalDate
 
 @BehandlingTestdataDslMarker
 class KjørelisteTestdataDsl {
     internal var periode: Datoperiode? = null
-    internal var kjørteDager: List<Pair<LocalDate, Int?>> = mutableListOf() // dato med parkeringsutgifter
+    internal var kjørteDager: List<KjørtDag> = mutableListOf()
     internal var reiseIdProvider: ((List<VilkårDagligReiseDto>) -> ReiseId)? = { it.first().reiseId }
 
     fun reiseId(provider: (List<VilkårDagligReiseDto>) -> ReiseId) {
@@ -24,15 +24,11 @@ class KjørelisteTestdataDsl {
         }
 
         val reiseId = reiseIdProvider!!.invoke(reiserMedPrivatBil)
-        val dagerKjørt =
-            kjørteDager.map { (dato, parkeringsutgift) ->
-                KjørelisteSkjemaUtil.KjørtDag(dato, parkeringsutgift)
-            }
 
         return KjørelisteSkjemaUtil.kjørelisteSkjema(
             reiseId = reiseId.toString(),
             periode = periode!!,
-            dagerKjørt = dagerKjørt,
+            dagerKjørt = kjørteDager,
         )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteTest.kt
@@ -11,6 +11,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.DagligReiseVedtakService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.DagligReiseVilkårService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
@@ -48,8 +49,8 @@ class BehandleMottattKjørelisteTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(fom, 2 januar 2026)
                     kjørteDager =
                         listOf(
-                            1 januar 2026 to 50,
-                            2 januar 2026 to 50,
+                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/EndreAvklarteUkerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/EndreAvklarteUkerTest.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagReques
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -37,13 +38,13 @@ class EndreAvklarteUkerTest : CleanDatabaseIntegrationTest() {
             opprettBehandlingOgSendInnKjøreliste(
                 dagerKjørt =
                     listOf(
-                        5 januar 2026 to 50,
-                        6 januar 2026 to 50,
-                        7 januar 2026 to 50,
-                        8 januar 2026 to 50,
-                        9 januar 2026 to 50,
-                        10 januar 2026 to 50,
-                        11 januar 2026 to 50,
+                        KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 7 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 8 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 9 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 10 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 11 januar 2026, parkeringsutgift = 50),
                     ),
             )
 
@@ -119,9 +120,9 @@ class EndreAvklarteUkerTest : CleanDatabaseIntegrationTest() {
             opprettBehandlingOgSendInnKjøreliste(
                 dagerKjørt =
                     listOf(
-                        5 januar 2026 to 50,
-                        6 januar 2026 to 50,
-                        7 januar 2026 to 50,
+                        KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 7 januar 2026, parkeringsutgift = 50),
                     ),
             )
 
@@ -171,9 +172,9 @@ class EndreAvklarteUkerTest : CleanDatabaseIntegrationTest() {
             opprettBehandlingOgSendInnKjøreliste(
                 dagerKjørt =
                     listOf(
-                        5 januar 2026 to 50,
-                        6 januar 2026 to 50,
-                        7 januar 2026 to 50,
+                        KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
+                        KjørtDag(dato = 7 januar 2026, parkeringsutgift = 50),
                     ),
             )
 
@@ -207,7 +208,7 @@ class EndreAvklarteUkerTest : CleanDatabaseIntegrationTest() {
             .isEqualTo("Alle dager i uke må sendes inn")
     }
 
-    private fun opprettBehandlingOgSendInnKjøreliste(dagerKjørt: List<Pair<LocalDate, Int>>): Saksbehandling {
+    private fun opprettBehandlingOgSendInnKjøreliste(dagerKjørt: List<KjørtDag>): Saksbehandling {
         every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
 
         val rammebehandlingContext =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/GjenbrukUkerIKjørelistebehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/GjenbrukUkerIKjørelistebehandlingIntegrationTest.kt
@@ -14,8 +14,8 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomf�
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -52,8 +52,8 @@ class GjenbrukUkerIKjørelistebehandlingIntegrationTest : IntegrationTest() {
                     periode = Datoperiode(førsteUkeFom, førsteUkeTom)
                     kjørteDager =
                         listOf(
-                            5 januar 2026 to 50,
-                            6 januar 2026 to 50,
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }
@@ -86,9 +86,9 @@ class GjenbrukUkerIKjørelistebehandlingIntegrationTest : IntegrationTest() {
                     periode = Datoperiode(andreUkeFom, tredjeUkeTom),
                     dagerKjørt =
                         listOf(
-                            KjørtDag(12 januar 2026, 50),
-                            KjørtDag(13 januar 2026, 50),
-                            KjørtDag(20 januar 2026, 50),
+                            KjørtDag(dato = 12 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 13 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 20 januar 2026, parkeringsutgift = 50),
                         ),
                 ),
             ident = førstegangsBehandlingContext.ident,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
@@ -14,8 +14,8 @@ import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -87,9 +87,9 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
                         periode = Datoperiode(fomRamme1, tomRamme1),
                         dagerKjørt =
                             listOf(
-                                KjørtDag(5 januar 2026, 50),
-                                KjørtDag(12 januar 2026, 50),
-                                KjørtDag(19 januar 2026, 50),
+                                KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                                KjørtDag(dato = 12 januar 2026, parkeringsutgift = 50),
+                                KjørtDag(dato = 19 januar 2026, parkeringsutgift = 50),
                             ),
                     ),
             )
@@ -120,9 +120,9 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
                         periode = Datoperiode(fomRamme2, tomRamme2),
                         dagerKjørt =
                             listOf(
-                                KjørtDag(12 januar 2026, 50),
-                                KjørtDag(19 januar 2026, 50),
-                                KjørtDag(26 januar 2026, 50),
+                                KjørtDag(dato = 12 januar 2026, parkeringsutgift = 50),
+                                KjørtDag(dato = 19 januar 2026, parkeringsutgift = 50),
+                                KjørtDag(dato = 26 januar 2026, parkeringsutgift = 50),
                             ),
                     ),
             )
@@ -156,7 +156,7 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
                         periode = Datoperiode(fomRamme1, 11 januar 2026),
                         dagerKjørt =
                             listOf(
-                                KjørtDag(5 januar 2026, 50),
+                                KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
                             ),
                     ),
             )
@@ -171,8 +171,8 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
                         periode = Datoperiode(12 januar 2026, tomRamme1),
                         dagerKjørt =
                             listOf(
-                                KjørtDag(12 januar 2026, 50),
-                                KjørtDag(19 januar 2026, 50),
+                                KjørtDag(dato = 12 januar 2026, parkeringsutgift = 50),
+                                KjørtDag(dato = 19 januar 2026, parkeringsutgift = 50),
                             ),
                     ),
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikDag
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UtfyltDagAutomatiskVurdering
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -58,8 +59,8 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(1 januar 2026, 4 januar 2026)
                     kjørteDager =
                         listOf(
-                            1 januar 2026 to 50,
-                            2 januar 2026 to 50,
+                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }
@@ -127,10 +128,10 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(5 januar 2026, 11 januar 2026)
                     kjørteDager =
                         listOf(
-                            5 januar 2026 to 50,
-                            6 januar 2026 to 50,
-                            7 januar 2026 to 50,
-                            8 januar 2026 to 50,
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 7 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 8 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }
@@ -196,8 +197,8 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(1 januar 2026, 2 januar 2026)
                     kjørteDager =
                         listOf(
-                            1 januar 2026 to 50,
-                            2 januar 2026 to 150,
+                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 150),
                         )
                 }
             }
@@ -241,10 +242,10 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(1 januar 2026, 4 januar 2026)
                     kjørteDager =
                         listOf(
-                            1 januar 2026 to 50,
-                            2 januar 2026 to 50,
-                            3 januar 2026 to 50,
-                            4 januar 2026 to 50,
+                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 3 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 4 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }
@@ -314,10 +315,10 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(5 januar 2026, 11 januar 2026)
                     kjørteDager =
                         listOf(
-                            5 januar 2026 to 50,
-                            6 januar 2026 to 50,
-                            7 januar 2026 to 50,
-                            8 januar 2026 to 50,
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 7 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 8 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValideringTest.kt
@@ -38,7 +38,7 @@ class AvklartKjørelisteValideringTest {
                 KjørelisteUtil.kjøreliste(
                     reiseId = reiseId,
                     periode = Datoperiode(mandag, tirsdag),
-                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(mandag, null)),
+                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(dato = mandag, parkeringsutgift = null)),
                 )
 
             assertDoesNotThrow {
@@ -53,7 +53,7 @@ class AvklartKjørelisteValideringTest {
                 KjørelisteUtil.kjøreliste(
                     reiseId = reiseId,
                     periode = Datoperiode(mandag, tirsdag),
-                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(mandag, null)),
+                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(dato = mandag, parkeringsutgift = null)),
                 )
 
             assertThatThrownBy {
@@ -68,7 +68,7 @@ class AvklartKjørelisteValideringTest {
                 KjørelisteUtil.kjøreliste(
                     reiseId = reiseId,
                     periode = Datoperiode(mandag, lørdag),
-                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(mandag, null)),
+                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(dato = mandag, parkeringsutgift = null)),
                 )
 
             assertThatThrownBy {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/varsel/KjørelisteVarselInteragtionTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/varsel/KjørelisteVarselInteragtionTest.kt
@@ -18,6 +18,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørAlleTa
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteRepository
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.finnNesteSøndag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -79,7 +80,7 @@ class KjørelisteVarselInteragtionTest : CleanDatabaseIntegrationTest() {
                 periode = Datoperiode(fom1, tom1)
                 kjørteDager =
                     listOf(
-                        fom1 to 50,
+                        KjørtDag(dato = fom1, parkeringsutgift = 50),
                     )
                 reiseIdProvider = { it.first().reiseId }
             }
@@ -110,7 +111,7 @@ class KjørelisteVarselInteragtionTest : CleanDatabaseIntegrationTest() {
                 periode = Datoperiode(fom, tom)
                 kjørteDager =
                     listOf(
-                        fom to 50,
+                        KjørtDag(dato = fom, parkeringsutgift = 50),
                     )
             }
         }
@@ -141,7 +142,7 @@ class KjørelisteVarselInteragtionTest : CleanDatabaseIntegrationTest() {
                 periode = Datoperiode(fom, tomKjoreliste)
                 kjørteDager =
                     listOf(
-                        fom to 50,
+                        KjørtDag(dato = fom, parkeringsutgift = 50),
                     )
             }
         }
@@ -172,7 +173,7 @@ class KjørelisteVarselInteragtionTest : CleanDatabaseIntegrationTest() {
                 periode = Datoperiode(fom, tomKjoreliste)
                 kjørteDager =
                     listOf(
-                        fom to 50,
+                        KjørtDag(dato = fom, parkeringsutgift = 50),
                     )
             }
         }
@@ -203,7 +204,7 @@ class KjørelisteVarselInteragtionTest : CleanDatabaseIntegrationTest() {
                     periode = Datoperiode(fom, fom.finnNesteSøndag())
                     kjørteDager =
                         listOf(
-                            fom to 50,
+                            KjørtDag(dato = fom, parkeringsutgift = 50),
                         )
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -24,6 +24,7 @@ import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjen
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.privatBil.SatsDagligReisePrivatBilProvider
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
@@ -31,7 +32,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
-import java.time.LocalDate
 
 class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
     @Autowired
@@ -52,9 +52,9 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
         val reiseavstandEnVei = BigDecimal(7.9)
         val kjørteDager =
             listOf(
-                2 februar 2026 to 50,
-                4 februar 2026 to 50,
-                5 februar 2026 to 50,
+                KjørtDag(dato = 2 februar 2026, parkeringsutgift = 50),
+                KjørtDag(dato = 4 februar 2026, parkeringsutgift = 50),
+                KjørtDag(dato = 5 februar 2026, parkeringsutgift = 50),
             )
         val delperioder =
             listOf(
@@ -194,7 +194,7 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
                 KjørelisteSkjemaUtil.kjørelisteSkjema(
                     rammevedtak1.reiseId,
                     periode = Datoperiode(fom, tom),
-                    dagerKjørt = listOf(KjørelisteSkjemaUtil.KjørtDag(fom)),
+                    dagerKjørt = listOf(KjørtDag(dato = fom)),
                 ),
             ident = førstegangsBehandlingContext.ident,
         )
@@ -213,7 +213,7 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
                 KjørelisteSkjemaUtil.kjørelisteSkjema(
                     rammevedtak2.reiseId,
                     periode = Datoperiode(fom, tom),
-                    dagerKjørt = listOf(KjørelisteSkjemaUtil.KjørtDag(fom)),
+                    dagerKjørt = listOf(KjørtDag(dato = fom)),
                 ),
             ident = førstegangsBehandlingContext.ident,
         )
@@ -257,14 +257,14 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
         assertThat(andel.reiseId).isNotNull
     }
 
-    private fun List<Pair<LocalDate, Int>>.kalkulerForventetBeløp(reiseavstandEnVei: BigDecimal): Int =
-        sumOf { (dato, parkeringskostnader) ->
+    private fun List<KjørtDag>.kalkulerForventetBeløp(reiseavstandEnVei: BigDecimal): Int =
+        sumOf { kjørtDag ->
             satsDagligReisePrivatBilProvider
-                .finnSatsForÅr(dato.year)
+                .finnSatsForÅr(kjørtDag.dato.year)
                 .beløp
                 .multiply(reiseavstandEnVei)
                 .multiply(2.toBigDecimal())
-                .plus(parkeringskostnader.toBigDecimal())
+                .plus(kjørtDag.parkeringsutgift!!.toBigDecimal())
         }.avrundetStønadsbeløp()
             .toInt()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/KjørelisteSkjemaUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/KjørelisteSkjemaUtil.kt
@@ -7,7 +7,7 @@ import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.Reisedag
 import no.nav.tilleggsstonader.kontrakter.søknad.UkeMedReisedager
 import no.nav.tilleggsstonader.kontrakter.søknad.VerdiFelt
-import java.time.LocalDate
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 
 object KjørelisteSkjemaUtil {
     fun kjørelisteSkjema(
@@ -42,9 +42,4 @@ object KjørelisteSkjemaUtil {
             dokumentasjon = listOf(),
         )
     }
-
-    data class KjørtDag(
-        val dato: LocalDate,
-        val parkeringsutgift: Int? = null,
-    )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilStatistikkIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilStatistikkIntegrationTest.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.finnPåTopic
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.verdiEllerFeil
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -55,7 +56,7 @@ class DagligReisePrivatBilStatistikkIntegrationTest : IntegrationTest() {
 
                 sendInnKjøreliste {
                     periode = Datoperiode(fom, tom)
-                    kjørteDager = listOf(fom to 50)
+                    kjørteDager = listOf(KjørtDag(dato = fom, parkeringsutgift = 50))
                 }
             }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWith
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.opprettOgTilordneOppgaveForBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.dummyReiseId
 import no.nav.tilleggsstonader.sak.util.fagsak
@@ -234,13 +235,13 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
 
         val innsendteKjørteDager =
             listOf(
-                29 desember 2025 to 50,
-                1 januar 2026 to 100,
-                5 januar 2026 to null,
-                6 januar 2026 to null,
-                12 januar 2026 to null,
-                13 januar 2026 to 60,
-                14 januar 2026 to null,
+                KjørtDag(dato = 29 desember 2025, parkeringsutgift = 50),
+                KjørtDag(dato = 1 januar 2026, parkeringsutgift = 100),
+                KjørtDag(dato = 5 januar 2026),
+                KjørtDag(dato = 6 januar 2026),
+                KjørtDag(dato = 12 januar 2026),
+                KjørtDag(dato = 13 januar 2026, parkeringsutgift = 60),
+                KjørtDag(dato = 14 januar 2026),
             )
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/InnvilgePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/InnvilgePrivatBilIntegrationTest.kt
@@ -17,8 +17,8 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomf�
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteRepository
 import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilDto
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeDagligReise
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.FaktaPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
@@ -66,9 +66,9 @@ class InnvilgePrivatBilIntegrationTest : IntegrationTest() {
 
         val dagerKjørt =
             listOf(
-                KjørelisteSkjemaUtil.KjørtDag(1 februar 2026),
-                KjørelisteSkjemaUtil.KjørtDag(9 februar 2026),
-                KjørelisteSkjemaUtil.KjørtDag(22 februar 2026),
+                KjørtDag(dato = 1 februar 2026),
+                KjørtDag(dato = 9 februar 2026),
+                KjørtDag(dato = 22 februar 2026),
             )
         val kjøreliste =
             kjørelisteSkjema(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteKlarTilInnsendingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteKlarTilInnsendingIntegrationTest.kt
@@ -12,8 +12,8 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.forventAntallMeld
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteRepository
-import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -52,9 +52,9 @@ class KjørelisteKlarTilInnsendingIntegrationTest : IntegrationTest() {
 
         val dagerKjørt =
             listOf(
-                KjørelisteSkjemaUtil.KjørtDag(dagensDato.minusWeeks(2)),
-                KjørelisteSkjemaUtil.KjørtDag(dagensDato.minusWeeks(1)),
-                KjørelisteSkjemaUtil.KjørtDag(dagensDato.minusDays(2)),
+                KjørtDag(dato = dagensDato.minusWeeks(2)),
+                KjørtDag(dato = dagensDato.minusWeeks(1)),
+                KjørtDag(dato = dagensDato.minusDays(2)),
             )
         val kjøreliste =
             kjørelisteSkjema(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -81,9 +81,9 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(2 februar 2026, 50),
-                        KjørelisteUtil.KjørtDag(3 februar 2026, 120),
-                        KjørelisteUtil.KjørtDag(4 februar 2026, 3),
+                        KjørelisteUtil.KjørtDag(dato = 2 februar 2026, parkeringsutgift = 50),
+                        KjørelisteUtil.KjørtDag(dato = 3 februar 2026, parkeringsutgift = 120),
+                        KjørelisteUtil.KjørtDag(dato = 4 februar 2026, parkeringsutgift = 3),
                     ),
             )
         val avklarteUker = avklarUkerFraKjøreliste(kjøreliste)
@@ -167,8 +167,8 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(2 februar 2026),
-                        KjørelisteUtil.KjørtDag(3 februar 2026),
+                        KjørelisteUtil.KjørtDag(dato = 2 februar 2026),
+                        KjørelisteUtil.KjørtDag(dato = 3 februar 2026),
                     ),
             )
         val avklarteUker = avklarUkerFraKjøreliste(kjøreliste)
@@ -250,8 +250,8 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(30 desember 2025),
-                        KjørelisteUtil.KjørtDag(2 januar 2026),
+                        KjørelisteUtil.KjørtDag(dato = 30 desember 2025),
+                        KjørelisteUtil.KjørtDag(dato = 2 januar 2026),
                     ),
             )
         val avklarteUker = avklarUkerFraKjøreliste(kjøreliste)
@@ -327,7 +327,7 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(fomRammevedtak),
+                        KjørelisteUtil.KjørtDag(dato = fomRammevedtak),
                     ),
             )
 
@@ -342,7 +342,7 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(tomRammevedtak),
+                        KjørelisteUtil.KjørtDag(dato = tomRammevedtak),
                     ),
             )
         val avklarteUker = avklarUkerFraKjøreliste(kjøreliste1) + avklarUkerFraKjøreliste(kjøreliste2)
@@ -454,7 +454,7 @@ class PrivatBilBeregningsresultatServiceTest {
                     // Mandag til søndag
                     kjørteDager =
                         listOf(
-                            KjørelisteUtil.KjørtDag(fomRammevedtak),
+                            KjørelisteUtil.KjørtDag(dato = fomRammevedtak),
                         ),
                 )
             }
@@ -532,7 +532,7 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(fomRammevedtak.plusDays(7)),
+                        KjørelisteUtil.KjørtDag(dato = fomRammevedtak.plusDays(7)),
                     ),
             )
         val avklarteUker = avklarUkerFraKjøreliste(kjøreliste)
@@ -588,7 +588,7 @@ class PrivatBilBeregningsresultatServiceTest {
                 // Mandag til søndag
                 kjørteDager =
                     listOf(
-                        KjørelisteUtil.KjørtDag(fomRammevedtak),
+                        KjørelisteUtil.KjørtDag(dato = fomRammevedtak),
                     ),
             )
         val avklarteUker = avklarUkerFraKjøreliste(kjøreliste)


### PR DESCRIPTION
## Endringer

Konsoliderer tre separate `KjørtDag`-klasser til én felles dataklasse i `KjørelisteUtil`.

- Fjerner lokal `KjørtDag` fra `KjørelisteTestdataDsl` og `KjørelisteSkjemaUtil`
- Alle testfiler bruker nå `KjørelisteUtil.KjørtDag` med navngitte parametere
- 20 filer oppdatert, ingen funksjonelle endringer

cc @runska @AStrand94