### PR TITLE
🦺 Gjør validering på boutgifter snillere

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -115,8 +115,7 @@ class BoutgifterBeregningService(
             .validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(
                 utgifter = utgifter,
                 finnMakssats = satsBoutgifterService::finnMakssats,
-            )
-            .map { lagBeregningsgrunnlag(periode = it, utgifter = utgifter, makssats = satsBoutgifterService.finnMakssats(it.fom)) }
+            ).map { lagBeregningsgrunnlag(periode = it, utgifter = utgifter, makssats = satsBoutgifterService.finnMakssats(it.fom)) }
             .validerIkkeUlikeKombinasjonerAvSvarPåFaktiskeUtgifter()
             .map {
                 BeregningsresultatForLøpendeMåned(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -112,7 +112,10 @@ class BoutgifterBeregningService(
             .map { UtbetalingPeriode(it, skalAvkorteUtbetalingPeriode(utgifter)) }
             .validerIngenLøpendeOgMidlertidigUtgiftISammeUtbetalingsperiode(utgifter)
             .validerIngenUtgifterTilOvernattingKrysserUtbetalingsperioder(utgifter)
-            .validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(utgifter)
+            .validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(
+                utgifter = utgifter,
+                finnMakssats = satsBoutgifterService::finnMakssats,
+            )
             .map { lagBeregningsgrunnlag(periode = it, utgifter = utgifter, makssats = satsBoutgifterService.finnMakssats(it.fom)) }
             .validerIkkeUlikeKombinasjonerAvSvarPåFaktiskeUtgifter()
             .map {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValidering.kt
@@ -4,11 +4,13 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.util.formatertPeriodeNorskFormat
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BoutgifterPerUtgiftstype
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
+import java.time.LocalDate
 
 fun List<UtbetalingPeriode>.validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(
     utgifter: BoutgifterPerUtgiftstype,
+    finnMakssats: (LocalDate) -> MakssatsBoutgifter,
 ): List<UtbetalingPeriode> {
-    val fasteUtgifter =
+    val løpendeUtgifter =
         listOf(
             TypeBoutgift.LØPENDE_UTGIFTER_EN_BOLIG,
             TypeBoutgift.LØPENDE_UTGIFTER_TO_BOLIGER,
@@ -18,9 +20,10 @@ fun List<UtbetalingPeriode>.validerIngenUtbetalingsperioderOverlapperFlereLøpen
 
     val utbetalingsperioderMedFlereUtgifter =
         mapNotNull { utbetalingsperiode ->
-            val utgifterSomOverlapper = fasteUtgifter.filter { utgift -> utgift.second.overlapper(utbetalingsperiode) }
+            val utgifterSomOverlapper = løpendeUtgifter.filter { utgift -> utgift.second.overlapper(utbetalingsperiode) }
+            val makssats = finnMakssats(utbetalingsperiode.fom).beløp
             utgifterSomOverlapper
-                .takeIf { it.size > 1 }
+                .takeIf { it.size > 1 && !it.alleUtgifterErOverMakssats(makssats) }
                 ?.let { utbetalingsperiode to it }
         }
 
@@ -47,6 +50,9 @@ fun List<UtbetalingPeriode>.validerIngenUtbetalingsperioderOverlapperFlereLøpen
 
     return this
 }
+
+private fun List<Pair<TypeBoutgift, UtgiftBeregningBoutgifter>>.alleUtgifterErOverMakssats(makssats: Int): Boolean =
+    all { (_, utgift) -> utgift.utgift >= makssats }
 
 private fun TypeBoutgift.mapType() =
     when (this) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValidering.kt
@@ -6,6 +6,13 @@ import no.nav.tilleggsstonader.sak.vedtak.boutgifter.domain.BoutgifterPerUtgifts
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeBoutgift
 import java.time.LocalDate
 
+/**
+ * Det kan inntreffe at to løpende utgifter med ulike kronebeløp treffer samme løpende måned. Da vet ikke systemet hvordan utgiftene skal
+ * fordeles i utbetalingsperioden, så dette stopper vi foreløpig.
+ *
+ * Hvis begge utgiftene uansett er over makssats, så trenger vi ikke lure på hvordan utgiftene skal fordeles, fordi makssatsen uansett nås.
+ * Så den casen støtter vi.
+ */
 fun List<UtbetalingPeriode>.validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(
     utgifter: BoutgifterPerUtgiftstype,
     finnMakssats: (LocalDate) -> MakssatsBoutgifter,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MakssatsBoutgifter.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/MakssatsBoutgifter.kt
@@ -1,6 +1,8 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.libs.utils.dato.desember
+import no.nav.tilleggsstonader.libs.utils.dato.januar
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -21,47 +23,46 @@ data class MakssatsBoutgifter(
     }
 }
 
-private val MAX = LocalDate.of(2099, 12, 31)
+private val MAX = 31 desember 2099
 
 val bekreftedeSatser =
     listOf(
         MakssatsBoutgifter(
-            fom = LocalDate.of(2026, 1, 1),
-            tom = LocalDate.of(2026, 12, 31),
+            fom = 1 januar 2026,
+            tom = 31 desember 2026,
             beløp = 5062,
         ),
         MakssatsBoutgifter(
-            fom = LocalDate.of(2025, 1, 1),
-            tom = LocalDate.of(2025, 12, 31),
+            fom = 1 januar 2025,
+            tom = 31 desember 2025,
             beløp = 4953,
         ),
         MakssatsBoutgifter(
-            fom = LocalDate.of(2024, 1, 1),
-            tom = LocalDate.of(2024, 12, 31),
+            fom = 1 januar 2024,
+            tom = 31 desember 2024,
             beløp = 4809,
         ),
         MakssatsBoutgifter(
-            fom = LocalDate.of(2023, 1, 1),
-            tom = LocalDate.of(2023, 12, 31),
+            fom = 1 januar 2023,
+            tom = 31 desember 2023,
             beløp = 4519,
         ),
         MakssatsBoutgifter(
-            fom = LocalDate.of(2022, 1, 1),
-            tom = LocalDate.of(2022, 12, 31),
+            fom = 1 januar 2022,
+            tom = 31 desember 2022,
             beløp = 4396,
         ),
         MakssatsBoutgifter(
-            fom = LocalDate.of(2021, 1, 1),
-            tom = LocalDate.of(2021, 12, 31),
+            fom = 1 januar 2021,
+            tom = 31 desember 2021,
             beløp = 4340,
         ),
         MakssatsBoutgifter(
-            fom = LocalDate.of(2020, 1, 1),
-            tom = LocalDate.of(2020, 12, 31),
+            fom = 1 januar 2020,
+            tom = 31 desember 2020,
             beløp = 4193,
         ),
     )
-
 val satser: List<MakssatsBoutgifter> =
     listOf(
         bekreftedeSatser.max().let {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/StønadsvilkårTestdataDsl.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/StønadsvilkårTestdataDsl.kt
@@ -123,6 +123,7 @@ class OpprettStønadsvilkårDsl {
     fun løpendeutgifterEnBolig(
         fom: LocalDate,
         tom: LocalDate,
+        utgift: Int = 10000,
     ) {
         add { behandlingId, _ ->
             OpprettVilkårDto(
@@ -132,7 +133,7 @@ class OpprettStønadsvilkårDsl {
                 vilkårType = VilkårType.LØPENDE_UTGIFTER_EN_BOLIG,
                 delvilkårsett = oppfylteDelvilkårLøpendeUtgifterEnBolig().map { it.tilDto() },
                 barnId = null,
-                utgift = 10000,
+                utgift = utgift,
                 erFremtidigUtgift = false,
                 offentligTransport = null,
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterRevurderingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterRevurderingIntegrationTest.kt
@@ -24,11 +24,11 @@ class BoutgifterRevurderingIntegrationTest(
     @Autowired private val utbetalingStatusHåndterer: UtbetalingStatusHåndterer,
 ) : IntegrationTest() {
     /**
-     * Dette er en reell case fra prod, der utgiften ble lavere midt i en beregnignsperiode. Det ble før stoppet av validering, men skal gå
+     * Dette er en reell case fra prod, der utgiften ble lavere midt i en beregningsperiode. Det ble før stoppet av validering, men skal gå
      * gjennom ettersom begge periodene uansett er over makssatsen.
      */
     @Test
-    fun `tillater flere løpende utgiftstyper i samme utbetalingsperiode når en enkeltutgift alene når makssats`() {
+    fun `tillater flere løpende utgifter i samme utbetalingsperiode når en enkeltutgift alene når makssats`() {
         val førstegangsbehandlingContext =
             opprettBehandlingOgGjennomførBehandlingsløp(
                 stønadstype = Stønadstype.BOUTGIFTER,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterRevurderingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterRevurderingIntegrationTest.kt
@@ -1,0 +1,99 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.august
+import no.nav.tilleggsstonader.libs.utils.dato.juni
+import no.nav.tilleggsstonader.libs.utils.dato.mai
+import no.nav.tilleggsstonader.libs.utils.dato.september
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.BehandlingContext
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.status.UtbetalingStatus
+import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.status.UtbetalingStatusHåndterer
+import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.status.UtbetalingStatusRecord
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class BoutgifterRevurderingIntegrationTest(
+    @Autowired private val utbetalingStatusHåndterer: UtbetalingStatusHåndterer,
+) : IntegrationTest() {
+    /**
+     * Dette er en reell case fra prod, der utgiften ble lavere midt i en beregnignsperiode. Det ble før stoppet av validering, men skal gå
+     * gjennom ettersom begge periodene uansett er over makssatsen.
+     */
+    @Test
+    fun `tillater flere løpende utgiftstyper i samme utbetalingsperiode når en enkeltutgift alene når makssats`() {
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BOUTGIFTER,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakBoutgifter(10 august 2025, 20 juni 2028)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(30 september 2024, 30 juni 2027)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        løpendeutgifterEnBolig(1 august 2025, 30 juni 2026, utgift = 7_400)
+                    }
+                }
+            }
+
+        kvitterOkFraOppdrag(førstegangsbehandlingContext)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            ) {
+                vilkår {
+                    oppdater { vilkårsvurdering ->
+                        with(vilkårsvurdering.vilkårsett.single { it.opphavsvilkår != null }) {
+                            SvarPåVilkårDto(
+                                id = id,
+                                behandlingId = behandlingId,
+                                delvilkårsett = delvilkårsett,
+                                fom = 1 august 2025,
+                                tom = 31 mai 2026,
+                                utgift = 7_400,
+                                erFremtidigUtgift = erFremtidigUtgift,
+                                offentligTransport = null,
+                            )
+                        }
+                    }
+                    opprett {
+                        løpendeutgifterEnBolig(1 juni 2026, 30 juni 2027, utgift = 5_600)
+                    }
+                }
+            }
+
+        val revurdering = kall.behandling.hent(revurderingId)
+
+        assertThat(revurdering.type).isEqualTo(BehandlingType.REVURDERING)
+        assertThat(revurdering.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
+        assertThat(revurdering.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+    }
+
+    private fun kvitterOkFraOppdrag(førstegangsbehandlingContext: BehandlingContext) {
+        utbetalingStatusHåndterer.behandleStatusoppdatering(
+            iverksettingId = førstegangsbehandlingContext.behandlingId.toString(),
+            melding =
+                UtbetalingStatusRecord(
+                    status = UtbetalingStatus.OK,
+                    detaljer = null,
+                    error = null,
+                ),
+            utbetalingGjelderFagsystem = UtbetalingStatusHåndterer.FAGSYSTEM_TILLEGGSSTØNADER,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValideringTest.kt
@@ -39,7 +39,10 @@ class HarIngenUtbetalingsperioderSomOverlapperFlereLøpendeUtgifterValideringTes
     @Test
     fun `verifiserer at feilmeldingen blir som forventet`() {
         assertThatThrownBy {
-            utbetalingsperioder.validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(utgifter)
+            utbetalingsperioder.validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(
+                utgifter = utgifter,
+                finnMakssats = { satser.finnMakssats(it) },
+            )
         }.hasMessage(
             """
             Vi støtter foreløpig ikke at utbetalingsperioder inneholder mer enn én løpende utgift.


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
I dagens løsning stoppes alle tilfeller der to løpende utgifter treffer innenfor samme beregningsperiode, fordi vi ikke vet hvordan vi skal fordele utgiftene i de ulike utbetalingsperiodene.

Det er imidlertid litt for strengt i tilfellet der begge utgiftene _er over makssats_. Da vil bruker få makssats uansett hvordan de blir fordelt. 

<img width="1537" height="461" alt="image" src="https://github.com/user-attachments/assets/f68fae58-e2a9-4c7f-91e1-e8449b8690ac" />