### PR TITLE
gjennomførBehandlingsløp kjører dynamisk gjennom alle steg i en behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegController.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.behandlingsflyt
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -21,12 +22,12 @@ class StegController(
     fun ferdigstillSteg(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody request: FerdigstillStegRequest,
-    ): BehandlingId {
+    ): StegFerdigstiltResponse {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
 
-        return stegService.håndterSteg(behandlingId, request.steg).id
+        return stegService.håndterSteg(behandlingId, request.steg).tilStegFerdigstiltResponse()
     }
 
     @PostMapping("behandling/{behandlingId}/reset")
@@ -49,3 +50,10 @@ class StegController(
         val steg: StegType,
     )
 }
+
+data class StegFerdigstiltResponse(
+    val behandlingId: BehandlingId,
+    val nesteSteg: StegType,
+)
+
+fun Behandling.tilStegFerdigstiltResponse() = StegFerdigstiltResponse(behandlingId = id, nesteSteg = steg)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnVedtakController.kt
@@ -3,7 +3,10 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.tilStegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -46,34 +49,34 @@ class TilsynBarnVedtakController(
     fun innvilge(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseTilsynBarnRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     @PostMapping("{behandlingId}/avslag")
     fun avslå(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: AvslagTilsynBarnDto,
-    ) {
+    ): StegFerdigstiltResponse {
         validerGyldigÅrsakAvslag.validerAvslagErGyldig(behandlingId, vedtak.årsakerAvslag, Stønadstype.BARNETILSYN)
-        lagreVedtak(behandlingId, vedtak)
+        return lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
     }
 
     @PostMapping("{behandlingId}/opphor")
     fun opphør(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: OpphørTilsynBarnRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     fun lagreVedtak(
         behandlingId: BehandlingId,
         vedtak: VedtakTilsynBarnRequest,
-    ) {
+    ): Behandling {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        stegService.håndterSteg(behandlingId = behandlingId, behandlingSteg = tilsynBarnBeregnYtelseSteg, data = vedtak)
+        return stegService.håndterSteg(
+            behandlingId = behandlingId,
+            behandlingSteg = tilsynBarnBeregnYtelseSteg,
+            data = vedtak,
+        )
     }
 
     @PostMapping("{behandlingId}/beregn")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakController.kt
@@ -3,7 +3,10 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.tilStegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -47,38 +50,34 @@ class BoutgifterVedtakController(
     fun innvilge(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseBoutgifterRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     @PostMapping("{behandlingId}/avslag")
     fun avslå(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: AvslagBoutgifterDto,
-    ) {
+    ): StegFerdigstiltResponse {
         validerGyldigÅrsakAvslag.validerAvslagErGyldig(
             behandlingId = behandlingId,
             årsakerAvslag = vedtak.årsakerAvslag,
             stønadstype = Stønadstype.BOUTGIFTER,
         )
-        lagreVedtak(behandlingId, vedtak)
+        return lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
     }
 
     @PostMapping("{behandlingId}/opphor")
     fun opphør(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: OpphørBoutgifterRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
-    fun lagreVedtak(
+    private fun lagreVedtak(
         behandlingId: BehandlingId,
         vedtak: VedtakBoutgifterRequest,
-    ) {
+    ): Behandling {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        stegService.håndterSteg(behandlingId, steg, vedtak)
+        return stegService.håndterSteg(behandlingId, steg, vedtak)
     }
 
     @PostMapping("{behandlingId}/beregn")

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -2,7 +2,10 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.tilStegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -49,23 +52,19 @@ class DagligReiseVedtakController(
     fun innvilge(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseDagligReiseTsoRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     @PostMapping("{behandlingId}/tsr/innvilgelse")
     fun innvilge(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseDagligReiseTsrRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     @PostMapping("{behandlingId}/avslag")
     fun avslå(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: AvslagDagligReiseDto,
-    ) {
+    ): StegFerdigstiltResponse {
         val stønadsType = behandlingService.hentSaksbehandling(behandlingId).stønadstype
 
         validerGyldigÅrsakAvslag.validerAvslagErGyldig(
@@ -74,7 +73,7 @@ class DagligReiseVedtakController(
             stønadsType,
         )
 
-        lagreVedtak(behandlingId, vedtak)
+        return lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
     }
 
     @GetMapping("{behandlingId}")
@@ -92,9 +91,7 @@ class DagligReiseVedtakController(
     fun opphor(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: OpphørDagligReiseRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     @PostMapping("{behandlingId}/tso/beregn")
     fun beregn(
@@ -154,10 +151,10 @@ class DagligReiseVedtakController(
     private fun lagreVedtak(
         behandlingId: BehandlingId,
         vedtak: VedtakDagligReiseRequest,
-    ) {
+    ): Behandling {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
 
-        stegService.håndterSteg(behandlingId, beregnYtelseSteg, vedtak)
+        return stegService.håndterSteg(behandlingId, beregnYtelseSteg, vedtak)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerVedtakController.kt
@@ -3,7 +3,10 @@ package no.nav.tilleggsstonader.sak.vedtak.læremidler
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegService
+import no.nav.tilleggsstonader.sak.behandlingsflyt.tilStegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -47,38 +50,34 @@ class LæremidlerVedtakController(
     fun innvilge(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: InnvilgelseLæremidlerRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     @PostMapping("{behandlingId}/avslag")
     fun avslå(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: AvslagLæremidlerDto,
-    ) {
+    ): StegFerdigstiltResponse {
         validerGyldigÅrsakAvslag.validerAvslagErGyldig(
             behandlingId = behandlingId,
             årsakerAvslag = vedtak.årsakerAvslag,
             stønadstype = Stønadstype.LÆREMIDLER,
         )
-        lagreVedtak(behandlingId, vedtak)
+        return lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
     }
 
     @PostMapping("{behandlingId}/opphor")
     fun opphør(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody vedtak: OpphørLæremidlerRequest,
-    ) {
-        lagreVedtak(behandlingId, vedtak)
-    }
+    ): StegFerdigstiltResponse = lagreVedtak(behandlingId, vedtak).tilStegFerdigstiltResponse()
 
     fun lagreVedtak(
         behandlingId: BehandlingId,
         vedtak: VedtakLæremidlerRequest,
-    ) {
+    ): Behandling {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        stegService.håndterSteg(behandlingId, steg, vedtak)
+        return stegService.håndterSteg(behandlingId, steg, vedtak)
     }
 
     @PostMapping("{behandlingId}/beregn")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
@@ -3,20 +3,17 @@ package no.nav.tilleggsstonader.sak.integrasjonstest
 import io.mockk.every
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.kontrakter.felles.gjelderDagligReise
 import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingÅrsak
 import no.nav.tilleggsstonader.sak.behandling.domain.HenlagtÅrsak
+import no.nav.tilleggsstonader.sak.behandling.dto.BehandlingDto
 import no.nav.tilleggsstonader.sak.behandling.dto.HenlagtDto
 import no.nav.tilleggsstonader.sak.behandling.dto.OpprettBehandlingDto
 import no.nav.tilleggsstonader.sak.behandling.opprettelse.ForenkletBehandlingstype
-import no.nav.tilleggsstonader.sak.behandlingsflyt.StegController
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
-import no.nav.tilleggsstonader.sak.brev.GenererPdfRequest
-import no.nav.tilleggsstonader.sak.felles.domain.BarnId
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.infrastruktur.mocks.PdlClientMockConfig
@@ -26,35 +23,16 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksK
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.defaultJournalpost
 import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.journalpostSøknadForStønadstype
-import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.tilVedtaksperiodeDagligReiseDto
 import no.nav.tilleggsstonader.sak.opplysninger.ytelse.YtelsePerioderUtil.ytelsePerioderDtoAAP
 import no.nav.tilleggsstonader.sak.util.SøknadBoutgifterUtil.søknadBoutgifter
 import no.nav.tilleggsstonader.sak.util.SøknadDagligReiseUtil.søknadDagligReise
 import no.nav.tilleggsstonader.sak.util.SøknadUtil.barnMedBarnepass
 import no.nav.tilleggsstonader.sak.util.SøknadUtil.søknadskjemaBarnetilsyn
 import no.nav.tilleggsstonader.sak.util.SøknadUtil.søknadskjemaLæremidler
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.InnvilgelseBoutgifterRequest
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterRequest
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseTsoRequest
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseTsrRequest
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.OpphørDagligReiseRequest
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerRequest
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerRequest
-import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDagligReisePrivatBilDto
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.LagreVilkårDagligReiseDto
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.VilkårDagligReiseDto
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.VilkårsvurderingDto
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperioderDto
-import org.springframework.test.web.servlet.client.RestTestClient
 import java.time.LocalDate
-import java.util.UUID
 
 data class BehandlingContext(
     val behandlingId: BehandlingId,
@@ -151,50 +129,9 @@ fun IntegrationTest.gjennomførBehandlingsløp(
 
     val testdata = BehandlingTestdataDsl.build(testdataProvider)
 
-    if (tilSteg == StegType.INNGANGSVILKÅR) {
-        return
-    }
-
-    gjennomførInngangsvilkårSteg(testdata, behandlingId)
-
-    if (tilSteg == StegType.VILKÅR) {
-        return
-    }
-
-    if (behandling.stønadstype != Stønadstype.LÆREMIDLER) {
-        gjennomførVilkårSteg(testdata, behandling.id, behandling.stønadstype)
-    }
-
-    if (tilSteg == StegType.BEREGNE_YTELSE) {
-        return
-    }
-
-    gjennomførBeregningSteg(behandling.id, behandling.stønadstype, testdata.vedtak.vedtak)
-
-    if (erRevurderingDagligReiseMedPrivatBil) {
-        gjennomførEkstraStegVedDagligReisePrivatBilRevurdering(behandling.id, tilSteg)
-    }
-
-    if (tilSteg == StegType.SIMULERING) {
-        return
-    }
-
-    gjennomførSimuleringSteg(behandlingId)
-
-    if (tilSteg == StegType.SEND_TIL_BESLUTTER) {
-        return
-    }
-
-    gjennomførSendTilBeslutterSteg(behandlingId)
-
-    if (tilSteg == StegType.BESLUTTE_VEDTAK) {
-        return
-    }
-
-    gjennomførBeslutteVedtakSteg(behandlingId)
-
-    if (tilSteg in setOf(StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV, StegType.FERDIGSTILLE_BEHANDLING)) {
-        return
+    var nåværendeSteg = behandling.steg
+    while (nåværendeSteg != tilSteg) {
+        nåværendeSteg = utførStegOgReturnerNesteSteg(nåværendeSteg, behandling, testdata)
     }
 
     // Ferdigstiller behandling
@@ -209,6 +146,27 @@ fun IntegrationTest.gjennomførBehandlingsløp(
         sendInnKjøreliste(kjøreliste, ident)
     }
 }
+
+fun IntegrationTest.utførStegOgReturnerNesteSteg(
+    steg: StegType,
+    behandling: BehandlingDto,
+    testdata: BehandlingTestdataDsl,
+): StegType =
+    when (steg) {
+        StegType.INNGANGSVILKÅR -> gjennomførInngangsvilkårSteg(testdata, behandling.id)
+        StegType.VILKÅR -> gjennomførVilkårSteg(testdata, behandling.id, behandling.stønadstype)
+        StegType.BEREGNE_YTELSE -> gjennomførBeregningSteg(behandling.id, behandling.stønadstype, testdata.vedtak.vedtak)
+        StegType.KJØRELISTE -> gjennomførKjørelisteSteg(behandling.id)
+        StegType.BEREGNING -> gjennomførBeregningStegDagligReise(behandling.id)
+        StegType.SIMULERING -> gjennomførSimuleringSteg(behandling.id)
+        StegType.SEND_TIL_BESLUTTER -> gjennomførSendTilBeslutterSteg(behandling.id)
+        StegType.BESLUTTE_VEDTAK -> gjennomførBeslutteVedtakSteg(behandling.id)
+        StegType.FULLFØR_KJØRELISTE,
+        StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV,
+        StegType.FERDIGSTILLE_BEHANDLING,
+        StegType.BEHANDLING_FERDIGSTILT,
+        -> error("$steg kan ikke gjennomføres gjennom api-kall")
+    }
 
 fun IntegrationTest.opprettRevurdering(opprettBehandlingDto: OpprettBehandlingDto): BehandlingId {
     val behandlingId = kall.behandling.opprettRevurdering(opprettBehandlingDto)
@@ -286,121 +244,6 @@ fun IntegrationTest.gjennomførHenleggelse(fraJournalpost: Journalpost = default
     return behandlingId
 }
 
-fun IntegrationTest.gjennomførBeslutteVedtakSteg(behandlingId: BehandlingId) {
-    medBrukercontext(bruker = "nissemor", roller = listOf(rolleConfig.beslutterRolle)) {
-        tilordneÅpenBehandlingOppgaveForBehandling(behandlingId)
-        kall.totrinnskontroll.beslutteVedtak(behandlingId, BeslutteVedtakDto(godkjent = true))
-    }
-    kjørTasksKlareForProsessering()
-}
-
-fun IntegrationTest.gjennomførSendTilBeslutterSteg(behandlingId: BehandlingId) {
-    kall.brev.genererPdf(behandlingId, GenererPdfRequest(MINIMALT_BREV))
-    kall.brevmottakere.hent(behandlingId)
-    kall.totrinnskontroll.sendTilBeslutter(behandlingId)
-    kjørTasksKlareForProsessering()
-}
-
-fun IntegrationTest.gjennomførSimuleringSteg(behandlingId: BehandlingId) {
-    kall.steg.ferdigstill(
-        behandlingId,
-        StegController.FerdigstillStegRequest(
-            steg = StegType.SIMULERING,
-        ),
-    )
-    kjørTasksKlareForProsessering()
-}
-
-fun IntegrationTest.gjennomførKjørelisteSteg(behandlingId: BehandlingId) {
-    kall.steg.ferdigstill(behandlingId, StegController.FerdigstillStegRequest(StegType.KJØRELISTE))
-}
-
-fun IntegrationTest.gjennomførBeregningStegDagligReise(behandlingId: BehandlingId) {
-    kall.steg.ferdigstill(behandlingId, StegController.FerdigstillStegRequest(StegType.BEREGNING))
-}
-
-fun IntegrationTest.gjennomførBeregningSteg(
-    behandlingId: BehandlingId,
-    stønadstype: Stønadstype,
-    opprettVedtak: OpprettVedtak = OpprettInnvilgelse(),
-) {
-    gjennomførBeregningStegKall(behandlingId, stønadstype, opprettVedtak)
-        .expectStatus()
-        .isOk
-}
-
-fun IntegrationTest.gjennomførBeregningStegKall(
-    behandlingId: BehandlingId,
-    stønadstype: Stønadstype,
-    opprettVedtak: OpprettVedtak = OpprettInnvilgelse(),
-): RestTestClient.ResponseSpec =
-    when (opprettVedtak) {
-        is OpprettInnvilgelse -> {
-            val vedtaksperioder =
-                opprettVedtak.vedtaksperioder ?: kall.vedtak
-                    .foreslåVedtaksperioder(behandlingId)
-                    .map { it.tilVedtaksperiodeDto() }
-            kall.vedtak.apiRespons
-                .lagreInnvilgelse(
-                    stønadstype = stønadstype,
-                    behandlingId = behandlingId,
-                    innvilgelseDto =
-                        when (stønadstype) {
-                            Stønadstype.BARNETILSYN -> InnvilgelseTilsynBarnRequest(vedtaksperioder = vedtaksperioder)
-                            Stønadstype.LÆREMIDLER -> InnvilgelseLæremidlerRequest(vedtaksperioder = vedtaksperioder)
-                            Stønadstype.BOUTGIFTER -> InnvilgelseBoutgifterRequest(vedtaksperioder = vedtaksperioder)
-                            Stønadstype.DAGLIG_REISE_TSO -> InnvilgelseDagligReiseTsoRequest(vedtaksperioder = vedtaksperioder)
-                            Stønadstype.DAGLIG_REISE_TSR ->
-                                InnvilgelseDagligReiseTsrRequest(
-                                    vedtaksperioder = vedtaksperioder.tilVedtaksperiodeDagligReiseDto(),
-                                )
-
-                            Stønadstype.REISE_TIL_SAMLING_TSO -> TODO("InnvilgelseReiseTilSamlingTsoRequest")
-                        },
-                )
-        }
-
-        is OpprettAvslag -> TODO()
-        is OpprettOpphør ->
-            kall.vedtak.apiRespons
-                .lagreOpphør(
-                    stønadstype = stønadstype,
-                    behandlingId = behandlingId,
-                    opphørDto =
-                        when (stønadstype) {
-                            Stønadstype.BARNETILSYN ->
-                                OpphørTilsynBarnRequest(
-                                    årsakerOpphør = opprettVedtak.årsaker,
-                                    begrunnelse = opprettVedtak.begrunnelse,
-                                    opphørsdato = opprettVedtak.opphørsdato,
-                                )
-
-                            Stønadstype.LÆREMIDLER ->
-                                OpphørLæremidlerRequest(
-                                    årsakerOpphør = opprettVedtak.årsaker,
-                                    begrunnelse = opprettVedtak.begrunnelse,
-                                    opphørsdato = opprettVedtak.opphørsdato,
-                                )
-
-                            Stønadstype.BOUTGIFTER ->
-                                OpphørBoutgifterRequest(
-                                    årsakerOpphør = opprettVedtak.årsaker,
-                                    begrunnelse = opprettVedtak.begrunnelse,
-                                    opphørsdato = opprettVedtak.opphørsdato,
-                                )
-
-                            Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR ->
-                                OpphørDagligReiseRequest(
-                                    årsakerOpphør = opprettVedtak.årsaker,
-                                    begrunnelse = opprettVedtak.begrunnelse,
-                                    opphørsdato = opprettVedtak.opphørsdato,
-                                )
-
-                            Stønadstype.REISE_TIL_SAMLING_TSO -> TODO("OpphørReiseTilSamlingTsoRequest")
-                        },
-                )
-    }
-
 sealed interface OpprettVedtak
 
 data class OpprettInnvilgelse(
@@ -414,146 +257,3 @@ data class OpprettOpphør(
     val begrunnelse: String = "annet",
     val opphørsdato: LocalDate,
 ) : OpprettVedtak
-
-private const val MINIMALT_BREV = """SAKSBEHANDLER_SIGNATUR - BREVDATO_PLACEHOLDER - BESLUTTER_SIGNATUR"""
-
-private fun IntegrationTest.gjennomførInngangsvilkårSteg(
-    testdataDsl: BehandlingTestdataDsl,
-    behandlingId: BehandlingId,
-) {
-    // Hentes ikke ut om man ikke trenger
-    val vilkårperioder: VilkårperioderDto by lazy {
-        kall.vilkårperiode.hentForBehandling(behandlingId).vilkårperioder
-    }
-
-    // Opprett aktiviteter
-    testdataDsl.aktivitet.opprettScope
-        .build(behandlingId)
-        .forEach { lagreVilkårperiode ->
-            kall.vilkårperiode
-                .opprett(lagreVilkårperiode)
-                .periode!!
-                .id
-        }
-
-    // Oppretter målgrupper
-    testdataDsl.målgruppe.opprettScope
-        .build(behandlingId)
-        .forEach { lagreVilkårperiode ->
-            kall.vilkårperiode
-                .opprett(lagreVilkårperiode)
-                .periode!!
-                .id
-        }
-
-    // Oppdater aktiviteter
-    testdataDsl.aktivitet.update.forEach { upd ->
-        val (vilkårperiodeId, lagreVilkårperiode) = upd(vilkårperioder.aktiviteter, behandlingId)
-        kall.vilkårperiode.oppdater(
-            vilkårperiodeId = vilkårperiodeId,
-            lagreVilkårperiode = lagreVilkårperiode,
-        )
-    }
-
-    // Slett aktiviteter
-    testdataDsl.aktivitet.delete.forEach { del ->
-        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.aktiviteter)
-        kall.vilkårperiode.apiRespons.slett(
-            vilkårperiodeId = idOgRequest.first,
-            slettVikårperiode = idOgRequest.second,
-        )
-    }
-
-    // Oppdater målgruppeer
-    testdataDsl.målgruppe.update.forEach { upd ->
-        val (vilkårperiodeId, lagreVilkårperiode) = upd(vilkårperioder.målgrupper, behandlingId)
-        kall.vilkårperiode.oppdater(
-            vilkårperiodeId = vilkårperiodeId,
-            lagreVilkårperiode = lagreVilkårperiode,
-        )
-    }
-
-    // Slett målgruppeer
-    testdataDsl.målgruppe.delete.forEach { del ->
-        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.målgrupper)
-        kall.vilkårperiode.apiRespons.slett(
-            vilkårperiodeId = idOgRequest.first,
-            slettVikårperiode = idOgRequest.second,
-        )
-    }
-
-    kall.steg.ferdigstill(
-        behandlingId,
-        StegController.FerdigstillStegRequest(
-            steg = StegType.INNGANGSVILKÅR,
-        ),
-    )
-    kjørTasksKlareForProsessering()
-}
-
-private fun IntegrationTest.gjennomførVilkårSteg(
-    testdataProvider: BehandlingTestdataDsl,
-    behandlingId: BehandlingId,
-    stønadstype: Stønadstype,
-) {
-    val vilkårDagligReise: List<VilkårDagligReiseDto> by lazy {
-        kall.vilkårDagligReise.hentVilkår(behandlingId)
-    }
-
-    val vilkår: VilkårsvurderingDto by lazy {
-        kall.vilkår.hentVilkår(behandlingId)
-    }
-
-    // Trenger kun hente ut om tilsyn-barn
-    val barnIder: List<BarnId> =
-        stønadstype
-            .takeIf { it == Stønadstype.BARNETILSYN }
-            ?.let { _ -> barnRepository.findByBehandlingId(behandlingId).map { it.id } }
-            ?: emptyList()
-
-    testdataProvider.vilkår.opprettScope
-        .build(
-            behandlingId,
-            barnIder,
-            aktiviteter =
-                kall.vilkårperiode
-                    .hentForBehandling(behandlingId)
-                    .vilkårperioder.aktiviteter,
-        ).forEach {
-            if (stønadstype.gjelderDagligReise()) {
-                kall.vilkårDagligReise.opprettVilkår(behandlingId, it as LagreVilkårDagligReiseDto)
-            } else {
-                kall.vilkår.opprettVilkår(it as OpprettVilkårDto)
-            }
-        }
-
-    if (stønadstype.gjelderDagligReise()) {
-        val aktiviteter =
-            kall.vilkårperiode
-                .hentForBehandling(behandlingId)
-                .vilkårperioder.aktiviteter
-        testdataProvider.vilkår.updateDagligReise
-            .map { it(vilkårDagligReise, aktiviteter) }
-            .forEach { (vilkårId, dto) -> kall.vilkårDagligReise.oppdaterVilkår(dto, vilkårId, behandlingId) }
-
-        testdataProvider.vilkår.deleteDagligReise
-            .map { it(vilkårDagligReise) }
-            .forEach { (vilkårId, dto) -> kall.vilkårDagligReise.slettVilkår(behandlingId, vilkårId, dto) }
-    } else {
-        testdataProvider.vilkår.update
-            .map { it(vilkår) }
-            .forEach { kall.vilkår.oppdaterVilkår(it) }
-
-        testdataProvider.vilkår.delete
-            .map { it(vilkår) }
-            .forEach { kall.vilkår.slettVilkår(it) }
-    }
-
-    kall.steg.ferdigstill(
-        behandlingId,
-        StegController.FerdigstillStegRequest(
-            steg = StegType.VILKÅR,
-        ),
-    )
-    kjørTasksKlareForProsessering()
-}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførBehandling.kt
@@ -113,7 +113,6 @@ fun IntegrationTest.gjennomførBehandlingsløp(
     behandlingId: BehandlingId,
     ident: String,
     tilSteg: StegType = StegType.BEHANDLING_FERDIGSTILT,
-    erRevurderingDagligReiseMedPrivatBil: Boolean = false,
     testdataProvider: BehandlingTestdataDsl.() -> Unit,
 ) {
     // Oppretter grunnlagsdata
@@ -129,9 +128,9 @@ fun IntegrationTest.gjennomførBehandlingsløp(
 
     val testdata = BehandlingTestdataDsl.build(testdataProvider)
 
-    var nåværendeSteg = behandling.steg
-    while (nåværendeSteg != tilSteg) {
-        nåværendeSteg = utførStegOgReturnerNesteSteg(nåværendeSteg, behandling, testdata)
+    var nesteSteg = behandling.steg
+    while (nesteSteg != tilSteg) {
+        nesteSteg = utførStegOgReturnerNesteSteg(nesteSteg, behandling, testdata)
     }
 
     // Ferdigstiller behandling
@@ -150,7 +149,7 @@ fun IntegrationTest.gjennomførBehandlingsløp(
 fun IntegrationTest.utførStegOgReturnerNesteSteg(
     steg: StegType,
     behandling: BehandlingDto,
-    testdata: BehandlingTestdataDsl,
+    testdata: BehandlingTestdataDsl = BehandlingTestdataDsl.utenData(),
 ): StegType =
     when (steg) {
         StegType.INNGANGSVILKÅR -> gjennomførInngangsvilkårSteg(testdata, behandling.id)
@@ -185,7 +184,6 @@ fun IntegrationTest.opprettRevurdering(opprettBehandlingDto: OpprettBehandlingDt
 fun IntegrationTest.opprettRevurderingOgGjennomførBehandlingsløp(
     fraBehandlingId: BehandlingId,
     tilSteg: StegType = StegType.BEHANDLING_FERDIGSTILT,
-    erRevurderingDagligReiseMedPrivatBil: Boolean = false,
     testdataProvider: BehandlingTestdataDsl.() -> Unit,
 ): BehandlingId {
     val behandling = kall.behandling.hent(fraBehandlingId)
@@ -200,14 +198,12 @@ fun IntegrationTest.opprettRevurderingOgGjennomførBehandlingsløp(
             ),
         tilSteg = tilSteg,
         testdataProvider = testdataProvider,
-        erRevurderingDagligReiseMedPrivatBil = erRevurderingDagligReiseMedPrivatBil,
     )
 }
 
 fun IntegrationTest.opprettRevurderingOgGjennomførBehandlingsløp(
     opprettBehandlingDto: OpprettBehandlingDto,
     tilSteg: StegType = StegType.BEHANDLING_FERDIGSTILT,
-    erRevurderingDagligReiseMedPrivatBil: Boolean = false,
     testdataProvider: BehandlingTestdataDsl.() -> Unit,
 ): BehandlingId {
     val revurderingId = opprettRevurdering(opprettBehandlingDto)
@@ -216,7 +212,6 @@ fun IntegrationTest.opprettRevurderingOgGjennomførBehandlingsløp(
         ident = testoppsettService.hentPersonidentForBehandlingId(revurderingId),
         tilSteg = tilSteg,
         testdataProvider = testdataProvider,
-        erRevurderingDagligReiseMedPrivatBil = erRevurderingDagligReiseMedPrivatBil,
     )
     return revurderingId
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførKjørelistebehandling.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførKjørelistebehandling.kt
@@ -4,13 +4,12 @@ import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.Behandling
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
-import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksKlareForProsesseringTilIngenTasksIgjen
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
 
 fun IntegrationTest.gjennomførKjørelisteBehandling(
     behandling: Behandling,
-    tilSteg: StegType? = StegType.FULLFØR_KJØRELISTE,
+    tilSteg: StegType? = StegType.BEHANDLING_FERDIGSTILT,
 ) {
     require(behandling.type == BehandlingType.KJØRELISTE) {
         "Behandling er ikke en kjøreliste-behandling"
@@ -18,36 +17,16 @@ fun IntegrationTest.gjennomførKjørelisteBehandling(
 
     // For at behandling skal oppdatere status OPPRETTET -> UTREDES. Henter også personpplysninger som trengs for å produsere internt vedtak
     // Vil alltid hentes fra frontend, så OK at vi gjør GET-kallet her selv uten at vi gjør noe med responsen
-    kall.behandling.hent(behandling.id)
     tilordneÅpenBehandlingOppgaveForBehandling(behandling.id)
+    val behandlingDto = kall.behandling.hent(behandling.id)
+    var nesteSteg = behandling.steg
+    while (nesteSteg != tilSteg) {
+        // Må generere kjørelistebrev før behandling blir sendt til beslutter
+        if (nesteSteg == StegType.SEND_TIL_BESLUTTER) {
+            kall.privatBil.genererKjørelisteVedtaksbrev(behandling.id)
+        }
+        nesteSteg = utførStegOgReturnerNesteSteg(nesteSteg, behandlingDto)
+    }
 
-    if (tilSteg == StegType.KJØRELISTE) return
-    gjennomførKjørelisteSteg(behandling.id)
-
-    if (tilSteg == StegType.BEREGNING) return
-    gjennomførBeregningStegDagligReise(behandling.id)
-
-    if (tilSteg == StegType.SIMULERING) return
-    gjennomførSimuleringSteg(behandling.id)
-
-    if (tilSteg == StegType.SEND_TIL_BESLUTTER) return
-    kall.privatBil.genererKjørelisteVedtaksbrev(behandling.id)
-    kall.totrinnskontroll.sendTilBeslutter(behandling.id)
-
-    if (tilSteg == StegType.BESLUTTE_VEDTAK) return
-    gjennomførBeslutteVedtakSteg(behandling.id)
-
-    if (tilSteg in setOf(StegType.JOURNALFØR_OG_DISTRIBUER_VEDTAKSBREV, StegType.FERDIGSTILLE_BEHANDLING)) return
     kjørTasksKlareForProsesseringTilIngenTasksIgjen()
-}
-
-fun IntegrationTest.gjennomførEkstraStegVedDagligReisePrivatBilRevurdering(
-    behandlingId: BehandlingId,
-    tilSteg: StegType? = StegType.FULLFØR_KJØRELISTE,
-) {
-    if (tilSteg == StegType.KJØRELISTE) return
-    gjennomførKjørelisteSteg(behandlingId)
-
-    if (tilSteg == StegType.BEREGNING) return
-    gjennomførBeregningStegDagligReise(behandlingId)
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførSteg.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførSteg.kt
@@ -1,0 +1,314 @@
+package no.nav.tilleggsstonader.sak.integrasjonstest
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.gjelderDagligReise
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegController
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegFerdigstiltResponse
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.brev.GenererPdfRequest
+import no.nav.tilleggsstonader.sak.felles.domain.BarnId
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.integrasjonstest.dsl.BehandlingTestdataDsl
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksKlareForProsessering
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.tilVedtaksperiodeDagligReiseDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.InnvilgelseBoutgifterRequest
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterRequest
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseTsoRequest
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseTsrRequest
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.OpphørDagligReiseRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerRequest
+import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.LagreVilkårDagligReiseDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.VilkårDagligReiseDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.OpprettVilkårDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.VilkårsvurderingDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.SlettVikårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperioderDto
+import org.springframework.test.web.servlet.client.RestTestClient
+import org.springframework.test.web.servlet.client.expectBody
+import java.util.UUID
+
+fun IntegrationTest.gjennomførInngangsvilkårSteg(
+    testdataDsl: BehandlingTestdataDsl,
+    behandlingId: BehandlingId,
+): StegType {
+    // Hentes ikke ut om man ikke trenger
+    val vilkårperioder: VilkårperioderDto by lazy {
+        kall.vilkårperiode.hentForBehandling(behandlingId).vilkårperioder
+    }
+
+    // Opprett aktiviteter
+    testdataDsl.aktivitet.opprettScope
+        .build(behandlingId)
+        .forEach { lagreVilkårperiode ->
+            kall.vilkårperiode
+                .opprett(lagreVilkårperiode)
+                .periode!!
+                .id
+        }
+
+    // Oppretter målgrupper
+    testdataDsl.målgruppe.opprettScope
+        .build(behandlingId)
+        .forEach { lagreVilkårperiode ->
+            kall.vilkårperiode
+                .opprett(lagreVilkårperiode)
+                .periode!!
+                .id
+        }
+
+    // Oppdater aktiviteter
+    testdataDsl.aktivitet.update.forEach { upd ->
+        val (vilkårperiodeId, lagreVilkårperiode) = upd(vilkårperioder.aktiviteter, behandlingId)
+        kall.vilkårperiode.oppdater(
+            vilkårperiodeId = vilkårperiodeId,
+            lagreVilkårperiode = lagreVilkårperiode,
+        )
+    }
+
+    // Slett aktiviteter
+    testdataDsl.aktivitet.delete.forEach { del ->
+        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.aktiviteter)
+        kall.vilkårperiode.apiRespons.slett(
+            vilkårperiodeId = idOgRequest.first,
+            slettVikårperiode = idOgRequest.second,
+        )
+    }
+
+    // Oppdater målgruppeer
+    testdataDsl.målgruppe.update.forEach { upd ->
+        val (vilkårperiodeId, lagreVilkårperiode) = upd(vilkårperioder.målgrupper, behandlingId)
+        kall.vilkårperiode.oppdater(
+            vilkårperiodeId = vilkårperiodeId,
+            lagreVilkårperiode = lagreVilkårperiode,
+        )
+    }
+
+    // Slett målgruppeer
+    testdataDsl.målgruppe.delete.forEach { del ->
+        val idOgRequest: Pair<UUID, SlettVikårperiode> = del(vilkårperioder.målgrupper)
+        kall.vilkårperiode.apiRespons.slett(
+            vilkårperiodeId = idOgRequest.first,
+            slettVikårperiode = idOgRequest.second,
+        )
+    }
+
+    val nesteSteg =
+        kall.steg
+            .ferdigstill(
+                behandlingId,
+                StegController.FerdigstillStegRequest(
+                    steg = StegType.INNGANGSVILKÅR,
+                ),
+            ).nesteSteg
+    kjørTasksKlareForProsessering()
+
+    return nesteSteg
+}
+
+fun IntegrationTest.gjennomførVilkårSteg(
+    testdata: BehandlingTestdataDsl,
+    behandlingId: BehandlingId,
+    stønadstype: Stønadstype,
+): StegType {
+    val vilkårDagligReise: List<VilkårDagligReiseDto> by lazy {
+        kall.vilkårDagligReise.hentVilkår(behandlingId)
+    }
+
+    val vilkår: VilkårsvurderingDto by lazy {
+        kall.vilkår.hentVilkår(behandlingId)
+    }
+
+    // Trenger kun hente ut om tilsyn-barn
+    val barnIder: List<BarnId> =
+        stønadstype
+            .takeIf { it == Stønadstype.BARNETILSYN }
+            ?.let { _ -> barnRepository.findByBehandlingId(behandlingId).map { it.id } }
+            ?: emptyList()
+
+    testdata.vilkår.opprettScope
+        .build(
+            behandlingId,
+            barnIder,
+            aktiviteter =
+                kall.vilkårperiode
+                    .hentForBehandling(behandlingId)
+                    .vilkårperioder.aktiviteter,
+        ).forEach {
+            if (stønadstype.gjelderDagligReise()) {
+                kall.vilkårDagligReise.opprettVilkår(behandlingId, it as LagreVilkårDagligReiseDto)
+            } else {
+                kall.vilkår.opprettVilkår(it as OpprettVilkårDto)
+            }
+        }
+
+    if (stønadstype.gjelderDagligReise()) {
+        val aktiviteter =
+            kall.vilkårperiode
+                .hentForBehandling(behandlingId)
+                .vilkårperioder.aktiviteter
+        testdata.vilkår.updateDagligReise
+            .map { it(vilkårDagligReise, aktiviteter) }
+            .forEach { (vilkårId, dto) -> kall.vilkårDagligReise.oppdaterVilkår(dto, vilkårId, behandlingId) }
+
+        testdata.vilkår.deleteDagligReise
+            .map { it(vilkårDagligReise) }
+            .forEach { (vilkårId, dto) -> kall.vilkårDagligReise.slettVilkår(behandlingId, vilkårId, dto) }
+    } else {
+        testdata.vilkår.update
+            .map { it(vilkår) }
+            .forEach { kall.vilkår.oppdaterVilkår(it) }
+
+        testdata.vilkår.delete
+            .map { it(vilkår) }
+            .forEach { kall.vilkår.slettVilkår(it) }
+    }
+
+    val nesteSteg =
+        kall.steg
+            .ferdigstill(
+                behandlingId,
+                StegController.FerdigstillStegRequest(
+                    steg = StegType.VILKÅR,
+                ),
+            ).nesteSteg
+
+    kjørTasksKlareForProsessering()
+
+    return nesteSteg
+}
+
+fun IntegrationTest.gjennomførBeregningSteg(
+    behandlingId: BehandlingId,
+    stønadstype: Stønadstype,
+    opprettVedtak: OpprettVedtak = OpprettInnvilgelse(),
+): StegType =
+    gjennomførBeregningStegKall(behandlingId, stønadstype, opprettVedtak)
+        .expectStatus()
+        .isOk
+        .expectBody<StegFerdigstiltResponse>()
+        .returnResult()
+        .responseBody!!
+        .nesteSteg
+
+fun IntegrationTest.gjennomførBeregningStegKall(
+    behandlingId: BehandlingId,
+    stønadstype: Stønadstype,
+    opprettVedtak: OpprettVedtak = OpprettInnvilgelse(),
+): RestTestClient.ResponseSpec =
+    when (opprettVedtak) {
+        is OpprettInnvilgelse -> {
+            val vedtaksperioder =
+                opprettVedtak.vedtaksperioder ?: kall.vedtak
+                    .foreslåVedtaksperioder(behandlingId)
+                    .map { it.tilVedtaksperiodeDto() }
+            kall.vedtak.apiRespons
+                .lagreInnvilgelse(
+                    stønadstype = stønadstype,
+                    behandlingId = behandlingId,
+                    innvilgelseDto =
+                        when (stønadstype) {
+                            Stønadstype.BARNETILSYN -> InnvilgelseTilsynBarnRequest(vedtaksperioder = vedtaksperioder)
+                            Stønadstype.LÆREMIDLER -> InnvilgelseLæremidlerRequest(vedtaksperioder = vedtaksperioder)
+                            Stønadstype.BOUTGIFTER -> InnvilgelseBoutgifterRequest(vedtaksperioder = vedtaksperioder)
+                            Stønadstype.DAGLIG_REISE_TSO -> InnvilgelseDagligReiseTsoRequest(vedtaksperioder = vedtaksperioder)
+                            Stønadstype.DAGLIG_REISE_TSR ->
+                                InnvilgelseDagligReiseTsrRequest(
+                                    vedtaksperioder = vedtaksperioder.tilVedtaksperiodeDagligReiseDto(),
+                                )
+
+                            Stønadstype.REISE_TIL_SAMLING_TSO -> TODO("InnvilgelseReiseTilSamlingTsoRequest")
+                        },
+                )
+        }
+
+        is OpprettAvslag -> TODO()
+        is OpprettOpphør ->
+            kall.vedtak.apiRespons
+                .lagreOpphør(
+                    stønadstype = stønadstype,
+                    behandlingId = behandlingId,
+                    opphørDto =
+                        when (stønadstype) {
+                            Stønadstype.BARNETILSYN ->
+                                OpphørTilsynBarnRequest(
+                                    årsakerOpphør = opprettVedtak.årsaker,
+                                    begrunnelse = opprettVedtak.begrunnelse,
+                                    opphørsdato = opprettVedtak.opphørsdato,
+                                )
+
+                            Stønadstype.LÆREMIDLER ->
+                                OpphørLæremidlerRequest(
+                                    årsakerOpphør = opprettVedtak.årsaker,
+                                    begrunnelse = opprettVedtak.begrunnelse,
+                                    opphørsdato = opprettVedtak.opphørsdato,
+                                )
+
+                            Stønadstype.BOUTGIFTER ->
+                                OpphørBoutgifterRequest(
+                                    årsakerOpphør = opprettVedtak.årsaker,
+                                    begrunnelse = opprettVedtak.begrunnelse,
+                                    opphørsdato = opprettVedtak.opphørsdato,
+                                )
+
+                            Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR ->
+                                OpphørDagligReiseRequest(
+                                    årsakerOpphør = opprettVedtak.årsaker,
+                                    begrunnelse = opprettVedtak.begrunnelse,
+                                    opphørsdato = opprettVedtak.opphørsdato,
+                                )
+
+                            Stønadstype.REISE_TIL_SAMLING_TSO -> TODO("OpphørReiseTilSamlingTsoRequest")
+                        },
+                )
+    }
+
+fun IntegrationTest.gjennomførKjørelisteSteg(behandlingId: BehandlingId) =
+    kall.steg.ferdigstill(behandlingId, StegController.FerdigstillStegRequest(StegType.KJØRELISTE)).nesteSteg
+
+fun IntegrationTest.gjennomførBeregningStegDagligReise(behandlingId: BehandlingId) =
+    kall.steg.ferdigstill(behandlingId, StegController.FerdigstillStegRequest(StegType.BEREGNING)).nesteSteg
+
+fun IntegrationTest.gjennomførSimuleringSteg(behandlingId: BehandlingId): StegType {
+    val nesteSteg =
+        kall.steg
+            .ferdigstill(
+                behandlingId,
+                StegController.FerdigstillStegRequest(
+                    steg = StegType.SIMULERING,
+                ),
+            ).nesteSteg
+
+    kjørTasksKlareForProsessering()
+
+    return nesteSteg
+}
+
+private const val MINIMALT_BREV = """SAKSBEHANDLER_SIGNATUR - BREVDATO_PLACEHOLDER - BESLUTTER_SIGNATUR"""
+
+fun IntegrationTest.gjennomførSendTilBeslutterSteg(behandlingId: BehandlingId): StegType {
+    kall.brev.genererPdf(behandlingId, GenererPdfRequest(MINIMALT_BREV))
+    kall.brevmottakere.hent(behandlingId)
+    kall.totrinnskontroll.sendTilBeslutter(behandlingId)
+    kjørTasksKlareForProsessering()
+
+    // Send-til-beslutter kall returnerer egen body men steg skal alltid være BESLUTTE_VEDTAK om kallet er OK
+    return StegType.BESLUTTE_VEDTAK
+}
+
+fun IntegrationTest.gjennomførBeslutteVedtakSteg(behandlingId: BehandlingId): StegType {
+    medBrukercontext(bruker = "nissemor", roller = listOf(rolleConfig.beslutterRolle)) {
+        tilordneÅpenBehandlingOppgaveForBehandling(behandlingId)
+        kall.totrinnskontroll.beslutteVedtak(behandlingId, BeslutteVedtakDto(godkjent = true))
+    }
+    kjørTasksKlareForProsessering()
+
+    // Beslutte-vedtak steg returnerer egen body men steg skal alltid være BEHANDLING_FERDIGSTILT om kallet er OK,
+    // slik at gjennomførBehandlingsløp()-funksjon kan avslutte steg-gjennomføring
+    return StegType.BEHANDLING_FERDIGSTILT
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/BehandlingTestdataDsl.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/dsl/BehandlingTestdataDsl.kt
@@ -40,6 +40,8 @@ class BehandlingTestdataDsl internal constructor() {
 
     companion object {
         fun build(block: BehandlingTestdataDsl.() -> Unit): BehandlingTestdataDsl = BehandlingTestdataDsl().apply(block)
+
+        fun utenData() = BehandlingTestdataDsl()
     }
 
     private val defaultFom = 1 januar 2026

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/StegKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/StegKall.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall
 
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegController
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegFerdigstiltResponse
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.integrasjonstest.Testklient
 
@@ -19,7 +20,7 @@ class StegKall(
     fun ferdigstill(
         behandlingId: BehandlingId,
         dto: StegController.FerdigstillStegRequest,
-    ): BehandlingId = apiRespons.ferdigstill(behandlingId, dto).expectOkWithBody()
+    ): StegFerdigstiltResponse = apiRespons.ferdigstill(behandlingId, dto).expectOkWithBody()
 
     // Gir tilgang til "rå"-endepunktene slik at tester kan skrive egne assertions på responsen.
     val apiRespons = StegApi()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/utsjekk/utbetaling/UtbetalingDagligReisePrivatBilIntegrationTest.kt
@@ -138,8 +138,8 @@ class UtbetalingDagligReisePrivatBilIntegrationTest : IntegrationTest() {
         assertThat(ferdigstiltKjørelistebehandling.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
 
         val oppgaverPåKjørelisteBehandling = oppgaveRepository.findByBehandlingId(kjørelisteBehandling.id)
-        assertThat(oppgaverPåKjørelisteBehandling).hasSize(1)
-        assertThat(oppgaverPåKjørelisteBehandling.single().status).isEqualTo(Oppgavestatus.FERDIGSTILT)
+        assertThat(oppgaverPåKjørelisteBehandling).hasSize(2)
+        assertThat(oppgaverPåKjørelisteBehandling).allMatch { it.status == Oppgavestatus.FERDIGSTILT }
 
         val gjeldendeIverksatteBehandlinger =
             testoppsettService.hentGjeldendeIverksatteBehandlinger(Stønadstype.DAGLIG_REISE_TSO)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/OpphørPrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/OpphørPrivatBilIntegrationTest.kt
@@ -66,7 +66,6 @@ class OpphørPrivatBilIntegrationTest(
         val revurderingId =
             opprettRevurderingOgGjennomførBehandlingsløp(
                 fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                erRevurderingDagligReiseMedPrivatBil = true,
             ) {
                 vedtak {
                     opphør(opphørsdato = opphørsdato)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Er nå lagt opp mye logikk i gjennomførBehandlingsløp ut fra hvilke steg som skal kjøres for en gitt stønadstype, og hvilken rekkefølge disse skal kjøre i (spesielt daglig reise og kjørelister har en litt annen flytt). 

Endrer alle steg-endepunkt (ferdigstill-steg og vedtak-endepunkt (innvilge, opphør avslag)) til å returnere hvilket steg som er neste steg.
- Samtlige disse endepunktene har til nå returner tom response, og skal da ikke påvirke frontend

Flytter også funksjoner for gjennomføring av steg i integrasjonstester ut til en ny fil, da `GjennomførBehandling.kt` hadde litt vel mange hundre linjer 😅 