### PR TITLE
🐛 Detaljerte vedtaksperioder for daglig reise lager en rad per reiseId

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
@@ -2,62 +2,68 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise.detaljerteVedtaksperioder
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeDagligReise
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 
 object DetaljertVedtaksperioderDagligReiseMapper {
     fun finnDetaljerteVedtaksperioderDagligReise(
         vedtaksdataTso: InnvilgelseEllerOpphørDagligReise?,
         vedtaksdataTsr: InnvilgelseEllerOpphørDagligReise?,
-        adresseTso: String?,
-        adresseTsr: String?,
+        adresserTso: Map<ReiseId, String>,
+        adresserTsr: Map<ReiseId, String>,
     ): List<DetaljertVedtaksperiodeDagligReise> {
-        val alleReisePerioderTso = vedtaksdataTso?.tilReiseperioder()
-        val alleReisePerioderTsr = vedtaksdataTsr?.tilReiseperioder()
-
-        val beregningsresultatDetaljeertForDagligReiseTSO =
-            alleReisePerioderTso?.tilDetaljertBeregningsperioder(Stønadstype.DAGLIG_REISE_TSO, adresseTso)
-        val beregningsresultatDetaljeertForDagligReiseTSR =
-            alleReisePerioderTsr?.tilDetaljertBeregningsperioder(Stønadstype.DAGLIG_REISE_TSR, adresseTsr)
-        val beregningsDetaljertForDagligReise =
-            listOf(
-                beregningsresultatDetaljeertForDagligReiseTSO.orEmpty(),
-                beregningsresultatDetaljeertForDagligReiseTSR.orEmpty(),
-            ).flatten()
-        return beregningsDetaljertForDagligReise
-    }
-
-    private fun InnvilgelseEllerOpphørDagligReise.tilReiseperioder() =
-        beregningsresultat.offentligTransport?.reiser?.flatMap { reise ->
-            reise.perioder
-        }
-
-    private fun List<BeregningsresultatForPeriode>.tilDetaljertBeregningsperioder(
-        stønadstype: Stønadstype,
-        adresse: String?,
-    ): List<DetaljertVedtaksperiodeDagligReise> {
-        val detaljertBeregningsperioder =
-            this.sortedByDescending { it.grunnlag.fom }.map { beregningsresultatForPeriode ->
-                DetaljertBeregningsperioder(
-                    fom = beregningsresultatForPeriode.grunnlag.fom,
-                    tom = beregningsresultatForPeriode.grunnlag.tom,
-                    prisEnkeltbillett = beregningsresultatForPeriode.grunnlag.prisEnkeltbillett,
-                    prisSyvdagersbillett = beregningsresultatForPeriode.grunnlag.prisSyvdagersbillett,
-                    pris30dagersbillett = beregningsresultatForPeriode.grunnlag.pris30dagersbillett,
-                    beløp = beregningsresultatForPeriode.beløp,
-                    billettdetaljer = beregningsresultatForPeriode.billettdetaljer,
-                    antallReisedager = beregningsresultatForPeriode.grunnlag.antallReisedager,
-                    antallReisedagerPerUke = beregningsresultatForPeriode.grunnlag.antallReisedagerPerUke,
-                )
-            }
+        val reiserTso = vedtaksdataTso?.tilReiser()
+        val reiserTsr = vedtaksdataTsr?.tilReiser()
 
         return listOf(
-            DetaljertVedtaksperiodeDagligReise(
+            reiserTso.tilDetaljertBeregningsperioder(Stønadstype.DAGLIG_REISE_TSO, adresserTso),
+            reiserTsr.tilDetaljertBeregningsperioder(Stønadstype.DAGLIG_REISE_TSR, adresserTsr),
+        ).flatten()
+    }
+
+    private fun InnvilgelseEllerOpphørDagligReise.tilReiser(): List<BeregningsresultatForReise> =
+        beregningsresultat.offentligTransport?.reiser.orEmpty()
+
+    private fun List<BeregningsresultatForReise>?.tilDetaljertBeregningsperioder(
+        stønadstype: Stønadstype,
+        adresser: Map<ReiseId, String>,
+    ): List<DetaljertVedtaksperiodeDagligReise> =
+        this.orEmpty().map { reise ->
+            reise.tilDetaljertBeregningsperiode(
                 stønadstype = stønadstype,
-                typeDagligReise = TypeDagligReise.OFFENTLIG_TRANSPORT,
-                detaljertBeregningsperioder = detaljertBeregningsperioder,
-                adresse = adresse,
-            ),
+                adresse = adresser[reise.reiseId] ?: "adresse mangler",
+            )
+        }
+
+    private fun BeregningsresultatForReise.tilDetaljertBeregningsperiode(
+        stønadstype: Stønadstype,
+        adresse: String,
+    ): DetaljertVedtaksperiodeDagligReise {
+        val detaljertBeregningsperioder =
+            perioder
+                .sortedByDescending { it.grunnlag.fom }
+                .map { it.tilDetaljertBeregningsperiode() }
+
+        return DetaljertVedtaksperiodeDagligReise(
+            stønadstype = stønadstype,
+            typeDagligReise = TypeDagligReise.OFFENTLIG_TRANSPORT,
+            detaljertBeregningsperioder = detaljertBeregningsperioder,
+            adresse = adresse,
         )
     }
+
+    private fun BeregningsresultatForPeriode.tilDetaljertBeregningsperiode() =
+        DetaljertBeregningsperioder(
+            fom = grunnlag.fom,
+            tom = grunnlag.tom,
+            prisEnkeltbillett = grunnlag.prisEnkeltbillett,
+            prisSyvdagersbillett = grunnlag.prisSyvdagersbillett,
+            pris30dagersbillett = grunnlag.pris30dagersbillett,
+            beløp = beløp,
+            billettdetaljer = billettdetaljer,
+            antallReisedager = grunnlag.antallReisedager,
+            antallReisedagerPerUke = grunnlag.antallReisedagerPerUke,
+        )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
@@ -14,8 +14,8 @@ object DetaljertVedtaksperioderDagligReiseMapper {
         adresserTso: Map<ReiseId, String>,
         adresserTsr: Map<ReiseId, String>,
     ): List<DetaljertVedtaksperiodeDagligReise> {
-        val reiserTso = vedtaksdataTso?.tilReiser()
-        val reiserTsr = vedtaksdataTsr?.tilReiser()
+        val reiserTso = vedtaksdataTso?.hentUtOffentligTransport()
+        val reiserTsr = vedtaksdataTsr?.hentUtOffentligTransport()
 
         return listOf(
             reiserTso.tilDetaljerteVedtaksperioder(Stønadstype.DAGLIG_REISE_TSO, adresserTso),
@@ -23,7 +23,7 @@ object DetaljertVedtaksperioderDagligReiseMapper {
         ).flatten()
     }
 
-    private fun InnvilgelseEllerOpphørDagligReise.tilReiser(): List<BeregningsresultatForReise> =
+    private fun InnvilgelseEllerOpphørDagligReise.hentUtOffentligTransport(): List<BeregningsresultatForReise> =
         beregningsresultat.offentligTransport?.reiser.orEmpty()
 
     private fun List<BeregningsresultatForReise>?.tilDetaljerteVedtaksperioder(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
@@ -18,15 +18,15 @@ object DetaljertVedtaksperioderDagligReiseMapper {
         val reiserTsr = vedtaksdataTsr?.tilReiser()
 
         return listOf(
-            reiserTso.tilDetaljertBeregningsperioder(Stønadstype.DAGLIG_REISE_TSO, adresserTso),
-            reiserTsr.tilDetaljertBeregningsperioder(Stønadstype.DAGLIG_REISE_TSR, adresserTsr),
+            reiserTso.tilDetaljerteVedtaksperioder(Stønadstype.DAGLIG_REISE_TSO, adresserTso),
+            reiserTsr.tilDetaljerteVedtaksperioder(Stønadstype.DAGLIG_REISE_TSR, adresserTsr),
         ).flatten()
     }
 
     private fun InnvilgelseEllerOpphørDagligReise.tilReiser(): List<BeregningsresultatForReise> =
         beregningsresultat.offentligTransport?.reiser.orEmpty()
 
-    private fun List<BeregningsresultatForReise>?.tilDetaljertBeregningsperioder(
+    private fun List<BeregningsresultatForReise>?.tilDetaljerteVedtaksperioder(
         stønadstype: Stønadstype,
         adresser: Map<ReiseId, String>,
     ): List<DetaljertVedtaksperiodeDagligReise> =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
@@ -33,13 +33,13 @@ object DetaljertVedtaksperioderDagligReiseMapper {
         this.orEmpty().map { reise ->
             reise.tilDetaljertBeregningsperiode(
                 stønadstype = stønadstype,
-                adresse = adresser[reise.reiseId] ?: "adresse mangler",
+                adresse = adresser[reise.reiseId],
             )
         }
 
     private fun BeregningsresultatForReise.tilDetaljertBeregningsperiode(
         stønadstype: Stønadstype,
-        adresse: String,
+        adresse: String?,
     ): DetaljertVedtaksperiodeDagligReise {
         val detaljertBeregningsperioder =
             perioder

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/vedtaksperioderOversikt/VedtaksperioderOversiktService.kt
@@ -23,6 +23,7 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksdata
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.detaljerteVedtaksperioder.DetaljertVedtaksperiodeLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.detaljerteVedtaksperioder.DetaljertVedtaksperioderLæremidlerMapper.finnDetaljerteVedtaksperioder
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import org.springframework.stereotype.Service
 
 @Service
@@ -66,9 +67,7 @@ class VedtaksperioderOversiktService(
             Stønadstype.DAGLIG_REISE_TSR,
             Stønadstype.DAGLIG_REISE_TSO,
             ->
-                finnDetaljerteVedtaksperioderForDagligReise(
-                    behandling = behandling,
-                )
+                finnDetaljerteVedtaksperioderForDagligReise(behandling = behandling)
 
             Stønadstype.REISE_TIL_SAMLING_TSO -> TODO()
         }
@@ -106,14 +105,14 @@ class VedtaksperioderOversiktService(
             fagsakIdDagligReiseTsr?.let {
                 behandlingService.finnSisteIverksatteBehandling(fagsakIdDagligReiseTsr)?.id
             }
-        val adresseTso = behandlingIdDagligReiseTso?.let { hentAdresse(it) }
-        val adresseTsr = behandlingIdDagligReiseTsr?.let { hentAdresse(it) }
+        val adresserTso = behandlingIdDagligReiseTso?.let { hentAdresser(it) }.orEmpty()
+        val adresserTsr = behandlingIdDagligReiseTsr?.let { hentAdresser(it) }.orEmpty()
 
         return finnDetaljerteVedtaksperioderDagligReise(
             vedtaksdataTso = vedtaksdataTso,
             vedtaksdataTsr = vedtaksdataTsr,
-            adresseTso = adresseTso,
-            adresseTsr = adresseTsr,
+            adresserTso = adresserTso,
+            adresserTsr = adresserTsr,
         )
     }
 
@@ -143,7 +142,7 @@ class VedtaksperioderOversiktService(
 
     private fun oppsummerVedtaksperioderDagligReiseTso(fagsakId: FagsakId): List<DetaljertVedtaksperiodeDagligReise> {
         val behandlingId = behandlingService.finnSisteIverksatteBehandling(fagsakId)?.id
-        val adresseTso = hentAdresse(behandlingId)
+        val adresserTso = hentAdresser(behandlingId)
         val vedtakForSisteIverksatteBehandling =
             hentVedtaksdataForSisteIverksatteBehandling<InnvilgelseEllerOpphørDagligReise>(fagsakId)
                 ?: return emptyList()
@@ -151,14 +150,14 @@ class VedtaksperioderOversiktService(
         return finnDetaljerteVedtaksperioderDagligReise(
             vedtaksdataTso = vedtakForSisteIverksatteBehandling,
             vedtaksdataTsr = null,
-            adresseTso = adresseTso,
-            adresseTsr = null,
+            adresserTso = adresserTso,
+            adresserTsr = emptyMap(),
         )
     }
 
     private fun oppsummerVedtaksperioderDagligReiseTsr(fagsakId: FagsakId): List<DetaljertVedtaksperiodeDagligReise> {
         val behandlingId = behandlingService.finnSisteIverksatteBehandling(fagsakId)?.id
-        val adresseTsr = hentAdresse(behandlingId)
+        val adresserTsr = hentAdresser(behandlingId)
         val vedtakForSisteIverksatteBehandling =
             hentVedtaksdataForSisteIverksatteBehandling<InnvilgelseEllerOpphørDagligReise>(fagsakId)
                 ?: return emptyList()
@@ -166,8 +165,8 @@ class VedtaksperioderOversiktService(
         return finnDetaljerteVedtaksperioderDagligReise(
             vedtaksdataTso = null,
             vedtaksdataTsr = vedtakForSisteIverksatteBehandling,
-            adresseTso = null,
-            adresseTsr = adresseTsr,
+            adresserTso = emptyMap(),
+            adresserTsr = adresserTsr,
         )
     }
 
@@ -176,10 +175,13 @@ class VedtaksperioderOversiktService(
             vedtakService.hentVedtak<T>(it.id).data
         }
 
-    private fun hentAdresse(behandlingId: BehandlingId?): String? =
+    private fun hentAdresser(behandlingId: BehandlingId?): Map<ReiseId, String> =
         behandlingId
             ?.let { vilkårService.hentVilkår(it) }
-            ?.firstOrNull()
-            ?.fakta
-            ?.adresse
+            ?.mapNotNull { vilkår ->
+                vilkår.fakta?.let { fakta ->
+                    fakta.reiseId to (fakta.adresse ?: "adresse mangler")
+                }
+            }?.toMap()
+            .orEmpty()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapperTest.kt
@@ -22,6 +22,7 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
@@ -61,8 +62,8 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
             finnDetaljerteVedtaksperioderDagligReise(
                 vedtaksdataTso = tsoVedtak.data,
                 vedtaksdataTsr = tsrVedtak.data,
-                adresseTso = "adresseTso",
-                adresseTsr = "adresseTsr",
+                adresserTso = mapOf(dummyReiseId to "adresseTso"),
+                adresserTsr = mapOf(dummyReiseId to "adresseTsr"),
             )
         val forventetTso =
             DetaljertVedtaksperiodeDagligReise(
@@ -99,6 +100,42 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
         assertThat(resultat).containsExactly(forventetTso, forventetTsr)
     }
 
+    @Test
+    fun `skal opprette en detaljert vedtaksperiode for hver adresse`() {
+        val førsteReiseId = ReiseId.random()
+        val andreReiseId = ReiseId.random()
+        val tsoVedtak =
+            innvilgelse(
+                InnvilgelseDagligReise(
+                    vedtaksperioder = defaultVedtaksperioder,
+                    beregningsresultat =
+                        lagBeregningsresultatMedToReiser(
+                            førsteReiseId = førsteReiseId,
+                            andreReiseId = andreReiseId,
+                            fom = førsteJanuar,
+                            tom = sisteJanuar,
+                        ),
+                    rammevedtakPrivatBil = null,
+                    beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
+                ),
+            )
+
+        val resultat =
+            finnDetaljerteVedtaksperioderDagligReise(
+                vedtaksdataTso = tsoVedtak.data,
+                vedtaksdataTsr = null,
+                adresserTso =
+                    mapOf(
+                        førsteReiseId to "adresse 1",
+                        andreReiseId to "adresse 2",
+                    ),
+                adresserTsr = emptyMap(),
+            )
+
+        assertThat(resultat).hasSize(2)
+        assertThat(resultat.map { it.adresse }).containsExactly("adresse 1", "adresse 2")
+    }
+
     private fun innvilgelse(data: InnvilgelseDagligReise = defaultInnvilgelseDagligReise) =
         GeneriskVedtak(
             behandlingId = BehandlingId.random(),
@@ -109,23 +146,9 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
             opphørsdato = null,
         )
 
-    private fun toVedtaksperioder(
-        fom1: LocalDate,
-        tom1: LocalDate,
-        fom2: LocalDate,
-        tom2: LocalDate,
-    ) = InnvilgelseDagligReise(
-        vedtaksperioder =
-            listOf(
-                vedtaksperiode(fom = fom1, tom = tom1),
-                vedtaksperiode(fom = fom2, tom = tom2),
-            ),
-        beregningsresultat = lagBeregningsresultatMedToPerioder(fom1, tom1, fom2, tom2),
-        rammevedtakPrivatBil = null,
-        beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
-    )
-
     private fun lagBeregningsresultatMedToReiser(
+        førsteReiseId: ReiseId = dummyReiseId,
+        andreReiseId: ReiseId = ReiseId.random(),
         fom: LocalDate,
         tom: LocalDate,
     ) = BeregningsresultatDagligReise(
@@ -134,14 +157,14 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
                 reiser =
                     listOf(
                         BeregningsresultatForReise(
-                            reiseId = dummyReiseId,
+                            reiseId = førsteReiseId,
                             perioder =
                                 listOf(
                                     beregningsresultatForPeriode(fom, tom),
                                 ),
                         ),
                         BeregningsresultatForReise(
-                            reiseId = dummyReiseId,
+                            reiseId = andreReiseId,
                             perioder =
                                 listOf(
                                     beregningsresultatForPeriode(fom, tom),
@@ -150,29 +173,6 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
                     ),
             ),
         privatBil = null, // TODO
-    )
-
-    private fun lagBeregningsresultatMedToPerioder(
-        fom1: LocalDate,
-        tom1: LocalDate,
-        fom2: LocalDate,
-        tom2: LocalDate,
-    ) = BeregningsresultatDagligReise(
-        offentligTransport =
-            BeregningsresultatOffentligTransport(
-                reiser =
-                    listOf(
-                        BeregningsresultatForReise(
-                            reiseId = dummyReiseId,
-                            perioder =
-                                listOf(
-                                    beregningsresultatForPeriode(fom1, tom1),
-                                    beregningsresultatForPeriode(fom2, tom2),
-                                ),
-                        ),
-                    ),
-            ),
-        privatBil = null,
     )
 
     val defaultVedtaksperioder =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

# Før/etter for denne beregningstabellen:
<img width="1347" height="423" alt="image" src="https://github.com/user-attachments/assets/18fdc9c9-f518-43c2-a455-6e7f61a4f9c5" />

## Før 
<img width="981" height="125" alt="image" src="https://github.com/user-attachments/assets/5eccdb27-25e2-4dea-adf0-2e4d287548aa" />
<img width="993" height="385" alt="image" src="https://github.com/user-attachments/assets/c27a7025-80e9-4e31-8664-2fea9e33a199" />

## Etter
<img width="974" height="168" alt="image" src="https://github.com/user-attachments/assets/2a617262-5b00-4021-a849-50a80fccc229" />
<img width="976" height="498" alt="image" src="https://github.com/user-attachments/assets/52869ed7-fb75-4d9a-86c3-3628ba0060b5" />