### PR TITLE
Ved et opphør - ikke opphør utbetalinger som faktisk ikke har blitt sendt til utbetaling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
@@ -221,8 +221,8 @@ class UtbetalingV3Mapper(
                 .toSet()
         }
 
-    private fun AndelTilkjentYtelse.mapTilUtbetalingId(fagsakutbetalingIder: Collection<FagsakUtbetalingId>): FagsakUtbetalingId =
-        fagsakutbetalingIder.single { utbetalingId ->
+    private fun AndelTilkjentYtelse.mapTilUtbetalingId(fagsakUtbetalingIder: Collection<FagsakUtbetalingId>): FagsakUtbetalingId =
+        fagsakUtbetalingIder.singleOrNull { utbetalingId ->
             this.type == utbetalingId.typeAndel && this.reiseId == utbetalingId.reiseId
-        }
+        } ?: error("Fant ikke utbetalingId for type=${this.type} reiseId=${this.reiseId}")
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingV3Mapper.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.utbetaling.utsjekk.utbetaling
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.utbetaling.id.FagsakUtbetalingId
 import no.nav.tilleggsstonader.sak.utbetaling.id.FagsakUtbetalingIdService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.AndelTilkjentYtelse
@@ -101,14 +102,18 @@ class UtbetalingV3Mapper(
         behandling: Saksbehandling,
         andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
     ): List<UtbetalingDto> =
-        finnTypeAndelerSomSkalAnnulleres(behandling, andelerTilkjentYtelse)
-            .map { typeAndel ->
-                lagUtbetaling(
-                    behandling = behandling,
-                    typeAndelOgReiseId = typeAndel,
-                    andeler = emptyList(), // periodene skal annuleres 💥
-                )
-            }
+        finnUtbetalingIderSomSkalAnnulleres(behandling, andelerTilkjentYtelse)
+            .map { utbetalingId -> lagAnnulleringUtbetaling(utbetalingId, behandling.stønadstype) }
+
+    private fun lagAnnulleringUtbetaling(
+        fagsakUtbetalingId: FagsakUtbetalingId,
+        stønadstype: Stønadstype,
+    ) = UtbetalingDto(
+        id = fagsakUtbetalingId.utbetalingId,
+        stønad = mapTilStønadUtbetaling(fagsakUtbetalingId.typeAndel),
+        perioder = emptyList(),
+        brukFagområdeTillst = stønadstype.skalBrukeGamleFagområder(),
+    )
 
     // Grupperer alle andeler som har samme fom. NB: hvis vi tar i bruk noe annet enn dagsats må dette endres, da tom kan være ulik
     private fun grupperPåDagOgMapTilPerioder(andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>): List<UtbetalingPeriodeDto> =
@@ -178,27 +183,46 @@ class UtbetalingV3Mapper(
             else -> error("Skal ikke sende andelstype=$typeAndel på kafka")
         }
 
