### PR TITLE
Ta høyde for helligdager ved innsending av kjøreliste

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,6 +105,8 @@ dependencies {
     implementation("no.nav.tilleggsstonader.kontrakter:kontrakter-felles:$tilleggsstønaderKontrakterVersion")
     implementation("no.nav.tilleggsstonader.kontrakter:pdl-personhendelser-avro:$tilleggsstønaderKontrakterVersion")
 
+    implementation("io.github.mikaojk:norwegian-holidays:1.0.13")
+
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "mockito-core")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 
+import io.github.mikaojk.holiday.getNorwegianHolidays
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
@@ -251,11 +252,13 @@ class AvklartKjørelisteService(
     private fun utledAvvik(kjørelisteDag: KjørelisteDag): List<TypeAvvikDag> =
         listOfNotNull(
             TypeAvvikDag.FOR_HØY_PARKERINGSUTGIFT.takeIf { kjørelisteDag.parkeringsutgift != null && kjørelisteDag.parkeringsutgift > 100 },
-            TypeAvvikDag.HELLIDAG_ELLER_HELG.takeIf { kjørelisteDag.harKjørt && kjørelisteDag.dato.erHelg() },
+            TypeAvvikDag.HELLIDAG_ELLER_HELG.takeIf { kjørelisteDag.harKjørt && kjørelisteDag.dato.erHelgEllerHelligdag() },
         )
 
-    // TODO: Bruk fra kontrakter
-    private fun LocalDate.erHelg() = this.dayOfWeek == DayOfWeek.SATURDAY || this.dayOfWeek == DayOfWeek.SUNDAY
+    private fun LocalDate.erHelgEllerHelligdag() =
+        this.dayOfWeek == DayOfWeek.SATURDAY ||
+            this.dayOfWeek == DayOfWeek.SUNDAY ||
+            getNorwegianHolidays(year).map { it.date }.contains(this)
 
     private fun henteReiseFraVedtak(
         behandlingId: BehandlingId,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/AutomatiskKjørelisteBehandlingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/AutomatiskKjørelisteBehandlingTest.kt
@@ -61,10 +61,9 @@ class AutomatiskKjørelisteBehandlingTest : CleanDatabaseIntegrationTest() {
                 defaultDagligReisePrivatBilTsoTestdata(fom, tom)
 
                 sendInnKjøreliste {
-                    periode = Datoperiode(fom, 2 januar 2026)
+                    periode = Datoperiode(fom, 4 januar 2026)
                     kjørteDager =
                         listOf(
-                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 100),
                             KjørtDag(dato = 2 januar 2026, parkeringsutgift = 50),
                         )
                 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
@@ -41,13 +41,13 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                 stønadstype = Stønadstype.DAGLIG_REISE_TSO,
             ) {
                 defaultDagligReisePrivatBilTsoTestdata(
-                    1 januar 2026,
-                    4 januar 2026,
+                    5 januar 2026,
+                    8 januar 2026,
                     delperioder =
                         listOf(
                             FaktaDelperiodePrivatBilDto(
-                                fom = 1 januar 2026,
-                                tom = 4 januar 2026,
+                                fom = 5 januar 2026,
+                                tom = 8 januar 2026,
                                 reisedagerPerUke = 2,
                                 bompengerPerDag = null,
                                 fergekostnadPerDag = null,
@@ -56,11 +56,11 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                 )
 
                 sendInnKjøreliste {
-                    periode = Datoperiode(1 januar 2026, 4 januar 2026)
+                    periode = Datoperiode(5 januar 2026, 8 januar 2026)
                     kjørteDager =
                         listOf(
-                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
-                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 6 januar 2026, parkeringsutgift = 50),
                         )
                 }
             }
@@ -75,25 +75,25 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
         val forventedeDager =
             listOf(
                 avklartKjørtDag(
-                    1 januar 2026,
+                    5 januar 2026,
                     godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                     parkeringsutgift = 50,
                 ),
                 avklartKjørtDag(
-                    2 januar 2026,
+                    6 januar 2026,
                     godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                     parkeringsutgift = 50,
                 ),
                 avklartKjørtDag(
-                    3 januar 2026,
+                    7 januar 2026,
                     godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                     parkeringsutgift = null,
                 ),
                 avklartKjørtDag(
-                    4 januar 2026,
+                    8 januar 2026,
                     godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                     parkeringsutgift = null,
@@ -191,14 +191,14 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
             opprettBehandlingOgGjennomførBehandlingsløp(
                 stønadstype = Stønadstype.DAGLIG_REISE_TSO,
             ) {
-                defaultDagligReisePrivatBilTsoTestdata(1 januar 2026, 2 januar 2026)
+                defaultDagligReisePrivatBilTsoTestdata(5 januar 2026, 6 januar 2026)
 
                 sendInnKjøreliste {
-                    periode = Datoperiode(1 januar 2026, 2 januar 2026)
+                    periode = Datoperiode(5 januar 2026, 6 januar 2026)
                     kjørteDager =
                         listOf(
-                            KjørtDag(dato = 1 januar 2026, parkeringsutgift = 50),
-                            KjørtDag(dato = 2 januar 2026, parkeringsutgift = 150),
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 6 januar 2026, parkeringsutgift = 150),
                         )
                 }
             }
@@ -213,13 +213,13 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
         val forventedeDager =
             listOf(
                 avklartKjørtDag(
-                    1 januar 2026,
+                    5 januar 2026,
                     godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                     parkeringsutgift = 50,
                 ),
                 avklartKjørtDag(
-                    2 januar 2026,
+                    6 januar 2026,
                     godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.IKKE_VURDERT,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.AVVIK,
                     avvik = listOf(TypeAvvikDag.FOR_HØY_PARKERINGSUTGIFT),
@@ -231,7 +231,7 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
     }
 
     @Test
-    fun `skal melde avvik på dag dersom det er en helgedag`() {
+    fun `skal melde avvik på dag dersom det er en helg eller helligdag`() {
         val rammebehandlingId =
             opprettBehandlingOgGjennomførBehandlingsløp(
                 stønadstype = Stønadstype.DAGLIG_REISE_TSO,
@@ -261,9 +261,10 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
             listOf(
                 avklartKjørtDag(
                     1 januar 2026,
-                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
-                    automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
-                    parkeringsutgift = 50,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.IKKE_VURDERT,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.AVVIK,
+                    parkeringsutgift = null,
+                    avvik = listOf(TypeAvvikDag.HELLIDAG_ELLER_HELG),
                 ),
                 avklartKjørtDag(
                     2 januar 2026,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
@@ -3,7 +3,9 @@ package no.nav.tilleggsstonader.sak.privatbil
 import io.mockk.every
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
@@ -285,6 +287,83 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
                     parkeringsutgift = null,
                     automatiskVurdering = UtfyltDagAutomatiskVurdering.AVVIK,
                     avvik = listOf(TypeAvvikDag.HELLIDAG_ELLER_HELG),
+                ),
+            )
+
+        sammenlignDager(faktiskeDager = innsendtUke.dager, forventedeDager = forventedeDager)
+    }
+
+    @Test
+    fun `skal melde avvik på dag dersom det er kjørt skjærtorsdag og langfredag`() {
+        val rammebehandlingId =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(30 mars 2026, 5 april 2026)
+
+                sendInnKjøreliste {
+                    periode = Datoperiode(30 mars 2026, 5 april 2026)
+                    kjørteDager =
+                        listOf(
+                            KjørtDag(dato = 1 april 2026),
+                            KjørtDag(dato = 2 april 2026),
+                            KjørtDag(dato = 3 april 2026),
+                        )
+                }
+            }
+
+        val innsendtUke = finnInnsendtUkeIKjørelistebehandling(rammebehandlingId)
+
+        assertThat(innsendtUke.avvik).isNull()
+        assertThat(innsendtUke.status).isEqualTo(UkeStatus.AVVIK)
+        assertThat(innsendtUke.avklartUkeId).isNotNull()
+        assertThat(innsendtUke.behandletDato).isNull()
+
+        val forventedeDager =
+            listOf(
+                avklartKjørtDag(
+                    30 mars 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                    parkeringsutgift = null,
+                ),
+                avklartKjørtDag(
+                    31 mars 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                    parkeringsutgift = null,
+                ),
+                avklartKjørtDag(
+                    1 april 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                    parkeringsutgift = null,
+                ),
+                avklartKjørtDag(
+                    2 april 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.IKKE_VURDERT,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.AVVIK,
+                    parkeringsutgift = null,
+                    avvik = listOf(TypeAvvikDag.HELLIDAG_ELLER_HELG),
+                ),
+                avklartKjørtDag(
+                    3 april 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.IKKE_VURDERT,
+                    parkeringsutgift = null,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.AVVIK,
+                    avvik = listOf(TypeAvvikDag.HELLIDAG_ELLER_HELG),
+                ),
+                avklartKjørtDag(
+                    4 april 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                    parkeringsutgift = null,
+                ),
+                avklartKjørtDag(
+                    4 april 2026,
+                    godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.NEI,
+                    automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                    parkeringsutgift = null,
                 ),
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilStatistikkIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilStatistikkIntegrationTest.kt
@@ -56,7 +56,7 @@ class DagligReisePrivatBilStatistikkIntegrationTest : IntegrationTest() {
 
                 sendInnKjøreliste {
                     periode = Datoperiode(fom, tom)
-                    kjørteDager = listOf(KjørtDag(dato = fom, parkeringsutgift = 50))
+                    kjørteDager = listOf(KjørtDag(dato = 7 april 2026, parkeringsutgift = 50))
                 }
             }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakControllerTest.kt
@@ -236,7 +236,7 @@ class DagligReiseVedtakControllerTest : CleanDatabaseIntegrationTest() {
         val innsendteKjørteDager =
             listOf(
                 KjørtDag(dato = 29 desember 2025, parkeringsutgift = 50),
-                KjørtDag(dato = 1 januar 2026, parkeringsutgift = 100),
+                KjørtDag(dato = 2 januar 2026, parkeringsutgift = 100),
                 KjørtDag(dato = 5 januar 2026),
                 KjørtDag(dato = 6 januar 2026),
                 KjørtDag(dato = 12 januar 2026),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Oppretter avvik om bruker sender inn kjøreliste på en helligdag. Kjørelisten skal da sees på av saksbehandler og ikke gå automatisk. Vi har allerede et avvik-enum  som passer for både helg og helligdag `TypeAvvikDag.HELLIDAG_ELLER_HELG`. Kan sikkert være fornuftig å splitte den i to senere :eyes:

Drar inn mini-bilbiotek https://github.com/MikAoJk/norwegian-holidays for å kunne liste opp helligdager for et gitt år.