### PR TITLE
Utbedrer beregningen av avstand mellom punkter på en reiserute

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonService.kt
@@ -11,16 +11,12 @@ class BomstasjonService(
     fun harBomstasjonPåRute(encodedPolyline: String): Boolean {
         val punkter = encodedPolyline.decodePolyline()
         val bomstasjoner = hentAlleBomstasjoner()
-        val terskelMeter = 50.0
+        val terskelMeter = 30.0
 
-        val treffStasjoner =
-            bomstasjoner
-                .filter { stasjon ->
-                    punkter.any { punkt ->
-                        finnBomstasjonPåRute(punkt.lat, punkt.lng, stasjon.lat, stasjon.lng) < terskelMeter
-                    }
-                }.distinctBy { it.navn }
-
-        return treffStasjoner.isNotEmpty()
+        return bomstasjoner
+            .filter { stasjon ->
+                beregnKortestAvstandFraPunktTilRute(stasjon.lat, stasjon.lng, punkter) < terskelMeter
+            }.distinctBy { it.navn }
+            .isNotEmpty()
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonUtils.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonUtils.kt
@@ -41,15 +41,59 @@ fun String.decodePolyline(): List<GeoPoint> {
     return punkter
 }
 
-fun finnBomstasjonPåRute(
-    punktLat: Double,
-    punktLng: Double,
-    stasjonLat: Double,
-    stasjonLng: Double,
+fun beregnAvstandMellomPunkterMeter(
+    fraLat: Double,
+    fraLng: Double,
+    tilLat: Double,
+    tilLng: Double,
 ): Double {
     val jordRadiusM = 6_371_000.0
-    val dLat = Math.toRadians(stasjonLat - punktLat)
-    val dLon = Math.toRadians(stasjonLng - punktLng)
-    val a = sin(dLat / 2).pow(2) + cos(Math.toRadians(punktLat)) * cos(Math.toRadians(stasjonLat)) * sin(dLon / 2).pow(2)
+    val dLat = Math.toRadians(tilLat - fraLat)
+    val dLon = Math.toRadians(tilLng - fraLng)
+    val a = sin(dLat / 2).pow(2) + cos(Math.toRadians(fraLat)) * cos(Math.toRadians(tilLat)) * sin(dLon / 2).pow(2)
     return jordRadiusM * 2 * asin(sqrt(a))
 }
+
+/**
+ * Korteste avstand (meter) fra et punkt til linjestykket p1→p2.
+ * Finner nærmeste punkt på linjen ved å sammenligne punktet med punktene på linjen.
+ */
+fun beregnKortestAvstandFraPunktTilLinjestykke(
+    punktLat: Double,
+    punktLng: Double,
+    p1: GeoPoint,
+    p2: GeoPoint,
+): Double {
+    val meterPerLatGrad = 111_320.0
+    val cosLat = cos(Math.toRadians((p1.lat + p2.lat) / 2.0))
+    val meterPerLngGrad = meterPerLatGrad * cosLat
+
+    val abX = (p2.lng - p1.lng) * meterPerLngGrad
+    val abY = (p2.lat - p1.lat) * meterPerLatGrad
+    val apX = (punktLng - p1.lng) * meterPerLngGrad
+    val apY = (punktLat - p1.lat) * meterPerLatGrad
+
+    val ab2 = abX * abX + abY * abY
+    if (ab2 == 0.0) return beregnAvstandMellomPunkterMeter(p1.lat, p1.lng, punktLat, punktLng)
+
+    val t = ((apX * abX + apY * abY) / ab2).coerceIn(0.0, 1.0)
+
+    val narmesteSegmentpunktLat = p1.lat + t * (p2.lat - p1.lat)
+    val narmesteSegmentpunktLng = p1.lng + t * (p2.lng - p1.lng)
+
+    return beregnAvstandMellomPunkterMeter(narmesteSegmentpunktLat, narmesteSegmentpunktLng, punktLat, punktLng)
+}
+
+/**
+ * Korteste avstand (meter) fra et punkt til en rute (liste med punkter).
+ * Returnerer [Double.MAX_VALUE] for tom liste.
+ */
+fun beregnKortestAvstandFraPunktTilRute(
+    punktLat: Double,
+    punktLng: Double,
+    rutePunkter: List<GeoPoint>,
+): Double =
+    rutePunkter
+        .zipWithNext()
+        .minOfOrNull { (p1, p2) -> beregnKortestAvstandFraPunktTilLinjestykke(punktLat, punktLng, p1, p2) }
+        ?: Double.MAX_VALUE

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonServiceTest.kt
@@ -41,7 +41,6 @@ class BomstasjonServiceTest {
         val bomstasjonResponse = jsonMapper.readValue<NvdbBomstasjonResponse>(bomstasjonJson)
         every { nvdbBomstasjonClient.hentAlleBomstasjoner() } returns bomstasjonResponse.objekter.mapNotNull { it.tilDomene() }
 
-        // Bergen — hundrevis av km unna
         oppdaterMed(NvdbBomstasjon(id = 2L, lat = 60.418, lng = 5.313, navn = null, takstLitenBilRush = null))
 
         Assertions.assertThat(bomstasjonService.harBomstasjonPåRute(osloPolyline)).isFalse()
@@ -49,10 +48,24 @@ class BomstasjonServiceTest {
     }
 
     @Test
+    fun `harBomvei returnerer true når bomstasjon er nær slutten av ruten`() {
+        // Bomstasjonen er IKKE nær startpunktet,
+        // men nær slutten av ruten (~11m fra (59.93544, 10.6964283))
+        oppdaterMed(NvdbBomstasjon(id = 3L, lat = 59.9355, lng = 10.6964, navn = null, takstLitenBilRush = null))
+
+        Assertions.assertThat(bomstasjonService.harBomstasjonPåRute(osloPolyline)).isTrue()
+    }
+
+    @Test
+    fun `harBomvei returnerer false for bomstasjon langt fra ruten selv om terskel er 30m`() {
+        // Bekrefter at vi ikke får falske treff: stasjon ~120m fra nærmeste punkt OG langt fra alle segmenter
+        oppdaterMed(NvdbBomstasjon(id = 4L, lat = 59.9232, lng = 10.7569, navn = null, takstLitenBilRush = null))
+
+        Assertions.assertThat(bomstasjonService.harBomstasjonPåRute(osloPolyline)).isFalse()
+    }
+
+    @Test
     fun `harBomvei returnerer false med tom bomstasjonsliste`() {
-        val bomstasjonJson = FileUtil.readFile("no/nav/tilleggsstonader/sak/nvdb/nvdb_bomstasjoner.json")
-        val bomstasjonResponse = jsonMapper.readValue<NvdbBomstasjonResponse>(bomstasjonJson)
-        every { nvdbBomstasjonClient.hentAlleBomstasjoner() } returns bomstasjonResponse.objekter.mapNotNull { it.tilDomene() }
         oppdaterMed()
 
         Assertions.assertThat(bomstasjonService.harBomstasjonPåRute(osloPolyline)).isFalse()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonUtilsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/nvdbApi/BomstasjonUtilsTest.kt
@@ -1,0 +1,71 @@
+package no.nav.tilleggsstonader.sak.nvdbApi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset.offset
+import org.junit.jupiter.api.Test
+
+class BomstasjonUtilsTest {
+    // Koordinater fra Elstrømbrua-scenariet.
+    // Bomstasjonen er ~117m fra nærmeste rutepunkt, men under 1m fra linjestykket mellom p1 og p2.
+    private val segmentP1 = GeoPoint(lat = 59.19511, lng = 9.58613)
+    private val segmentP2 = GeoPoint(lat = 59.19690, lng = 9.58346)
+    private val elstrombru =
+        NvdbBomstasjon(id = 732290254, navn = "Elstrømbrua", takstLitenBilRush = 29.0, lat = 59.19610052, lng = 9.58466914)
+
+    @Test
+    fun `gir liten avstand når bomstasjonen treffer midt på et linjestykke`() {
+        val avstand = beregnKortestAvstandFraPunktTilLinjestykke(elstrombru.lat, elstrombru.lng, segmentP1, segmentP2)
+
+        assertThat(avstand).isLessThan(5.0)
+    }
+
+    @Test
+    fun `avstand til linjestykke er mye kortere enn avstand til nærmeste endepunkt`() {
+        val segmentAvstand = beregnKortestAvstandFraPunktTilLinjestykke(elstrombru.lat, elstrombru.lng, segmentP1, segmentP2)
+        val punktAvstandP1 = beregnAvstandMellomPunkterMeter(segmentP1.lat, segmentP1.lng, elstrombru.lat, elstrombru.lng)
+        val punktAvstandP2 = beregnAvstandMellomPunkterMeter(segmentP2.lat, segmentP2.lng, elstrombru.lat, elstrombru.lng)
+
+        assertThat(minOf(punktAvstandP1, punktAvstandP2)).isGreaterThan(100.0)
+        assertThat(segmentAvstand).isLessThan(5.0)
+    }
+
+    @Test
+    fun `gir samme avstand som til endepunkt når bomstasjonen er utenfor stykket`() {
+        // Punktet er sør-øst for p1, utenfor stykket — nærmeste punkt er p1
+        val utenforSegmentet = GeoPoint(lat = 59.19400, lng = 9.58700)
+        val segmentAvstand = beregnKortestAvstandFraPunktTilLinjestykke(utenforSegmentet.lat, utenforSegmentet.lng, segmentP1, segmentP2)
+        val punktAvstand = beregnAvstandMellomPunkterMeter(segmentP1.lat, segmentP1.lng, utenforSegmentet.lat, utenforSegmentet.lng)
+
+        assertThat(segmentAvstand).isCloseTo(punktAvstand, offset(0.01))
+    }
+
+    @Test
+    fun `gir riktig avstand når p1 og p2 er samme punkt`() {
+        val avstand = beregnKortestAvstandFraPunktTilLinjestykke(elstrombru.lat, elstrombru.lng, segmentP1, segmentP1)
+        val forventet = beregnAvstandMellomPunkterMeter(segmentP1.lat, segmentP1.lng, elstrombru.lat, elstrombru.lng)
+
+        assertThat(avstand).isCloseTo(forventet, offset(0.01))
+    }
+
+    @Test
+    fun `finner riktig minimumsavstand over alle linjestykker i ruten`() {
+        val punkter =
+            listOf(
+                GeoPoint(lat = 59.19400, lng = 9.59000),
+                segmentP1,
+                segmentP2,
+                GeoPoint(lat = 59.19800, lng = 9.58200),
+            )
+
+        val avstand = beregnKortestAvstandFraPunktTilRute(elstrombru.lat, elstrombru.lng, punkter)
+
+        assertThat(avstand).isLessThan(5.0)
+    }
+
+    @Test
+    fun `returnerer MAX_VALUE for tom ruteliste`() {
+        val avstand = beregnKortestAvstandFraPunktTilRute(elstrombru.lat, elstrombru.lng, emptyList())
+
+        assertThat(avstand).isEqualTo(Double.MAX_VALUE)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjør om på beregningen av punkter slik at den er vesentlig mer nøyaktig med å sjekke punktene (bomstasjonene) på linjen, slik at vi ikke skal få tilfeller hvor bomstasjoner mellom punktene på linjen ikke blir fanget opp. 

Her er eksempelet som ble meldt inn utbedret:
<img width="3191" height="1202" alt="Screenshot 2026-06-15 at 14 07 51" src="https://github.com/user-attachments/assets/a1e65c85-4a56-4f94-a0f4-1ad54640cd7c" />

Den nye beregningen er også mer nøyaktig slik at falske positiver ikke blir med. Her er et eksempel på at jeg stopper rett før en bomstasjon:
<img width="3384" height="1175" alt="Screenshot 2026-06-15 at 14 09 26" src="https://github.com/user-attachments/assets/04dd4d9d-23b2-484d-a6e0-4d56732b5e36" />

Og her passerer vi akkurat: 
<img width="3437" height="1136" alt="Screenshot 2026-06-15 at 14 11 05" src="https://github.com/user-attachments/assets/d021983d-a7c7-45e1-9704-e6bfdfef2368" />
