### PR TITLE
✨ Marker avklarte dager som slettet hvis de er utenfor rammevedtaket

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/GjenbrukDataRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/GjenbrukDataRevurderingService.kt
@@ -60,7 +60,7 @@ class GjenbrukDataRevurderingService(
             )
         }
 
-        avklartKjørelisteService.nullstillOgGjenbrukAvklarteUker(behandling, behandlingIdForGjenbruk)
+        avklartKjørelisteService.nullstillOgGjenbrukAvklarteUker(behandling.id, behandlingIdForGjenbruk)
     }
 
     fun finnBehandlingIdForGjenbruk(fagsakId: FagsakId): BehandlingId? =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/BehandleMottattKjørelisteService.kt
@@ -62,7 +62,7 @@ class BehandleMottattKjørelisteService(
             logger.info("Legger til kjøreliste=${kjøreliste.id} i behandling=${gjenbrukBehandling.id}")
             countersPerUtfall.getValue(KjørelisteBehandlingUtfall.MANUELL_GJENBRUK).increment()
             avklartKjørelisteService.avklarUkerFraKjøreliste(
-                behandling = gjenbrukBehandling,
+                behandlingId = gjenbrukBehandling.id,
                 kjøreliste = kjøreliste,
             )
         } else {
@@ -139,7 +139,7 @@ class BehandleMottattKjørelisteService(
         gjenbrukData(kjørelistebehandling)
 
         avklartKjørelisteService.avklarUkerFraKjøreliste(
-            behandling = kjørelistebehandling,
+            behandlingId = kjørelistebehandling.id,
             kjøreliste = kjøreliste,
         )
         return kjørelistebehandling

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikDag
@@ -53,4 +54,5 @@ data class AvklartDagDto(
     val avvik: List<TypeAvvikDag>,
     val begrunnelse: String?, // må fylles ut om avvik?
     val parkeringsutgift: Int?,
+    val avklartKjørtDagStatus: AvklartKjørtDagStatus,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -82,5 +82,6 @@ object ReisevurderingPrivatBilMapper {
             avvik = avvik,
             begrunnelse = begrunnelse,
             parkeringsutgift = parkeringsutgift,
+            avklartKjørtDagStatus = avklartKjørtDagStatus,
         )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -102,6 +102,7 @@ class AvklartKjørelisteService(
                 } else {
                     AvklartKjørtUkeStatus.UENDRET
                 }
+
             AvklartKjørtUkeStatus.ENDRET -> {
                 val forrigeUke = hentForrigeBehandlingsUke(behandlingId, eksisterendeUke)
                 if (forrigeUke != null && !erDagerEndret(forrigeUke.dager, oppdaterteDager)) {
@@ -110,6 +111,7 @@ class AvklartKjørelisteService(
                     AvklartKjørtUkeStatus.ENDRET
                 }
             }
+
             AvklartKjørtUkeStatus.NY -> AvklartKjørtUkeStatus.NY
             AvklartKjørtUkeStatus.SLETTET -> AvklartKjørtUkeStatus.SLETTET
         }
@@ -248,6 +250,7 @@ class AvklartKjørelisteService(
             automatiskVurdering = if (avvik.isEmpty()) UtfyltDagAutomatiskVurdering.OK else UtfyltDagAutomatiskVurdering.AVVIK,
             begrunnelse = null,
             parkeringsutgift = if (godkjentGjennomførtKjøring == GodkjentGjennomførtKjøring.JA) kjørelisteDag.parkeringsutgift else null,
+            avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
         )
     }
 
@@ -296,7 +299,10 @@ class AvklartKjørelisteService(
         avklartKjørtUkeRepository.deleteAll(avklarteUkerNyBehandling)
 
         // Kopier over avklarte uker fra forrige behandling
-        val nyeAvklarteUker = avklarteUkerForrigeBehandling.map { it.kopierTilNyBehandling(behandling.id) }
+        val nyeAvklarteUker =
+            avklarteUkerForrigeBehandling
+                .filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.SLETTET }
+                .map { it.kopierTilNyBehandling(behandling.id) }
         avklartKjørtUkeRepository.insertAll(nyeAvklarteUker)
 
         // Avklar nye kjørelister på nytt
@@ -305,22 +311,56 @@ class AvklartKjørelisteService(
         }
     }
 
-    fun sletteMarkerUkerUtenforAvkortetRammevedtak(
+    fun sletteMarkerUkerOgDagerUtenforAvkortetRammevedtak(
         behandlingId: BehandlingId,
         rammevedtak: RammevedtakPrivatBil,
     ) {
-        val avklarteUker = hentAvklarteUkerForBehandling(behandlingId)
+        val oppdaterteUker =
+            hentAvklarteUkerForBehandling(behandlingId).mapNotNull { uke ->
+                val rammevedtakForReise = rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
+                val sisteDagIRammevedtak = rammevedtakForReise.grunnlag.tom
 
-        val ukerSomSkalSlettes =
-            avklarteUker.filter { uke ->
-                val reise = rammevedtak.reiser.find { it.reiseId == uke.reiseId }
-                reise != null && uke.fom > reise.grunnlag.tom
+                when {
+                    uke.fom > sisteDagIRammevedtak -> uke.markerHeleUkaSomSlettet()
+                    uke.inneholder(sisteDagIRammevedtak) -> uke.markerDelerAvUkaSomSlettet(fraDato = sisteDagIRammevedtak)
+                    else -> null
+                }
             }
 
-        if (ukerSomSkalSlettes.isNotEmpty()) {
-            avklartKjørtUkeRepository.updateAll(
-                ukerSomSkalSlettes.map { it.copy(avklartKjørtUkeStatus = AvklartKjørtUkeStatus.SLETTET) },
-            )
+        if (oppdaterteUker.isNotEmpty()) {
+            avklartKjørtUkeRepository.updateAll(oppdaterteUker)
+        }
+    }
+
+    private fun AvklartKjørtUke.markerHeleUkaSomSlettet(): AvklartKjørtUke =
+        copy(
+            avklartKjørtUkeStatus = AvklartKjørtUkeStatus.SLETTET,
+            dager =
+                dager
+                    .map { it.copy(avklartKjørtDagStatus = AvklartKjørtDagStatus.SLETTET) }
+                    .toSet(),
+        )
+
+    private fun AvklartKjørtUke.markerDelerAvUkaSomSlettet(fraDato: LocalDate): AvklartKjørtUke? {
+        val oppdaterteDager =
+            dager
+                .map { dag ->
+                    if (dag.dato > fraDato && dag.avklartKjørtDagStatus != AvklartKjørtDagStatus.SLETTET) {
+                        dag.copy(avklartKjørtDagStatus = AvklartKjørtDagStatus.SLETTET)
+                    } else {
+                        dag
+                    }
+                }.toSet()
+        return if (oppdaterteDager != dager) {
+            val nyUkeStatus =
+                if (avklartKjørtUkeStatus == AvklartKjørtUkeStatus.UENDRET) {
+                    AvklartKjørtUkeStatus.ENDRET
+                } else {
+                    avklartKjørtUkeStatus
+                }
+            copy(dager = oppdaterteDager, avklartKjørtUkeStatus = nyUkeStatus)
+        } else {
+            null
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -335,22 +335,11 @@ class AvklartKjørelisteService(
     private fun AvklartKjørtUke.markerHeleUkaSomSlettet(): AvklartKjørtUke =
         copy(
             avklartKjørtUkeStatus = AvklartKjørtUkeStatus.SLETTET,
-            dager =
-                dager
-                    .map { it.copy(avklartKjørtDagStatus = AvklartKjørtDagStatus.SLETTET) }
-                    .toSet(),
+            dager = dager.markerSomSlettet(),
         )
 
     private fun AvklartKjørtUke.markerDelerAvUkaSomSlettet(fraDato: LocalDate): AvklartKjørtUke? {
-        val oppdaterteDager =
-            dager
-                .map { dag ->
-                    if (dag.dato > fraDato && dag.avklartKjørtDagStatus != AvklartKjørtDagStatus.SLETTET) {
-                        dag.copy(avklartKjørtDagStatus = AvklartKjørtDagStatus.SLETTET)
-                    } else {
-                        dag
-                    }
-                }.toSet()
+        val oppdaterteDager = dager.markerSomSlettet(fraDato)
         return if (oppdaterteDager != dager) {
             val nyUkeStatus =
                 if (avklartKjørtUkeStatus == AvklartKjørtUkeStatus.UENDRET) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -5,7 +5,6 @@ import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
-import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
@@ -37,10 +36,10 @@ class AvklartKjørelisteService(
     fun hentAvklartUke(ukeId: UUID): AvklartKjørtUke = avklartKjørtUkeRepository.findByIdOrThrow(ukeId)
 
     fun avklarUkerFraKjøreliste(
-        behandling: Behandling,
+        behandlingId: BehandlingId,
         kjøreliste: Kjøreliste,
     ) {
-        val rammeForReise = henteReiseFraVedtak(behandling.id, kjøreliste.data.reiseId)
+        val rammeForReise = henteReiseFraVedtak(behandlingId, kjøreliste.data.reiseId)
 
         validerAtAlleDagerIKjørelistaErInnenForRammevedtaket(rammeForReise, kjøreliste)
 
@@ -49,7 +48,7 @@ class AvklartKjørelisteService(
         val avklarteUker =
             kjørelisteGruppertPåUker.map { (ukeIÅr, reisedager) ->
                 utledAvklartUke(
-                    behandlingId = behandling.id,
+                    behandlingId = behandlingId,
                     ukeIÅr = ukeIÅr,
                     reisedager = reisedager,
                     kjørelisteId = kjøreliste.id,
@@ -281,11 +280,11 @@ class AvklartKjørelisteService(
     }
 
     fun nullstillOgGjenbrukAvklarteUker(
-        behandling: Behandling,
+        behandlingId: BehandlingId,
         behandlingIdForGjenbruk: BehandlingId,
     ) {
         val avklarteUkerForrigeBehandling = hentAvklarteUkerForBehandling(behandlingIdForGjenbruk)
-        val avklarteUkerNyBehandling = hentAvklarteUkerForBehandling(behandling.id)
+        val avklarteUkerNyBehandling = hentAvklarteUkerForBehandling(behandlingId)
 
         val kjørelisterSomFinneIForrigeBehandling = avklarteUkerForrigeBehandling.map { it.kjørelisteId }.toSet()
         val kjørelisterSomFinneINyMenIkkeGammelBehandling =
@@ -302,12 +301,12 @@ class AvklartKjørelisteService(
         val nyeAvklarteUker =
             avklarteUkerForrigeBehandling
                 .filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.SLETTET }
-                .map { it.kopierTilNyBehandling(behandling.id) }
+                .map { it.kopierTilNyBehandling(behandlingId) }
         avklartKjørtUkeRepository.insertAll(nyeAvklarteUker)
 
         // Avklar nye kjørelister på nytt
         kjørelisterSomFinneINyMenIkkeGammelBehandling.forEach {
-            avklarUkerFraKjøreliste(behandling, it)
+            avklarUkerFraKjøreliste(behandlingId, it)
         }
     }
 
@@ -317,7 +316,8 @@ class AvklartKjørelisteService(
     ) {
         val oppdaterteUker =
             hentAvklarteUkerForBehandling(behandlingId).mapNotNull { uke ->
-                val rammevedtakForReise = rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
+                val rammevedtakForReise =
+                    rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
                 val sisteDagIRammevedtak = rammevedtakForReise.grunnlag.tom
 
                 when {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -298,11 +298,11 @@ class AvklartKjørelisteService(
         avklartKjørtUkeRepository.deleteAll(avklarteUkerNyBehandling)
 
         // Kopier over avklarte uker fra forrige behandling
-        val nyeAvklarteUker =
+        val avklarteUkerFraForrigeBehandling =
             avklarteUkerForrigeBehandling
                 .filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.SLETTET }
                 .map { it.kopierTilNyBehandling(behandlingId) }
-        avklartKjørtUkeRepository.insertAll(nyeAvklarteUker)
+        avklartKjørtUkeRepository.insertAll(avklarteUkerFraForrigeBehandling)
 
         // Avklar nye kjørelister på nytt
         kjørelisterSomFinneINyMenIkkeGammelBehandling.forEach {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
@@ -25,18 +25,19 @@ data class AvklartKjørtDag(
     val avklartKjørtDagStatus: AvklartKjørtDagStatus,
 ) {
     fun markerSomSlettet(): AvklartKjørtDag = copy(avklartKjørtDagStatus = AvklartKjørtDagStatus.SLETTET)
+
+    fun markerSomSlettetHvisEtter(fraDato: LocalDate): AvklartKjørtDag =
+        if (dato > fraDato) {
+            markerSomSlettet()
+        } else {
+            this
+        }
 }
 
 fun Collection<AvklartKjørtDag>.markerSomSlettet(): Set<AvklartKjørtDag> = map { it.markerSomSlettet() }.toSet()
 
 fun Collection<AvklartKjørtDag>.markerSomSlettet(fraDato: LocalDate): Set<AvklartKjørtDag> =
-    map { dag ->
-        if (dag.dato > fraDato) {
-            dag.markerSomSlettet()
-        } else {
-            dag
-        }
-    }.toSet()
+    map { dag -> dag.markerSomSlettetHvisEtter(fraDato) }.toSet()
 
 enum class AvklartKjørtDagStatus {
     NY,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
@@ -23,7 +23,20 @@ data class AvklartKjørtDag(
     val sporbar: Sporbar = Sporbar(),
     @Column("avklart_kjort_dag_status")
     val avklartKjørtDagStatus: AvklartKjørtDagStatus,
-)
+) {
+    fun markerSomSlettet(): AvklartKjørtDag = copy(avklartKjørtDagStatus = AvklartKjørtDagStatus.SLETTET)
+}
+
+fun Collection<AvklartKjørtDag>.markerSomSlettet(): Set<AvklartKjørtDag> = map { it.markerSomSlettet() }.toSet()
+
+fun Collection<AvklartKjørtDag>.markerSomSlettet(fraDato: LocalDate): Set<AvklartKjørtDag> =
+    map { dag ->
+        if (dag.dato > fraDato) {
+            dag.markerSomSlettet()
+        } else {
+            dag
+        }
+    }.toSet()
 
 enum class AvklartKjørtDagStatus {
     NY,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
@@ -21,7 +21,16 @@ data class AvklartKjørtDag(
     val parkeringsutgift: Int? = null,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
+    @Column("avklart_kjort_dag_status")
+    val avklartKjørtDagStatus: AvklartKjørtDagStatus,
 )
+
+enum class AvklartKjørtDagStatus {
+    NY,
+    ENDRET,
+    UENDRET,
+    SLETTET,
+}
 
 enum class GodkjentGjennomførtKjøring {
     JA,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
@@ -48,7 +48,11 @@ data class AvklartKjørtUke(
         copy(
             id = UUID.randomUUID(),
             behandlingId = nyBehandlingId,
-            dager = dager.map { it.copy(id = UUID.randomUUID()) }.toSet(),
+            dager =
+                dager
+                    .filter { it.avklartKjørtDagStatus != AvklartKjørtDagStatus.SLETTET }
+                    .map { it.copy(id = UUID.randomUUID(), avklartKjørtDagStatus = AvklartKjørtDagStatus.UENDRET) }
+                    .toSet(),
             avklartKjørtUkeStatus = AvklartKjørtUkeStatus.UENDRET,
         )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.behandling.GjenbrukDataRevurderingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
@@ -29,6 +30,7 @@ class DagligReiseBeregnYtelseSteg(
     private val dagligReiseVedtakService: DagligReiseVedtakService,
     private val opprettAndelerDagligReiseService: OpprettAndelerDagligReiseService,
     private val avklartKjørelisteService: AvklartKjørelisteService,
+    private val gjenbrukDataRevurderingService: GjenbrukDataRevurderingService,
     vedtakRepository: VedtakRepository,
     tilkjentYtelseService: TilkjentYtelseService,
     simuleringService: SimuleringService,
@@ -65,6 +67,9 @@ class DagligReiseBeregnYtelseSteg(
         saksbehandling: Saksbehandling,
         vedtak: VedtakDagligReiseRequest,
     ) {
+        gjenbrukDataRevurderingService.finnBehandlingIdForGjenbruk(saksbehandling.fagsakId)?.let {
+            avklartKjørelisteService.nullstillOgGjenbrukAvklarteUker(saksbehandling.id, it)
+        }
         when (vedtak) {
             is InnvilgelseDagligReiseRequest -> beregnOgLagreInnvilgelse(saksbehandling, vedtak)
             is AvslagDagligReiseDto -> dagligReiseVedtakService.lagreAvslag(saksbehandling, vedtak)
@@ -113,7 +118,8 @@ class DagligReiseBeregnYtelseSteg(
             "Opphørsdato er ikke satt"
         }
         val opphørsdato = vedtak.opphørsdato
-        val forrigeVedtak = dagligReiseVedtakService.hentInnvilgelseEllerOpphørVedtak(saksbehandling.forrigeIverksatteBehandlingId)
+        val forrigeVedtak =
+            dagligReiseVedtakService.hentInnvilgelseEllerOpphørVedtak(saksbehandling.forrigeIverksatteBehandlingId)
 
         opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
@@ -144,7 +144,7 @@ class DagligReiseBeregnYtelseSteg(
         )
 
         rammevedtakPrivatBil?.let {
-            avklartKjørelisteService.sletteMarkerUkerUtenforAvkortetRammevedtak(
+            avklartKjørelisteService.sletteMarkerUkerOgDagerUtenforAvkortetRammevedtak(
                 behandlingId = saksbehandling.id,
                 rammevedtak = it,
             )

--- a/src/main/resources/db/migration/V137__avklart_kjort_dag_status.sql
+++ b/src/main/resources/db/migration/V137__avklart_kjort_dag_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE avklart_kjort_dag
+    ADD COLUMN avklart_kjort_dag_status VARCHAR NOT NULL DEFAULT 'NY';
+
+ALTER TABLE avklart_kjort_dag
+    ALTER COLUMN avklart_kjort_dag_status DROP DEFAULT;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
@@ -317,9 +317,10 @@ class NullstillBehandlingServiceTest : CleanDatabaseIntegrationTest() {
 
         assertThat(gjenbruktAvklartKjørtDag)
             .usingRecursiveComparison()
-            .ignoringFields("id")
+            .ignoringFields("id", "avklartKjørtDagStatus")
             .isEqualTo(avklartKjørtDag)
         assertThat(gjenbruktAvklartKjørtDag.id).isNotEqualTo(avklartKjørtDag.id)
+        assertThat(gjenbruktAvklartKjørtDag.avklartKjørtDagStatus).isEqualTo(AvklartKjørtDagStatus.UENDRET)
     }
 
     private fun assertIngenDataPåRevurdering() {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/NullstillBehandlingServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientMockConfig
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteRepository
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeRepository
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
@@ -365,6 +366,7 @@ class NullstillBehandlingServiceTest : CleanDatabaseIntegrationTest() {
                             godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
                             automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                             avvik = listOf(),
+                            avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
                         ),
                     ),
             ),

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/GjenbrukUkerIKjørelistebehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/GjenbrukUkerIKjørelistebehandlingIntegrationTest.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBeha
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
@@ -125,6 +126,11 @@ class GjenbrukUkerIKjørelistebehandlingIntegrationTest : IntegrationTest() {
             reisevurderingForAndreKjørelistebehandling.uker.single { it.fraDato == andreUkeFom }
 
         assertUkerErLike(førsteUkeIFørsteBehandling, førsteUkeIAndreBehandling)
+        assertThat(
+            førsteUkeIAndreBehandling.dager.all {
+                it.avklartDag?.avklartKjørtDagStatus == AvklartKjørtDagStatus.UENDRET
+            },
+        ).isTrue()
 
         assertThat(andreUkeIAndreBehandling.status).isEqualTo(UkeStatus.OK_AUTOMATISK)
         assertThat(andreUkeIAndreBehandling.kjørelisteId).isNotNull()
@@ -185,7 +191,10 @@ class GjenbrukUkerIKjørelistebehandlingIntegrationTest : IntegrationTest() {
             .sortedBy { it.dato }
             .zip(ukeBehandling2.dager.sortedBy { it.dato })
             .forEach { (dagBehandling1, dagBehandling2) ->
-                assertThat(dagBehandling1).isEqualTo(dagBehandling2)
+                assertThat(dagBehandling1)
+                    .usingRecursiveComparison()
+                    .ignoringFields("avklartDag.avklartKjørtDagStatus")
+                    .isEqualTo(dagBehandling2)
             }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisterPåParallelleRammevedtakIntegrationTest.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksK
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.sendInnKjøreliste
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
 import no.nav.tilleggsstonader.sak.util.KjørelisteSkjemaUtil.kjørelisteSkjema
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
@@ -138,10 +139,16 @@ class KjørelisterPåParallelleRammevedtakIntegrationTest : CleanDatabaseIntegra
         reisevurderingerBehandling2.ramme1!!.uker.forEachIndexed { index, uke ->
             assertThat(uke)
                 .usingRecursiveComparison()
-                .ignoringFields("avklartUkeId", "avklartKjørtUkeStatus") // AvklartUkeId vil være forskjellig siden de kopieres over
+                .ignoringFields("avklartUkeId", "avklartKjørtUkeStatus")
+                .ignoringFieldsMatchingRegexes(".*avklartKjørtDagStatus.*")
                 .isEqualTo(reisevurderingerBehandling1.ramme1.uker[index])
 
             assertThat(uke.avklartKjørtUkeStatus).isEqualTo(AvklartKjørtUkeStatus.UENDRET)
+            uke.dager.forEach { dag ->
+                dag.avklartDag?.let {
+                    assertThat(it.avklartKjørtDagStatus).isEqualTo(AvklartKjørtDagStatus.UENDRET)
+                }
+            }
         }
 
         // Data skal være innsendt og vurdert for rammevedtak 2

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/UtledAvklartKjørtUkeTest.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.integrasjonstest.BehandlingContext
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikDag
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikUke
@@ -465,5 +466,6 @@ class UtledAvklartKjørtUkeTest : CleanDatabaseIntegrationTest() {
         begrunnelse = null,
         avvik = avvik,
         automatiskVurdering = automatiskVurdering,
+        avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
     )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
@@ -293,6 +293,7 @@ class AvklartKjørelisteServiceTest {
                             avvik = emptyList(),
                             parkeringsutgift = if (dagOffset == 0) parkeringPåMandag else null,
                             begrunnelse = if (dagOffset == 0) begrunnelsePåMandag else null,
+                            avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
                         )
                     }.toSet(),
         )
@@ -314,13 +315,13 @@ class AvklartKjørelisteServiceTest {
     }
 
     @Nested
-    inner class SletteMarkerUkerUtenforAvkortetRammevedtak {
+    inner class SletteMarkerUkerOgDagerUtenforAvkortetRammevedtak {
         @Test
-        fun `uker etter siste dato i reisen markeres SLETTET`() {
+        fun `uker etter siste dato i reisen markeres SLETTET med alle dager, og dager i delvis avkortet uke markeres SLETTET`() {
             val mandagUke1 = 5 januar 2026
             val mandagUke2 = 12 januar 2026
             val mandagUke3 = 19 januar 2026
-            val sisteDagIAvkortetRammevedtak = 15 januar 2026
+            val sisteDagIAvkortetRammevedtak = 15 januar 2026 // torsdag i uke 2
 
             val uker =
                 listOf(
@@ -346,42 +347,18 @@ class AvklartKjørelisteServiceTest {
             every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns uker
             every { avklartKjørtUkeRepository.updateAll(capture(updateSlot)) } answers { updateSlot.captured }
 
-            service.sletteMarkerUkerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
+            service.sletteMarkerUkerOgDagerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
 
-            assertThat(updateSlot.captured).hasSize(1)
-            assertThat(updateSlot.captured[0].fom).isEqualTo(mandagUke3)
-            assertThat(updateSlot.captured[0].avklartKjørtUkeStatus).isEqualTo(AvklartKjørtUkeStatus.SLETTET)
-        }
+            // Uke 2 er delvis avkortet — fredag 16. jan er etter tom 15. jan — status skal bli ENDRET
+            val uke2 = updateSlot.captured.single { it.fom == mandagUke2 }
+            assertThat(uke2.avklartKjørtUkeStatus).isEqualTo(AvklartKjørtUkeStatus.ENDRET)
+            assertThat(uke2.dager.filter { it.avklartKjørtDagStatus == AvklartKjørtDagStatus.SLETTET }.map { it.dato })
+                .containsExactly(mandagUke2.plusDays(4)) // fredag
 
-        @Test
-        fun `uker på eller før siste dato berøres ikke`() {
-            val mandagUke1 = 5 januar 2026
-            val mandagUke2 = 12 januar 2026
-            val sisteDagIAvkortetRammevedtak = mandagUke2.plusDays(2) // onsdag i uke 2
-
-            val uker =
-                listOf(
-                    lagUke(fom = mandagUke1, tom = mandagUke1.plusDays(4), status = AvklartKjørtUkeStatus.UENDRET),
-                    lagUke(fom = mandagUke2, tom = mandagUke2.plusDays(4), status = AvklartKjørtUkeStatus.UENDRET),
-                )
-
-            val rammevedtak =
-                RammevedtakPrivatBil(
-                    reiser =
-                        listOf(
-                            lagRammeForReise(
-                                reiseId = reiseId,
-                                fom = mandagUke1,
-                                tom = sisteDagIAvkortetRammevedtak,
-                            ),
-                        ),
-                )
-
-            every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns uker
-
-            service.sletteMarkerUkerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
-
-            verify(exactly = 0) { avklartKjørtUkeRepository.updateAll(any()) }
+            // Uke 3 er helt utenfor rammevedtaket
+            val uke3 = updateSlot.captured.single { it.fom == mandagUke3 }
+            assertThat(uke3.avklartKjørtUkeStatus).isEqualTo(AvklartKjørtUkeStatus.SLETTET)
+            assertThat(uke3.dager).allMatch { it.avklartKjørtDagStatus == AvklartKjørtDagStatus.SLETTET }
         }
 
         @Test
@@ -430,7 +407,7 @@ class AvklartKjørelisteServiceTest {
             every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns uker
             every { avklartKjørtUkeRepository.updateAll(capture(updateSlot)) } answers { updateSlot.captured }
 
-            service.sletteMarkerUkerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
+            service.sletteMarkerUkerOgDagerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
 
             // Uke 1 (reiseId) er innenfor rammevedtak, Uke 2 (reiseId) er etter, skal slettes
             // Uke 3 (reise2) finnes ikke i rammevedtak, hoppes over
@@ -440,7 +417,7 @@ class AvklartKjørelisteServiceTest {
         }
 
         @Test
-        fun `ingen forandring på status når ingen uker skal slettes`() {
+        fun `ingen forandring når ingen uker eller dager er utenfor rammevedtaket`() {
             val mandagUke1 = 5 januar 2026
             val uker =
                 listOf(lagUke(fom = mandagUke1, tom = mandagUke1.plusDays(4), status = AvklartKjørtUkeStatus.UENDRET))
@@ -459,7 +436,7 @@ class AvklartKjørelisteServiceTest {
 
             every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns uker
 
-            service.sletteMarkerUkerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
+            service.sletteMarkerUkerOgDagerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
 
             verify(exactly = 0) { avklartKjørtUkeRepository.updateAll(any()) }
         }
@@ -503,6 +480,7 @@ class AvklartKjørelisteServiceTest {
                             avvik = emptyList(),
                             parkeringsutgift = null,
                             begrunnelse = null,
+                            avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
                         )
                     }.toSet(),
         )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValideringTest.kt
@@ -367,6 +367,7 @@ class AvklartKjørelisteValideringTest {
         avvik = emptyList(),
         parkeringsutgift = parkeringsutgift,
         begrunnelse = begrunnelse,
+        avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
     )
 
     private fun kjørelisteDag(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
@@ -922,6 +923,7 @@ class PrivatBilBeregningsresultatServiceTest {
                                     automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
                                     avvik = emptyList(),
                                     parkeringsutgift = it.parkeringsutgift,
+                                    avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
                                 )
                             }.toSet(),
                 )


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Nå er det en begrensing ved at man kun kan opphøre hele uker. Dette er da vi ikke vet hvilke enkeltdager som havner utenfor rammevedtaket ved opphør. Denne endringen marker dagene som havner utenfor rammevedtaket med status slettet slik at vi videre kan bruke dette i beregningen for å opphøre fra en hvilken som helst dag. 

Nå kopieres avklarte uker inn i behandlingen på nytt før man beregner. Dette er for å nullstille eventuelle endringer som er gjort på de avklarte ukene tildligere i samme behandling. Dette håndterer at saksbehandler beveger seg frem og tilbake mellom faner og ender på opphørsdatoen.

Vi innfører generelt en status på avklart dag (NY, ENDRET, UENDRET, SLETTET) og oppdaterer disse statusene ved kopier av avklarte dager.

Ved kopiering av avklarte uker og dager vil vil ikke perider med status SLETTET kopiers til neste behandling.

ℹ️ Selve beregningen kommer i neste PR