### PR TITLE
Oppretter manuell behandling dersom ny mottat kjøreliste er satt på vent

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteService.kt
@@ -58,7 +58,8 @@ class BehandleMottattKjørelisteService(
     private fun opprettBehandlingFraKjøreliste(kjøreliste: Kjøreliste) {
         val nyBehandling = opprettKjørelisteBehandling(kjøreliste)
 
-        val skalOppretteAutomatiskTask = kanAutomatiskBehandles(nyBehandling.id)
+        val skalOppretteAutomatiskTask =
+            nyBehandling.status != BehandlingStatus.SATT_PÅ_VENT && kanAutomatiskBehandles(nyBehandling.id)
 
         if (skalOppretteAutomatiskTask) {
             logger.info(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/AutomatiskKjørelisteBehandlingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/AutomatiskKjørelisteBehandlingTest.kt
@@ -12,8 +12,11 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KafkaFake
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.forventAntallMeldingerPåTopic
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
+import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.DagligReiseVedtakService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.DagligReiseVilkårService
@@ -128,5 +131,67 @@ class AutomatiskKjørelisteBehandlingTest : CleanDatabaseIntegrationTest() {
         assertThat(behandlinger).hasSize(2)
         assertThat(kjørelistebehandling.behandlingMetode).isEqualTo(BehandlingMetode.MANUELL)
         assertThat(kjørelistebehandling.status).isEqualTo(BehandlingStatus.OPPRETTET)
+    }
+
+    @Test
+    fun `skal opprette manuell behandling og sette på vent selv uten avvik når det utredes en behandling med avvik`() {
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
+
+                // Avvik i parkeringsutgifter gir manuell kjørelistebehandling
+                sendInnKjøreliste {
+                    periode = Datoperiode(fom, 2 januar 2026)
+                    kjørteDager =
+                        listOf(
+                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 250),
+                        )
+                }
+            }
+
+        val førsteKjørelistebehandling =
+            behandlingService
+                .hentBehandlinger(behandlingContext.fagsakId)
+                .single { it.type == BehandlingType.KJØRELISTE }
+
+        // Påbegynt behandling skal ikke gjenbrukes når ny kjøreliste kommer inn.
+        tilordneÅpenBehandlingOppgaveForBehandling(førsteKjørelistebehandling.id)
+
+        val reiseId =
+            kall.privatBil
+                .hentRammevedtak(behandlingContext.ident)
+                .single()
+                .reiseId
+
+        sendInnKjøreliste(
+            kjøreliste =
+                kjørelisteSkjema(
+                    reiseId = reiseId,
+                    periode = Datoperiode(3 januar 2026, 4 januar 2026),
+                    dagerKjørt =
+                        listOf(
+                            KjørtDag(dato = 3 januar 2026, parkeringsutgift = 50),
+                        ),
+                ),
+            ident = behandlingContext.ident,
+        )
+
+        val kjørelistebehandlinger =
+            behandlingService
+                .hentBehandlinger(behandlingContext.fagsakId)
+                .filter { it.type == BehandlingType.KJØRELISTE }
+
+        assertThat(kjørelistebehandlinger).hasSize(2)
+        assertThat(kjørelistebehandlinger).allMatch { it.behandlingMetode == BehandlingMetode.MANUELL }
+
+        val oppdatertFørsteKjørelistebehandling =
+            kjørelistebehandlinger.single { it.id == førsteKjørelistebehandling.id }
+        assertThat(oppdatertFørsteKjørelistebehandling.status).isEqualTo(BehandlingStatus.OPPRETTET)
+
+        val andreKjørelistebehandling = kjørelistebehandlinger.single { it.id != førsteKjørelistebehandling.id }
+        assertThat(andreKjørelistebehandling.status).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å forhindre at man ender opp i en state hvor man har en automatisk kjørelistebehandling som ikke kan behandles fordi den er satt på vent. 

