### PR TITLE
Dropper kolonne kilde_behandling_id på andel_tilkjent_ytelse.kilde_behandling_id da dette feltet ikke ser ut til å brukes, og ei heller ha vært i bruk siden 2024.

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettService.kt
@@ -68,9 +68,6 @@ class IverksettService(
         )
     }
 
-    fun hentAndelTilkjentYtelse(behandlingId: BehandlingId) =
-        andelTilkjentYtelseRepository.findAndelTilkjentYtelsesByKildeBehandlingId(behandlingId)
-
     private fun andelerForFørsteIverksettingAvBehandling(
         behandling: Saksbehandling,
         tilkjentYtelse: TilkjentYtelse,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseService.kt
@@ -74,7 +74,6 @@ class TilkjentYtelseService(
                 tom = måned.atDay(1),
                 satstype = Satstype.UGYLDIG,
                 type = TypeAndel.UGYLDIG,
-                kildeBehandlingId = tilkjentYtelse.behandlingId,
                 iverksetting = iverksetting,
                 statusIverksetting = StatusIverksetting.SENDT,
                 utbetalingsdato = måned.atDay(1),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.libs.log.logger
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.SporbarUtils
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
@@ -42,7 +41,6 @@ data class AndelTilkjentYtelse(
     override val tom: LocalDate,
     val satstype: Satstype,
     val type: TypeAndel,
-    val kildeBehandlingId: BehandlingId,
     @Version
     val version: Int = 0,
     val statusIverksetting: StatusIverksetting = StatusIverksetting.UBEHANDLET,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepository.kt
@@ -25,7 +25,5 @@ interface AndelTilkjentYtelseRepository :
 
     fun findByIverksettingIverksettingId(iverksettingId: UUID): List<AndelTilkjentYtelse>
 
-    fun findAndelTilkjentYtelsesByKildeBehandlingId(behandlingId: BehandlingId): List<AndelTilkjentYtelse>
-
     fun findAllByStatusIverksettingIn(status: List<StatusIverksetting>): List<AndelTilkjentYtelse>
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnAndelTilkjentYtelseMapper.kt
@@ -28,7 +28,6 @@ fun BeregningsresultatTilsynBarn.mapTilAndelTilkjentYtelse(saksbehandling: Saksb
                 tom = beløpsperiode.dato,
                 satstype = satstype,
                 type = beløpsperiode.målgruppe.tilTypeAndel(Stønadstype.BARNETILSYN),
-                kildeBehandlingId = saksbehandling.id,
                 utbetalingsdato = førsteHverdagIMåneden,
             )
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapper.kt
@@ -2,14 +2,13 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.tilFørsteDagIMåneden
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BeregningsresultatBoutgifter
 
-fun BeregningsresultatBoutgifter.mapTilAndelTilkjentYtelse(behandlingId: BehandlingId): List<AndelTilkjentYtelse> =
+fun BeregningsresultatBoutgifter.mapTilAndelTilkjentYtelse(): List<AndelTilkjentYtelse> =
     perioder
         .sorted()
         .map {
@@ -20,7 +19,6 @@ fun BeregningsresultatBoutgifter.mapTilAndelTilkjentYtelse(behandlingId: Behandl
                 tom = førsteUkedagIMåneden,
                 satstype = Satstype.DAG,
                 type = it.grunnlag.målgruppe.tilTypeAndel(Stønadstype.BOUTGIFTER),
-                kildeBehandlingId = behandlingId,
                 statusIverksetting = StatusIverksetting.fraSatsBekreftet(it.grunnlag.makssatsBekreftet),
                 utbetalingsdato = it.fom.datoEllerNesteMandagHvisLørdagEllerSøndag(),
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
@@ -229,7 +229,7 @@ class BoutgifterBeregnYtelseSteg(
     ) {
         tilkjentYtelseService.lagreTilkjentYtelse(
             behandlingId = behandlingId,
-            andeler = beregningsresultat.mapTilAndelTilkjentYtelse(behandlingId),
+            andeler = beregningsresultat.mapTilAndelTilkjentYtelse(),
         )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -122,7 +122,6 @@ private fun lagAndelForDagligReise(
         tom = fomUkedag,
         satstype = Satstype.DAG,
         type = typeAndel,
-        kildeBehandlingId = saksbehandling.id,
         utbetalingsdato = fomUkedag,
         brukersNavKontor = brukersNavKontor,
         reiseId = reiseId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapper.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.læremidler
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
@@ -12,7 +11,7 @@ import java.time.LocalDate
 import kotlin.collections.component1
 import kotlin.collections.component2
 
-fun BeregningsresultatLæremidler.mapTilAndelTilkjentYtelse(behandlingId: BehandlingId): List<AndelTilkjentYtelse> =
+fun BeregningsresultatLæremidler.mapTilAndelTilkjentYtelse(): List<AndelTilkjentYtelse> =
     perioder
         .groupBy { it.grunnlag.utbetalingsdato }
         .entries
@@ -25,13 +24,12 @@ fun BeregningsresultatLæremidler.mapTilAndelTilkjentYtelse(behandlingId: Behand
                 "Alle perioder for et utbetalingsdato må være bekreftet eller ikke bekreftet"
             }
 
-            mapTilYtelse(perioderMedSammeUtbetalingsdato, utbetalingsdato, behandlingId, satsBekreftet)
+            mapTilYtelse(perioderMedSammeUtbetalingsdato, utbetalingsdato, satsBekreftet)
         }
 
 private fun mapTilYtelse(
     perioder: List<BeregningsresultatForMåned>,
     utbetalingsdato: LocalDate,
-    behandlingId: BehandlingId,
     satsBekreftet: Boolean,
 ): List<AndelTilkjentYtelse> =
     perioder
@@ -43,7 +41,6 @@ private fun mapTilYtelse(
                 tom = utbetalingsdato,
                 satstype = Satstype.DAG,
                 type = typeAndel,
-                kildeBehandlingId = behandlingId,
                 statusIverksetting = StatusIverksetting.fraSatsBekreftet(satsBekreftet),
                 utbetalingsdato = utbetalingsdato,
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -202,7 +202,7 @@ class LæremidlerBeregnYtelseSteg(
         saksbehandling: Saksbehandling,
         beregningsresultat: BeregningsresultatLæremidler,
     ) {
-        val andeler = beregningsresultat.mapTilAndelTilkjentYtelse(saksbehandling.id)
+        val andeler = beregningsresultat.mapTilAndelTilkjentYtelse()
         tilkjentYtelseService.lagreTilkjentYtelse(saksbehandling.id, andeler)
     }
 }

--- a/src/main/resources/db/migration/V129__drop_andel_kilde_behandling_id.sql
+++ b/src/main/resources/db/migration/V129__drop_andel_kilde_behandling_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE andel_tilkjent_ytelse DROP COLUMN kilde_behandling_id;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
@@ -173,8 +173,8 @@ class NullstillBehandlingServiceTest : CleanDatabaseIntegrationTest() {
 
     @Test
     fun `skal slette tilkjent ytelse`() {
-        tilkjentYtelseRepository.insert(tilkjentYtelse(behandling.id, andelTilkjentYtelse(behandling.id)))
-        tilkjentYtelseRepository.insert(tilkjentYtelse(revurdering.id, andelTilkjentYtelse(revurdering.id)))
+        tilkjentYtelseRepository.insert(tilkjentYtelse(behandling.id, andelTilkjentYtelse()))
+        tilkjentYtelseRepository.insert(tilkjentYtelse(revurdering.id, andelTilkjentYtelse()))
 
         nullstillBehandlingService.nullstillBehandling(revurdering)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/FagsakRepositoryTest.kt
@@ -54,7 +54,6 @@ class FagsakRepositoryTest : CleanDatabaseIntegrationTest() {
             )
         val andel =
             andelTilkjentYtelse(
-                behandling.id,
                 fom = LocalDate.now().datoEllerNesteMandagHvisLørdagEllerSøndag(),
                 tom = LocalDate.now().datoEllerNesteMandagHvisLørdagEllerSøndag(),
             )
@@ -80,7 +79,6 @@ class FagsakRepositoryTest : CleanDatabaseIntegrationTest() {
             tilkjentYtelse(
                 behandling.id,
                 andelTilkjentYtelse(
-                    kildeBehandlingId = behandling.id,
                     fom = LocalDate.now().datoEllerNesteMandagHvisLørdagEllerSøndag(),
                 ),
             ),
@@ -89,7 +87,6 @@ class FagsakRepositoryTest : CleanDatabaseIntegrationTest() {
             tilkjentYtelse(
                 behandling.id,
                 andelTilkjentYtelse(
-                    kildeBehandlingId = behandling.id,
                     fom = LocalDate.now().datoEllerNesteMandagHvisLørdagEllerSøndag(),
                 ),
             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/BoutgifterUtbetalingerTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/BoutgifterUtbetalingerTestdata.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.statistikk.vedtak.domene
 
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
@@ -82,7 +81,6 @@ fun lagBoutgifterInnvilgelseMedBeløp(
             beløp = månedsbeløp,
             satstype = Satstype.DAG,
             type = TypeAndel.BOUTGIFTER_AAP,
-            kildeBehandlingId = BehandlingId.random(),
             utbetalingsdato = fom,
         )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/DagligReiseUtbetalingerTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/DagligReiseUtbetalingerTestdata.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.statistikk.vedtak.domene
 
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
@@ -112,7 +111,6 @@ fun lagDagligReiseInnvilgelseMedBeløp(
             satstype = Satstype.DAG,
             utbetalingsdato = fom,
             type = TypeAndel.DAGLIG_REISE_AAP,
-            kildeBehandlingId = BehandlingId.random(),
         )
 
     return vedtaksdata to andel

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/TilsynBarnUtbetalingerTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/statistikk/vedtak/domene/TilsynBarnUtbetalingerTestdata.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.statistikk.vedtak.domene
 
 import no.nav.tilleggsstonader.sak.felles.domain.BarnId
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
@@ -98,7 +97,6 @@ fun lagTilsynBarnInnvilgelseMedBeløp(
             satstype = Satstype.DAG,
             utbetalingsdato = fom,
             type = TypeAndel.TILSYN_BARN_AAP,
-            kildeBehandlingId = BehandlingId.random(),
         )
 
     return vedtaksdata to andel

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/AndelTilkjentYtelseTilPeriodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/AndelTilkjentYtelseTilPeriodeServiceTest.kt
@@ -39,7 +39,7 @@ class AndelTilkjentYtelseTilPeriodeServiceTest {
                 behandlingId = behandlingId,
                 andeler =
                     vedtak.data.beregningsresultat
-                        .mapTilAndelTilkjentYtelse(behandlingId)
+                        .mapTilAndelTilkjentYtelse()
                         .toTypedArray(),
             )
         every { vedtakservice.hentVedtak(behandlingId) } returns vedtak

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettServiceTest.kt
@@ -111,8 +111,8 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
                 forrigeIverksatteBehandlingId = behandling.id,
             )
 
-        val tilkjentYtelse = tilkjentYtelse(behandlingId = behandling.id, andeler = lagAndeler(behandling))
-        val tilkjentYtelse2 = tilkjentYtelse(behandlingId = behandling2.id, andeler = lagAndeler(behandling2))
+        val tilkjentYtelse = tilkjentYtelse(behandlingId = behandling.id, andeler = lagAndeler())
+        val tilkjentYtelse2 = tilkjentYtelse(behandlingId = behandling2.id, andeler = lagAndeler())
 
         @BeforeEach
         fun setUp() {
@@ -284,7 +284,7 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
             tilkjentYtelseRepository.insert(
                 tilkjentYtelse(
                     behandling2.id,
-                    lagAndel(behandling2, forrigeMåned, beløp = 0),
+                    lagAndel(forrigeMåned, beløp = 0),
                 ),
             )
             testoppsettService.lagreTotrinnskontroll(totrinnskontroll(behandling2.id))
@@ -319,7 +319,7 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
             tilkjentYtelseRepository.insert(
                 tilkjentYtelse(
                     behandling2.id,
-                    lagAndel(behandling2, forrigeMåned, beløp = 100),
+                    lagAndel(forrigeMåned, beløp = 100),
                 ),
             )
             testoppsettService.lagreTotrinnskontroll(totrinnskontroll(behandling2.id))
@@ -350,7 +350,6 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
                     andelerTilkjentYtelse =
                         tilkjentYtelse.andelerTilkjentYtelse.plus(
                             lagAndel(
-                                behandling,
                                 treMndFrem,
                                 statusIverksetting = StatusIverksetting.VENTER_PÅ_SATS_ENDRING,
                             ),
@@ -362,7 +361,7 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
             tilkjentYtelseRepository.insert(
                 tilkjentYtelse(
                     behandling2.id,
-                    lagAndel(behandling2, forrigeMåned, beløp = 100),
+                    lagAndel(forrigeMåned, beløp = 100),
                 ),
             )
             testoppsettService.lagreTotrinnskontroll(totrinnskontroll(behandling2.id))
@@ -371,9 +370,6 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
             val andeler = hentAndeler(behandling)
 
             andeler.forMåned(forrigeMåned).assertHarStatusOgId(StatusIverksetting.OK, behandling.id)
-            andeler.forMåned(nesteMåned).assertHarStatusOgId(StatusIverksetting.UAKTUELL)
-            andeler.forMåned(nestNesteMåned).assertHarStatusOgId(StatusIverksetting.UAKTUELL)
-            andeler.forMåned(treMndFrem).assertHarStatusOgId(StatusIverksetting.UAKTUELL)
 
             if (!erHelgOgFørsteEllerAndreDagIMåned()) {
                 andeler.forMåned(nåværendeMåned).assertHarStatusOgId(StatusIverksetting.OK, behandling.id)
@@ -408,20 +404,17 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
         fun `Skal kun iverksette andeler innenfor en måned som gjelder for gitt utbetalingsdato`() {
             val andel1 =
                 andelTilkjentYtelse(
-                    kildeBehandlingId = behandling.id,
                     fom = nåværendeMåned.atDay(1).datoEllerNesteMandagHvisLørdagEllerSøndag(),
                     utbetalingsdato = nåværendeMåned.atDay(1),
                     type = TypeAndel.LÆREMIDLER_AAP,
                 )
             val andel2 =
                 andelTilkjentYtelse(
-                    kildeBehandlingId = behandling.id,
                     fom = nesteMåned.atDay(1).datoEllerNesteMandagHvisLørdagEllerSøndag(),
                     type = TypeAndel.LÆREMIDLER_AAP,
                 )
             val andel3 =
                 andelTilkjentYtelse(
-                    kildeBehandlingId = behandling.id,
                     fom = nesteMåned.atDay(15).datoEllerNesteMandagHvisLørdagEllerSøndag(),
                     type = TypeAndel.LÆREMIDLER_AAP,
                 )
@@ -466,17 +459,14 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
                 tilkjentYtelse(
                     behandlingId = behandling.id,
                     lagAndel(
-                        behandling = behandling,
                         måned = forrigeMåned,
                         type = TypeAndel.LÆREMIDLER_AAP,
                     ),
                     lagAndel(
-                        behandling = behandling,
                         måned = nesteMåned,
                         type = TypeAndel.LÆREMIDLER_AAP,
                     ),
                     lagAndel(
-                        behandling = behandling,
                         måned = nestNesteMåned,
                         type = TypeAndel.LÆREMIDLER_AAP,
                         statusIverksetting = StatusIverksetting.VENTER_PÅ_SATS_ENDRING,
@@ -507,7 +497,6 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
                 tilkjentYtelse(
                     behandlingId = behandling.id,
                     lagAndel(
-                        behandling = behandling,
                         måned = forrigeMåned,
                         statusIverksetting = StatusIverksetting.VENTER_PÅ_SATS_ENDRING,
                         type = TypeAndel.LÆREMIDLER_AAP,
@@ -568,16 +557,15 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
         andelTilkjentYtelseRepository.updateAll(oppdaterteAndeler)
     }
 
-    private fun lagAndeler(behandling: Behandling) =
+    private fun lagAndeler() =
         arrayOf(
-            lagAndel(behandling, forrigeMåned),
-            lagAndel(behandling, nåværendeMåned),
-            lagAndel(behandling, nesteMåned),
-            lagAndel(behandling, nestNesteMåned),
+            lagAndel(forrigeMåned),
+            lagAndel(nåværendeMåned),
+            lagAndel(nesteMåned),
+            lagAndel(nestNesteMåned),
         )
 
     private fun lagAndel(
-        behandling: Behandling,
         måned: YearMonth,
         beløp: Int = 10,
         statusIverksetting: StatusIverksetting = StatusIverksetting.UBEHANDLET,
@@ -585,7 +573,6 @@ class IverksettServiceTest : CleanDatabaseIntegrationTest() {
     ): AndelTilkjentYtelse {
         val fom = måned.atDay(1).datoEllerNesteMandagHvisLørdagEllerSøndag()
         return andelTilkjentYtelse(
-            kildeBehandlingId = behandling.id,
             fom = fom,
             tom = fom,
             beløp = beløp,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.fagsak.domain.PersonIdent
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
@@ -31,7 +30,6 @@ class TilkjentYtelseServiceTest {
         internal fun `skal returnere true hvis det finnes andel med sluttdato etter idag`() {
             val andelTilkjentYtelse =
                 andelTilkjentYtelse(
-                    kildeBehandlingId = BehandlingId.random(),
                     beløp = 1,
                     fom = LocalDate.now().plusDays(1).datoEllerNesteMandagHvisLørdagEllerSøndag(),
                     tom = LocalDate.now().plusDays(1).datoEllerNesteMandagHvisLørdagEllerSøndag(),
@@ -47,7 +45,6 @@ class TilkjentYtelseServiceTest {
         internal fun `skal returnere false hvis det finnes andel med sluttdato før idag`() {
             val andelTilkjentYtelse =
                 andelTilkjentYtelse(
-                    kildeBehandlingId = BehandlingId.random(),
                     beløp = 1,
                     fom = LocalDate.now().minusDays(10).datoEllerNesteMandagHvisLørdagEllerSøndag(),
                     tom = LocalDate.now().minusDays(10).datoEllerNesteMandagHvisLørdagEllerSøndag(),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/TilkjentYtelseUtil.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 object TilkjentYtelseUtil {
     fun tilkjentYtelse(
         behandlingId: BehandlingId,
-        vararg andeler: AndelTilkjentYtelse = arrayOf(andelTilkjentYtelse(kildeBehandlingId = behandlingId)),
+        vararg andeler: AndelTilkjentYtelse = arrayOf(andelTilkjentYtelse()),
     ): TilkjentYtelse =
         TilkjentYtelse(
             behandlingId = behandlingId,
@@ -20,7 +20,6 @@ object TilkjentYtelseUtil {
         )
 
     fun andelTilkjentYtelse(
-        kildeBehandlingId: BehandlingId = BehandlingId.random(),
         beløp: Int = 11554,
         fom: LocalDate = LocalDate.of(2021, 1, 1),
         tom: LocalDate = fom,
@@ -35,14 +34,12 @@ object TilkjentYtelseUtil {
         tom = tom,
         satstype = satstype,
         type = type,
-        kildeBehandlingId = kildeBehandlingId,
         statusIverksetting = statusIverksetting,
         iverksetting = iverksetting,
         utbetalingsdato = utbetalingsdato,
     )
 
     fun nullAndel(
-        kildeBehandlingId: BehandlingId = BehandlingId.random(),
         fom: LocalDate = LocalDate.now(),
         tom: LocalDate = fom,
         statusIverksetting: StatusIverksetting = StatusIverksetting.SENDT,
@@ -54,7 +51,6 @@ object TilkjentYtelseUtil {
         tom = tom,
         satstype = Satstype.UGYLDIG,
         type = TypeAndel.UGYLDIG,
-        kildeBehandlingId = kildeBehandlingId,
         statusIverksetting = statusIverksetting,
         iverksetting = iverksetting,
         utbetalingsdato = utbetalingsdato,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelseRepositoryTest.kt
@@ -30,14 +30,12 @@ class AndelTilkjentYtelseRepositoryTest : CleanDatabaseIntegrationTest() {
         val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
         val andel1 =
             andelTilkjentYtelse(
-                kildeBehandlingId = behandling.id,
                 beløp = 100,
                 fom = LocalDate.of(2023, 1, 2),
                 tom = LocalDate.of(2023, 1, 2),
             )
         val andel2 =
             andelTilkjentYtelse(
-                kildeBehandlingId = behandling.id,
                 beløp = 200,
                 fom = LocalDate.of(2023, 1, 2),
                 tom = LocalDate.of(2023, 1, 2),
@@ -73,7 +71,6 @@ class AndelTilkjentYtelseRepositoryTest : CleanDatabaseIntegrationTest() {
         val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
         val andel1 =
             andelTilkjentYtelse(
-                kildeBehandlingId = behandling.id,
                 beløp = 100,
                 fom = LocalDate.of(2023, 1, 2),
                 tom = LocalDate.of(2023, 1, 2),
@@ -154,7 +151,6 @@ class AndelTilkjentYtelseRepositoryTest : CleanDatabaseIntegrationTest() {
         ) {
             val andel1 =
                 andelTilkjentYtelse(
-                    kildeBehandlingId = behandling.id,
                     beløp = 100,
                     fom = LocalDate.of(2023, 1, 2),
                     tom = LocalDate.of(2023, 1, 2),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/TilkjentYtelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/TilkjentYtelseRepositoryTest.kt
@@ -45,7 +45,7 @@ internal class TilkjentYtelseRepositoryTest : CleanDatabaseIntegrationTest() {
     @Test
     fun `Opprett og hent andeler tilkjent ytelse`() {
         val behandling = testoppsettService.opprettBehandlingMedFagsak(behandling())
-        val andeler = arrayOf(andelTilkjentYtelse(behandling.id), andelTilkjentYtelse(behandling.id))
+        val andeler = arrayOf(andelTilkjentYtelse(), andelTilkjentYtelse())
         val tilkjentYtelse = tilkjentYtelse(behandling.id, *andeler)
 
         val tilkjentYtelseId = repository.insert(tilkjentYtelse).id
@@ -81,7 +81,7 @@ internal class TilkjentYtelseRepositoryTest : CleanDatabaseIntegrationTest() {
                     val tilkjentYtelse = repository.findByBehandlingIdForUpdate(behandling.id)!!
                     latch.countDown() // sier ifra at job1 startet
                     Thread.sleep(500)
-                    val andel = andelTilkjentYtelse(kildeBehandlingId = behandling.id, beløp = beløpJob1)
+                    val andel = andelTilkjentYtelse(beløp = beløpJob1)
                     repository.update(tilkjentYtelse.copy(andelerTilkjentYtelse = setOf(andel)))
                 }
             }
@@ -90,7 +90,7 @@ internal class TilkjentYtelseRepositoryTest : CleanDatabaseIntegrationTest() {
                 latch.await() // venter på at job1 har startet
                 transactionHandler.runInNewTransaction {
                     val tilkjentYtelse = repository.findByBehandlingIdForUpdate(behandling.id)!!
-                    val andel = andelTilkjentYtelse(kildeBehandlingId = behandling.id, beløp = beløpJob2)
+                    val andel = andelTilkjentYtelse(beløp = beløpJob2)
                     repository.update(tilkjentYtelse.copy(andelerTilkjentYtelse = setOf(andel)))
                 }
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -159,43 +159,36 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
             val forventedeAndeler =
                 listOf(
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = vedtaksperiode1.fom,
                         beløp = finnTotalbeløp(dagsatsForUtgift100, 5),
                         utbetalingsdato = januar.atDay(2),
                     ),
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = vedtaksperiode2.fom,
                         beløp = finnTotalbeløp(dagsatsForUtgift100, 2),
                         utbetalingsdato = januar.atDay(2),
                     ),
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = vedtaksperiode3.fom,
                         beløp = finnTotalbeløp(dagsatsForUtgift100, 6),
                         utbetalingsdato = januar.atDay(2),
                     ),
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = februar.atDay(1),
                         beløp = finnTotalbeløp(dagsatsForUtgift100, 3),
                         utbetalingsdato = februar.atDay(1),
                     ),
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = vedtaksperiode4.fom,
                         beløp = finnTotalbeløp(dagsatsForUtgift100, 1),
                         utbetalingsdato = februar.atDay(1),
                     ),
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = mars.atDay(1),
                         beløp = finnTotalbeløp(dagsatsForUtgift200, 23),
                         utbetalingsdato = mars.atDay(1),
                     ),
                     andelTilkjentYtelse(
-                        kildeBehandlingId = behandling.id,
                         fom = april.atDay(3),
                         beløp = finnTotalbeløp(dagsatsForUtgift200, 1),
                         utbetalingsdato = april.atDay(3),
@@ -546,7 +539,6 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                         fom = it.fom,
                         tom = it.fom,
                         beløp = beløp1DagUtgift100,
-                        kildeBehandlingId = behandling.id,
                         type = TypeAndel.TILSYN_BARN_AAP,
                     )
                 }
@@ -593,7 +585,6 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     fom = vedtaksperiode.fom,
                     tom = vedtaksperiode.fom,
                     beløp = beløp1DagUtgift100,
-                    kildeBehandlingId = behandling.id,
                     type = TypeAndel.TILSYN_BARN_ENSLIG_FORSØRGER,
                 )
             assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())
@@ -637,7 +628,6 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     fom = vedtaksperiode.fom,
                     tom = vedtaksperiode.fom,
                     beløp = beløp1DagUtgift100,
-                    kildeBehandlingId = behandling.id,
                     type = TypeAndel.TILSYN_BARN_ETTERLATTE,
                 )
             assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterAndelTilkjentYtelseMapperTest.kt
@@ -1,16 +1,11 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 
-import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
-import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
-import no.nav.tilleggsstonader.sak.util.behandling
-import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.BoutgifterTestUtil.lagUtgiftBeregningBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregnUtil.beregnStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.Beregningsgrunnlag
@@ -183,7 +178,7 @@ class BoutgifterAndelTilkjentYtelseMapperTest {
                     perioder = beregningsgrunnlag.map { BeregningsresultatForLøpendeMåned(it, it.beregnStønadsbeløp()) },
                 )
 
-            val andeler = beregningsresultat.mapTilAndelTilkjentYtelse(BehandlingId.random())
+            val andeler = beregningsresultat.mapTilAndelTilkjentYtelse()
 
             andeler.forEachIndexed { index, andel ->
                 val periodeFraAndel = finnPeriodeFraAndel(beregningsresultat, andel)
@@ -195,9 +190,6 @@ class BoutgifterAndelTilkjentYtelseMapperTest {
 }
 
 private fun finnAndelTilkjentYtelse(vararg beregningsgrunnlag: Beregningsgrunnlag): List<AndelTilkjentYtelse> {
-    val fagsak = fagsak(stønadstype = Stønadstype.BOUTGIFTER)
-    val behandling = behandling(fagsak = fagsak, steg = StegType.BEREGNE_YTELSE)
-
     val beregningsresultat =
         BeregningsresultatBoutgifter(
             perioder =
@@ -205,7 +197,7 @@ private fun finnAndelTilkjentYtelse(vararg beregningsgrunnlag: Beregningsgrunnla
                     BeregningsresultatForLøpendeMåned(grunnlag = it, stønadsbeløp = it.beregnStønadsbeløp())
                 },
         )
-    return beregningsresultat.mapTilAndelTilkjentYtelse(behandling.id)
+    return beregningsresultat.mapTilAndelTilkjentYtelse()
 }
 
 private fun lagBeregningsgrunnlagMedEnkeltutgift(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerAndelTilkjentYtelseMapperTest.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.november
 import no.nav.tilleggsstonader.libs.utils.dato.oktober
 import no.nav.tilleggsstonader.libs.utils.dato.september
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil.beregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.domain.BeregningsresultatLæremidler
 import org.assertj.core.api.Assertions.assertThat
@@ -47,7 +46,7 @@ class LæremidlerAndelTilkjentYtelseMapperTest {
                     ),
             )
 
-        val andeler = beregningsresultat.mapTilAndelTilkjentYtelse(behandlingId = BehandlingId.random())
+        val andeler = beregningsresultat.mapTilAndelTilkjentYtelse()
 
         assertThat(andeler).hasSize(2)
         with(andeler[0]) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegStepDefinitions.kt
@@ -210,7 +210,6 @@ class LæremidlerBeregnYtelseStegStepDefinitions {
                         tom = it.tom,
                         satstype = it.satstype,
                         type = it.type,
-                        kildeBehandlingId = behandlingId,
                         utbetalingsdato = it.utbetalingsdato,
                     )
                 }.toSet()


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Fant ut av denne kolonnen ifbm feilsøking av saker meldt av dvh, hvor de har fått vedtaksstatistikk med duplikate utbetalinger i noen saker. Denne https://github.com/navikt/tilleggsstonader-sak/commit/6458845c87b94327db59d8015842542da74faa54 var årsaken til dette, man hentet ut andeler for en behandling basert på denne kolonnen.

Ved query:
```
select * from tilkjent_ytelse ty join andel_tilkjent_ytelse aty on ty.id = aty.tilkjent_ytelse_id where ty.behandling_id != aty.kilde_behandling_id;
```
så returneres det kun 15 rader. Alle disse kommer enten fra `2024-09-30` eller `2024-10-09`. Så det er visst noe det har fantes kode for en gang i tiden, men feltet settes i dag til den tilhørende behandlingen sin ID. Så ser ut som det fort ble fjernet 😅 Kanskje noe som ble med i flyttelasset fra EF? 🤷 

Dropper da denne kolonnen for å unngå forvirring 🙃 🔪 