### PR TITLE
Legger til stønadstype på tilbakekreving kravgrunnlaget

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/hendelse/TilbakekrevingFagsysteminfoSvar.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/hendelse/TilbakekrevingFagsysteminfoSvar.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.tilbakekreving.hendelse
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -9,6 +10,7 @@ data class TilbakekrevingFagsysteminfoSvar(
     override val eksternFagsakId: String,
     val hendelseOpprettet: LocalDateTime,
     val mottaker: TilbakekrevingMottaker,
+    val stønadstype: Stønadstype,
     val revurdering: TilbakekrevingFagsysteminfoSvarRevurdering,
     val utvidPerioder: List<UtvidetPeriode>,
     val behandlendeEnhet: String?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/håndter/FagsysteminfoBehovHåndterer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/håndter/FagsysteminfoBehovHåndterer.kt
@@ -92,6 +92,7 @@ class FagsysteminfoBehovHåndterer(
                     eksternFagsakId = fagsystemBehovMelding.eksternFagsakId,
                     hendelseOpprettet = LocalDateTime.now(),
                     mottaker = TilbakekrevingMottaker(ident = behandling.ident),
+                    stønadstype = behandling.stønadstype,
                     revurdering = mapRevurderinginformsjon(saksbehandling = behandling, eksternBehandlingId = referanse),
                     utvidPerioder = mapUtvidedePerioder(behandling.forrigeIverksatteBehandlingId),
                     behandlendeEnhet = finnBehandlendeEnhet(behandling),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingHendelseIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingHendelseIntegrationTest.kt
@@ -183,6 +183,7 @@ class TilbakekrevingHendelseIntegrationTest : IntegrationTest() {
             val tilbakekrevingFagsysteminfoSvar = jsonMapper.readValue<TilbakekrevingFagsysteminfoSvar>(publisertHendelse.value())
             assertThat(tilbakekrevingFagsysteminfoSvar.utvidPerioder).isNotEmpty
             assertThat(tilbakekrevingFagsysteminfoSvar.behandlendeEnhet).isNotNull
+            assertThat(tilbakekrevingFagsysteminfoSvar.stønadstype).isEqualTo(Stønadstype.LÆREMIDLER)
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For at team tilbakekreving kan lese av hvilke stønadstype tilbakekrevingen gjelder for

Enumen som blir sendt:

```
enum class Stønadstype(
    val visningsnavn: String,
    val grunnlagAntallMånederBakITiden: Int,
) {
    BARNETILSYN(
        visningsnavn = "stønad til pass av barn",
        grunnlagAntallMånederBakITiden = 3,
    ),
    LÆREMIDLER(
        visningsnavn = "støtte til læremidler",
        grunnlagAntallMånederBakITiden = 6,
    ),
    BOUTGIFTER(
        visningsnavn = "støtte til bolig eller overnatting",
        grunnlagAntallMånederBakITiden = 6,
    ),
    DAGLIG_REISE_TSO(
        visningsnavn = "støtte til daglige reiser",
        grunnlagAntallMånederBakITiden = 3,
    ),
    DAGLIG_REISE_TSR(
        visningsnavn = "støtte til daglige reiser",
        grunnlagAntallMånederBakITiden = 3,
    ),
    REISE_TIL_SAMLING_TSO(
        visningsnavn = "støtte ved reise til samling",
        grunnlagAntallMånederBakITiden = 6,
    ),
}
```

**Note: Må informere team tilbke før koden merges**