### PR TITLE
🚧 WIP: Fang opp endring av MålgruppeType i fraTidligereVedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
@@ -1,17 +1,26 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport
 
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.tidligsteendring.ForenkletMålgruppe
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørDagligReise
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeMålgruppe
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
 @Service
 class OffentligTransportBeregningRevurderingService(
     private val vedtakService: VedtakService,
+    private val vilkårperiodeService: VilkårperiodeService,
 ) {
     /**
      * Beholder de reisene og perioder fra forrige iverksatte behandling som er berørt av revurderingen, slik at vi ikke risikerer at gamle
@@ -22,8 +31,10 @@ class OffentligTransportBeregningRevurderingService(
         behandling: Saksbehandling,
         beregnFra: LocalDate?,
     ): BeregningsresultatOffentligTransport {
+        val forrigeIverksatteBehandlingId = behandling.forrigeIverksatteBehandlingId ?: return nyttBeregningsresultat
         val forrigeIverksatte =
-            hentForrigeIverksatteVedtak(behandling)?.beregningsresultat?.offentligTransport ?: return nyttBeregningsresultat
+            hentForrigeIverksatteVedtak(forrigeIverksatteBehandlingId)?.beregningsresultat?.offentligTransport
+                ?: return nyttBeregningsresultat
 
         brukerfeilHvis(beregnFra == null) { "Kan ikke beregne ytelse fordi det ikke er gjort noen endringer i revurderingen" }
 
@@ -32,10 +43,19 @@ class OffentligTransportBeregningRevurderingService(
             reiserForrigeBehandling = forrigeIverksatte.reiser,
         )
 
+        val nåværendeMålgrupper = vilkårperiodeService.hentVilkårperioder(behandling.id).målgrupper
+        val tidligereMålgrupper = vilkårperiodeService.hentVilkårperioder(forrigeIverksatteBehandlingId).målgrupper
+
         return BeregningsresultatOffentligTransport(
             reiser =
                 nyttBeregningsresultat.reiser.map { reise ->
-                    slåSammenNyeOgGamlePerioder(reise, forrigeIverksatte, beregnFra)
+                    slåSammenNyeOgGamlePerioder(
+                        nyBeregningForReise = reise,
+                        forrigeBeregning = forrigeIverksatte,
+                        beregnFra = beregnFra,
+                        nåværendeMålgrupper = nåværendeMålgrupper,
+                        tidligereMålgrupper = tidligereMålgrupper,
+                    )
                 },
         )
     }
@@ -51,6 +71,8 @@ class OffentligTransportBeregningRevurderingService(
         nyBeregningForReise: BeregningsresultatForReise,
         forrigeBeregning: BeregningsresultatOffentligTransport,
         beregnFra: LocalDate,
+        nåværendeMålgrupper: List<VilkårperiodeMålgruppe>,
+        tidligereMålgrupper: List<VilkårperiodeMålgruppe>,
     ): BeregningsresultatForReise {
         // hvis ikke reisen eksisterer i forrige vedtak, er det bare ny beregning som gjelder
         val reisenIForrigeVedtak =
@@ -67,8 +89,15 @@ class OffentligTransportBeregningRevurderingService(
             nyBeregningForReise.perioder
                 .filter { it.grunnlag.fom.plusDays(30L) > beregnFra }
                 .map { nyPeriode ->
-                    val tilsvarendePeriodeIForrigeVedtak = reisenIForrigeVedtak.singleOrNull { it.grunnlag == nyPeriode.grunnlag }
-                    tilsvarendePeriodeIForrigeVedtak?.copy(fraTidligereVedtak = true) ?: nyPeriode.copy(fraTidligereVedtak = false)
+                    val tilsvarendePeriodeIForrigeVedtak =
+                        reisenIForrigeVedtak.singleOrNull { it.grunnlag == nyPeriode.grunnlag }
+                    if (tilsvarendePeriodeIForrigeVedtak != null &&
+                        !erMålgruppeTypeEndretForPeriode(nyPeriode.grunnlag, nåværendeMålgrupper, tidligereMålgrupper)
+                    ) {
+                        tilsvarendePeriodeIForrigeVedtak.copy(fraTidligereVedtak = true)
+                    } else {
+                        nyPeriode.copy(fraTidligereVedtak = false)
+                    }
                 }
 
         return nyBeregningForReise.copy(
@@ -76,9 +105,36 @@ class OffentligTransportBeregningRevurderingService(
         )
     }
 
-    private fun hentForrigeIverksatteVedtak(behandling: Saksbehandling): InnvilgelseEllerOpphørDagligReise? =
-        behandling.forrigeIverksatteBehandlingId
-            ?.let {
-                vedtakService.hentVedtak<InnvilgelseEllerOpphørDagligReise>(it)
-            }?.data
+    /**
+     * Sjekker om MålgruppeType-dekning er endret for perioden – enten ved at en type er fjernet
+     * eller at datointervallet til en type har endret seg innenfor perioden.
+     * Brukes for å fange opp endringer der MålgruppeType endres (f.eks. DAGPENGER → TILTAKSPENGER) selv om begge
+     * mapper til samme FaktiskMålgruppe (ARBEIDSSØKER), slik at slike perioder vises i beregningsresultet og brevet dersom målgruppe er endret.
+     * Rene tillegg (ny type lagt til uten at eksisterende fjernes eller endres) regnes ikke som en endring.
+     */
+    private fun erMålgruppeTypeEndretForPeriode(
+        periode: Periode<LocalDate>,
+        nåværendeMålgrupper: List<VilkårperiodeMålgruppe>,
+        tidligereMålgrupper: List<VilkårperiodeMålgruppe>,
+    ): Boolean {
+        fun aktiveDekninger(målgrupper: List<VilkårperiodeMålgruppe>): Set<ForenkletMålgruppe> =
+            målgrupper
+                .filter { it.status != Vilkårstatus.SLETTET && it.resultat == ResultatVilkårperiode.OPPFYLT }
+                .filter { it.overlapper(periode) }
+                .map {
+                    ForenkletMålgruppe(
+                        type = it.type as MålgruppeType,
+                        fom = maxOf(it.fom, periode.fom),
+                        tom = minOf(it.tom, periode.tom),
+                        resultat = ResultatVilkårperiode.OPPFYLT,
+                    )
+                }.toSet()
+
+        val tidligereDekninger = aktiveDekninger(tidligereMålgrupper)
+        val nåværendeDekninger = aktiveDekninger(nåværendeMålgrupper)
+        return !nåværendeDekninger.containsAll(tidligereDekninger)
+    }
+
+    private fun hentForrigeIverksatteVedtak(behandlingId: BehandlingId): InnvilgelseEllerOpphørDagligReise? =
+        vedtakService.hentVedtak<InnvilgelseEllerOpphørDagligReise>(behandlingId)?.data
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
@@ -443,7 +443,7 @@ private fun IntegrationTest.gjennomførInngangsvilkårSteg(
 
     // Slett aktiviteter
     testdataDsl.aktivitet.delete.forEach { del ->
-        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.aktiviteter)
+        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.aktiviteter, behandlingId)
         kall.vilkårperiode.apiRespons.slett(
             vilkårperiodeId = idOgRequest.first,
             slettVikårperiode = idOgRequest.second,
@@ -461,7 +461,7 @@ private fun IntegrationTest.gjennomførInngangsvilkårSteg(
 
     // Slett målgruppeer
     testdataDsl.målgruppe.delete.forEach { del ->
-        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.målgrupper)
+        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.målgrupper, behandlingId)
         kall.vilkårperiode.apiRespons.slett(
             vilkårperiodeId = idOgRequest.first,
             slettVikårperiode = idOgRequest.second,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/VilkårperiodeTestdataDsl.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/VilkårperiodeTestdataDsl.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class VilkårperiodeTestdataDsl {
     internal val opprettScope = OpprettVilkårperiodeDsl()
     internal val update = mutableListOf<(List<VilkårperiodeDto>, BehandlingId) -> Pair<UUID, LagreVilkårperiode>>()
-    internal val delete = mutableListOf<(List<VilkårperiodeDto>) -> Pair<UUID, SlettVikårperiode>>()
+    internal val delete = mutableListOf<(List<VilkårperiodeDto>, BehandlingId) -> Pair<UUID, SlettVikårperiode>>()
 
     fun opprett(builder: OpprettVilkårperiodeDsl.() -> Unit) {
         opprettScope.apply(builder)
@@ -33,7 +33,7 @@ class VilkårperiodeTestdataDsl {
         update += builder
     }
 
-    fun slett(builder: (List<VilkårperiodeDto>) -> Pair<UUID, SlettVikårperiode>) {
+    fun slett(builder: (List<VilkårperiodeDto>, BehandlingId) -> Pair<UUID, SlettVikårperiode>) {
         delete += builder
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingServiceTest.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport
 
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.desember
 import no.nav.tilleggsstonader.libs.utils.dato.februar
@@ -12,11 +13,14 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWith
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.tilLagreDagligReiseDto
+import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.tilLagreVilkårperiodeMålgruppe
 import no.nav.tilleggsstonader.sak.util.lagreVilkårperiodeAktivitet
 import no.nav.tilleggsstonader.sak.util.lagreVilkårperiodeMålgruppe
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.BeregningsresultatForReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseResponse
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -195,6 +199,195 @@ class OffentligTransportBeregningRevurderingServiceTest : CleanDatabaseIntegrati
 
     private fun lagreMålgruppe(behandlingId: BehandlingId): LagreVilkårperiode =
         lagreVilkårperiodeMålgruppe(behandlingId, fom = 1 januar 2024, tom = 30 mars 2026)
+
+    @Test
+    fun `ved endring av målgruppeType fra dagpenger til tiltakspenger skal perioden ikke markeres som fraTidligereVedtak`() {
+        val fom = 1 januar 2025
+        val tom = 31 januar 2025
+
+        val behandlingId = gjennomførEnTsrFørstegangsbehandling(reiseFom = fom, reiseTom = tom)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                målgruppe {
+                    slett { målgrupper, behandlingId ->
+                        val dagpenger = målgrupper.single { it.type == MålgruppeType.DAGPENGER }
+                        dagpenger.id to SlettVikårperiode(behandlingId = behandlingId, kommentar = "Endret til tiltakspenger")
+                    }
+                    opprett {
+                        målgruppeTiltakspenger(fom, tom)
+                    }
+                }
+            }
+
+        with(hentBeregnedeReiserTsr(revurderingId).single().perioder) {
+            assertThat(all { it.fraTidligereVedtak }).isFalse()
+        }
+    }
+
+    @Test
+    fun `ved uendret målgruppeType skal perioden markeres som fraTidligereVedtak`() {
+        val fom = 1 januar 2025
+        val tom = 31 januar 2025
+        val forlengetTom = 28 februar 2025
+
+        val behandlingId = gjennomførEnTsrFørstegangsbehandling(reiseFom = fom, reiseTom = tom)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                vilkår {
+                    oppdaterDagligReise { vilkårDagligReise ->
+                        with(vilkårDagligReise.single()) {
+                            id to tilLagreDagligReiseDto().copy(tom = forlengetTom)
+                        }
+                    }
+                }
+            }
+
+        with(hentBeregnedeReiserTsr(revurderingId).single().perioder) {
+            assertThat(all { it.fraTidligereVedtak }).isTrue()
+        }
+    }
+
+    @Test
+    fun `ved tillegg av ny målgruppeType uten at eksisterende fjernes skal perioden markeres som fraTidligereVedtak`() {
+        val fom = 1 januar 2025
+        val tom = 31 januar 2025
+        val forlengetTom = 28 februar 2025
+
+        val behandlingId = gjennomførEnTsrFørstegangsbehandling(reiseFom = fom, reiseTom = tom)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                // Forlenger reisen for å sikre at beregnFra settes
+                vilkår {
+                    oppdaterDagligReise { vilkårDagligReise ->
+                        with(vilkårDagligReise.single()) {
+                            id to tilLagreDagligReiseDto().copy(tom = forlengetTom)
+                        }
+                    }
+                }
+                // Legger til tiltakspenger uten å fjerne dagpenger
+                målgruppe {
+                    opprett {
+                        målgruppeTiltakspenger(fom, tom)
+                    }
+                }
+            }
+
+        with(hentBeregnedeReiserTsr(revurderingId).single().perioder) {
+            assertThat(size).isEqualTo(2)
+            assertThat(first().fraTidligereVedtak).isTrue()
+            assertThat(last().fraTidligereVedtak).isFalse()
+        }
+    }
+
+    @Test
+    fun `ved tillegg av ny målgruppeType kombinert med endring av eksisterende skal perioden markeres som fraTidligereVedtak`() {
+        val fom = 1 januar 2025
+        val tom = 31 januar 2025
+
+        val behandlingId = gjennomførEnTsrFørstegangsbehandling(reiseFom = fom, reiseTom = tom)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                målgruppe {
+                    // Endrer eksisterende dagpenger (forlenger utover reiseperioden) og legger til tiltakspenger
+                    // DAGPENGER dekker fortsatt reiseperioden fullt ut → ingen endring i dekning → fraTidligereVedtak = true
+                    oppdater { målgrupper, behandlingId ->
+                        val dagpenger = målgrupper.single { it.type == MålgruppeType.DAGPENGER }
+                        dagpenger.id to dagpenger.tilLagreVilkårperiodeMålgruppe(behandlingId).copy(tom = 28 februar 2025)
+                    }
+                    opprett {
+                        målgruppeTiltakspenger(fom, tom)
+                    }
+                }
+            }
+
+        with(hentBeregnedeReiserTsr(revurderingId).single().perioder) {
+            assertThat(all { it.fraTidligereVedtak }).isTrue()
+        }
+    }
+
+    @Test
+    fun `ved endring av datointervall for eksisterende målgruppeType skal perioden ikke markeres som fraTidligereVedtak`() {
+        val fom = 1 januar 2025
+        val tom = 31 januar 2025
+
+        val behandlingId = gjennomførEnTsrFørstegangsbehandling(reiseFom = fom, reiseTom = tom)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                målgruppe {
+                    // Korter ned dagpenger – datointervallet endres fra Jan 1-31 til Jan 1-15
+                    oppdater { målgrupper, behandlingId ->
+                        val dagpenger = målgrupper.single { it.type == MålgruppeType.DAGPENGER }
+                        dagpenger.id to dagpenger.tilLagreVilkårperiodeMålgruppe(behandlingId).copy(tom = 15 januar 2025)
+                    }
+                    // Legger til tiltakspenger for resten av perioden
+                    opprett {
+                        målgruppeTiltakspenger(fom, tom)
+                    }
+                }
+            }
+
+        with(hentBeregnedeReiserTsr(revurderingId).single().perioder) {
+            assertThat(all { it.fraTidligereVedtak }).isFalse()
+        }
+    }
+
+    private fun hentBeregnedeReiserTsr(revurderingId: BehandlingId): List<BeregningsresultatForReiseDto> =
+        kall.vedtak
+            .hentVedtak(
+                Stønadstype.DAGLIG_REISE_TSR,
+                revurderingId,
+            ).expectOkWithBody<InnvilgelseDagligReiseResponse>()
+            .beregningsresultat
+            .offentligTransport!!
+            .reiser
+
+    private fun gjennomførEnTsrFørstegangsbehandling(
+        reiseFom: LocalDate,
+        reiseTom: LocalDate,
+    ): BehandlingId =
+        opprettBehandlingOgGjennomførBehandlingsløp(
+            stønadstype = Stønadstype.DAGLIG_REISE_TSR,
+        ) {
+            aktivitet {
+                opprett {
+                    aktivitetTiltakTsr(
+                        fom = reiseFom,
+                        tom = reiseTom,
+                        typeAktivitet = TypeAktivitet.GRUPPEAMO,
+                    )
+                }
+            }
+            målgruppe {
+                opprett {
+                    målgruppeDagpenger(reiseFom, reiseTom)
+                }
+            }
+            vilkår {
+                opprett {
+                    offentligTransport(fom = reiseFom, tom = reiseTom)
+                }
+            }
+        }.behandlingId
 
     private fun endreAlleBeløpTilNoeHeltTulleteStort() {
         jdbcTemplate.update(


### PR DESCRIPTION
**Bakgrunn**

Ved revurdering av daglig reise brukes `fraTidligereVedtak = true` for å markere perioder som er uendret fra forrige vedtak – disse beholder det gamle beregningsresultatet og vises ikke som endrede i brevet til bruker.

Problemet er at logikken sammenlignet `FaktiskMålgruppe` (f.eks. `ARBEIDSSØKER`), ikke `MålgruppeType`. For daglig reise TSR mappes alle stønadsmålgrupper (DAGPENGER, TILTAKSPENGER, KVALIFISERINGSSTØNAD m.fl.) til `FaktiskMålgruppe.ARBEIDSSØKER`. Dette betyr at hvis saksbehandler endrer målgruppen fra f.eks. DAGPENGER til TILTAKSPENGER, ble ikke endringen oppdaget – perioden fikk `fraTidligereVedtak = true` og endringen ble ikke vist til bruker.

**Datafeil**

Beregningen gjøres fra datoen målgruppen endres, så det nye beregningsresultatet er korrekt. Feilen er at perioden feilaktig merkes med `fraTidligereVedtak = true` selv om den faktisk er beregnet på nytt. Konsekvensen er at vedtaket viser perioden som om den er uendret fra forrige behandling, og brevet til bruker gjenspeiler ikke den faktiske endringen saksbehandler har gjort.

**Hva jeg har gjort**

I stedet for å sammenligne `FaktiskMålgruppe` sammenligner jeg nå hvilke `(MålgruppeType, fom, tom)`-kombinasjoner som er aktive innenfor perioden. Jeg bruker `containsAll`-logikk: en periode regnes som endret kun hvis en tidligere aktiv dekning ikke lenger finnes i nåværende behandling. Rene tillegg (ny type lagt til uten at eksisterende fjernes eller endres) regnes ikke som en endring.

Konkret: jeg henter vilkårperioder for både nåværende og forrige iverksatte behandling og sammenligner `ForenkletMålgruppe`-sett avgrenset til perioden.

**Avgrensning**

Endringen påvirker kun `OffentligTransportBeregningRevurderingService` – altså daglig reise offentlig transport. Dette er bevisst siden problemet primært finnes for TSR der alle målgrupper mappes til samme `FaktiskMålgruppe`. Andre stønadstyper er ikke berørt.

**Det jeg ikke har rukket**

- Jeg har ikke testet dette grundig nok i praksis
- Jeg har ikke tenkt tilstrekkelig gjennom edge-caser, f.eks.:
  - Delvis overlappende perioder på tvers av revurderinger
  - Flere aktive målgrupper med ulike datointervaller
  - Hva skjer hvis målgruppe-periodene ikke er sammenhengende
- `ForenkletMålgruppe` er definert i `tidligsteendring`-pakken – det er en kobling på tvers av bounded contexts som bør ryddes opp

**Tester**

Jeg har lagt til 5 integrasjonstester som dekker de mest sentrale scenariene:
1. DAGPENGER → TILTAKSPENGER → ikke markert som fraTidligereVedtak ✅
2. Uendret målgruppeType → markert som fraTidligereVedtak ✅
3. Ny type lagt til uten at eksisterende fjernes → markert som fraTidligereVedtak ✅
4. Ny type lagt til kombinert med endring av eksisterende (men dekning innen perioden er uendret) → markert som fraTidligereVedtak ✅
5. Datointervall for eksisterende type kortes ned → ikke markert som fraTidligereVedtak ✅