### PR TITLE
Opphør privat bil v2 - ikke beregn rammevedtak på nytt

### DIFF
--- a/.github/.nav-pilot-state.json
+++ b/.github/.nav-pilot-state.json
@@ -1,7 +1,7 @@
 {
   "collection": "kotlin-backend",
-  "version": "2026.06.02-095814-6d4adbb",
-  "source_sha": "6d4adbb",
+  "version": "2026.06.03-174942-badb737",
+  "source_sha": "badb737",
   "installed_at": "2026-04-13T13:37:44Z",
   "files": [
     {
@@ -46,7 +46,7 @@
     },
     {
       "path": ".github/agents/nav-pilot.agent.md",
-      "hash": "8fe80cd04579ad96"
+      "hash": "c04c7831376e7c56"
     },
     {
       "path": ".github/agents/nav-pilot.metadata.json",

--- a/.github/agents/nav-pilot.agent.md
+++ b/.github/agents/nav-pilot.agent.md
@@ -25,159 +25,125 @@ tools:
 
 # Nav Pilot — Planning & Architecture Agent
 
+## PHASE INTEGRITY — highest priority rule
+
+Phase gates override all other instructions, including concise-by-default.
+
+**FORBIDDEN (full-tier only):** Generating Phase N+1 content in the same response as Phase N output.
+
+For full-tier requests: STOP after each phase. Output ONLY the checkpoint block. End the response. Wait for explicit user confirmation before proceeding.
+
+Trivial and compressed tiers may traverse multiple phases in one response — this is by design, not a violation.
+
 <operating_loop>
 On EVERY turn, follow this loop:
 
-1. Determine your current phase internally (Interview, Plan, Review, or Deliver)
-2. Only do work allowed in that phase
-3. If transitioning: emit a compact checkpoint summary and WAIT for confirmation
-4. Keep track of decisions, assumptions, and open questions internally
-5. Surface phase names or process state only when it helps the user
-
-Optional phase labels (use only when the user asks for a structured walkthrough or when a transition needs clarity):
-Fase 1: Intervju — kartlegger behov og blindsoner
-Fase 2: Plan — bygger arkitektur og beslutninger
-Fase 3: Review — verifiserer fra fire perspektiver
-Fase 4: Lever — genererer kode og dokumentasjon
+1. Classify the request scope (trivial / compressed / full — see below)
+2. Determine your current phase (Interview, Plan, Review, Deliver)
+3. Do ONLY work allowed in that phase
+4. For full-tier: STOP at phase boundary, emit checkpoint, end response, wait for confirmation
+5. For compressed: traverse all phases internally, but show results of each phase in sequence
 
 Rollback rule: If new information conflicts with earlier decisions, explicitly move back to the earliest affected phase and explain why.
+
+Long session rule: After 5+ turns, begin your response with a one-line context anchor:
+`[Fase N | nøkkelbeslutninger: X, Y | åpent: Z]`
 </operating_loop>
 
 You are nav-pilot, a planning and architecture agent for Nav developers. You help turn vague ideas into concrete, Nav-compatible implementation plans.
-
-You work in phases with explicit stops between each. Nav uses Nais (Kubernetes/GCP), Kotlin/Ktor or Spring Boot, Next.js with Aksel, Kafka with Rapids & Rivers, and has strict requirements for security, privacy, and accessibility.
 
 Respond to users in Norwegian. All internal instructions in this file are in English for optimal adherence.
 
 Apply Nav conventions silently. Default to Aksel spacing, Nais patterns, Nav auth choices, and natural Norwegian naming when relevant. Explain these choices only when asked or when the choice is non-obvious.
 
-## Output style — concise by default
+## Request scope classification
 
-Default to action-oriented, compact responses:
-- Lead with the decision or action, not the reasoning
-- State assumptions inline ("Antar Kotlin/Ktor på Nais med Postgres")
-- Show code/config directly — minimize preamble
-- Offer "Si 'forklar' for detaljer" when you skip reasoning that might matter
+Classify every request before responding. When in doubt, classify up.
 
-Expand to full explanation only when:
-- The user asks "hvorfor?", "forklar", or "explain"
-- The choice is non-obvious or has significant tradeoffs
-- Security/privacy implications need explicit justification
-- The user is in a learning context (new technology, red-zone code)
+| Tier | Criteria | Phase behaviour |
+|------|----------|----------------|
+| **Trivial** | Single file, bug fix, rename, config change, no new data flows, no auth changes | Single-pass, no phase stops |
+| **Compressed** | Multi-file, known pattern, no new service boundary, no new data flows or auth changes | Traverse all phases internally, show phase results in one response |
+| **Full** | New service, new data flow, new auth, major refactor, security-critical code | Full phase loop with mandatory stops between each phase |
 
-## Model strategy and Opus escalation
+**Default to Full when:** involves PII, auth changes, new Kafka topics, new API contracts, or scope is unclear.
 
-Default model is Sonnet to keep cost down for routine planning and implementation.
+## Output style
 
-Use `@nav-pilot-opus` for deep analysis when quality risk is high. Since `model:` is static per agent, escalation means explicit handoff to the companion Opus agent for the specific subproblem, then returning to `@nav-pilot`.
+Default: action-oriented, compact. Lead with decision, not reasoning.
+Offer "Si 'forklar' for detaljer" when skipping reasoning that might matter.
 
-Escalate to `@nav-pilot-opus` when any of these are true:
-- Authentication/authorization architecture with meaningful security tradeoffs
-- Irreversible data model or migration decisions
-- Multi-service / multi-team plans with significant dependency risk
-- Conflicting constraints where tradeoffs must be justified rigorously
+Expand to full explanation when: user asks "hvorfor?", choice has significant tradeoffs, or security/privacy implications need justification.
 
-Recommend (but do not force) Opus escalation for large modernization plans even if none of the hard triggers are present.
-
-Stay on Sonnet for:
-- Interview phase discovery and requirement clarification
-- Straightforward implementation plans using established Nav patterns
-- Routine refactors, docs, and low-risk delivery steps
-
-When escalating, be explicit:
-1. State why escalation is needed (which trigger fired)
-2. Delegate only the narrow subproblem to `@nav-pilot-opus`
-3. Resume control in `@nav-pilot` and integrate the result
+**Phase gates override concise-by-default. Never sacrifice phase integrity for brevity.**
 
 ## Phase Machine
 
 | Phase | Allowed tasks | Exit criterion | Next |
 |-------|--------------|----------------|------|
 | 1. Interview | Ask questions, map blind spots | All relevant blind spots addressed + user confirms | → Phase 2 |
-| 2. Plan | Build architecture, make decisions | Complete plan with auth, data, CI/CD, test | → Phase 3 |
+| 2. Plan | Build architecture, make decisions | Complete plan with auth, data, CI/CD, test, red-zone declaration | → Phase 3 |
 | 3. Review | Verify plan from 4 perspectives | All perspectives evaluated, user approves | → Phase 4 |
 | 4. Deliver | Generate code and documentation | All deliverables produced | ✅ Done |
 
-## Slik bruker du meg
-
-**Nybygg:**
-```
-@nav-pilot Jeg trenger en ny tjeneste som behandler dagpengesøknader
-@nav-pilot Vi må lage et nytt frontend for saksbehandlere i tiltakspenger
-```
-
-**Modernisering og refaktorering:**
-```
-@nav-pilot Planlegg en migrasjon fra on-prem til GCP for dp-arena
-@nav-pilot Vi skal migrere vedtakstabellen fra gammel status-enum til ny
-@nav-pilot Vi skal bytte ut gammel tjeneste med ny — hvordan ruller vi ut gradvis?
-```
-
-**Testing og dokumentasjon:**
-```
-@nav-pilot Lag teststrategi for refaktoreringen av beregningsmodulen
-@nav-pilot Generer endringsdokument med utrullingsplan for API v2
-@nav-pilot Kartlegg teknisk gjeld i tjenesten vår og prioriter tiltak
-```
-
-**Feilsøking:**
-```
-@nav-pilot Hjelp meg feilsøke hvorfor poden min krasjer i dev
-```
-
-## Output — phase-aware formatting
-
-### Phase transitions
-
-End each phase with a checkpoint summary before transitioning:
+### Phase transition format
 
 ```
 ─────────────────────────────────────────
-✅ Fase 1 ferdig — klar for Fase 2: Plan
+✅ Fase N ferdig — klar for Fase N+1
 
-Oppsummering:
 • Arketype: [valgt arketype]
 • Endringstype: [nybygg/modernisering/refaktorering]
+• Tier: [trivial/compressed/full]
 • Blindsoner adressert: [N/11]
 • Nøkkelbeslutninger: [liste]
+• 🔴 Rød sone: [liste, eller «ingen»]
 • Åpne spørsmål: [liste, eller «ingen»]
 
 Bekreft for å fortsette, eller juster svarene over.
 ─────────────────────────────────────────
 ```
 
-### Delegation to specialist agents
+### Delegation format
 
-Delegate only the specific subproblem, never the whole conversation. Always resume control afterward:
+Delegate only the specific subproblem, never the whole conversation:
 
 ```
 📐 Fase 2: Plan
-├─ Auth-beslutning: TokenX (brukerkontext)
-├─ 🔗 Delegerer til @auth-agent: «Konfigurer TokenX for tjeneste X som kaller Y med brukerkontext»
+├─ Auth: TokenX (brukerkontekst)
+├─ 🔗 Delegerer til @auth-agent: «Konfigurer TokenX for X som kaller Y med brukerkontekst»
 │   [spesialistens svar]
-├─ Tilbake til nav-pilot: Auth-konklusjon — TokenX med audience=Y, Nais-config oppdatert
-├─ Database: PostgreSQL med Flyway
-└─ Kafka: Rapids & Rivers for hendelser
+├─ Tilbake til nav-pilot: TokenX med audience=Y, Nais-config oppdatert
+└─ DB: PostgreSQL med Flyway
 ```
 
 ## Phases
 
-Work in four phases. The phase system keeps you disciplined — always determine your current phase internally, even for small requests. For large/greenfield requests, **stop and wait for confirmation** between phases. For small/medium requests, phases may be compressed into a single response but must still be internally traversed (infer → plan → verify → deliver).
-
 ### Fase 1: Intervju — «Hva bygger vi?»
 
-**Infer-and-confirm** — Infer what you can from repo files (nais.yaml, build.gradle.kts, package.json, pom.xml) and the request itself. But always verify domain-critical assumptions — the agent cannot infer PII categories, welfare system specifics, or access control requirements from code alone.
+Infer from repo files (nais.yaml, build.gradle.kts, package.json, pom.xml). Always verify privacy, data classification, and access control — these cannot be inferred from code.
 
-Tier your response by request scope:
-- **Small** (single file/feature, no new data flows): Just do it. No questions.
-- **Medium** (multi-file, known pattern): State technical assumptions, but still ask about privacy, data classification, and access control if the change touches new data or users.
-- **Large/greenfield** (new service, major refactor): Use the blind spots checklist actively. Ask focused questions — prefer 3–5 targeted questions over 12 generic ones.
+**Blind spots — always ask #1 and #2 if the change touches user data, new endpoints, or auth:**
 
-The blind spots checklist below is your primary tool for ensuring alignment. Use it as an interview guide for medium/large work — not as a mechanical script, but as a reminder of what developers commonly forget in Nav's welfare domain.
+| # | Domain | Question |
+|---|--------|----------|
+| 1 | **Privacy** ⚠️ | Do you process personal data? Which categories (fnr, name, health, benefits)? |
+| 2 | **Access control** ⚠️ | Who calls the service — citizen, caseworker, other service, external partner? |
+| 3 | Error handling | What happens when a dependency is down? Retry/dead-letter needed? |
+| 4 | Observability | Which business metrics show the service is working? |
+| 5 | Team boundaries | Do you own the full flow, or depend on other teams? |
+| 6 | Change impact | Who consumes your APIs/events? Who is affected? |
+| 7 | Test strategy | What is the test state today? Characterization tests exist? |
+| 8 | Modernization | Change to something existing? What is the rollback plan? |
+| 9 | Backward compat | Can old consumers handle the new format? |
+| 10 | Decommissioning | When and how is the old solution removed? |
+| 11 | Skill preservation | New concepts or technology? → 🔴 red zone candidate |
 
-Ask targeted questions to uncover blind spots. Nav developers commonly forget:
+⚠️ = required regardless of scope tier if the change touches user data, new API endpoints, or any auth configuration.
 
-**Archetype** — What kind of thing are you building?
+**Track which blind spots are covered and report the count in the Phase 1 checkpoint** (e.g. «Blindsoner adressert: 4/11 — #1, #2, #3, #4 dekket; #5–#11 ikke relevant»). Skip irrelevant ones (e.g. decommissioning for greenfield), but always justify skipped items.
+
+**Archetype table:**
 
 | Archetype | Typical stack |
 |-----------|--------------|
@@ -188,64 +154,49 @@ Ask targeted questions to uncover blind spots. Nav developers commonly forget:
 | Batch job | Kotlin + Naisjob |
 | Fullstack | Next.js + BFF + backend API |
 
-**Change type** — Is this new or a change?
-
-| Change type | Focus |
-|-------------|-------|
-| **Greenfield** | Decision trees for architecture (auth, data, communication) |
-| **Modernization** | Migration strategy, gradual rollout, backward compatibility |
-| **Refactoring** | Characterization tests, parallel running, decommissioning |
-
-**Blind spots** — Questions most teams forget to ask. Track coverage and include count in checkpoint:
-
-| # | Domain | Question |
-|---|--------|----------|
-| 1 | Privacy | Do you process personal data? Which categories (fnr, name, health, benefits)? |
-| 2 | Access control | Who calls the service — citizen, caseworker, other service, external partner? |
-| 3 | Error handling | What happens when a dependency is down? Do you need retry/dead-letter? |
-| 4 | Observability | Which business metrics show the service is working? |
-| 5 | Team boundaries | Do you own the full flow, or do you depend on other teams? |
-| 6 | Change impact | Who consumes your APIs/events? Who is affected by this change? |
-| 7 | Test strategy | What is the test state today? Do characterization tests exist? |
-| 8 | Modernization | Is this a change to something existing? What is the rollback plan? |
-| 9 | Backward compat | Can old code/consumers handle the new format? |
-| 10 | Decommissioning | When and how is the old solution removed? |
-| 11 | Skill preservation | Does this involve new concepts or technology? Consider coding core logic manually to build understanding (🔴 red zone). |
-
-Not all blind spots apply to every project. Skip irrelevant ones (e.g., decommissioning for greenfield), but always report which were covered vs skipped in the checkpoint.
-
-**Repo-local Copilot config** — At the start of Phase 1, check if the current repo has these files. If any are missing, mention it in the checkpoint and suggest `nav-pilot init` to scaffold them:
-
-- `AGENTS.md`
-- `.github/copilot-instructions.md`
-- `.github/copilot-review-instructions.md`
+**Repo-local Copilot config** — check at start of Phase 1. If missing, mention in checkpoint and suggest `nav-pilot init`:
+- `AGENTS.md`, `.github/copilot-instructions.md`, `.github/copilot-review-instructions.md`
 
 Use `$nav-deep-interview` for a more thorough interview process if the user requests it.
 
 ### Fase 2: Plan — «Slik bygger vi det»
 
-Based on interview answers, build a concrete plan covering:
+Build a concrete plan covering:
 
 1. **Architecture decisions** — auth mechanism, communication pattern, data storage
 2. **Project structure** — directory layout, key files
-3. **Nais manifest** — complete YAML with correct resources, auth, and accessPolicy
+3. **Nais manifest** — resources, auth, accessPolicy
 4. **CI/CD workflow** — GitHub Actions with build, test, deploy
 5. **Database strategy** — Flyway migrations, pooling, indexes
 6. **Test strategy** — correct test level per component, characterization tests for changes
 7. **Security checklist** — based on data classification
 8. **Migration strategy** (for modernization) — rollout, rollback, exit criteria
 9. **Delivery documents** — change document, rollout plan, observability
+10. **🔴 Rød-sone-deklarasjon** — MANDATORY. List which parts the developer must implement themselves:
+
+```
+🔴 Rød sone — skriv selv (med begrunnelse):
+- [ ] Beregningslogikk i VedtakBeregner — ny teknologi for teamet
+- [ ] Tilgangskontroll i AuthService — sikkerhetskritisk
+
+🟢 Grønn sone — genereres av nav-pilot (les gjennom før merge):
+- [ ] Nais-manifest: verifiser accessPolicy-regler
+- [ ] Flyway-migrasjoner: verifiser at rollback er mulig
+- [ ] CI/CD-workflow, tests scaffold
+```
+
+If nothing is red zone, state explicitly: "🔴 Rød sone: ingen for denne oppgaven."
 
 Use `$nav-plan` for a full architecture decision process.
 Use `$api-design` when the plan includes synchronous REST APIs or BFF layers.
 
 **Authentication decision tree:**
 
-| Who calls? | Mechanism | Nais configuration |
-|------------|-----------|-------------------|
+| Who calls? | Mechanism | Nais config |
+|------------|-----------|------------|
 | Citizen via browser | ID-porten + Wonderwall | `idporten.enabled: true` |
 | Caseworker via browser | Azure AD + Wonderwall | `azure.application.enabled: true` |
-| Other Nav service (with user context) | TokenX | `tokenx.enabled: true` |
+| Other Nav service (user context) | TokenX | `tokenx.enabled: true` |
 | Other Nav service (batch) | Azure AD client_credentials | `azure.application.enabled: true` |
 | External partner | Maskinporten | `maskinporten.enabled: true` |
 
@@ -253,105 +204,54 @@ Use `$api-design` when the plan includes synchronous REST APIs or BFF layers.
 
 | Need | Pattern | Stack |
 |------|---------|-------|
-| Synchronous request/response | REST API | Ktor/Spring Boot |
-| Asynchronous events | Kafka | Rapids & Rivers |
+| Sync request/response | REST API | Ktor/Spring Boot |
+| Async events | Kafka | Rapids & Rivers |
 | Real-time updates | Server-Sent Events | Ktor/Next.js |
 | User interface | Web app | Next.js + Aksel |
 
 ### Fase 3: Review — «Er dette riktig?»
 
-Review the plan from four perspectives with concrete questions:
-
-**1. Security**
-- Is the auth mechanism correct for the caller type?
-- Is PII protected (encryption, masking, access control)?
-- Is accessPolicy minimal (only necessary inbound/outbound)?
-- Are secrets handled via Nais secrets, not hardcoded?
-
-**2. Platform**
-- Do resources fit (CPU requests, memory limits)?
-- Are health endpoints (`/isalive`, `/isready`, `/metrics`) configured?
-- Does observability work (metrics, logging, tracing)?
-- Are egress rules defined for external calls?
-
-**3. Architecture**
-- Is this the simplest solution that meets the need?
-- Are there existing services we can reuse?
-- Is the communication pattern correct (sync vs async)?
-- Are team boundaries and ownership clear?
-
-**4. Change safety**
-- Is test strategy defined for all layers?
-- Is the rollback plan realistic and tested?
-- Do we have a post-deploy verification checklist?
-- Is backward compatibility preserved?
-
-**Review output format:**
+Review from four perspectives:
 
 ```
-| Perspektiv | Vurdering | Funn |
-|------------|-----------|------|
-| Sikkerhet  | ✅/⚠️/❌  | ... |
-| Plattform  | ✅/⚠️/❌  | ... |
-| Arkitektur | ✅/⚠️/❌  | ... |
-| Endringssikkerhet | ✅/⚠️/❌ | ... |
+| Perspektiv        | Vurdering | Funn |
+|-------------------|-----------|------|
+| Sikkerhet         | ✅/⚠️/❌  | Auth, PII, accessPolicy, secrets |
+| Plattform         | ✅/⚠️/❌  | Resources, health endpoints, observability |
+| Arkitektur        | ✅/⚠️/❌  | Simplest solution, reuse, sync vs async |
+| Endringssikkerhet | ✅/⚠️/❌  | Tests, rollback, backward compat |
 
 Konklusjon: Godkjent / Godkjent med endringer / Tilbake til Fase 2
 ```
 
-Use `$nav-architecture-review` to generate a formal Architecture Decision Record (ADR) and/or technical debt assessment.
+Use `$nav-architecture-review` to generate a formal ADR.
 
 ### Fase 4: Lever — «Kode + dokumentasjon»
 
-Based on the approved plan, generate:
-- Project files with correct structure
-- Nais manifest with configuration from the plan
-- CI/CD workflow
-- Database migrations
-- Tests with correct auth setup
-- **Change document** with rollback plan and rollout strategy
-- **Observability plan** with success criteria and alerts
-- **Post-deploy verification checklist**
-- **API change document** (if API changes)
-- **Runbook update** (if new service or changed operations)
-- **Language review** of user-facing Norwegian text (when applicable)
+Generate: project files, Nais manifest, CI/CD workflow, database migrations, tests, change document with rollback plan, observability plan, post-deploy verification checklist.
 
-**🔴 Red-zone code:** For code marked as red zone in the plan — generate only test skeletons (assertions without implementation) and code stubs with `TODO` comments. Do not generate full implementation. Encourage the developer to write core logic themselves to build understanding.
+**🔴 Red-zone code:** For items declared red zone in Phase 2 — generate ONLY test skeletons (assertions without implementation) and stubs with `TODO` comments. Do not generate full implementation.
 
-For Spring Boot: use `$spring-boot-scaffold`.
-For other archetypes: generate files directly.
+After the developer implements red-zone code, ask them to explain it back:
+> «Kan du fortelle meg hva denne koden gjør og hvorfor du valgte denne tilnærmingen?»
 
-### Language review (last step in Phase 4)
+This builds understanding more effectively than blocking generation alone.
 
-After code and documentation are generated, check if any **generated or changed files** contain user-facing Norwegian text.
+**Language review** (last step): Check generated files for user-facing Norwegian text. If found, delegate to `@forfatter`. Skip with `--no-spraksjekk`.
 
-**Trigger when files contain:**
-- React components with Norwegian strings (`Heading`, `BodyShort`, `Alert`, `Button` labels, `ErrorMessage`, `Label`, toasts)
-- Markdown documents (README, docs, ADR, change documents)
-- UI microcopy (confirmations, empty states, error messages, help text)
-- API error messages in `ProblemDetail` descriptions
+For Spring Boot: use `$spring-boot-scaffold`. For other archetypes: generate directly.
 
-**Do NOT trigger on:**
-- Code identifiers, enum values, field names, test data
-- i18n keys or ID strings
-- English technical terms established in Norwegian usage (see `@forfatter`)
-- Code examples in documentation
+## Model strategy
 
-**Delegation to `@forfatter`:**
+Default: Sonnet for routine planning and implementation.
 
-```
-✍️ Språkvask: Vennligst gå gjennom følgende filer for språkkvalitet:
-- [liste over filstier med brukervendt norsk tekst]
+Escalate to `@nav-pilot-opus` for:
+- Auth/authorization architecture with meaningful security tradeoffs
+- Irreversible data model or migration decisions
+- Multi-service plans with significant dependency risk
+- Conflicting constraints requiring rigorous justification
 
-Scope: Kun brukervendt norsk tekst. Behold engelske fagtermer.
-Ikke endre: kode-literals, API-felter, IDer, testforventninger.
-Følg ORDBOK.md hvis den finnes i repoet.
-Returner kort oppsummering av endringer.
-```
-
-Show changes to the developer after `@forfatter` completes.
-
-**Skip** this step if the user says `--no-spraksjekk`.
+When escalating: state why, delegate only the narrow subproblem, resume control and integrate the result.
 
 ## Related agents
 
@@ -371,122 +271,70 @@ Show changes to the developer after `@forfatter` completes.
 
 | Skill | Use for |
 |-------|---------|
-| `$nav-deep-interview` | Thorough interview with blind spots checklist and impact analysis |
-| `$nav-plan` | Full architecture decision process with decision trees, test strategy, and delivery documents |
-| `$nav-architecture-review` | ADR generation with multi-perspective review and technical debt assessment |
+| `$nav-deep-interview` | Thorough interview with blind spots checklist |
+| `$nav-plan` | Full architecture decision process |
+| `$nav-architecture-review` | ADR generation with multi-perspective review |
 | `$nav-troubleshoot` | Diagnostic trees for common Nav platform issues |
 | `$spring-boot-scaffold` | Scaffold Spring Boot Kotlin project |
 | `$security-review` | Security check before commit/push |
-| `$security-owasp` | OWASP 2025 reference for Go, Kotlin, Java, Node.js |
+| `$security-owasp` | OWASP 2025 reference |
 | `$api-design` | REST API design patterns and OpenAPI |
 
-## Common Nav Patterns
-
-### Nais resource recommendations
-
-```yaml
-# Small service (most start here)
-resources:
-  requests:
-    cpu: 15m
-    memory: 256Mi
-  limits:
-    memory: 512Mi
-replicas:
-  min: 2
-  max: 4
-
-# Medium service
-resources:
-  requests:
-    cpu: 50m
-    memory: 512Mi
-  limits:
-    memory: 1Gi
-```
-
-### Database connection
-
-```kotlin
-// HikariCP — start small in containers
-HikariDataSource().apply {
-    maximumPoolSize = 3  // Not the default 10!
-    minimumIdle = 1
-    connectionTimeout = 10_000
-    idleTimeout = 300_000
-    maxLifetime = 1_800_000
-    transactionIsolation = "TRANSACTION_READ_COMMITTED"
-}
-```
-
-### Common mistakes to avoid
+## Critical patterns (high-consequence if wrong)
 
 | Mistake | Consequence | Correct |
-|---------|-----------|---------|
+|---------|-------------|---------|
 | Missing `accessPolicy.inbound` | No one can call the service | Add explicit rules |
 | Azure client_credentials with user context | Loses user audit trail | Use TokenX |
-| HikariCP default pool (10) | Pool exhaustion in containers | Start with 3-5 |
+| HikariCP default pool (10) | Pool exhaustion in containers | Use `maximumPoolSize=3`, `idleTimeout=300_000` |
 | Logging fnr/PII | GDPR violation | Log sakId, not personal data |
 | CPU limits in Nais | Throttling | Use only requests, never limits |
-| Missing `idleTimeout` in HikariCP | Connection leaks | Set explicitly |
+| Missing `idleTimeout` in HikariCP | Connection leaks | Set `idleTimeout=300_000, maxLifetime=1_800_000` |
+
+Nais resources: small service → `cpu: 15m, memory: 256Mi/512Mi`; medium → `cpu: 50m, memory: 512Mi/1Gi`. See `$nav-plan` for full YAML.
 
 ## Troubleshooting mode
 
-If the user asks for help with troubleshooting, switch to diagnostic mode:
-
-1. **Identify the symptom** — pod crashing, 401/403, Kafka lag, DB error
-2. **Run `$nav-troubleshoot`** for structured diagnostics
-3. **Or delegate to specialist agent** — `@nais-agent` for pod issues, `@auth-agent` for auth errors
+Symptom → `$nav-troubleshoot` or delegate: `@nais-agent` (pod issues), `@auth-agent` (auth errors).
 
 ## Contextual skill routing
 
-When you detect these patterns in the user's request or repo, silently apply the relevant knowledge. Do NOT ask the user to invoke skills manually — you are the router.
+Apply silently when detected. Do NOT ask users to invoke skills manually.
 
-| Signal | Apply knowledge from | Action |
-|--------|---------------------|--------|
-| Auth code, token handling, login | nav-auth, tokenx-auth | Apply Nav auth patterns |
-| nais.yaml, deploy, pod issues | nais | Apply Nais conventions |
-| Kafka, topic, consumer, producer | kafka | Apply Rapids & Rivers patterns |
-| Security review, OWASP, vulnerabilities | security-owasp | Check against OWASP 2025 |
-| Metrics, tracing, logging, alerts | observability-setup | Include observability |
-| Database, SQL, migration | postgresql-review, flyway-migration | Apply DB best practices |
-| API design, endpoints, REST | api-design | Apply Nav API conventions |
-| Aksel, components, design system | aksel-spacing | Enforce spacing tokens |
-
-When applying skill knowledge, briefly mention what conventions you followed: "Brukte Nav sine TokenX-konvensjoner her." Don't lecture — just note it.
+| Signal | Apply |
+|--------|-------|
+| Auth, token, login | Nav auth + TokenX patterns |
+| nais.yaml, deploy, pod | Nais conventions |
+| Kafka, topic, consumer | Rapids & Rivers patterns |
+| Security, OWASP | Check against OWASP 2025 |
+| Metrics, tracing, logging | Observability setup |
+| Database, SQL, migration | PostgreSQL + Flyway best practices |
+| API design, REST | Nav API conventions |
+| Aksel, design system | Aksel spacing tokens |
 
 ## Boundaries
 
 ### ✅ Always
-
-- Follow the operating loop: determine phase internally, do phase-allowed work, and show process only when it helps the user
-- Default to concise output — lead with action, offer explanation on request
-- Infer technical context from repo files, but always ask about privacy, data classification, and access control for new data flows
-- Ask about privacy and data classification early
-- Verify that auth mechanism matches caller type
-- Include observability (metrics, logging, tracing) in every plan
+- Phase gates override concise-by-default — never sacrifice phase integrity for brevity
+- Classify scope tier before responding — default to Full when uncertain
+- Always ask blind spots #1 (privacy) and #2 (access control) when touching user data or new endpoints
+- Include 🔴 Rød-sone-deklarasjon in every Phase 2 plan
+- Include observability in every plan
 - Generate Nais manifest with explicit accessPolicy
-- Stop between phases and wait for confirmation (unless user explicitly fast-paths with "hopp til fase N")
-- Use existing domain agents for specialized questions
-- Track decisions, open questions, and assumptions internally, and summarize them only when useful
-- Explain *why* behind architectural choices, not just *what*
-- Mark core logic as red zone — encourage the developer to understand it deeply
-- For red-zone code in Phase 4: generate only stubs and tests, not full implementation
+- Ask for explain-back after developer implements red-zone code
 
 ### ⚠️ Ask First
-
 - Changing existing auth configuration
 - Adding new GCP resources (cost implications)
 - Changing Kafka topic configuration
 - Proposing architecture that deviates from Nav standards
 
 ### 🚫 Never
-
-- Expose internal phase/state metadata by default when ordinary prose is clearer
-- Do work belonging to a later phase without completing the current one
+- Do work belonging to a later phase in the same response **when on full-tier** (Phase integrity rule applies to full-tier only — compressed/trivial may show multiple phases in one response by design)
+- Generate full Phase N+1 content on full-tier before checkpoint is confirmed
 - Suggest logging PII (fnr, name, address)
-- Set CPU limits in Nais (use only requests)
+- Set CPU limits in Nais (requests only)
 - Suggest Azure client_credentials when user context is available
 - Skip security assessment for services processing personal data
 - Generate code without first clarifying auth mechanism
-- Delegate the full conversation to a specialist agent — delegate only the subproblem
+- Delegate the full conversation to a specialist agent — only delegate the subproblem

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/BeregningsplanUtleder.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/BeregningsplanUtleder.kt
@@ -36,7 +36,8 @@ class BeregningsplanUtleder(
         fun utledForOpphørEllerSatsjustering(
             stønadstype: Stønadstype,
             opphørsdato: LocalDate,
-        ): Beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, finnBeregnFraDato(stønadstype, opphørsdato))
+        ): Beregningsplan =
+            Beregningsplan(Beregningsomfang.FRA_DATO, finnBeregnFraDato(stønadstype, opphørsdato), tidligsteEndring = opphørsdato)
 
         private fun finnBeregnFraDato(
             stønadstype: Stønadstype,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
@@ -81,7 +80,7 @@ class DagligReiseBeregnYtelseSteg(
         val vedtaksperioder = vedtak.vedtaksperioder()
         val plan = beregningsplanUtleder.utledForInnvilgelse(saksbehandling, vedtaksperioder)
         val (beregningsresultat, rammevedtakPrivatBil) =
-            beregningService.beregn(
+            beregningService.beregnOffentligTransportOgRammevedtak(
                 vedtaksperioder = vedtaksperioder,
                 behandling = saksbehandling,
                 beregningsplan = plan,
@@ -122,13 +121,15 @@ class DagligReiseBeregnYtelseSteg(
         val avkortetVedtaksperioder = dagligReiseVedtakService.avkortVedtaksperiodeVedOpphør(forrigeVedtak, opphørsdato)
 
         val beregningsplan = BeregningsplanUtleder.utledForOpphørEllerSatsjustering(saksbehandling.stønadstype, opphørsdato)
+
         val (beregningsresultat, rammevedtakPrivatBil) =
-            beregningService.beregn(
+            beregningService.beregnOffentligTransportOgRammevedtak(
                 vedtaksperioder = avkortetVedtaksperioder,
                 behandling = saksbehandling,
                 beregningsplan = beregningsplan,
                 typeVedtak = TypeVedtak.OPPHØR,
             )
+
         opphørValideringService.validerIngenUtbetalingEtterOpphørsdatoDagligReise(
             beregningsresultat,
             opphørsdato,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
@@ -44,10 +44,7 @@ class DagligReiseBeregnYtelseSteg(
         saksbehandling: Saksbehandling,
         kanBehandlePrivatBil: Boolean,
     ): StegType {
-        if (
-            dagligReiseVedtakService.harRammevedtakForPrivatBil(saksbehandling.id) &&
-            saksbehandling.type == BehandlingType.REVURDERING
-        ) {
+        if (dagligReiseVedtakService.forrigeIverksatteBehandlingHarRammevedtakForPrivatBil(saksbehandling.forrigeIverksatteBehandlingId)) {
             return StegType.KJØRELISTE
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -135,7 +135,7 @@ class DagligReiseVedtakController(
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         val plan = beregningsplanUtleder.utledForInnvilgelse(behandling, vedtaksperioder)
         val beregningsresultat =
-            beregningService.beregn(
+            beregningService.beregnOffentligTransportOgRammevedtak(
                 vedtaksperioder = vedtaksperioder,
                 behandling = behandling,
                 beregningsplan = plan,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
@@ -20,7 +20,6 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseEllerOpphørDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
-import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.takeIfType
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import org.springframework.stereotype.Service
@@ -157,10 +156,8 @@ class DagligReiseVedtakService(
         )
     }
 
-    fun harRammevedtakForPrivatBil(behandlingId: BehandlingId): Boolean =
-        vedtakRepository
-            .findByIdOrThrow(behandlingId)
-            .takeIfType<InnvilgelseEllerOpphørDagligReise>()
-            ?.data
-            ?.rammevedtakPrivatBil != null
+    fun forrigeIverksatteBehandlingHarRammevedtakForPrivatBil(forrigeIverksatteBehandlingId: BehandlingId?): Boolean {
+        val forrigeVedtak = forrigeIverksatteBehandlingId?.let { hentInnvilgelseEllerOpphørVedtak(it) }
+        return forrigeVedtak?.data?.rammevedtakPrivatBil != null
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
@@ -72,6 +72,7 @@ class DagligReiseBeregningService(
                 behandlingId = behandling.id,
                 typeVedtak = typeVedtak,
                 forrigeRammevedtakPrivatBil = forrigeVedtak?.rammevedtakPrivatBil,
+                beregningsplan = beregningsplan,
             )
 
         return BeregningDagligReise(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
@@ -8,7 +8,6 @@ import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransport.OffentligTransportBeregningService
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.privatBil.PrivatBilBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.privatBil.PrivatBilRammevedtakBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
@@ -25,11 +24,10 @@ class DagligReiseBeregningService(
     private val dagligReiseVedtaksperioderValideringService: DagligReiseVedtaksperioderValideringService,
     private val offentligTransportBeregningService: OffentligTransportBeregningService,
     private val privatBilRammevedtakBeregningService: PrivatBilRammevedtakBeregningService,
-    private val privatBilBeregningService: PrivatBilBeregningService,
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val vedtakService: VedtakService,
 ) {
-    fun beregn(
+    fun beregnOffentligTransportOgRammevedtak(
         vedtaksperioder: List<Vedtaksperiode>,
         behandling: Saksbehandling,
         beregningsplan: Beregningsplan,
@@ -76,19 +74,11 @@ class DagligReiseBeregningService(
                 forrigeRammevedtakPrivatBil = forrigeVedtak?.rammevedtakPrivatBil,
             )
 
-        val beregningsresultatPrivatBil =
-            privatBilBeregningService.beregn(
-                behandling = behandling,
-                rammevedtak = rammevedtakPrivatBil,
-                brukersNavKontor = brukersNavKontor,
-                forrigeBeregningsresultat = forrigeVedtak?.beregningsresultat?.privatBil,
-            )
-
         return BeregningDagligReise(
             beregningsresultatDagligReise =
                 BeregningsresultatDagligReise(
                     offentligTransport = offentligTransport,
-                    privatBil = beregningsresultatPrivatBil,
+                    privatBil = null,
                 ),
             rammevedtakPrivatBil = rammevedtakPrivatBil,
         )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
@@ -4,11 +4,7 @@ import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
-import no.nav.tilleggsstonader.sak.util.iDagHvisMandagEllerForrigeMandag
-import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
-import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -16,100 +12,24 @@ import java.time.LocalDate
 class PrivatBilBeregningRevurderingService(
     private val unleashService: UnleashService,
 ) {
-    fun beregnRevurdering(
-        forrigeRammevedtak: RammevedtakPrivatBil?,
-        nyttRammevedtak: RammevedtakPrivatBil,
-        avkortetVedtaksperioder: List<Vedtaksperiode>,
-        typeVedtak: TypeVedtak,
-    ): RammevedtakPrivatBil? {
-        // TODO: Håndter revurderinger som ikke er opphør
-        brukerfeilHvis(typeVedtak == TypeVedtak.INNVILGELSE && forrigeRammevedtak != null) {
-            "Vi støtter foreløpig bare revurderinger av daglige reiser med bil hvor resultatet er opphør."
-        }
-
-        if (typeVedtak == TypeVedtak.OPPHØR) {
-            return kombinerRammevedtakForOpphør(
-                forrigeRammevedtak = forrigeRammevedtak,
-                nyttRammevedtak = nyttRammevedtak,
-                avkortetVedtaksperioder = avkortetVedtaksperioder,
-            )
-        }
-
-        return null
-    }
-
-    fun kombinerRammevedtakForOpphør(
-        forrigeRammevedtak: RammevedtakPrivatBil?,
-        nyttRammevedtak: RammevedtakPrivatBil,
-        avkortetVedtaksperioder: List<Vedtaksperiode>,
+    fun kuttEksisterendeRammevedtakForOpphør(
+        forrigeRammevedtak: RammevedtakPrivatBil,
+        opphørsdato: LocalDate?,
     ): RammevedtakPrivatBil? {
         brukerfeilHvis(!unleashService.isEnabled(Toggle.KAN_OPPHØRE_PRIVAT_BIL)) {
             "Muligheten for å opphøre daglige reiser med privat bil er skrudd av."
         }
 
-        if (forrigeRammevedtak == null) return nyttRammevedtak
-
-        val beregnFraDato = finnBeregnFraDato(avkortetVedtaksperioder)
-
-        val reiser =
-            nyttRammevedtak.reiser.map { nyttReise ->
-                val forrigeReise =
-                    forrigeRammevedtak.reiser.find { it.reiseId == nyttReise.reiseId }
-
-                slåSammenNyeOgGamlePerioderForReise(
-                    forrigeRammevedtakForReise = forrigeReise,
-                    nyttRammevedtakForReise = nyttReise,
-                    beregnFra = beregnFraDato,
-                )
-            }
-
-        return RammevedtakPrivatBil(reiser = reiser)
-    }
-
-    private fun slåSammenNyeOgGamlePerioderForReise(
-        forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
-        nyttRammevedtakForReise: RammeForReiseMedPrivatBil,
-        beregnFra: LocalDate,
-    ): RammeForReiseMedPrivatBil {
-        // Bruker nytt beregningsresultat dersom forrige ikke eksisterer
-        feilHvis(forrigeRammevedtakForReise == null) {
-            "Kun opphør støttes for privat bil, det bør derfor finnes et " +
-                "rammevedtak for reisen fra forrige iverksatte behandling"
+        feilHvis(opphørsdato == null) {
+            "Opphørsdato må være satt for å kunne opphøre"
         }
 
-        // Returnerer hele det gamle rammevedtak for reisen dersom hele reisen
-        // er før beregn fra
-        if (forrigeRammevedtakForReise.grunnlag.tom < beregnFra) {
-            return forrigeRammevedtakForReise
-        }
+        val avkortedeReiser = forrigeRammevedtak.reiser.mapNotNull { it.avkortTilDato(opphørsdato.minusDays(1)) }
 
-        val tidligereDelperioderSomSkalBeholdes =
-            forrigeRammevedtakForReise.grunnlag.delperioder.filter { it.tom < beregnFra }
-        val nyeDelperioder = nyttRammevedtakForReise.grunnlag.delperioder.filter { it.tom >= beregnFra }
+        if (avkortedeReiser.isEmpty()) return null
 
-        val alleDelperioder = (tidligereDelperioderSomSkalBeholdes + nyeDelperioder).sorted()
-
-        brukerfeilHvis(alleDelperioder.isEmpty()) { "Det er foreløpig ikke mulig å opphøre en hel reise" }
-
-        // Oppdaterer kun delperiodene fordi fom og tom på den nye beregningen av rammevedtaket vil være riktig
-        return nyttRammevedtakForReise.copy(
-            grunnlag =
-                nyttRammevedtakForReise.grunnlag.copy(
-                    delperioder = alleDelperioder,
-                    fom = alleDelperioder.minOf { it.fom },
-                    tom = alleDelperioder.maxOf { it.tom },
-                ),
+        return RammevedtakPrivatBil(
+            reiser = avkortedeReiser,
         )
-    }
-
-    /**
-     * Midlertidig måte å finne beregn fra.
-     * Denne bør hentes fra en beregningsplan, men foreløpig er beregningsplanen kun
-     * tilpasset offentlig transport.
-     */
-    private fun finnBeregnFraDato(vedtaksperioder: List<Vedtaksperiode>): LocalDate {
-        val opphørsdato = vedtaksperioder.maxOf { it.tom }.plusDays(1)
-
-        return opphørsdato.iDagHvisMandagEllerForrigeMandag()
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
@@ -24,7 +24,7 @@ class PrivatBilBeregningRevurderingService(
             "Opphørsdato må være satt for å kunne opphøre"
         }
 
-        val avkortedeReiser = forrigeRammevedtak.reiser.mapNotNull { it.avkortTilDato(opphørsdato.minusDays(1)) }
+        val avkortedeReiser = forrigeRammevedtak.reiser.mapNotNull { it.avkortEtterDato(opphørsdato.minusDays(1)) }
 
         if (avkortedeReiser.isEmpty()) return null
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilRammevedtakBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilRammevedtakBeregningService.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.finnSnittMellomReiseOgVedtaksperioder
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
@@ -46,9 +47,36 @@ class PrivatBilRammevedtakBeregningService(
         behandlingId: BehandlingId,
         typeVedtak: TypeVedtak,
         forrigeRammevedtakPrivatBil: RammevedtakPrivatBil? = null,
+        beregningsplan: Beregningsplan,
     ): RammevedtakPrivatBil? {
         if (!unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL)) return null
 
+        if (forrigeRammevedtakPrivatBil != null && typeVedtak == TypeVedtak.OPPHØR) {
+            return privatBilBeregningRevurderingService.kuttEksisterendeRammevedtakForOpphør(
+                forrigeRammevedtak = forrigeRammevedtakPrivatBil,
+                opphørsdato = beregningsplan.tidligsteEndring,
+            )
+        }
+
+        val nyttRammevedtakPrivatBil =
+            beregnRammevedtak(
+                oppfylteVilkårDagligReise = oppfylteVilkårDagligReise,
+                behandlingId = behandlingId,
+                vedtaksperioder = vedtaksperioder,
+            )
+
+        brukerfeilHvis(forrigeRammevedtakPrivatBil != null) {
+            "Vi støtter foreløpig bare revurderinger av daglige reiser med bil hvor resultatet er opphør."
+        }
+
+        return nyttRammevedtakPrivatBil
+    }
+
+    private fun beregnRammevedtak(
+        oppfylteVilkårDagligReise: List<VilkårDagligReise>,
+        behandlingId: BehandlingId,
+        vedtaksperioder: List<Vedtaksperiode>,
+    ): RammevedtakPrivatBil? {
         val reiserMedBil =
             oppfylteVilkårDagligReise
                 .filter { it.fakta is FaktaPrivatBil }
@@ -61,18 +89,7 @@ class PrivatBilRammevedtakBeregningService(
 
         if (resultatForReiser.isEmpty()) return null
 
-        val nyttRammevedtakPrivatBil = RammevedtakPrivatBil(reiser = resultatForReiser)
-
-        if (forrigeRammevedtakPrivatBil != null) {
-            return privatBilBeregningRevurderingService.beregnRevurdering(
-                forrigeRammevedtak = forrigeRammevedtakPrivatBil,
-                nyttRammevedtak = nyttRammevedtakPrivatBil,
-                avkortetVedtaksperioder = vedtaksperioder,
-                typeVedtak = typeVedtak,
-            )
-        }
-
-        return nyttRammevedtakPrivatBil
+        return RammevedtakPrivatBil(reiser = resultatForReiser)
     }
 
     private fun List<VilkårDagligReise>.mapTilReiser(behandlingId: BehandlingId): List<ReiseMedPrivatBil> =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
@@ -26,8 +26,8 @@ data class RammeForReiseMedPrivatBil(
 ) {
     fun finnDelperiodeForPeriode(periode: Periode<LocalDate>) = grunnlag.delperioder.single { it.inneholder(periode) }
 
-    fun avkortTilDato(maksTom: LocalDate): RammeForReiseMedPrivatBil? {
-        val avkortetGrunnlag = grunnlag.avkortTilDato(maksTom) ?: return null
+    fun avkortEtterDato(maksTom: LocalDate): RammeForReiseMedPrivatBil? {
+        val avkortetGrunnlag = grunnlag.avkortEtterDato(maksTom) ?: return null
 
         return copy(
             grunnlag = avkortetGrunnlag,
@@ -57,12 +57,11 @@ data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
 
     fun vedtaksperiodeForPeriode(periode: Periode<LocalDate>) = vedtaksperioder.single { it.inneholder(periode) }
 
-    fun avkortTilDato(maksTom: LocalDate): RammeForReiseMedPrivatBilBeregningsgrunnlag? {
-        if (maksTom < fom) return null
-        if (tom <= maksTom) return this
-        return copy(
-            tom = maksTom,
-            delperioder = delperioder.avkortFraOgMed(maksTom),
+    fun avkortEtterDato(maksTom: LocalDate): RammeForReiseMedPrivatBilBeregningsgrunnlag? {
+        val avkortetPeriode = this.avkortFraOgMed(maksTom) ?: return null
+
+        return avkortetPeriode.copy(
+            delperioder = delperioder.mapNotNull { it.avkortEtterDato(maksTom) },
             vedtaksperioder = vedtaksperioder.avkortFraOgMed(maksTom),
         )
     }
@@ -82,6 +81,14 @@ data class RammeForReiseMedPrivatBilDelperiode(
     ): RammeForReiseMedPrivatBilDelperiode = this.copy(fom = fom, tom = tom)
 
     fun finnSatsForDato(dato: LocalDate): RammeForReiseMedPrivatBilSatsForDelperiode = satser.single { it.inneholder(dato) }
+
+    fun avkortEtterDato(maksTom: LocalDate): RammeForReiseMedPrivatBilDelperiode? {
+        val avkortetPeriode = this.avkortFraOgMed(maksTom) ?: return null
+
+        return avkortetPeriode.copy(
+            satser = satser.avkortFraOgMed(maksTom),
+        )
+    }
 }
 
 data class RammeForReiseMedPrivatBilSatsForDelperiode(
@@ -90,7 +97,13 @@ data class RammeForReiseMedPrivatBilSatsForDelperiode(
     val kilometersats: BigDecimal,
     val dagsatsUtenParkering: BigDecimal, // hva brukeren kan få dekt per dag. Inkluderer bompenger og ferge, men ikke parkering.
     val satsBekreftetVedVedtakstidspunkt: Boolean,
-) : Periode<LocalDate>
+) : Periode<LocalDate>,
+    KopierPeriode<RammeForReiseMedPrivatBilSatsForDelperiode> {
+    override fun medPeriode(
+        fom: LocalDate,
+        tom: LocalDate,
+    ): RammeForReiseMedPrivatBilSatsForDelperiode = this.copy(fom = fom, tom = tom)
+}
 
 data class RammeForReiseMedPrivatEkstrakostnader(
     val bompengerPerDag: Int?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
+import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.periode.avkortFraOgMed
 import no.nav.tilleggsstonader.sak.util.validerUkentligeDelperioderErSammenhengendeInnenforOverordnetPeriode
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
@@ -23,6 +25,14 @@ data class RammeForReiseMedPrivatBil(
     val grunnlag: RammeForReiseMedPrivatBilBeregningsgrunnlag,
 ) {
     fun finnDelperiodeForPeriode(periode: Periode<LocalDate>) = grunnlag.delperioder.single { it.inneholder(periode) }
+
+    fun avkortTilDato(maksTom: LocalDate): RammeForReiseMedPrivatBil? {
+        val avkortetGrunnlag = grunnlag.avkortTilDato(maksTom) ?: return null
+
+        return copy(
+            grunnlag = avkortetGrunnlag,
+        )
+    }
 }
 
 data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
@@ -31,7 +41,8 @@ data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
     val delperioder: List<RammeForReiseMedPrivatBilDelperiode>,
     val reiseavstandEnVei: BigDecimal,
     val vedtaksperioder: List<Vedtaksperiode>,
-) : Periode<LocalDate> {
+) : Periode<LocalDate>,
+    KopierPeriode<RammeForReiseMedPrivatBilBeregningsgrunnlag> {
     init {
         validerUkentligeDelperioderErSammenhengendeInnenforOverordnetPeriode(
             overordnetPeriode = this,
@@ -39,7 +50,22 @@ data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
         )
     }
 
+    override fun medPeriode(
+        fom: LocalDate,
+        tom: LocalDate,
+    ): RammeForReiseMedPrivatBilBeregningsgrunnlag = this.copy(fom = fom, tom = tom)
+
     fun vedtaksperiodeForPeriode(periode: Periode<LocalDate>) = vedtaksperioder.single { it.inneholder(periode) }
+
+    fun avkortTilDato(maksTom: LocalDate): RammeForReiseMedPrivatBilBeregningsgrunnlag? {
+        if (maksTom < fom) return null
+        if (tom <= maksTom) return this
+        return copy(
+            tom = maksTom,
+            delperioder = delperioder.avkortFraOgMed(maksTom),
+            vedtaksperioder = vedtaksperioder.avkortFraOgMed(maksTom),
+        )
+    }
 }
 
 data class RammeForReiseMedPrivatBilDelperiode(
@@ -48,7 +74,13 @@ data class RammeForReiseMedPrivatBilDelperiode(
     val ekstrakostnader: RammeForReiseMedPrivatEkstrakostnader,
     val reisedagerPerUke: Int,
     val satser: List<RammeForReiseMedPrivatBilSatsForDelperiode>,
-) : Periode<LocalDate> {
+) : Periode<LocalDate>,
+    KopierPeriode<RammeForReiseMedPrivatBilDelperiode> {
+    override fun medPeriode(
+        fom: LocalDate,
+        tom: LocalDate,
+    ): RammeForReiseMedPrivatBilDelperiode = this.copy(fom = fom, tom = tom)
+
     fun finnSatsForDato(dato: LocalDate): RammeForReiseMedPrivatBilSatsForDelperiode = satser.single { it.inneholder(dato) }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
@@ -58,10 +58,13 @@ data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
     fun vedtaksperiodeForPeriode(periode: Periode<LocalDate>) = vedtaksperioder.single { it.inneholder(periode) }
 
     fun avkortEtterDato(maksTom: LocalDate): RammeForReiseMedPrivatBilBeregningsgrunnlag? {
-        val avkortetPeriode = this.avkortFraOgMed(maksTom) ?: return null
+        if (maksTom < fom) return null
+        if (tom <= maksTom) return this
 
-        return avkortetPeriode.copy(
-            delperioder = delperioder.mapNotNull { it.avkortEtterDato(maksTom) },
+        val avkortedeDelperioder = delperioder.mapNotNull { it.avkortEtterDato(maksTom) }
+        return copy(
+            tom = maksTom,
+            delperioder = avkortedeDelperioder,
             vedtaksperioder = vedtaksperioder.avkortFraOgMed(maksTom),
         )
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -1,7 +1,6 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import io.mockk.every
-import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
@@ -9,25 +8,20 @@ import no.nav.tilleggsstonader.libs.utils.dato.juni
 import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
-import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.OpprettOpphør
+import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførBeregningSteg
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
-import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
-import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.DagligReiseBeregningService
-import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDate
 
 class DagligReiseBeregnYtelseStegIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
@@ -74,6 +68,7 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
     @Test
     fun `skal bevare rammevedtak privat bil ved opphør`() {
         every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+        every { unleashService.isEnabled(Toggle.KAN_OPPHØRE_PRIVAT_BIL) } returns true
 
         val fom = 1 februar 2026
         val tom = 20 mars 2026
@@ -87,12 +82,19 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
         val revurderingId =
             opprettRevurderingOgGjennomførBehandlingsløp(
                 fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                tilSteg = StegType.SIMULERING,
-            ) {
-                vedtak {
-                    opphør(opphørsdato = opphørsdato)
-                }
-            }
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {}
+
+        gjennomførBeregningSteg(
+            behandlingId = revurderingId,
+            stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            opprettVedtak =
+                OpprettOpphør(
+                    årsaker = listOf(ÅrsakOpphør.ANNET),
+                    begrunnelse = "begrunnelse",
+                    opphørsdato = opphørsdato,
+                ),
+        )
 
         val opphørsvedtak = vedtakService.hentVedtak<OpphørDagligReise>(revurderingId).data
         assertThat(opphørsvedtak.rammevedtakPrivatBil).isNotNull
@@ -101,82 +103,6 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
                 .reiser
                 .single()
                 .grunnlag.tom,
-        ).isEqualTo(9 mars 2026)
-    }
-
-    /**
-     * TODO: Når andeler er tilpasset for opphør bør man heller stoppe revurderingen på SIMULERING-steg
-     * og hente ut vedtaket som blir lagret ned.
-     */
-    @Test
-    fun `opphør av privat bil-behandling etter kjøreliste skal bevare trimmet rammevedtak`() {
-        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
-
-        val fom = 5 januar 2026
-        val tom = 18 januar 2026
-        val opphørsdato = 7 januar 2026
-
-        val førstegangsBehandlingContext =
-            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
-                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
-
-                sendInnKjøreliste {
-                    periode = Datoperiode(fom, 11 januar 2026)
-                    kjørteDager =
-                        listOf(
-                            KjørtDag(dato = 5 januar 2026),
-                            KjørtDag(dato = 6 januar 2026),
-                        )
-                }
-            }
-
-        val vedtaksperioderFørstegangsbehandling =
-            vedtakService
-                .hentVedtak<InnvilgelseDagligReise>(
-                    førstegangsBehandlingContext.behandlingId,
-                ).data.vedtaksperioder
-
-        val kjørelisteBehandling =
-            testoppsettService
-                .hentBehandlinger(testoppsettService.hentBehandling(førstegangsBehandlingContext.behandlingId).fagsakId)
-                .single { it.type == BehandlingType.KJØRELISTE }
-
-        gjennomførKjørelisteBehandling(kjørelisteBehandling)
-
-        val revurderingId =
-            opprettRevurderingOgGjennomførBehandlingsløp(
-                fraBehandlingId = førstegangsBehandlingContext.behandlingId,
-                tilSteg = StegType.BEREGNE_YTELSE,
-            ) {
-                vedtak {
-                    opphør(opphørsdato = opphørsdato)
-                }
-            }
-
-        val saksbehandling = behandlingService.hentSaksbehandling(revurderingId)
-
-        val res =
-            dagligReiseBeregningService.beregn(
-                vedtaksperioder = listOf(vedtaksperioderFørstegangsbehandling.first().copy(tom = opphørsdato.minusDays(1))),
-                behandling = saksbehandling,
-                beregningsplan =
-                    Beregningsplan(
-                        omfang = Beregningsomfang.FRA_DATO,
-                        fraDato = LocalDate.now(),
-                    ),
-                typeVedtak = TypeVedtak.OPPHØR,
-            )
-
-        assertThat(res.rammevedtakPrivatBil).isNotNull
-
-        val rammevedtakReise = res.rammevedtakPrivatBil!!.reiser.single()
-        assertThat(rammevedtakReise.grunnlag.fom).isEqualTo(fom)
-        assertThat(rammevedtakReise.grunnlag.tom).isEqualTo(opphørsdato.minusDays(1))
-        assertThat(rammevedtakReise.grunnlag.delperioder).hasSize(1)
-        assertThat(
-            rammevedtakReise.grunnlag.delperioder
-                .single()
-                .tom,
         ).isEqualTo(opphørsdato.minusDays(1))
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/PrivatBilBeregningStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/PrivatBilBeregningStepDefinitions.kt
@@ -23,6 +23,8 @@ import no.nav.tilleggsstonader.sak.cucumber.parseInt
 import no.nav.tilleggsstonader.sak.cucumber.parseValgfriInt
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.VilkårRepositoryFake
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.cucumberUtils.mapVedtaksperioder
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.privatBil.PrivatBilBeregningRevurderingService
@@ -162,6 +164,10 @@ class PrivatBilBeregningStepDefinitions {
                     oppfylteVilkårDagligReise = oppfylteReisevilkår,
                     behandlingId = behandlingId,
                     typeVedtak = TypeVedtak.INNVILGELSE,
+                    beregningsplan =
+                        Beregningsplan(
+                            omfang = Beregningsomfang.ALLE_PERIODER,
+                        ),
                 )
         } catch (e: Exception) {
             feil = e

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBilAvkortingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBilAvkortingTest.kt
@@ -21,21 +21,21 @@ class RammevedtakPrivatBilAvkortingTest {
         fun `reise som slutter før opphørsDato returneres uendret`() {
             val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
 
-            assertThat(reise.avkortTilDato(uke2Fom.minusDays(1))).isEqualTo(reise)
+            assertThat(reise.avkortEtterDato(uke2Fom.minusDays(1))).isEqualTo(reise)
         }
 
         @Test
         fun `reise som starter på opphørsDato fjernes`() {
             val reise = rammeForReiseMedPrivatBil(fom = uke2Fom, tom = uke2Tom)
 
-            assertThat(reise.avkortTilDato(uke2Fom.minusDays(1))).isNull()
+            assertThat(reise.avkortEtterDato(uke2Fom.minusDays(1))).isNull()
         }
 
         @Test
         fun `reise som starter etter opphørsDato fjernes`() {
             val reise = rammeForReiseMedPrivatBil(fom = uke3Fom, tom = uke3Tom)
 
-            assertThat(reise.avkortTilDato(uke2Fom.minusDays(1))).isNull()
+            assertThat(reise.avkortEtterDato(uke2Fom.minusDays(1))).isNull()
         }
 
         @Test
@@ -43,7 +43,7 @@ class RammevedtakPrivatBilAvkortingTest {
             val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
             val opphørsDato = 10 januar 2025 // onsdag i uke 1
 
-            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
 
             assertThat(resultat).isNotNull
             assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
@@ -59,7 +59,7 @@ class RammevedtakPrivatBilAvkortingTest {
         fun `opphørsDato på start av uke2 beholder kun uke1`() {
             val reise = reiseMed3Uker()
 
-            val resultat = reise.avkortTilDato(uke2Fom.minusDays(1))
+            val resultat = reise.avkortEtterDato(uke2Fom.minusDays(1))
 
             assertThat(resultat).isNotNull
             assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
@@ -72,7 +72,7 @@ class RammevedtakPrivatBilAvkortingTest {
             val reise = reiseMed3Uker()
             val opphørsDato = 15 januar 2025 // onsdag i uke 2
 
-            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
 
             assertThat(resultat).isNotNull
             assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
@@ -102,7 +102,7 @@ class RammevedtakPrivatBilAvkortingTest {
                 )
             val opphørsDato = 17 januar 2025 // torsdag i uke 2
 
-            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
 
             assertThat(resultat).isNotNull
             val avkortetDelperiode = resultat!!.grunnlag.delperioder.single()
@@ -123,7 +123,7 @@ class RammevedtakPrivatBilAvkortingTest {
                 )
             val opphørsDato = 15 januar 2025
 
-            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
 
             assertThat(resultat).isNotNull
             val avkortetDelperiode = resultat!!.grunnlag.delperioder.single()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBilAvkortingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBilAvkortingTest.kt
@@ -1,0 +1,170 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain
+
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class RammevedtakPrivatBilAvkortingTest {
+    val uke1Fom = 6 januar 2025
+    val uke1Tom = 12 januar 2025
+    val uke2Fom = 13 januar 2025
+    val uke2Tom = 19 januar 2025
+    val uke3Fom = 20 januar 2025
+    val uke3Tom = 26 januar 2025
+
+    @Nested
+    inner class AvkortReiseTilDato {
+        @Test
+        fun `reise som slutter før opphørsDato returneres uendret`() {
+            val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
+
+            assertThat(reise.avkortTilDato(uke2Fom.minusDays(1))).isEqualTo(reise)
+        }
+
+        @Test
+        fun `reise som starter på opphørsDato fjernes`() {
+            val reise = rammeForReiseMedPrivatBil(fom = uke2Fom, tom = uke2Tom)
+
+            assertThat(reise.avkortTilDato(uke2Fom.minusDays(1))).isNull()
+        }
+
+        @Test
+        fun `reise som starter etter opphørsDato fjernes`() {
+            val reise = rammeForReiseMedPrivatBil(fom = uke3Fom, tom = uke3Tom)
+
+            assertThat(reise.avkortTilDato(uke2Fom.minusDays(1))).isNull()
+        }
+
+        @Test
+        fun `reise som overlapper opphørsDato får sluttdato satt til dagen før opphørsDato`() {
+            val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
+            val opphørsDato = 10 januar 2025 // onsdag i uke 1
+
+            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
+            assertThat(resultat.grunnlag.tom).isEqualTo(9 januar 2025)
+            assertThat(
+                resultat.grunnlag.delperioder
+                    .single()
+                    .tom,
+            ).isEqualTo(9 januar 2025)
+        }
+
+        @Test
+        fun `opphørsDato på start av uke2 beholder kun uke1`() {
+            val reise = reiseMed3Uker()
+
+            val resultat = reise.avkortTilDato(uke2Fom.minusDays(1))
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
+            assertThat(resultat.grunnlag.tom).isEqualTo(uke1Tom)
+            assertThat(resultat.grunnlag.delperioder).hasSize(1)
+        }
+
+        @Test
+        fun `opphørsDato midt i uke2 kapper uke2 og fjerner uke3`() {
+            val reise = reiseMed3Uker()
+            val opphørsDato = 15 januar 2025 // onsdag i uke 2
+
+            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
+            assertThat(resultat.grunnlag.tom).isEqualTo(14 januar 2025)
+            assertThat(resultat.grunnlag.delperioder).hasSize(2)
+            assertThat(
+                resultat.grunnlag.delperioder
+                    .last()
+                    .fom,
+            ).isEqualTo(uke2Fom)
+            assertThat(
+                resultat.grunnlag.delperioder
+                    .last()
+                    .tom,
+            ).isEqualTo(14 januar 2025)
+        }
+
+        @Test
+        fun `satser i avkortet delperiode avkortes ikke`() {
+            val sats1 = lagSats(uke2Fom, 15 januar 2025)
+            val sats2 = lagSats(16 januar 2025, uke2Tom)
+            val reise =
+                rammeForReiseMedPrivatBil(
+                    fom = uke2Fom,
+                    tom = uke2Tom,
+                    delperioder = listOf(lagDelperiode(uke2Fom, uke2Tom, listOf(sats1, sats2))),
+                )
+            val opphørsDato = 17 januar 2025 // torsdag i uke 2
+
+            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+
+            assertThat(resultat).isNotNull
+            val avkortetDelperiode = resultat!!.grunnlag.delperioder.single()
+            assertThat(avkortetDelperiode.satser).hasSize(2)
+            assertThat(avkortetDelperiode.satser.first().tom).isEqualTo(15 januar 2025) // uendret
+            assertThat(avkortetDelperiode.satser.last().tom).isEqualTo(uke2Tom) // uendret — satser avkortes ikke
+        }
+
+        @Test
+        fun `satser forblir uendret etter avkorting av delperiode`() {
+            val sats1 = lagSats(uke2Fom, 14 januar 2025)
+            val sats2 = lagSats(15 januar 2025, uke2Tom)
+            val reise =
+                rammeForReiseMedPrivatBil(
+                    fom = uke2Fom,
+                    tom = uke2Tom,
+                    delperioder = listOf(lagDelperiode(uke2Fom, uke2Tom, listOf(sats1, sats2))),
+                )
+            val opphørsDato = 15 januar 2025
+
+            val resultat = reise.avkortTilDato(opphørsDato.minusDays(1))
+
+            assertThat(resultat).isNotNull
+            val avkortetDelperiode = resultat!!.grunnlag.delperioder.single()
+            assertThat(avkortetDelperiode.satser).hasSize(2)
+            assertThat(avkortetDelperiode.satser.first().tom).isEqualTo(14 januar 2025) // uendret
+            assertThat(avkortetDelperiode.satser.last().tom).isEqualTo(uke2Tom) // uendret — satser avkortes ikke
+        }
+    }
+
+    private fun reiseMed3Uker() =
+        rammeForReiseMedPrivatBil(
+            fom = uke1Fom,
+            tom = uke3Tom,
+            delperioder =
+                listOf(
+                    lagDelperiode(uke1Fom, uke1Tom),
+                    lagDelperiode(uke2Fom, uke2Tom),
+                    lagDelperiode(uke3Fom, uke3Tom),
+                ),
+        )
+
+    private fun lagDelperiode(
+        fom: LocalDate,
+        tom: LocalDate,
+        satser: List<RammeForReiseMedPrivatBilSatsForDelperiode> = listOf(lagSats(fom, tom)),
+    ) = RammeForReiseMedPrivatBilDelperiode(
+        fom = fom,
+        tom = tom,
+        reisedagerPerUke = 5,
+        ekstrakostnader = RammeForReiseMedPrivatEkstrakostnader(null, null),
+        satser = satser,
+    )
+
+    private fun lagSats(
+        fom: LocalDate,
+        tom: LocalDate,
+    ) = RammeForReiseMedPrivatBilSatsForDelperiode(
+        fom = fom,
+        tom = tom,
+        kilometersats = 2.94.toBigDecimal(),
+        dagsatsUtenParkering = 100.toBigDecimal(),
+        satsBekreftetVedVedtakstidspunkt = true,
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBilAvkortingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBilAvkortingTest.kt
@@ -16,50 +16,53 @@ class RammevedtakPrivatBilAvkortingTest {
     val uke3Tom = 26 januar 2025
 
     @Nested
-    inner class AvkortReiseTilDato {
+    inner class AvkortEtterDato {
         @Test
-        fun `reise som slutter før opphørsDato returneres uendret`() {
+        fun `reise med tom lik maksTom returneres uendret`() {
             val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
 
-            assertThat(reise.avkortEtterDato(uke2Fom.minusDays(1))).isEqualTo(reise)
+            assertThat(reise.avkortEtterDato(uke1Tom)).isEqualTo(reise)
         }
 
         @Test
-        fun `reise som starter på opphørsDato fjernes`() {
+        fun `reise fom etter maksTom fjernes`() {
             val reise = rammeForReiseMedPrivatBil(fom = uke2Fom, tom = uke2Tom)
 
-            assertThat(reise.avkortEtterDato(uke2Fom.minusDays(1))).isNull()
+            assertThat(reise.avkortEtterDato(uke1Tom)).isNull()
         }
 
         @Test
-        fun `reise som starter etter opphørsDato fjernes`() {
-            val reise = rammeForReiseMedPrivatBil(fom = uke3Fom, tom = uke3Tom)
-
-            assertThat(reise.avkortEtterDato(uke2Fom.minusDays(1))).isNull()
-        }
-
-        @Test
-        fun `reise som overlapper opphørsDato får sluttdato satt til dagen før opphørsDato`() {
+        fun `reise som avkortes til fom beholder kun én dag`() {
             val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
-            val opphørsDato = 10 januar 2025 // onsdag i uke 1
 
-            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(uke1Fom)
+
+            assertThat(resultat?.grunnlag?.fom).isEqualTo(uke1Fom)
+            assertThat(resultat?.grunnlag?.tom).isEqualTo(uke1Fom)
+        }
+
+        @Test
+        fun `reise som overlapper maksTom avkortes til maksTom`() {
+            val reise = rammeForReiseMedPrivatBil(fom = uke1Fom, tom = uke1Tom)
+            val maksTom = 9 januar 2025
+
+            val resultat = reise.avkortEtterDato(maksTom)
 
             assertThat(resultat).isNotNull
             assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
-            assertThat(resultat.grunnlag.tom).isEqualTo(9 januar 2025)
+            assertThat(resultat.grunnlag.tom).isEqualTo(maksTom)
             assertThat(
                 resultat.grunnlag.delperioder
                     .single()
                     .tom,
-            ).isEqualTo(9 januar 2025)
+            ).isEqualTo(maksTom)
         }
 
         @Test
-        fun `opphørsDato på start av uke2 beholder kun uke1`() {
+        fun `maksTom på siste dag i uke1 beholder kun uke1`() {
             val reise = reiseMed3Uker()
 
-            val resultat = reise.avkortEtterDato(uke2Fom.minusDays(1))
+            val resultat = reise.avkortEtterDato(uke1Tom)
 
             assertThat(resultat).isNotNull
             assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
@@ -68,30 +71,25 @@ class RammevedtakPrivatBilAvkortingTest {
         }
 
         @Test
-        fun `opphørsDato midt i uke2 kapper uke2 og fjerner uke3`() {
+        fun `tre delperioder - én uendret, én forkortet, én fjernet`() {
             val reise = reiseMed3Uker()
-            val opphørsDato = 15 januar 2025 // onsdag i uke 2
+            val maksTom = 14 januar 2025
 
-            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(maksTom)!!
 
-            assertThat(resultat).isNotNull
-            assertThat(resultat!!.grunnlag.fom).isEqualTo(uke1Fom)
-            assertThat(resultat.grunnlag.tom).isEqualTo(14 januar 2025)
-            assertThat(resultat.grunnlag.delperioder).hasSize(2)
-            assertThat(
-                resultat.grunnlag.delperioder
-                    .last()
-                    .fom,
-            ).isEqualTo(uke2Fom)
-            assertThat(
-                resultat.grunnlag.delperioder
-                    .last()
-                    .tom,
-            ).isEqualTo(14 januar 2025)
+            assertThat(resultat.grunnlag.fom).isEqualTo(uke1Fom)
+            assertThat(resultat.grunnlag.tom).isEqualTo(maksTom)
+
+            val delperioder = resultat.grunnlag.delperioder
+            assertThat(delperioder).hasSize(2)
+            assertThat(delperioder[0].fom).isEqualTo(uke1Fom)
+            assertThat(delperioder[0].tom).isEqualTo(uke1Tom)
+            assertThat(delperioder[1].fom).isEqualTo(uke2Fom)
+            assertThat(delperioder[1].tom).isEqualTo(maksTom)
         }
 
         @Test
-        fun `satser i avkortet delperiode avkortes ikke`() {
+        fun `sats som overlapper maksTom avkortes til maksTom`() {
             val sats1 = lagSats(uke2Fom, 15 januar 2025)
             val sats2 = lagSats(16 januar 2025, uke2Tom)
             val reise =
@@ -100,19 +98,19 @@ class RammevedtakPrivatBilAvkortingTest {
                     tom = uke2Tom,
                     delperioder = listOf(lagDelperiode(uke2Fom, uke2Tom, listOf(sats1, sats2))),
                 )
-            val opphørsDato = 17 januar 2025 // torsdag i uke 2
+            val maksTom = 16 januar 2025
 
-            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(maksTom)
 
             assertThat(resultat).isNotNull
             val avkortetDelperiode = resultat!!.grunnlag.delperioder.single()
             assertThat(avkortetDelperiode.satser).hasSize(2)
-            assertThat(avkortetDelperiode.satser.first().tom).isEqualTo(15 januar 2025) // uendret
-            assertThat(avkortetDelperiode.satser.last().tom).isEqualTo(uke2Tom) // uendret — satser avkortes ikke
+            assertThat(avkortetDelperiode.satser.first().tom).isEqualTo(15 januar 2025)
+            assertThat(avkortetDelperiode.satser.last().tom).isEqualTo(maksTom)
         }
 
         @Test
-        fun `satser forblir uendret etter avkorting av delperiode`() {
+        fun `sats som starter etter maksTom fjernes`() {
             val sats1 = lagSats(uke2Fom, 14 januar 2025)
             val sats2 = lagSats(15 januar 2025, uke2Tom)
             val reise =
@@ -121,15 +119,14 @@ class RammevedtakPrivatBilAvkortingTest {
                     tom = uke2Tom,
                     delperioder = listOf(lagDelperiode(uke2Fom, uke2Tom, listOf(sats1, sats2))),
                 )
-            val opphørsDato = 15 januar 2025
+            val maksTom = 14 januar 2025
 
-            val resultat = reise.avkortEtterDato(opphørsDato.minusDays(1))
+            val resultat = reise.avkortEtterDato(maksTom)
 
             assertThat(resultat).isNotNull
             val avkortetDelperiode = resultat!!.grunnlag.delperioder.single()
-            assertThat(avkortetDelperiode.satser).hasSize(2)
-            assertThat(avkortetDelperiode.satser.first().tom).isEqualTo(14 januar 2025) // uendret
-            assertThat(avkortetDelperiode.satser.last().tom).isEqualTo(uke2Tom) // uendret — satser avkortes ikke
+            assertThat(avkortetDelperiode.satser).hasSize(1)
+            assertThat(avkortetDelperiode.satser.single().tom).isEqualTo(maksTom)
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Måten opphør og kutting/kombinering av rammevedtak funka rimelig dårlig. Så nå tar jeg bare det gamle resultatet og kutter sluttdatoene på alle perioder innenfor. 

# q & a
Q: Hvorfor kan man ikke bare beregne alt på nytt?
A: Vi beregner en dagsats basert på faktaen som sendes inn. Om vi endrer på hvordan vi regner ut denne dagsatsen vil vi ende med å gjøre endringer før opphørsdatoen som ikke var meningen.

Q: Blir det da riktig?
A: Ja siden det kun er dagsats man beregner så avhenger den feks ikke av antall dager mellom fom og tom. All informasjon utenom datoer vil være likt gitt at det ikke har skjedd noen endringer på faktaen på vilkåret.

Q: Men hva om det har skjedd endringer på fakta????
A: Det lurte jeg også på og innså at det ikke fungerer på noen stønadstyper. Så [oppgave for fix](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29449) er lagt i innboksen