### PR TITLE
Utvider valideringen til å sjekke om allerede utbetalte perioder

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValidering.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransp
 
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
+import no.nav.tilleggsstonader.kontrakter.felles.overlapper
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
@@ -42,10 +43,16 @@ fun validerEndringAvAlleredeUtbetaltPeriode(
                 .filter { it.grunnlag.tom <= dagensDato }
 
         for (utbetaltPeriode in alleredeUtbetaltePerioder) {
-            val overlappendePeriodeIRevurdering =
-                reise.perioder.firstOrNull {
-                    it.grunnlag.tom >= utbetaltPeriode.grunnlag.fom
+            val overlappendePerioderIRevurdering =
+                reise.perioder.filter {
+                    it.grunnlag.overlapper(utbetaltPeriode.grunnlag)
                 }
+
+            brukerfeilHvis(overlappendePerioderIRevurdering.size > 1) {
+                "Fant flere overlappende revurderingsperioder for samme utbetalte periode"
+            }
+
+            val overlappendePeriodeIRevurdering = overlappendePerioderIRevurdering.singleOrNull()
 
             if (overlappendePeriodeIRevurdering != null) {
                 val endrerFraEnkeltbilletterTilMånedskort =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValidering.kt
@@ -2,10 +2,10 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransp
 
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.mergeSammenhengende
-import no.nav.tilleggsstonader.kontrakter.felles.overlapper
 import no.nav.tilleggsstonader.kontrakter.felles.overlapperEllerPåfølgesAv
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.tilleggsstonader.sak.util.datoEllerNesteMandagHvisLørdagEllerSøndag
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
@@ -40,7 +40,7 @@ fun validerEndringAvAlleredeUtbetaltPeriode(
         val alleredeUtbetaltePerioder =
             reiseIForrigeBeregningsresultat
                 .flatMap { it.perioder }
-                .filter { it.grunnlag.tom <= dagensDato }
+                .filter { it.grunnlag.fom.datoEllerNesteMandagHvisLørdagEllerSøndag() <= dagensDato }
 
         for (utbetaltPeriode in alleredeUtbetaltePerioder) {
             val overlappendePerioderIRevurdering =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValidering.kt
@@ -35,36 +35,36 @@ fun validerEndringAvAlleredeUtbetaltPeriode(
     for (reise in nyttBeregningsresultat.reiser) {
         val reiseIForrigeBeregningsresultat = reiserForrigeBehandling.filter { it.reiseId == reise.reiseId }
         if (reiseIForrigeBeregningsresultat.isEmpty()) continue
-        // Hvis vi kommer hit, vet vi at reisen har blitt endret på i revurderingen
 
-        // Sjekker om det finnes en periode som inneholder dagens dato i revurderingen
-        val dagensPeriodeIRevurdering = finnPeriodeMedDato(reise.perioder, dagensDato)
+        val alleredeUtbetaltePerioder =
+            reiseIForrigeBeregningsresultat
+                .flatMap { it.perioder }
+                .filter { it.grunnlag.tom <= dagensDato }
 
-        // Sjekker om det finnes en periode som inneholder dagens dato i førstegangsbehandlingen
-        val dagensPeriodeIFørstegangs =
-            finnPeriodeMedDato(reiseIForrigeBeregningsresultat.flatMap { it.perioder }, dagensDato)
+        for (utbetaltPeriode in alleredeUtbetaltePerioder) {
+            val overlappendePeriodeIRevurdering =
+                reise.perioder.firstOrNull {
+                    it.grunnlag.tom >= utbetaltPeriode.grunnlag.fom
+                }
 
-        // Sjekk om perioden som inneholder dagens dato sin billetttype endrer seg fra enkeltbilletter til månedskort
-        val endrerFraEnkeltbilletterTilMånedskort =
-            endrerFraEnkeltbilletterTilMånedskort(
-                dagensPeriodeIFørstegangs,
-                dagensPeriodeIRevurdering,
-            )
+            if (overlappendePeriodeIRevurdering != null) {
+                val endrerFraEnkeltbilletterTilMånedskort =
+                    endrerFraEnkeltbilletterTilMånedskort(
+                        utbetaltPeriode,
+                        overlappendePeriodeIRevurdering,
+                    )
 
-        brukerfeilHvis(endrerFraEnkeltbilletterTilMånedskort) {
-            """
-            I den revurderte beregningen vil en allerede utbetalt periode med enkeltbilletter bli endret 
-            til en periode med månedskort, som kan være til ugunst for søker. For å hindre dette kan du legge 
-            inn en ny reise i stedet for å forlenge den eksisterende.
-            """.trimIndent()
+                brukerfeilHvis(endrerFraEnkeltbilletterTilMånedskort) {
+                    """
+                    I den revurderte beregningen vil en allerede utbetalt periode med enkeltbilletter bli endret 
+                    til en periode med månedskort, som kan være til ugunst for søker. For å hindre dette kan du legge 
+                    inn en ny reise i stedet for å forlenge den eksisterende.
+                    """.trimIndent()
+                }
+            }
         }
     }
 }
-
-private fun finnPeriodeMedDato(
-    perioder: List<BeregningsresultatForPeriode>,
-    dato: LocalDate,
-): BeregningsresultatForPeriode? = perioder.firstOrNull { periode -> periode.grunnlag.inneholder(dato) }
 
 private fun endrerFraEnkeltbilletterTilMånedskort(
     førstegangs: BeregningsresultatForPeriode?,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
@@ -1,5 +1,8 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport
 
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.util.dummyReiseId
 import no.nav.tilleggsstonader.sak.util.vedtaksperiode
@@ -20,11 +23,11 @@ import java.time.LocalDate
 import java.util.UUID.randomUUID
 
 class OffentligTransportBeregningValideringTest {
-    val førsteJanuar = LocalDate.of(2025, 1, 1)
-    val sisteJanuar = LocalDate.of(2025, 1, 31)
+    val førsteJanuar = 1 januar 2025
+    val sisteJanuar = 31 januar 2025
 
-    val førsteFebruar = LocalDate.of(2025, 2, 1)
-    val sisteFebruar = LocalDate.of(2025, 2, 28)
+    val førsteFebruar = 1 februar 2025
+    val sisteFebruar = 28 februar 2025
 
     val vedtaksperiodeJanFeb = listOf(vedtaksperiode(fom = førsteJanuar, tom = sisteFebruar))
     val vedtaksperioderJanFebMedSplitt =
@@ -98,8 +101,8 @@ class OffentligTransportBeregningValideringTest {
 
     @Nested
     inner class ValiderEndringAvAlleredeUtbetaltPeriode {
-        private val januar2026 = LocalDate.of(2026, 1, 1)
-        private val mars2026 = LocalDate.of(2026, 3, 31)
+        private val januar2026 = 1 januar 2026
+        private val mars2026 = 31 mars 2026
         private val dagensDato = LocalDate.now()
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
@@ -149,6 +149,55 @@ class OffentligTransportBeregningValideringTest {
                 .isThrownBy { validerEndringAvAlleredeUtbetaltPeriode(revurdering, listOf(førstegangsbehandling)) }
         }
 
+        @Test
+        fun `skal varsle for periode der fom er passert men tom er i fremtiden`() {
+            val fomPassert = LocalDate.now().minusWeeks(2)
+            val tomFremtid = LocalDate.now().plusMonths(2)
+
+            val førstegangsbehandling =
+                offentligTransportReise(fom = fomPassert, tom = tomFremtid, beløp = 1500, antallDager = 20)
+            val revurdering =
+                BeregningsresultatOffentligTransport(
+                    reiser =
+                        listOf(
+                            offentligTransportReise(
+                                fom = fomPassert,
+                                tom = tomFremtid,
+                                beløp = 1806,
+                                antallDager = 60,
+                            ),
+                        ),
+                )
+
+            assertThatExceptionOfType(ApiFeil::class.java)
+                .isThrownBy { validerEndringAvAlleredeUtbetaltPeriode(revurdering, listOf(førstegangsbehandling)) }
+                .withMessageContaining("allerede utbetalt periode med enkeltbilletter")
+        }
+
+        @Test
+        fun `skal ikke varsle for periode der fom ikke er passert ennå`() {
+            val fomFremtid = LocalDate.now().plusWeeks(2)
+            val tomFremtid = LocalDate.now().plusMonths(2)
+
+            val førstegangsbehandling =
+                offentligTransportReise(fom = fomFremtid, tom = tomFremtid, beløp = 1500, antallDager = 20)
+            val revurdering =
+                BeregningsresultatOffentligTransport(
+                    reiser =
+                        listOf(
+                            offentligTransportReise(
+                                fom = fomFremtid,
+                                tom = tomFremtid,
+                                beløp = 1806,
+                                antallDager = 60,
+                            ),
+                        ),
+                )
+
+            assertThatNoException()
+                .isThrownBy { validerEndringAvAlleredeUtbetaltPeriode(revurdering, listOf(førstegangsbehandling)) }
+        }
+
         private fun offentligTransportReise(
             fom: LocalDate,
             tom: LocalDate,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
@@ -1,14 +1,23 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport
 
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
+import no.nav.tilleggsstonader.sak.util.dummyReiseId
 import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.util.vilkårDagligReise
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsgrunnlagOffentligTransport
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.VilkårDagligReise
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.UUID.randomUUID
 
 class OffentligTransportBeregningValideringTest {
     val førsteJanuar = LocalDate.of(2025, 1, 1)
@@ -85,5 +94,104 @@ class OffentligTransportBeregningValideringTest {
                 .isThrownBy { validerReiser(vilkår, vedtaksperioder) }
                 .withMessage(forventetFeilmeldingIkkeVilkårForAlleVedtaksperioder)
         }
+    }
+
+    @Nested
+    inner class ValiderEndringAvAlleredeUtbetaltPeriode {
+        private val januar2026 = LocalDate.of(2026, 1, 1)
+        private val mars2026 = LocalDate.of(2026, 3, 31)
+        private val dagensDato = LocalDate.now()
+
+        @Test
+        fun `skal varsle hvis allerede utbetalt periode endres fra enkeltbilletter til månedskort`() {
+            val førstegangsbehandling =
+                offentligTransportReise(fom = januar2026, tom = mars2026, beløp = 1500, antallDager = 20)
+            val revurdering =
+                BeregningsresultatOffentligTransport(
+                    reiser =
+                        listOf(
+                            offentligTransportReise(
+                                fom = januar2026,
+                                tom = dagensDato,
+                                beløp = 1806,
+                                antallDager = 60,
+                            ),
+                        ),
+                )
+
+            assertThatExceptionOfType(ApiFeil::class.java)
+                .isThrownBy { validerEndringAvAlleredeUtbetaltPeriode(revurdering, listOf(førstegangsbehandling)) }
+                .withMessageContaining("allerede utbetalt periode med enkeltbilletter")
+        }
+
+        @Test
+        fun `skal ikke varsle hvis revurdering ikke endrer billetttype for utbetalt periode`() {
+            val førstegangsbehandling =
+                offentligTransportReise(fom = januar2026, tom = mars2026, beløp = 1500, antallDager = 20)
+            val revurdering =
+                BeregningsresultatOffentligTransport(
+                    reiser =
+                        listOf(
+                            offentligTransportReise(
+                                fom = januar2026,
+                                tom = dagensDato,
+                                beløp = 1500,
+                                antallDager = 50,
+                            ),
+                        ),
+                )
+
+            assertThatNoException()
+                .isThrownBy { validerEndringAvAlleredeUtbetaltPeriode(revurdering, listOf(førstegangsbehandling)) }
+        }
+
+        private fun offentligTransportReise(
+            fom: LocalDate,
+            tom: LocalDate,
+            beløp: Int,
+            antallDager: Int,
+        ) = BeregningsresultatForReise(
+            reiseId = dummyReiseId,
+            perioder =
+                listOf(
+                    BeregningsresultatForPeriode(
+                        grunnlag =
+                            BeregningsgrunnlagOffentligTransport(
+                                fom = fom,
+                                tom = tom,
+                                prisEnkeltbillett = 75,
+                                prisSyvdagersbillett = 662,
+                                pris30dagersbillett = 1806,
+                                antallReisedagerPerUke = 5,
+                                vedtaksperioder =
+                                    listOf(
+                                        vedtaksperiodeGrunnlag(
+                                            fom = fom,
+                                            tom = tom,
+                                            antallDager = antallDager,
+                                        ),
+                                    ),
+                                antallReisedager = antallDager,
+                                brukersNavKontor = null,
+                            ),
+                        beløp = beløp,
+                        billettdetaljer = emptyMap(),
+                    ),
+                ),
+        )
+
+        private fun vedtaksperiodeGrunnlag(
+            fom: LocalDate,
+            tom: LocalDate,
+            antallDager: Int,
+        ) = VedtaksperiodeGrunnlag(
+            id = randomUUID(),
+            fom = fom,
+            tom = tom,
+            aktivitet = AktivitetType.TILTAK,
+            typeAktivitet = null,
+            målgruppe = MålgruppeType.AAP.faktiskMålgruppe(),
+            antallReisedagerIVedtaksperioden = antallDager,
+        )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningValideringTest.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport
 
+import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.mars
@@ -103,7 +104,7 @@ class OffentligTransportBeregningValideringTest {
     inner class ValiderEndringAvAlleredeUtbetaltPeriode {
         private val januar2026 = 1 januar 2026
         private val mars2026 = 31 mars 2026
-        private val dagensDato = LocalDate.now()
+        private val april2026 = 1 april 2026
 
         @Test
         fun `skal varsle hvis allerede utbetalt periode endres fra enkeltbilletter til månedskort`() {
@@ -115,7 +116,7 @@ class OffentligTransportBeregningValideringTest {
                         listOf(
                             offentligTransportReise(
                                 fom = januar2026,
-                                tom = dagensDato,
+                                tom = april2026,
                                 beløp = 1806,
                                 antallDager = 60,
                             ),
@@ -137,7 +138,7 @@ class OffentligTransportBeregningValideringTest {
                         listOf(
                             offentligTransportReise(
                                 fom = januar2026,
-                                tom = dagensDato,
+                                tom = april2026,
                                 beløp = 1500,
                                 antallDager = 50,
                             ),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Oppgave i favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-28662)

**Revurderer allerede utbetalte perioder:**
<img width="1575" height="1149" alt="Screenshot 2026-05-19 at 10 34 47" src="https://github.com/user-attachments/assets/0ad8da5d-947a-4a7e-bf2c-2bf9db0fdd0f" />
-- feilmeldingen dukker opp når jeg endrer fra 27.04 - 30.04 da det lønner seg med månedskort istedenfor enkeltbilletter.

<img width="1141" height="989" alt="Screenshot 2026-05-19 at 10 34 15" src="https://github.com/user-attachments/assets/5c710803-70d6-4b9c-8415-d8607e2cffcb" />


**Funksjonaliteten som var er fortsatt støttet - ved at den sjekker **
<img width="1582" height="951" alt="Screenshot 2026-05-19 at 10 37 16" src="https://github.com/user-attachments/assets/000f9a5c-b9aa-4817-a504-64e23e42b173" />
