### PR TITLE
🚩 Feature-toggle håndtering av journalposter av reise til samling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaHåndtererService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/hendelser/journalføring/JournalhendelseKafkaHåndtererService.kt
@@ -3,16 +3,19 @@ package no.nav.tilleggsstonader.sak.hendelser.journalføring
 import no.nav.tilleggsstonader.kontrakter.felles.Tema
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.libs.log.logger
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.ekstern.journalføring.HåndterMottattKjørelisteService
 import no.nav.tilleggsstonader.sak.ekstern.journalføring.HåndterSøknadService
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
 import no.nav.tilleggsstonader.sak.journalføring.brevkoder
 import no.nav.tilleggsstonader.sak.journalføring.dokumentBrevkode
 import no.nav.tilleggsstonader.sak.journalføring.erInnkommende
 import no.nav.tilleggsstonader.sak.journalføring.gjelderKanalSkanningEllerNavNo
 import no.nav.tilleggsstonader.sak.journalføring.gjelderKjøreliste
+import no.nav.tilleggsstonader.sak.journalføring.gjelderReiseTilSamlingNyttSkjema
 import no.nav.tilleggsstonader.sak.journalføring.gjelderSøknad
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 /**
@@ -25,9 +28,8 @@ class JournalhendelseKafkaHåndtererService(
     private val håndterSøknadService: HåndterSøknadService,
     private val journalpostMottattMetrikker: JournalpostMottattMetrikker,
     private val håndterMottattKjørelisteService: HåndterMottattKjørelisteService,
+    private val unleashService: UnleashService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
     fun behandleJournalhendelse(journalpostId: String) {
         val journalpost = journalpostService.hentJournalpost(journalpostId)
 
@@ -55,12 +57,17 @@ class JournalhendelseKafkaHåndtererService(
         }
     }
 
-    private fun Journalpost.kanBehandles() =
-        Tema.gjelderTemaTilleggsstønader(this.tema) &&
+    private fun Journalpost.kanBehandles(): Boolean {
+        if (this.gjelderReiseTilSamlingNyttSkjema()) {
+            return unleashService.isEnabled(Toggle.TA_I_MOT_JOURNALFØRINGER_REISE_TIL_SAMLING)
+        }
+
+        return Tema.gjelderTemaTilleggsstønader(this.tema) &&
             this.erInnkommende() &&
             this.gjelderKanalSkanningEllerNavNo() &&
             (this.gjelderSøknad() || this.gjelderKjøreliste()) &&
             !this.erFerdigstilt()
+    }
 
     /*
      Kan komme inn ferdigstilte journalposter om man har endret sakstilknytning på et allerede journalført dokument.

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -25,9 +25,10 @@ enum class Toggle(
 
     BRUK_OPPFOLGINGSENHET_FOR_UTBETALING("sak.bruk-oppfolgingsenhet-for-utbetaling"),
 
-    SØKNAD_ROUTING_REISE_TIL_SAMLING("sak.soknad-routing.reise-til-samling"),
-
     KAN_OPPHØRE_PRIVAT_BIL("sak.opphore-privat-bil"),
 
+    // Reise til samling
+    SØKNAD_ROUTING_REISE_TIL_SAMLING("sak.soknad-routing.reise-til-samling"),
     KAN_BEHANDLE_REISE_TIL_SAMLING("sak.reise-til-samling"),
+    TA_I_MOT_JOURNALFØRINGER_REISE_TIL_SAMLING("sak.ta-i-mot-journalforinger-reise-til-samling"),
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/journalføring/JournalpostUtil.kt
@@ -19,6 +19,8 @@ fun Journalpost.gjelderSøknad() =
             DokumentBrevkode.REISE_TIL_SAMLING,
         )
 
+fun Journalpost.gjelderReiseTilSamlingNyttSkjema() = dokumentBrevkode() == DokumentBrevkode.REISE_TIL_SAMLING
+
 fun Journalpost.gjelderKjøreliste() = this.dokumentBrevkode() == DokumentBrevkode.DAGLIG_REISE_KJØRELISTE
 
 /**


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når bruker fyller inn digitalt i dag får journalpostene brevkode NAV 11-12.17B .
Men når bruker fyller ut digitalt, printer ut og sender i posten, så kommer det inn til skanning. Da må en saksbehandler manuelt velge brevkoden og da hender det at de velger NAV 11-12.17 (altså uten B). Det er dumt hvis de havner hos oss før saksbehandling av reise til samling er klar. 