### PR TITLE
🧵 Håndter race condition for mellomalgring av brev

### DIFF
--- a/.github/.nav-pilot-state.json
+++ b/.github/.nav-pilot-state.json
@@ -1,7 +1,7 @@
 {
   "collection": "kotlin-backend",
-  "version": "2026.04.30-090824-bb25c0e",
-  "source_sha": "14b480c",
+  "version": "2026.05.08-074522-0bbf582",
+  "source_sha": "0bbf582",
   "installed_at": "2026-04-13T13:37:44Z",
   "files": [
     {
@@ -46,7 +46,7 @@
     },
     {
       "path": ".github/agents/nav-pilot.agent.md",
-      "hash": "8384742b958b4b84"
+      "hash": "71eaa207ac601d66"
     },
     {
       "path": ".github/agents/nav-pilot.metadata.json",
@@ -82,7 +82,7 @@
     },
     {
       "path": ".github/skills/nav-deep-interview/",
-      "hash": "42e9aab52e591ef0"
+      "hash": "eeb3399ecd4e352c"
     },
     {
       "path": ".github/skills/nav-architecture-review/",

--- a/.github/agents/nav-pilot.agent.md
+++ b/.github/agents/nav-pilot.agent.md
@@ -34,7 +34,7 @@ On EVERY turn, follow this loop:
 5. End EVERY response with a compact state footer
 
 Phase headers (mandatory first line):
-🔍 Fase 1: Intervju — kartlegger behov og blinde flekker
+🔍 Fase 1: Intervju — kartlegger behov og blindsoner
 📐 Fase 2: Plan — bygger arkitektur og beslutninger
 🔎 Fase 3: Review — verifiserer fra fire perspektiver
 🚀 Fase 4: Lever — genererer kode og dokumentasjon
@@ -102,7 +102,7 @@ End each phase with a checkpoint summary before transitioning:
 Oppsummering:
 • Arketype: [valgt arketype]
 • Endringstype: [nybygg/modernisering/refaktorering]
-• Blinde flekker adressert: [N/11]
+• Blindsoner adressert: [N/11]
 • Nøkkelbeslutninger: [liste]
 • Åpne spørsmål: [liste, eller «ingen»]
 

--- a/.github/skills/nav-deep-interview/SKILL.md
+++ b/.github/skills/nav-deep-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nav-deep-interview
-description: Strukturert intervju som avdekker blinde flekker i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet
+description: Strukturert intervju som avdekker blindsoner i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet
 license: MIT
 metadata:
   domain: general
@@ -9,7 +9,7 @@ metadata:
 
 # Deep Interview — Nav Project Clarification
 
-Kjør et strukturert intervju for å avdekke blinde flekker *før* implementering starter. Basert på vanlige feil og oversikter i Nav-prosjekter.
+Kjør et strukturert intervju for å avdekke blindsoner *før* implementering starter. Basert på vanlige feil og oversikter i Nav-prosjekter.
 
 ## Workflow
 
@@ -94,13 +94,13 @@ Still disse spørsmålene hvis T1 avdekker modernisering/refaktorering:
 | M7 | Finnes det data som må migreres? Hvor mye? | Påvirker migreringspipeline og nedetid |
 | M8 | Har dere karakteriseringstester som låser dagens adferd? | Nødvendig for trygg refaktorering |
 
-## Steg 3: Sjekk blinde flekker
+## Steg 3: Sjekk blindsoner
 
-Etter intervjuet, sjekk om noen av disse vanlige blinde flekkene ble avdekket. Hvis ikke — still oppfølgingsspørsmål.
+Etter intervjuet, sjekk om noen av disse vanlige blindsonene ble avdekket. Hvis ikke — still oppfølgingsspørsmål.
 
 Se [blind-spots.md](./references/blind-spots.md) for en komplett liste over vanlige oversikter.
 
-**Kritiske blinde flekker (still alltid):**
+**Kritiske blindsoner (still alltid):**
 
 - [ ] Er auth-mekanismen verifisert mot caller-typen?
 - [ ] Er `accessPolicy.inbound` definert i Nais-manifestet?
@@ -109,7 +109,7 @@ Se [blind-spots.md](./references/blind-spots.md) for en komplett liste over vanl
 - [ ] Er det satt opp structured logging (JSON)?
 - [ ] Finnes det en strategi for dependency failure?
 
-**Ekstra blinde flekker for modernisering (still hvis T1 = modernisering):**
+**Ekstra blindsoner for modernisering (still hvis T1 = modernisering):**
 
 - [ ] Er bakoverkompatibilitet vurdert? (Kan gammel kode lese nytt skjema?)
 - [ ] Er rollback-plan definert og testet?

--- a/.github/skills/nav-deep-interview/metadata.json
+++ b/.github/skills/nav-deep-interview/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Strukturert intervju som avdekker blinde flekker i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet",
+  "description": "Strukturert intervju som avdekker blindsoner i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet",
   "domain": "general",
   "tags": ["planning", "requirements", "interview", "onboarding", "nav-pilot"],
   "references": [
@@ -9,7 +9,7 @@
   "examples": [
     {
       "prompt": "Kjør et dypintervju for den nye dp-behandling-tjenesten",
-      "scenario": "Avdekk blinde flekker i nytt prosjekt"
+      "scenario": "Avdekk blindsoner i nytt prosjekt"
     },
     {
       "prompt": "Still de viktige spørsmålene vi glemmer før vi begynner å kode",

--- a/.github/skills/nav-deep-interview/references/blind-spots.md
+++ b/.github/skills/nav-deep-interview/references/blind-spots.md
@@ -1,11 +1,11 @@
-# Vanlige blinde flekker i Nav-prosjekter
+# Vanlige blindsoner i Nav-prosjekter
 
 Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltakspenger, fp-sak) og vanlige feil som oppdages sent i utviklingsprosessen.
 
 ## Autentisering og autorisasjon
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Feil auth-mekanisme for caller-type | Token-validering feiler i prod | «Hvem kaller tjenesten — bruker via nettleser eller tjeneste-til-tjeneste?» |
 | Azure client_credentials med brukerkontext | Mister bruker-audit trail, kan ikke spore hvem som gjorde hva | «Trenger du brukerens identitet nedover i kjeden?» |
 | Manglende `accessPolicy.inbound` | Ingen kan kalle tjenesten, feiler stille | «Hvilke tjenester skal ha lov til å kalle deg?» |
@@ -13,8 +13,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Database
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | HikariCP default pool (10) | Pool exhaustion i containere med 2-4 replicas | «Hvor mange samtidige database-tilkoblinger trenger dere?» |
 | Manglende indekser på foreign keys | Sakte queries ved JOIN, lås-eskalering | «Hvilke kolonner vil dere filtrere/joine på?» |
 | Ingen retensjonsstrategi | Data vokser ubegrenset, GDPR-brudd | «Hvor lenge skal data lagres? Finnes det slettekrav?» |
@@ -22,8 +22,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Kafka og hendelser
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Ingen dead-letter-strategi | Poison pills stopper konsument | «Hva skjer med meldinger som ikke kan prosesseres?» |
 | Manglende idempotens | Duplikate hendelser gir duplikate vedtak | «Kan tjenesten håndtere samme melding to ganger?» |
 | Feil partisjonering | Rekkefølge-garanti brytes | «Er rekkefølgen på hendelser viktig?» |
@@ -31,8 +31,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Observerbarhet
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Kun tekniske metrikker | Vet ikke om forretningslogikken fungerer | «Hvilke forretningsmetrikker viser at tjenesten gjør jobben sin?» |
 | Manglende correlation ID | Kan ikke spore forespørsler på tvers av tjenester | «Propagerer dere callId/correlationId?» |
 | Logging av PII | GDPR-brudd, Personvernombudet tar kontakt | «Hva logges? Er fnr/navn filtrert ut?» |
@@ -40,8 +40,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Frontend
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Manglende universell utforming | Lovbrudd (likestillingsloven) | «Er UU-krav ivaretatt? Bruker dere Aksel-komponenter?» |
 | Direkte API-kall fra klient | CORS-problemer, token-eksponering | «Bruker dere BFF-mønster med server-side proxy?» |
 | Tailwind p-/m- i stedet for Aksel tokens | Inkonsistent design, vanskelig vedlikehold | «Bruker dere Aksel spacing-tokens (Box, VStack)?» |
@@ -49,8 +49,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Sikkerhet
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | SQL string concatenation | SQL injection | «Er alle database-queries parameteriserte?» |
 | CORS `*` | Cross-site request forgery | «Hvilke domener skal ha CORS-tilgang?» |
 | Manglende input-validering | Injection, crash | «Valideres all ekstern input?» |

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -24,14 +24,12 @@ class MellomlagringBrevService(
         feilHvis(behandlingService.behandlingErLåstForVidereRedigering(behandlingId)) {
             "Kan ikke mellomlagre brev for behandling=$behandlingId når behandlingen er låst."
         }
-        slettMellomlagringHvisFinnes(behandlingId)
-        val mellomlagretBrev =
-            MellomlagretBrev(
-                behandlingId,
-                brevverdier,
-                brevmal,
-            )
-        return mellomlagerBrevRepository.insert(mellomlagretBrev).behandlingId
+        val eksisterende = mellomlagerBrevRepository.findByIdOrNull(behandlingId)
+        return if (eksisterende == null) {
+            mellomlagerBrevRepository.insert(MellomlagretBrev(behandlingId, brevverdier, brevmal))
+        } else {
+            mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
+        }.behandlingId
     }
 
     @Transactional
@@ -61,10 +59,6 @@ class MellomlagringBrevService(
         mellomlagerBrevRepository.findByIdOrNull(behhandlingId)?.let {
             MellomlagreBrevDto(it.brevverdier, it.brevmal)
         }
-
-    fun slettMellomlagringHvisFinnes(behandlingId: BehandlingId) {
-        mellomlagerBrevRepository.deleteById(behandlingId)
-    }
 
     fun slettMellomlagretFrittståendeBrev(
         fagsakId: FagsakId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -26,9 +26,10 @@ class MellomlagringBrevService(
         feilHvis(behandlingService.behandlingErLåstForVidereRedigering(behandlingId)) {
             "Kan ikke mellomlagre brev for behandling=$behandlingId når behandlingen er låst."
         }
-        return advisoryLockService.lockForTransaction(behandlingId) {
-            lagreMellomlagretBrev(behandlingId, brevverdier, brevmal)
-        }.behandlingId
+        return advisoryLockService
+            .lockForTransaction(behandlingId) {
+                lagreMellomlagretBrev(behandlingId, brevverdier, brevmal)
+            }.behandlingId
     }
 
     private fun lagreMellomlagretBrev(
@@ -50,8 +51,7 @@ class MellomlagringBrevService(
         eksisterende: MellomlagretBrev,
         brevverdier: String,
         brevmal: String,
-    ): MellomlagretBrev =
-        mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
+    ): MellomlagretBrev = mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
 
     @Transactional
     fun mellomLagreFrittståendeSanitybrev(
@@ -59,15 +59,42 @@ class MellomlagringBrevService(
         brevverdier: String,
         brevmal: String,
     ): FagsakId {
-        slettMellomlagretFrittståendeBrev(fagsakId, SikkerhetContext.hentSaksbehandler())
-        val mellomlagretBrev =
+        val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
+        return advisoryLockService
+            .lockForTransaction(fagsakId to saksbehandlerIdent) {
+                lagreMellomlagretFrittståendeBrev(fagsakId, brevverdier, brevmal, saksbehandlerIdent)
+            }.fagsakId
+    }
+
+    private fun lagreMellomlagretFrittståendeBrev(
+        fagsakId: FagsakId,
+        brevverdier: String,
+        brevmal: String,
+        saksbehandlerIdent: String,
+    ): MellomlagretFrittståendeBrev =
+        mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, saksbehandlerIdent)?.let {
+            oppdaterMellomlagretFrittståendeBrev(it, brevverdier, brevmal)
+        } ?: opprettMellomlagretFrittståendeBrev(fagsakId, brevverdier, brevmal)
+
+    private fun opprettMellomlagretFrittståendeBrev(
+        fagsakId: FagsakId,
+        brevverdier: String,
+        brevmal: String,
+    ): MellomlagretFrittståendeBrev =
+        mellomlagerFrittståendeBrevRepository.insert(
             MellomlagretFrittståendeBrev(
                 fagsakId = fagsakId,
                 brevverdier = brevverdier,
                 brevmal = brevmal,
-            )
-        return mellomlagerFrittståendeBrevRepository.insert(mellomlagretBrev).fagsakId
-    }
+            ),
+        )
+
+    private fun oppdaterMellomlagretFrittståendeBrev(
+        eksisterende: MellomlagretFrittståendeBrev,
+        brevverdier: String,
+        brevmal: String,
+    ): MellomlagretFrittståendeBrev =
+        mellomlagerFrittståendeBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
 
     fun hentMellomlagretFrittståendeSanitybrev(fagsakId: FagsakId): MellomlagreBrevDto? =
         mellomlagerFrittståendeBrevRepository

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -1,10 +1,14 @@
 package no.nav.tilleggsstonader.sak.brev.mellomlager
 
+import no.nav.tilleggsstonader.libs.log.logger
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,8 +18,8 @@ class MellomlagringBrevService(
     private val behandlingService: BehandlingService,
     private val mellomlagerBrevRepository: MellomlagerBrevRepository,
     private val mellomlagerFrittståendeBrevRepository: MellomlagerFrittståendeBrevRepository,
+    private val transactionHandler: TransactionHandler,
 ) {
-    @Transactional
     fun mellomlagreBrev(
         behandlingId: BehandlingId,
         brevverdier: String,
@@ -26,11 +30,49 @@ class MellomlagringBrevService(
         }
         val eksisterende = mellomlagerBrevRepository.findByIdOrNull(behandlingId)
         return if (eksisterende == null) {
-            mellomlagerBrevRepository.insert(MellomlagretBrev(behandlingId, brevverdier, brevmal))
+            opprettMellomlagretBrev(behandlingId, brevverdier, brevmal).behandlingId
         } else {
-            mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
-        }.behandlingId
+            oppdaterMellomlagretBrev(eksisterende, brevverdier, brevmal).behandlingId
+        }
     }
+
+    private fun opprettMellomlagretBrev(
+        behandlingId: BehandlingId,
+        brevverdier: String,
+        brevmal: String,
+    ): MellomlagretBrev =
+        try {
+            transactionHandler.runInNewTransaction {
+                mellomlagerBrevRepository.insert(MellomlagretBrev(behandlingId, brevverdier, brevmal))
+            }
+        } catch (_: DuplicateKeyException) {
+            håndterDuplikatVedOpprettelse(behandlingId, brevverdier, brevmal)
+        }
+
+    private fun håndterDuplikatVedOpprettelse(
+        behandlingId: BehandlingId,
+        brevverdier: String,
+        brevmal: String,
+    ): MellomlagretBrev {
+        logger.info(
+            "Mellomlagret brev finnes allerede behandling=$behandlingId (mulig race condition). Oppdaterer eksisterende.",
+        )
+        return transactionHandler.runInNewTransaction {
+            val eksisterende =
+                mellomlagerBrevRepository.findByIdOrNull(behandlingId)
+                    ?: feil("Fant ikke mellomlagret brev etter DuplicateKeyException for behandling=$behandlingId")
+            mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
+        }
+    }
+
+    private fun oppdaterMellomlagretBrev(
+        eksisterende: MellomlagretBrev,
+        brevverdier: String,
+        brevmal: String,
+    ): MellomlagretBrev =
+        transactionHandler.runInTransaction {
+            mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
+        }
 
     @Transactional
     fun mellomLagreFrittståendeSanitybrev(
@@ -55,8 +97,8 @@ class MellomlagringBrevService(
                 SikkerhetContext.hentSaksbehandler(),
             )?.let { MellomlagreBrevDto(it.brevverdier, it.brevmal) }
 
-    fun hentMellomlagretBrev(behhandlingId: BehandlingId): MellomlagreBrevDto? =
-        mellomlagerBrevRepository.findByIdOrNull(behhandlingId)?.let {
+    fun hentMellomlagretBrev(behandlingId: BehandlingId): MellomlagreBrevDto? =
+        mellomlagerBrevRepository.findByIdOrNull(behandlingId)?.let {
             MellomlagreBrevDto(it.brevverdier, it.brevmal)
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevService.kt
@@ -1,14 +1,11 @@
 package no.nav.tilleggsstonader.sak.brev.mellomlager
 
-import no.nav.tilleggsstonader.libs.log.logger
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
+import no.nav.tilleggsstonader.sak.infrastruktur.database.AdvisoryLockService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
-import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
-import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,8 +15,9 @@ class MellomlagringBrevService(
     private val behandlingService: BehandlingService,
     private val mellomlagerBrevRepository: MellomlagerBrevRepository,
     private val mellomlagerFrittståendeBrevRepository: MellomlagerFrittståendeBrevRepository,
-    private val transactionHandler: TransactionHandler,
+    private val advisoryLockService: AdvisoryLockService,
 ) {
+    @Transactional
     fun mellomlagreBrev(
         behandlingId: BehandlingId,
         brevverdier: String,
@@ -28,51 +26,32 @@ class MellomlagringBrevService(
         feilHvis(behandlingService.behandlingErLåstForVidereRedigering(behandlingId)) {
             "Kan ikke mellomlagre brev for behandling=$behandlingId når behandlingen er låst."
         }
-        val eksisterende = mellomlagerBrevRepository.findByIdOrNull(behandlingId)
-        return if (eksisterende == null) {
-            opprettMellomlagretBrev(behandlingId, brevverdier, brevmal).behandlingId
-        } else {
-            oppdaterMellomlagretBrev(eksisterende, brevverdier, brevmal).behandlingId
-        }
+        return advisoryLockService.lockForTransaction(behandlingId) {
+            lagreMellomlagretBrev(behandlingId, brevverdier, brevmal)
+        }.behandlingId
     }
+
+    private fun lagreMellomlagretBrev(
+        behandlingId: BehandlingId,
+        brevverdier: String,
+        brevmal: String,
+    ): MellomlagretBrev =
+        mellomlagerBrevRepository.findByIdOrNull(behandlingId)?.let {
+            oppdaterMellomlagretBrev(it, brevverdier, brevmal)
+        } ?: opprettMellomlagretBrev(behandlingId, brevverdier, brevmal)
 
     private fun opprettMellomlagretBrev(
         behandlingId: BehandlingId,
         brevverdier: String,
         brevmal: String,
-    ): MellomlagretBrev =
-        try {
-            transactionHandler.runInNewTransaction {
-                mellomlagerBrevRepository.insert(MellomlagretBrev(behandlingId, brevverdier, brevmal))
-            }
-        } catch (_: DuplicateKeyException) {
-            håndterDuplikatVedOpprettelse(behandlingId, brevverdier, brevmal)
-        }
-
-    private fun håndterDuplikatVedOpprettelse(
-        behandlingId: BehandlingId,
-        brevverdier: String,
-        brevmal: String,
-    ): MellomlagretBrev {
-        logger.info(
-            "Mellomlagret brev finnes allerede behandling=$behandlingId (mulig race condition). Oppdaterer eksisterende.",
-        )
-        return transactionHandler.runInNewTransaction {
-            val eksisterende =
-                mellomlagerBrevRepository.findByIdOrNull(behandlingId)
-                    ?: feil("Fant ikke mellomlagret brev etter DuplicateKeyException for behandling=$behandlingId")
-            mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
-        }
-    }
+    ): MellomlagretBrev = mellomlagerBrevRepository.insert(MellomlagretBrev(behandlingId, brevverdier, brevmal))
 
     private fun oppdaterMellomlagretBrev(
         eksisterende: MellomlagretBrev,
         brevverdier: String,
         brevmal: String,
     ): MellomlagretBrev =
-        transactionHandler.runInTransaction {
-            mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
-        }
+        mellomlagerBrevRepository.update(eksisterende.copy(brevverdier = brevverdier, brevmal = brevmal))
 
     @Transactional
     fun mellomLagreFrittståendeSanitybrev(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
@@ -50,8 +50,8 @@ class MellomlagringBrevServiceTest {
     fun resetMocks() {
         clearMocks(behandlingService, advisoryLockService, mellomlagerBrevRepository, mellomlagerFrittståendeBrevRepository)
         every { behandlingService.behandlingErLåstForVidereRedigering(any()) } returns false
-        every { advisoryLockService.lockForTransaction(any(), any<() -> MellomlagretBrev>()) } answers {
-            secondArg<() -> MellomlagretBrev>().invoke()
+        every { advisoryLockService.lockForTransaction(any(), any<Function0<Any?>>()) } answers {
+            secondArg<Function0<Any?>>().invoke()
         }
     }
 
@@ -68,7 +68,7 @@ class MellomlagringBrevServiceTest {
         assertThat(nyttBrev.captured.brevverdier).isEqualTo(brevverdier)
         assertThat(nyttBrev.captured.brevmal).isEqualTo(brevmal)
         verify(exactly = 1) {
-            advisoryLockService.lockForTransaction(behandlingId, any<() -> MellomlagretBrev>())
+            advisoryLockService.lockForTransaction(behandlingId, any<Function0<Any?>>())
         }
     }
 
@@ -89,7 +89,7 @@ class MellomlagringBrevServiceTest {
             ),
         )
         verify(exactly = 1) {
-            advisoryLockService.lockForTransaction(behandlingId, any<() -> MellomlagretBrev>())
+            advisoryLockService.lockForTransaction(behandlingId, any<Function0<Any?>>())
         }
     }
 
@@ -107,6 +107,55 @@ class MellomlagringBrevServiceTest {
                 brevverdier = mellomlagretBrev.brevverdier,
             ),
         )
+    }
+
+    @Test
+    fun `mellomLagreFrittståendeSanitybrev skal insert når brev ikke finnes`() {
+        val fagsakId = FagsakId.random()
+        val nyttBrev = slot<MellomlagretFrittståendeBrev>()
+        every {
+            mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, "bob")
+        } returns null
+        every { mellomlagerFrittståendeBrevRepository.insert(capture(nyttBrev)) } answers { nyttBrev.captured }
+
+        val resultat = mellomlagringBrevService.mellomLagreFrittståendeSanitybrev(fagsakId, brevverdier, brevmal)
+
+        assertThat(resultat).isEqualTo(fagsakId)
+        assertThat(nyttBrev.captured.fagsakId).isEqualTo(fagsakId)
+        assertThat(nyttBrev.captured.brevverdier).isEqualTo(brevverdier)
+        assertThat(nyttBrev.captured.brevmal).isEqualTo(brevmal)
+        verify(exactly = 1) {
+            advisoryLockService.lockForTransaction(fagsakId to "bob", any<Function0<Any?>>())
+        }
+    }
+
+    @Test
+    fun `mellomLagreFrittståendeSanitybrev skal update når brev finnes`() {
+        val fagsakId = FagsakId.random()
+        val oppdatertBrev = slot<MellomlagretFrittståendeBrev>()
+        val eksisterendeBrev =
+            MellomlagretFrittståendeBrev(
+                fagsakId = fagsakId,
+                brevverdier = "gammelVerdi",
+                brevmal = "gammelMal",
+            )
+        every {
+            mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, "bob")
+        } returns eksisterendeBrev
+        every { mellomlagerFrittståendeBrevRepository.update(capture(oppdatertBrev)) } answers { oppdatertBrev.captured }
+
+        val resultat = mellomlagringBrevService.mellomLagreFrittståendeSanitybrev(fagsakId, brevverdier, brevmal)
+
+        assertThat(resultat).isEqualTo(fagsakId)
+        assertThat(oppdatertBrev.captured).isEqualTo(
+            eksisterendeBrev.copy(
+                brevverdier = brevverdier,
+                brevmal = brevmal,
+            ),
+        )
+        verify(exactly = 1) {
+            advisoryLockService.lockForTransaction(fagsakId to "bob", any<Function0<Any?>>())
+        }
     }
 
     @Test
@@ -130,6 +179,25 @@ class MellomlagringBrevServiceTest {
                 brevverdier = mellomlagretBrev.brevverdier,
             ),
         )
+    }
+
+    @Test
+    fun `slettMellomlagretFrittståendeBrev skal slette eksisterende brev`() {
+        val fagsakId = FagsakId.random()
+        val brev = MellomlagretFrittståendeBrev(fagsakId = fagsakId, brevverdier = brevverdier, brevmal = brevmal)
+        every {
+            mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, "bob")
+        } returns brev
+        every { mellomlagerFrittståendeBrevRepository.deleteById(brev.id) } returns Unit
+
+        mellomlagringBrevService.slettMellomlagretFrittståendeBrev(fagsakId, "bob")
+
+        verify(exactly = 1) {
+            mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSporbarOpprettetAv(fagsakId, "bob")
+        }
+        verify(exactly = 1) {
+            mellomlagerFrittståendeBrevRepository.deleteById(brev.id)
+        }
     }
 
     private val behandlingId = BehandlingId.random()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
@@ -1,18 +1,23 @@
 package no.nav.tilleggsstonader.sak.brev.mellomlager
 
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkObject
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.repository.findByIdOrNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -25,17 +30,76 @@ class MellomlagringBrevServiceTest {
             behandlingService = behandlingService,
             mellomlagerBrevRepository = mellomlagerBrevRepository,
             mellomlagerFrittståendeBrevRepository = mellomlagerFrittståendeBrevRepository,
+            transactionHandler = TransactionHandler(),
         )
 
     @BeforeAll
     fun setUp() {
         mockkObject(SikkerhetContext)
         every { SikkerhetContext.hentSaksbehandler() } returns "bob"
+        every { SikkerhetContext.hentSaksbehandlerEllerSystembruker() } returns "bob"
     }
 
     @AfterAll
     fun tearDown() {
         unmockkObject(SikkerhetContext)
+    }
+
+    @BeforeEach
+    fun resetMocks() {
+        clearMocks(behandlingService, mellomlagerBrevRepository, mellomlagerFrittståendeBrevRepository)
+        every { behandlingService.behandlingErLåstForVidereRedigering(any()) } returns false
+    }
+
+    @Test
+    fun `mellomlagreBrev skal insert når brev ikke finnes`() {
+        val nyttBrev = slot<MellomlagretBrev>()
+        every { mellomlagerBrevRepository.findByIdOrNull(behandlingId) } returns null
+        every { mellomlagerBrevRepository.insert(capture(nyttBrev)) } answers { nyttBrev.captured }
+
+        val resultat = mellomlagringBrevService.mellomlagreBrev(behandlingId, brevverdier, brevmal)
+
+        assertThat(resultat).isEqualTo(behandlingId)
+        assertThat(nyttBrev.captured.behandlingId).isEqualTo(behandlingId)
+        assertThat(nyttBrev.captured.brevverdier).isEqualTo(brevverdier)
+        assertThat(nyttBrev.captured.brevmal).isEqualTo(brevmal)
+    }
+
+    @Test
+    fun `mellomlagreBrev skal update når brev finnes`() {
+        val oppdatertBrev = slot<MellomlagretBrev>()
+        val eksisterendeBrev = MellomlagretBrev(behandlingId, "gammelVerdi", "gammelMal")
+        every { mellomlagerBrevRepository.findByIdOrNull(behandlingId) } returns eksisterendeBrev
+        every { mellomlagerBrevRepository.update(capture(oppdatertBrev)) } answers { oppdatertBrev.captured }
+
+        val resultat = mellomlagringBrevService.mellomlagreBrev(behandlingId, brevverdier, brevmal)
+
+        assertThat(resultat).isEqualTo(behandlingId)
+        assertThat(oppdatertBrev.captured).isEqualTo(
+            eksisterendeBrev.copy(
+                brevverdier = brevverdier,
+                brevmal = brevmal,
+            ),
+        )
+    }
+
+    @Test
+    fun `mellomlagreBrev skal håndtere duplikat ved insert ved å oppdatere eksisterende brev`() {
+        val oppdatertBrev = slot<MellomlagretBrev>()
+        val eksisterendeBrev = MellomlagretBrev(behandlingId, "annenVerdi", "annenMal")
+        every { mellomlagerBrevRepository.findByIdOrNull(behandlingId) } returns null andThen eksisterendeBrev
+        every { mellomlagerBrevRepository.insert(any()) } throws DuplicateKeyException("duplikat")
+        every { mellomlagerBrevRepository.update(capture(oppdatertBrev)) } answers { oppdatertBrev.captured }
+
+        val resultat = mellomlagringBrevService.mellomlagreBrev(behandlingId, brevverdier, brevmal)
+
+        assertThat(resultat).isEqualTo(behandlingId)
+        assertThat(oppdatertBrev.captured).isEqualTo(
+            eksisterendeBrev.copy(
+                brevverdier = brevverdier,
+                brevmal = brevmal,
+            ),
+        )
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/MellomlagringBrevServiceTest.kt
@@ -6,10 +6,11 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
+import io.mockk.verify
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
-import no.nav.tilleggsstonader.sak.infrastruktur.felles.TransactionHandler
+import no.nav.tilleggsstonader.sak.infrastruktur.database.AdvisoryLockService
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.SikkerhetContext
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.junit.jupiter.api.AfterAll
@@ -17,12 +18,12 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.repository.findByIdOrNull
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MellomlagringBrevServiceTest {
     private val behandlingService = mockk<BehandlingService>()
+    private val advisoryLockService = mockk<AdvisoryLockService>()
     private val mellomlagerBrevRepository = mockk<MellomlagerBrevRepository>()
     private val mellomlagerFrittståendeBrevRepository = mockk<MellomlagerFrittståendeBrevRepository>()
     private val mellomlagringBrevService =
@@ -30,7 +31,7 @@ class MellomlagringBrevServiceTest {
             behandlingService = behandlingService,
             mellomlagerBrevRepository = mellomlagerBrevRepository,
             mellomlagerFrittståendeBrevRepository = mellomlagerFrittståendeBrevRepository,
-            transactionHandler = TransactionHandler(),
+            advisoryLockService = advisoryLockService,
         )
 
     @BeforeAll
@@ -47,8 +48,11 @@ class MellomlagringBrevServiceTest {
 
     @BeforeEach
     fun resetMocks() {
-        clearMocks(behandlingService, mellomlagerBrevRepository, mellomlagerFrittståendeBrevRepository)
+        clearMocks(behandlingService, advisoryLockService, mellomlagerBrevRepository, mellomlagerFrittståendeBrevRepository)
         every { behandlingService.behandlingErLåstForVidereRedigering(any()) } returns false
+        every { advisoryLockService.lockForTransaction(any(), any<() -> MellomlagretBrev>()) } answers {
+            secondArg<() -> MellomlagretBrev>().invoke()
+        }
     }
 
     @Test
@@ -63,6 +67,9 @@ class MellomlagringBrevServiceTest {
         assertThat(nyttBrev.captured.behandlingId).isEqualTo(behandlingId)
         assertThat(nyttBrev.captured.brevverdier).isEqualTo(brevverdier)
         assertThat(nyttBrev.captured.brevmal).isEqualTo(brevmal)
+        verify(exactly = 1) {
+            advisoryLockService.lockForTransaction(behandlingId, any<() -> MellomlagretBrev>())
+        }
     }
 
     @Test
@@ -81,25 +88,9 @@ class MellomlagringBrevServiceTest {
                 brevmal = brevmal,
             ),
         )
-    }
-
-    @Test
-    fun `mellomlagreBrev skal håndtere duplikat ved insert ved å oppdatere eksisterende brev`() {
-        val oppdatertBrev = slot<MellomlagretBrev>()
-        val eksisterendeBrev = MellomlagretBrev(behandlingId, "annenVerdi", "annenMal")
-        every { mellomlagerBrevRepository.findByIdOrNull(behandlingId) } returns null andThen eksisterendeBrev
-        every { mellomlagerBrevRepository.insert(any()) } throws DuplicateKeyException("duplikat")
-        every { mellomlagerBrevRepository.update(capture(oppdatertBrev)) } answers { oppdatertBrev.captured }
-
-        val resultat = mellomlagringBrevService.mellomlagreBrev(behandlingId, brevverdier, brevmal)
-
-        assertThat(resultat).isEqualTo(behandlingId)
-        assertThat(oppdatertBrev.captured).isEqualTo(
-            eksisterendeBrev.copy(
-                brevverdier = brevverdier,
-                brevmal = brevmal,
-            ),
-        )
+        verify(exactly = 1) {
+            advisoryLockService.lockForTransaction(behandlingId, any<() -> MellomlagretBrev>())
+        }
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I dag:

1. Kall A leser: "ingen rad for denne brev-IDen"
2. Kall B leser: "ingen red for denne brev-IDen
3. Begge prøver `insert` 
4. én vinner, én får `DuplicateKeyException` ☠️


Med advisory lock 🔐

1. Kall A tar låsen for brevId=123
2. Kall B prøver samme lås og må vente
3. A leser "rad finnes ikke" og kjører `insert`
4. A legger tilbake nøkkelen
5. B tar nøkkelen og leser "rad finnes", kjører `update` 💚