-    private fun finnTypeAndelerSomSkalAnnulleres(
+    /**
+     * En utbetalingId som ikke har noen tilknyttede andeler som skal iverksettes nå,
+     * men har andeler som ble iverksatt forrige behandling skal annulleres.
+     */
+    private fun finnUtbetalingIderSomSkalAnnulleres(
         behandling: Saksbehandling,
         andelerTilkjentYtelse: Collection<AndelTilkjentYtelse>,
-    ): Set<TypeAndelOgReiseId> {
+    ): Set<FagsakUtbetalingId> {
+        val fagsakutbetalingIder = fagsakUtbetalingIdService.hentUtbetalingIderForFagsakId(behandling.fagsakId)
+
+        val utbetalingIderIverksattForrigeBehandling = finnUtbetalingIderSomBleIverksattIForrigeBehandling(behandling, fagsakutbetalingIder)
+        val utbetalingIderSomSkalIverksettesNå =
+            andelerTilkjentYtelse
+                .map { it.mapTilUtbetalingId(fagsakutbetalingIder) }
+                .toSet()
+
+        return utbetalingIderIverksattForrigeBehandling
+            .filter {
+                it !in utbetalingIderSomSkalIverksettesNå
+            }.toSet()
+    }
+
+    private fun finnUtbetalingIderSomBleIverksattIForrigeBehandling(
+        behandling: Saksbehandling,
+        fagsakUtbetalingIder: Collection<FagsakUtbetalingId>,
+    ): Set<FagsakUtbetalingId> =
         if (behandling.forrigeIverksatteBehandlingId == null) {
-            return emptySet()
-        }
-        val andelerForrigeBehandling =
+            emptySet()
+        } else {
             tilkjentYtelseService
                 .hentForBehandling(behandling.forrigeIverksatteBehandlingId)
                 .andelerTilkjentYtelse
-
-        val typeAndelerOgReiseIdNåværendeBehandling =
-            andelerTilkjentYtelse
-                .map { TypeAndelOgReiseId(it.type, it.reiseId) }
+                .filter { it.type != TypeAndel.UGYLDIG }
+                .filter { it.iverksetting != null }
+                .map { it.mapTilUtbetalingId(fagsakUtbetalingIder) }
                 .toSet()
+        }
 
-        return andelerForrigeBehandling
-            .filter { it.type != TypeAndel.UGYLDIG }
-            .map { TypeAndelOgReiseId(it.type, it.reiseId) }
-            .filter { it !in typeAndelerOgReiseIdNåværendeBehandling }
-            .toSet()
-    }
+    private fun AndelTilkjentYtelse.mapTilUtbetalingId(fagsakutbetalingIder: Collection<FagsakUtbetalingId>): FagsakUtbetalingId =
+        fagsakutbetalingIder.single { utbetalingId ->
+            this.type == utbetalingId.typeAndel && this.reiseId == utbetalingId.reiseId
+        }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettingIntegrationTest.kt
@@ -4,12 +4,20 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KafkaFake
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.forventAntallMeldingerPåTopic
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.verdiEllerFeil
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.utbetaling.id.FagsakUtbetalingIdRepository
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
+import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.utbetaling.IverksettingDto
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 
-class IverksettingIntegrationTest : IntegrationTest() {
+class IverksettingIntegrationTest(
+    @Autowired private val fagsakUtbetalingIdRepository: FagsakUtbetalingIdRepository,
+) : IntegrationTest() {
     @Test
     fun `skal ikke sende noe på kafka hvis vi bare har andeler fram i tid`() {
         val omTrettiDager = LocalDate.now().plusDays(30)
@@ -32,5 +40,104 @@ class IverksettingIntegrationTest : IntegrationTest() {
         KafkaFake
             .sendteMeldinger()
             .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 0)
+    }
+
+    @Test
+    fun `skal ikke send noe til økonomi ved innvilgelse frem i tid og opphør av dette`() {
+        val omToUker = LocalDate.now().plusWeeks(2)
+        val omFireUker = LocalDate.now().plusWeeks(4)
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
+                defaultDagligReiseTsoTestdata(fom = omToUker, tom = omFireUker)
+            }
+
+        KafkaFake
+            .sendteMeldinger()
+            .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 0)
+
+        opprettRevurderingOgGjennomførBehandlingsløp(førstegangsbehandlingContext.behandlingId) {
+            vedtak {
+                opphør(opphørsdato = omToUker)
+            }
+        }
+
+        KafkaFake
+            .sendteMeldinger()
+            .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 0)
+    }
+
+    @Test
+    fun `skal ikke sende noe på kafka for utbetalingId'er som ikke har noen andeler sendt på seg ved opphør`() {
+        val toUkerSiden = LocalDate.now().minusWeeks(2)
+        val omToUker = LocalDate.now().plusWeeks(2)
+        val omFireUker = LocalDate.now().plusWeeks(4)
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
+                aktivitet {
+                    opprett {
+                        aktivitetUtdanningDagligReiseTso(toUkerSiden, omFireUker)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(toUkerSiden, omToUker)
+                        målgruppeOvergangsstønad(omToUker.plusDays(1), omFireUker)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        offentligTransport(fom = toUkerSiden, tom = omToUker)
+                        offentligTransport(fom = omToUker.plusDays(1), tom = omFireUker)
+                    }
+                }
+            }
+
+        val utbetalingIderPåFagsak = fagsakUtbetalingIdRepository.findByFagsakId(førstegangsbehandlingContext.fagsakId)
+        assertThat(utbetalingIderPåFagsak).hasSize(2)
+        assertThat(utbetalingIderPåFagsak.map { it.typeAndel }).containsExactlyInAnyOrder(
+            TypeAndel.DAGLIG_REISE_AAP,
+            TypeAndel.DAGLIG_REISE_ENSLIG_FORSØRGER,
+        )
+
+        val iverksettingFørstegangsbehandling =
+            KafkaFake
+                .sendteMeldinger()
+                .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 1)
+                .single()
+                .verdiEllerFeil<IverksettingDto>()
+
+        assertThat(iverksettingFørstegangsbehandling.utbetalinger).hasSize(1)
+        assertThat(iverksettingFørstegangsbehandling.utbetalinger.single().id).isEqualTo(
+            utbetalingIderPåFagsak
+                .single {
+                    it.typeAndel ==
+                        TypeAndel.DAGLIG_REISE_AAP
+                }.utbetalingId,
+        )
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        opprettRevurderingOgGjennomførBehandlingsløp(førstegangsbehandlingContext.behandlingId) {
+            vedtak {
+                opphør(opphørsdato = toUkerSiden)
+            }
+        }
+
+        val iverksettingOpphør =
+            KafkaFake
+                .sendteMeldinger()
+                .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 2)
+                .map { it.verdiEllerFeil<IverksettingDto>() }
+                .maxBy { it.vedtakstidspunkt }
+
+        assertThat(iverksettingOpphør.utbetalinger).hasSize(1)
+        assertThat(iverksettingOpphør.utbetalinger.single().id).isEqualTo(
+            utbetalingIderPåFagsak
+                .single {
+                    it.typeAndel ==
+                        TypeAndel.DAGLIG_REISE_AAP
+                }.utbetalingId,
+        )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/iverksetting/IverksettingIntegrationTest.kt
@@ -43,7 +43,7 @@ class IverksettingIntegrationTest(
     }
 
     @Test
