### PR TITLE
Sett revurdering på vent

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterSøknadService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterSøknadService.kt
@@ -11,12 +11,9 @@ import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.ytelse.ResultatKilde
 import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderDto
-import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService.Companion.MASKINELL_JOURNALFOERENDE_ENHET
-import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
-import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.journalføring.JournalføringService
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
@@ -25,8 +22,6 @@ import no.nav.tilleggsstonader.sak.journalføring.gjelderKanalNavNo
 import no.nav.tilleggsstonader.sak.journalføring.harStrukturertSøknad
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OpprettOppgave
 import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
-import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.identer
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.SøknadService
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.dagligReise.Reise
 import no.nav.tilleggsstonader.sak.opplysninger.søknad.domain.SøknadDagligReise
@@ -40,14 +35,10 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class HåndterSøknadService(
-    private val personService: PersonService,
     private val journalpostService: JournalpostService,
     private val taskService: TaskService,
     private val journalføringService: JournalføringService,
-    private val fagsakService: FagsakService,
-    private val behandlingService: BehandlingService,
     private val søknadService: SøknadService,
-    private val unleashService: UnleashService,
     private val ytelseService: YtelseService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -59,7 +50,7 @@ class HåndterSøknadService(
             finnStønadstyperSomKanOpprettesFraJournalpost(journalpost).defaultStønadstype
                 ?: error("Fant ikke dokument brevkode for journalpost")
 
-        if (kanAutomatiskJournalføre(personIdent, stønadstype, journalpost)) {
+        if (kanAutomatiskJournalføre(journalpost)) {
             return journalføringService.journalførTilNyBehandling(
                 journalpost = journalpost,
                 personIdent = personIdent,
@@ -90,6 +81,7 @@ class HåndterSøknadService(
                     finnStønadstypeForDagligReise(journalpost),
                     Stønadstype.entries.filter { it.gjelderDagligReise() },
                 )
+
             Skjematype.SØKNAD_REISE_TIL_SAMLING ->
                 ValgbareStønadstyperForJournalpost(
                     finnStønadstypeForReiseTilSamling(journalpost),
@@ -191,27 +183,15 @@ class HåndterSøknadService(
 
     private fun List<Reise>.finnSenesteDato() = flatMap { listOf(it.periode.fom, it.periode.tom) }.max()
 
-    fun kanAutomatiskJournalføre(
-        personIdent: String,
-        stønadstype: Stønadstype,
-        journalpost: Journalpost,
-    ): Boolean {
+    fun kanAutomatiskJournalføre(journalpost: Journalpost): Boolean {
         if (!journalpost.gjelderKanalNavNo()) {
             logger.info("Journalpost=${journalpost.journalpostId} kan ikke automatisk journalføres pga kanal=${journalpost.kanal}")
             return false
         }
-        val allePersonIdenter = personService.hentFolkeregisterIdenter(personIdent).identer()
-        val fagsak = fagsakService.finnFagsak(allePersonIdenter, stønadstype)
-
-        return if (fagsak == null) {
-            true
-        } else {
-            val behandlinger = behandlingService.hentBehandlinger(fagsak.id)
-            !harÅpenBehandling(behandlinger)
-        }
+        // NAV_NO-søknader skal journalføres automatisk.
+        // Hvis det finnes aktiv behandling, blir ny behandling satt på vent i OpprettBehandlingService.
+        return true
     }
-
-    private fun harÅpenBehandling(behandlinger: List<Behandling>): Boolean = behandlinger.any { !it.erFerdigstilt() }
 
     private fun håndterSøknadSomIkkeKanAutomatiskJournalføres(
         personIdent: String,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterSøknadIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterSøknadIntegrationTest.kt
@@ -1,18 +1,14 @@
 package no.nav.tilleggsstonader.sak.ekstern.journalføring
 
-import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
-import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.finnAlleTaskerMedType
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksKlareForProsesseringTilIngenTasksIgjen
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførHenleggelse
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.defaultJournalpost
-import no.nav.tilleggsstonader.sak.opplysninger.oppgave.tasks.OpprettOppgaveTask
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import tools.jackson.module.kotlin.readValue
 
 class HåndterSøknadIntegrationTest : CleanDatabaseIntegrationTest() {
     @Test
@@ -23,20 +19,16 @@ class HåndterSøknadIntegrationTest : CleanDatabaseIntegrationTest() {
     }
 
     @Test
-    fun `skal opprette journalføringsoppgave hvis det allerede finnes aktiv behandling`() {
+    fun `skal opprette ny behandling satt på vent hvis det allerede finnes aktiv behandling`() {
         // Første journalføring vil føre til at det opprettes behandling
-        val journalpostId = "1"
-        håndterSøknadService.håndterSøknad(defaultJournalpost.copy(journalpostId = journalpostId))
+        håndterSøknadService.håndterSøknad(defaultJournalpost)
         kjørTasksKlareForProsesseringTilIngenTasksIgjen()
 
-        // Andre journalføring skal føre til journalføringsoppgave
-        håndterSøknadService.håndterSøknad(defaultJournalpost)
+        // Andre journalføring skal føre til ny behandling satt på vent
+        val nyBehandling = håndterSøknadService.håndterSøknad(defaultJournalpost)
 
-        val oppgaveTask = finnAlleTaskerMedType(OpprettOppgaveTask.TYPE).single()
-        val payload = jsonMapper.readValue<OpprettOppgaveTask.OpprettOppgaveTaskData>(oppgaveTask.payload)
-
-        assertThat(payload.oppgave.journalpostId).isEqualTo(journalpostId)
-        assertThat(payload.oppgave.oppgavetype).isEqualTo(Oppgavetype.Journalføring)
+        assertThat(nyBehandling).isNotNull()
+        assertThat(nyBehandling!!.status).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaSøknadIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/MottaSøknadIntegrationTest.kt
@@ -23,6 +23,7 @@ import no.nav.tilleggsstonader.kontrakter.ytelse.TypeYtelsePeriode
 import no.nav.tilleggsstonader.kontrakter.ytelse.YtelsePerioderDto
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingRepository
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingsjournalpostRepository
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakRepository
@@ -97,6 +98,58 @@ class MottaSøknadIntegrationTest : CleanDatabaseIntegrationTest() {
     }
 
     @Test
+    fun `mottar flere boutgifter-søknader fra kafka, journalføres og oppretter sak`() {
+        val hendelse1 = journalfoeringHendelseRecord()
+        val hendelse2 = journalfoeringHendelseRecord()
+        val hendelse3 = journalfoeringHendelseRecord()
+
+        // Søknad 1 — ingen aktiv behandling, skal opprette behandling og journalføre
+        journalhendelseKafkaListener.listen(
+            ConsumerRecordUtil.lagConsumerRecord("key1", hendelse1),
+            mockk<Acknowledgment>(relaxed = true),
+        )
+        assertThat(hendelseRepository.findByTypeAndId(TypeHendelse.JOURNALPOST, hendelse1.hendelsesId)).isNotNull
+        mockJournalpost(brevkode = DokumentBrevkode.BOUTGIFTER, søknad = søknadBoutgifter(ident = ident))
+        kjørTasksKlareForProsessering()
+
+        // Søknad 2 — aktiv behandling finnes, ønsket atferd: ny behandling settes på vent
+        journalhendelseKafkaListener.listen(
+            ConsumerRecordUtil.lagConsumerRecord("key2", hendelse2),
+            mockk<Acknowledgment>(relaxed = true),
+        )
+        assertThat(hendelseRepository.findByTypeAndId(TypeHendelse.JOURNALPOST, hendelse2.hendelsesId)).isNotNull
+        mockJournalpost(brevkode = DokumentBrevkode.BOUTGIFTER, søknad = søknadBoutgifter(ident = ident))
+        kjørTasksKlareForProsessering()
+
+        // Søknad 3 — aktiv behandling finnes, ønsket atferd: ny behandling settes på vent
+        journalhendelseKafkaListener.listen(
+            ConsumerRecordUtil.lagConsumerRecord("key3", hendelse3),
+            mockk<Acknowledgment>(relaxed = true),
+        )
+        assertThat(hendelseRepository.findByTypeAndId(TypeHendelse.JOURNALPOST, hendelse3.hendelsesId)).isNotNull
+        mockJournalpost(brevkode = DokumentBrevkode.BOUTGIFTER, søknad = søknadBoutgifter(ident = ident))
+        kjørTasksKlareForProsessering()
+
+        val fagsak = fagsakRepository.findBySøkerIdent(setOf(ident)).single()
+        assertThat(fagsak.stønadstype).isEqualTo(Stønadstype.BOUTGIFTER)
+
+        val behandlinger = behandlingRepository.findByFagsakId(fagsak.id)
+
+        // Ønsket atferd: 3 søknader → 3 behandlinger, der søknad 2 og 3 er satt på vent
+        // Faktisk atferd (bug): kun 1 behandling opprettes — søknad 2 og 3 blir journalføringsoppgaver og mister koblingen til en behandling
+        assertThat(behandlinger).hasSize(3)
+
+        val førsteSøknadBehandling = behandlinger.minByOrNull { it.sporbar.opprettetTid }!!
+        assertThat(førsteSøknadBehandling.status).isEqualTo(BehandlingStatus.OPPRETTET)
+
+        val øvrigeBehandlinger = behandlinger.filter { it.id != førsteSøknadBehandling.id }
+        assertThat(øvrigeBehandlinger).allSatisfy { behandling ->
+            assertThat(behandling.status).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
+            assertThat(behandling.årsak).isEqualTo(BehandlingÅrsak.SØKNAD)
+        }
+    }
+
+    @Test
     fun `mottar barnetilsyn-søknad fra kafka, journalføres og oppretter sak`() {
         val hendelse = journalfoeringHendelseRecord()
 
@@ -139,7 +192,7 @@ class MottaSøknadIntegrationTest : CleanDatabaseIntegrationTest() {
     }
 
     @Test
-    fun `mottar to læremidler-søknad på samme bruker fra kafka, journalføres og oppretter sak og en jfr-oppgave`() {
+    fun `mottar to læremidler-søknad på samme bruker fra kafka, journalføres og oppretter to behandlinger hvor siste settes på vent`() {
         val hendelse1 = journalfoeringHendelseRecord(journalpostId = 67)
         val hendelse2 = journalfoeringHendelseRecord(journalpostId = 6767)
 
@@ -167,19 +220,21 @@ class MottaSøknadIntegrationTest : CleanDatabaseIntegrationTest() {
         )
         kjørTasksKlareForProsesseringTilIngenTasksIgjen()
 
-        validerFinnesBehandlingPåFagsakMedIdentAvTypeMedJournalpostRef(
-            ident,
-            Stønadstype.LÆREMIDLER,
-            hendelse1.journalpostId.toString(),
-        )
+        val fagsak = fagsakRepository.findBySøkerIdent(setOf(ident)).single()
+        assertThat(fagsak.stønadstype).isEqualTo(Stønadstype.LÆREMIDLER)
 
-        // Verifiserer at det har blitt opprettet jfr-oppgave for den andre søknaden
-        assertThat(
-            oppgavelager.alleOppgaver().filter {
-                it.journalpostId?.toLong() == hendelse2.journalpostId &&
-                    it.oppgavetype == "JFR"
-            },
-        ).hasSize(1)
+        val behandlinger = behandlingRepository.findByFagsakId(fagsak.id)
+        assertThat(behandlinger).hasSize(2)
+
+        val behandlingSortertPåTid = behandlinger.sortedBy { it.sporbar.opprettetTid }
+        assertThat(behandlingSortertPåTid.first().status).isEqualTo(BehandlingStatus.OPPRETTET)
+        assertThat(behandlingSortertPåTid.last().status).isEqualTo(BehandlingStatus.SATT_PÅ_VENT)
+
+        val førsteBehandlingJournalposter = behandlingsjournalpostRepository.findAllByBehandlingId(behandlingSortertPåTid.first().id)
+        assertThat(førsteBehandlingJournalposter.map { it.journalpostId }).contains(hendelse1.journalpostId.toString())
+
+        val andreBehandlingJournalposter = behandlingsjournalpostRepository.findAllByBehandlingId(behandlingSortertPåTid.last().id)
+        assertThat(andreBehandlingJournalposter.map { it.journalpostId }).contains(hendelse2.journalpostId.toString())
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å automatisk kunne opprette nye behandlinger basert på innsendte søknader. Dersom det finnes en aktiv behandling settes de nye behandlingene på vent. 

Meldt inn av SB at det forsvant en behandling da det kom inn to behandlinger på samme stønadstype samme dag. 

