### PR TITLE
👔 Fiks beregningsdato for daglige reiser

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/Beregningsplan.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/Beregningsplan.kt
@@ -3,7 +3,8 @@ package no.nav.tilleggsstonader.sak.vedtak
 import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.LocalDate
 
-data class Beregningsplan(
+@ConsistentCopyVisibility
+data class Beregningsplan internal constructor(
     val omfang: Beregningsomfang,
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val fraDato: LocalDate? = null,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/BeregningsplanUtleder.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/BeregningsplanUtleder.kt
@@ -1,9 +1,11 @@
 package no.nav.tilleggsstonader.sak.vedtak
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class BeregningsplanUtleder(
@@ -14,17 +16,36 @@ class BeregningsplanUtleder(
         vedtaksperioder: List<Vedtaksperiode>,
     ): Beregningsplan {
         if (saksbehandling.forrigeIverksatteBehandlingId == null) {
-            return Beregningsplan(omfang = Beregningsomfang.ALLE_PERIODER)
+            return Beregningsplan(Beregningsomfang.ALLE_PERIODER)
         }
         val tidligsteEndring =
             utledTidligsteEndringService.utledTidligsteEndringForBeregning(saksbehandling.id, vedtaksperioder)
         return if (tidligsteEndring != null) {
             Beregningsplan(
                 omfang = Beregningsomfang.FRA_DATO,
-                fraDato = tidligsteEndring,
+                fraDato = finnBeregnFraDato(saksbehandling.stønadstype, tidligsteEndring),
             )
         } else {
-            Beregningsplan(omfang = Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT)
+            Beregningsplan(Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT)
         }
+    }
+
+    companion object {
+        fun utledForOpphørEllerSatsjustering(
+            stønadstype: Stønadstype,
+            opphørsdato: LocalDate,
+        ): Beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, finnBeregnFraDato(stønadstype, opphørsdato))
+
+        private fun finnBeregnFraDato(
+            stønadstype: Stønadstype,
+            tidligsteEndring: LocalDate,
+        ): LocalDate =
+            when (stønadstype) {
+                // For daglig reise vil vi reberegne perioder som starter opptil 29 dager unna tidligste endring-datoen. Det er fordi stønaden til
+                // offentlig transport er delt inn i 30-dagersperioder, og vi ellers ville kunne risikere at bruker får for mye penger. Se TS-Docs
+                // for eksempler.
+                Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR -> tidligsteEndring.minusDays(29)
+                else -> tidligsteEndring
+            }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseSteg.kt
@@ -9,7 +9,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.BeregningsplanUtleder
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
@@ -107,7 +106,7 @@ class TilsynBarnBeregnYtelseSteg(
 
         val vedtaksperioder = finnNyeVedtaksperioderForOpphør(saksbehandling, opphørsdato)
 
-        val beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, opphørsdato)
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, opphørsdato)
 
         val beregningsresultat =
             beregningService.beregn(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseSteg.kt
@@ -10,7 +10,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.BeregningsplanUtleder
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
@@ -56,7 +55,7 @@ class BoutgifterBeregnYtelseSteg(
 
         val innvilgelse = vedtak as InnvilgelseBoutgifterRequest
         val vedtaksperioder = innvilgelse.vedtaksperioder.tilDomene().sorted()
-        val beregningsplan = Beregningsplan(omfang = Beregningsomfang.FRA_DATO, fraDato = satsjusteringFra)
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, satsjusteringFra)
         val beregningsresultat =
             beregningService.beregn(
                 vedtaksperioder = vedtaksperioder,
@@ -131,7 +130,7 @@ class BoutgifterBeregnYtelseSteg(
 
         val avkortedeVedtaksperioder = avkortVedtaksperiodeVedOpphør(forrigeVedtak, opphørsdato)
 
-        val beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, opphørsdato)
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, opphørsdato)
         val beregningsresultat =
             beregningService.beregn(
                 saksbehandling,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
@@ -7,8 +7,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.BeregningsplanUtleder
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
@@ -119,7 +117,7 @@ class DagligReiseBeregnYtelseSteg(
 
         val avkortetVedtaksperioder = dagligReiseVedtakService.avkortVedtaksperiodeVedOpphør(forrigeVedtak, opphørsdato)
 
-        val beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, opphørsdato)
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, opphørsdato)
         val (beregningsresultat, _) =
             beregningService.beregn(
                 vedtaksperioder = avkortetVedtaksperioder,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport
 
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
@@ -25,7 +25,7 @@ class OffentligTransportBeregningRevurderingService(
         val forrigeIverksatte =
             hentForrigeIverksatteVedtak(behandling)?.beregningsresultat?.offentligTransport ?: return nyttBeregningsresultat
 
-        brukerfeilHvis(beregnFra == null) { "Kan ikke beregne ytelse når beregnFra mangler" }
+        feilHvis(beregnFra == null) { "Vi mangler beregnFra-dato for å flette sammen nytt og gammelt vedtak." }
 
         validerEndringAvAlleredeUtbetaltPeriode(
             nyttBeregningsresultat = nyttBeregningsresultat,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
@@ -25,7 +25,7 @@ class OffentligTransportBeregningRevurderingService(
         val forrigeIverksatte =
             hentForrigeIverksatteVedtak(behandling)?.beregningsresultat?.offentligTransport ?: return nyttBeregningsresultat
 
-        brukerfeilHvis(beregnFra == null) { "Kan ikke beregne ytelse fordi det ikke er gjort noen endringer i revurderingen" }
+        brukerfeilHvis(beregnFra == null) { "Kan ikke beregne ytelse når beregnFra mangler" }
 
         validerEndringAvAlleredeUtbetaltPeriode(
             nyttBeregningsresultat = nyttBeregningsresultat,
@@ -41,11 +41,7 @@ class OffentligTransportBeregningRevurderingService(
     }
 
     /**
-     * Beholder alle perioder fra forrige vedtak som er starter tidligere enn 30 dager unna [beregnFra]-datoen.
-     *
-     * Dette gjøres for ikke å reberegne mer enn vi trenger å gjøre, men vi er samtidig nødt til å reberegne enkelte perioder som er f.eks.
-     * 25 dager unna [beregnFra]-datoen, ettersom det kan skje at denne perioden etter revurderingen skulle vært en 30-dagersperiode
-     * i stedet.
+     * Beholder alle perioder fra forrige vedtak som er starter tidligere [beregnFra]-datoen.
      */
     private fun slåSammenNyeOgGamlePerioder(
         nyBeregningForReise: BeregningsresultatForReise,
@@ -57,15 +53,16 @@ class OffentligTransportBeregningRevurderingService(
             forrigeBeregning.reiser.find { it.reiseId == nyBeregningForReise.reiseId }?.perioder
                 ?: return nyBeregningForReise
 
-        // Alle perioder som er tidligere enn 30 dager fra endringsdatoen skal kopieres fra tidligere vedtak
+        // Alle perioder som er tidligere beregn fra-datoen skal kopieres fra tidligere vedtak
         val bevarteGamlePerioder =
             reisenIForrigeVedtak
-                .filter { it.grunnlag.fom.plusDays(30L) <= beregnFra }
+                .filter { it.grunnlag.fom < beregnFra }
                 .map { it.copy(fraTidligereVedtak = true) }
 
+        // Perioder som har identisk grunnlag som forrige vedtak skal ikke reberegnes
         val nyeEllerOppdatertePerioder =
             nyBeregningForReise.perioder
-                .filter { it.grunnlag.fom.plusDays(30L) > beregnFra }
+                .filter { it.grunnlag.fom >= beregnFra }
                 .map { nyPeriode ->
                     val tilsvarendePeriodeIForrigeVedtak = reisenIForrigeVedtak.singleOrNull { it.grunnlag == nyPeriode.grunnlag }
                     tilsvarendePeriodeIForrigeVedtak?.copy(fraTidligereVedtak = true) ?: nyPeriode.copy(fraTidligereVedtak = false)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingService.kt
@@ -41,7 +41,7 @@ class OffentligTransportBeregningRevurderingService(
     }
 
     /**
-     * Beholder alle perioder fra forrige vedtak som er starter tidligere [beregnFra]-datoen.
+     * Beholder alle perioder fra forrige vedtak som starter før [beregnFra]-datoen.
      */
     private fun slåSammenNyeOgGamlePerioder(
         nyBeregningForReise: BeregningsresultatForReise,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseSteg.kt
@@ -10,7 +10,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.vedtak.BeregnYtelseSteg
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.BeregningsplanUtleder
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
@@ -72,7 +71,7 @@ class LæremidlerBeregnYtelseSteg(
         logger.info("Lagrer vedtak for satsjustering for behandling=${saksbehandling.id}, satsjusteringFra=$satsjusteringFra")
 
         val innvilgelse = vedtak as InnvilgelseLæremidlerRequest
-        val plan = Beregningsplan(Beregningsomfang.FRA_DATO, satsjusteringFra)
+        val plan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, satsjusteringFra)
         lagreInnvilgetVedtak(
             saksbehandling = saksbehandling,
             vedtaksperioder = innvilgelse.vedtaksperioder.tilDomene(),
@@ -150,7 +149,7 @@ class LæremidlerBeregnYtelseSteg(
         )
 
         val avkortetVedtaksperioder = avkortVedtaksperiodeVedOpphør(forrigeVedtak, opphørsdato)
-        val beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, opphørsdato)
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, opphørsdato)
         val beregningsresultat = beregningService.beregnForOpphør(saksbehandling, avkortetVedtaksperioder, opphørsdato)
 
         vedtakRepository.insert(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/BeregningsplanUtlederTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/BeregningsplanUtlederTest.kt
@@ -1,0 +1,44 @@
+package no.nav.tilleggsstonader.sak.vedtak
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class BeregningsplanUtlederTest {
+    @ParameterizedTest
+    @EnumSource(value = Stønadstype::class, names = ["DAGLIG_REISE_TSO", "DAGLIG_REISE_TSR"])
+    fun `fraDato skal forskyves 29 dager tilbake for daglig reise`(stønadstype: Stønadstype) {
+        val opphørsdato = 30 januar 2026
+
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(stønadstype, opphørsdato)
+
+        assertThat(beregningsplan.omfang).isEqualTo(Beregningsomfang.FRA_DATO)
+        assertThat(beregningsplan.fraDato).isEqualTo(1 januar 2026)
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Stønadstype::class, names = ["DAGLIG_REISE_TSO", "DAGLIG_REISE_TSR"], mode = EnumSource.Mode.EXCLUDE)
+    fun `fraDato skal være uendret for øvrige stønadstyper`(stønadstype: Stønadstype) {
+        val opphørsdato = 30 januar 2026
+
+        val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(stønadstype, opphørsdato)
+
+        assertThat(beregningsplan.omfang).isEqualTo(Beregningsomfang.FRA_DATO)
+        assertThat(beregningsplan.fraDato).isEqualTo(30 januar 2026)
+    }
+
+    @Test
+    fun `fraDato for daglig reise kan bli forskjøvet til forrige måned`() {
+        val opphørsdato = 15 mars 2026
+
+        val beregningsplan =
+            BeregningsplanUtleder.utledForOpphørEllerSatsjustering(Stønadstype.DAGLIG_REISE_TSO, opphørsdato)
+
+        assertThat(beregningsplan.fraDato).isEqualTo(14 februar 2026)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningRevurderingServiceTest.kt
@@ -14,6 +14,8 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomf
 import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.tilLagreDagligReiseDto
 import no.nav.tilleggsstonader.sak.util.lagreVilkårperiodeAktivitet
 import no.nav.tilleggsstonader.sak.util.lagreVilkårperiodeMålgruppe
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.BeregningsresultatDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.BeregningsresultatForReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseResponse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
@@ -156,15 +158,74 @@ class OffentligTransportBeregningRevurderingServiceTest : CleanDatabaseIntegrati
         }
     }
 
+    @Test
+    fun `vedtaksperiode fra tidligere vedtak som krysser beregnFra skal reberegnes`() {
+        // Reise med to 30-dagersperioder: [1 jan - 30 jan] og [31 jan - 28 feb]
+        val reiseFom = 1 januar 2025
+        val reiseOpprinneligTom = 28 februar 2025
+
+        val behandlingId = gjennomførEnFørstegangsbehandling(reiseFom, reiseOpprinneligTom)
+
+        endreAlleBeløpTilNoeHeltTulleteStort()
+
+        // Forlenger reisen til 30 mars → tidligsteEndring = 1 mars, beregnFra = 31 januar
+        val reiseForlengetTom = 30 mars 2025
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                vilkår {
+                    oppdaterDagligReise { vilkår ->
+                        with(vilkår.single()) {
+                            id to tilLagreDagligReiseDto().copy(tom = reiseForlengetTom)
+                        }
+                    }
+                }
+            }
+
+        val beregningsresultat = hentBeregningsresultat(revurderingId)
+
+        // Verifiser at beregnFra-datoen er forskjøvet 29 dager tilbake
+        assertThat(beregningsresultat.beregningsplan.omfang).isEqualTo(Beregningsomfang.FRA_DATO)
+        assertThat(beregningsresultat.beregningsplan.fraDato).isEqualTo(31 januar 2025)
+
+        with(
+            beregningsresultat.offentligTransport!!
+                .reiser
+                .single()
+                .perioder,
+        ) {
+            assertThat(size).isEqualTo(3)
+
+            // Første periode [1 jan - 30 jan]: fom (1 jan) < beregnFra (31 jan) → beholdes fra gammelt vedtak
+            assertThat(first().fom).isEqualTo(1 januar 2025)
+            assertThat(first().beløp).isEqualTo(999999999)
+            assertThat(first().fraTidligereVedtak).isTrue()
+
+            // Andre periode [31 jan - 28 feb]: fom (31 jan) ≥ beregnFra (31 jan) → reberegnes pga 29-dagersforskyvningen
+            assertThat(get(1).fom).isEqualTo(31 januar 2025)
+            assertThat(get(1).beløp).isEqualTo(800)
+
+            // Tredje periode er ny i revurderingen → reberegnes
+            assertThat(last().fom).isEqualTo(2 mars 2025)
+            assertThat(last().beløp).isEqualTo(800)
+        }
+    }
+
     private fun hentBeregnedeReiser(revurderingId: BehandlingId): List<BeregningsresultatForReiseDto> =
+        hentBeregningsresultat(revurderingId)
+            .offentligTransport!!
+            .reiser
+
+    private fun hentBeregningsresultat(behandlingId: BehandlingId): BeregningsresultatDagligReiseDto =
         kall.vedtak
             .hentVedtak(
                 Stønadstype.DAGLIG_REISE_TSO,
-                revurderingId,
+                behandlingId,
             ).expectOkWithBody<InnvilgelseDagligReiseResponse>()
             .beregningsresultat
-            .offentligTransport!!
-            .reiser
 
     private fun gjennomførEnFørstegangsbehandling(
         reiseFom: LocalDate,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Dypt nede i beregningskoden for daglige reiser var det en `beregnFra.plusdays(30)` som i praksis justerte beregningsdatoen for daglige reiser 30 dager tilbake i tid. Dette var ikke _feil oppførsel_, ettersom vi ønsker å reberegne eventuelle 30-dagersperioder som omfavner beregningsdatoen. Men det blir misvisende i datagrunnlaget, og feil dato presenteres i frontend under hvilken dato vi har beregnet fra.

I denne PR-en flyttes utledningen av `beregnFra`-dato til `BeregningsplanUtleder`, slik at `Beregningsplan` alltid inneholder den faktiske beregningsdatoen. 