-    fun `skal ikke send noe til økonomi ved innvilgelse frem i tid og opphør av dette`() {
+    fun `skal ikke sende noe til økonomi ved innvilgelse frem i tid og opphør av dette`() {
         val omToUker = LocalDate.now().plusWeeks(2)
         val omFireUker = LocalDate.now().plusWeeks(4)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -22,6 +22,7 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.Simuleringsresul
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.kontrakt.SimuleringResponseDto
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
 import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.utbetaling.SimuleringDto
 import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.utbetaling.UtbetalingV3Mapper
 import no.nav.tilleggsstonader.sak.util.FileUtil.readFile
@@ -72,6 +73,14 @@ internal class SimuleringServiceTest {
         every { fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(any(), any(), any()) } answers {
             FagsakUtbetalingId(fagsakId = FagsakId(firstArg()), typeAndel = secondArg(), reiseId = thirdArg())
         }
+        every { fagsakUtbetalingIdService.hentUtbetalingIderForFagsakId(any()) } returns
+            listOf(
+                FagsakUtbetalingId(
+                    fagsakId = FagsakId.random(),
+                    typeAndel = TypeAndel.TILSYN_BARN_AAP,
+                    reiseId = null,
+                ),
+            )
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -204,7 +204,7 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
                 .single { it.type == BehandlingType.KJØRELISTE }
 
         gjennomførKjørelisteBehandling(førsteKjørelistebehandling)
-        testoppsettService.settAndelerTilOkForBehandling(førsteKjørelistebehandling)
+        testoppsettService.settAndelerTilOkForBehandling(førsteKjørelistebehandling.id)
 
         // Sender inn kjøreliste for andre rammevedtak
         sendInnKjøreliste(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/TestoppsettService.kt
@@ -238,8 +238,8 @@ class TestoppsettService(
 
     fun hentPersonidentForBehandlingId(behandlingId: BehandlingId) = behandlingRepository.finnAktivIdent(behandlingId)
 
-    fun settAndelerTilOkForBehandling(behandling: Behandling) {
-        val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingId(behandling.id)!!
+    fun settAndelerTilOkForBehandling(behandlingId: BehandlingId) {
+        val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingId(behandlingId)!!
         tilkjentYtelseRepository.update(
             tilkjentYtelse.copy(
                 andelerTilkjentYtelse =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterRevurderingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterRevurderingIntegrationTest.kt
@@ -126,7 +126,7 @@ class BoutgifterRevurderingIntegrationTest(
                         opphør(opphørsdato = 1 april 2026)
                     }
                 }
-            testoppsettService.settAndelerTilOkForBehandling(testoppsettService.hentBehandling(opphørId))
+            testoppsettService.settAndelerTilOkForBehandling(opphørId)
 
             val tilkjentYtelseInnvilgelse = tilkjentYtelseRepository.findByBehandlingId(innvilgelseId)
             val tilkjentYtelseSatsjustering = tilkjentYtelseRepository.findByBehandlingId(satsjusteringId)
@@ -247,7 +247,7 @@ class BoutgifterRevurderingIntegrationTest(
                 ) {
                     defaultBoutgifterTestdata(fom = 19 august 2025, 30 juni 2026)
                 }
-            testoppsettService.settAndelerTilOkForBehandling(testoppsettService.hentBehandling(behandlingContext.behandlingId))
+            testoppsettService.settAndelerTilOkForBehandling(behandlingContext.behandlingId)
 
             // Simulerer en satsjustering ved å legge til ny aktivitet fra 1. januar slik at det beregnes fra 1. januar
             val satsjustering =
@@ -258,7 +258,7 @@ class BoutgifterRevurderingIntegrationTest(
                         }
                     }
                 }
-            testoppsettService.settAndelerTilOkForBehandling(testoppsettService.hentBehandling(satsjustering))
+            testoppsettService.settAndelerTilOkForBehandling(satsjustering)
 
             return Pair(behandlingContext.behandlingId, satsjustering)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilVedtakSideeffekterIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReisePrivatBilVedtakSideeffekterIntegrationTest.kt
@@ -78,7 +78,7 @@ class DagligReisePrivatBilVedtakSideeffekterIntegrationTest : IntegrationTest() 
         verifiserHarBlittProdusertVedtaksbrevForKjørelistebehandling(manuellKjørelisteBehandling.id)
         verifiserIkkeHarBlittProdusertInterntVedtakForBehandling(manuellKjørelisteBehandling.id)
 
-        testoppsettService.settAndelerTilOkForBehandling(manuellKjørelisteBehandling)
+        testoppsettService.settAndelerTilOkForBehandling(manuellKjørelisteBehandling.id)
         every { unleashService.isEnabled(Toggle.KAN_AUTOMATISK_BEHANDLE_KJØRELISTE) } returns true
         val reiseId =
             kall.privatBil


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I dag får vi feil hvis man har innvilget noe frem i tid og opphører (eller endrer) dette i en revurdering FØR utbetalingene har blitt sendt til økonomi. 

Denne feilen kommer pga ved førstegangsiverksetting av en behandling så henter vi ut alle UtbetalingId'er (en UtbetalingId peker på alle andeler med samme TypeAndel + reiseId for en sak) som finnes i forrige behandling men ikke på nåværende tidspunkt i revurdering, for å sende til helved at det ikke skal betales noe på denne.

Fikser dette ved å også filtrere på at UtbetalingId fra forrige behandling faktisk ble sendt til økonomi.

Gjør og en liten endring i hvordan vi henter ut UtbetalingId'er som skal annuleres, slik at det forhåpentligvis blir litt mer tydelig til senere :eyes:

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-27982

