### PR TITLE
✨ Kunne opphøre på alle dager

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -316,8 +316,7 @@ class AvklartKjørelisteService(
     ) {
         val oppdaterteUker =
             hentAvklarteUkerForBehandling(behandlingId).mapNotNull { uke ->
-                val rammevedtakForReise =
-                    rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
+                val rammevedtakForReise = rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
                 val sisteDagIRammevedtak = rammevedtakForReise.grunnlag.tom
 
                 when {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -316,7 +316,8 @@ class AvklartKjørelisteService(
     ) {
         val oppdaterteUker =
             hentAvklarteUkerForBehandling(behandlingId).mapNotNull { uke ->
-                val rammevedtakForReise = rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
+                val rammevedtakForReise =
+                    rammevedtak.reiser.find { it.reiseId == uke.reiseId } ?: return@mapNotNull null
                 val sisteDagIRammevedtak = rammevedtakForReise.grunnlag.tom
 
                 when {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtDag.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
@@ -33,6 +34,9 @@ data class AvklartKjørtDag(
             this
         }
 }
+
+fun List<AvklartKjørtDag>.finnDagerInnenforPeriode(periode: Periode<LocalDate>): List<AvklartKjørtDag> =
+    filter { dag -> periode.inneholder(dag.dato) }
 
 fun Collection<AvklartKjørtDag>.markerSomSlettet(): Set<AvklartKjørtDag> = map { it.markerSomSlettet() }.toSet()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
@@ -6,7 +6,6 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import org.springframework.stereotype.Service
-import java.time.DayOfWeek
 import java.time.LocalDate
 
 @Service
@@ -23,10 +22,6 @@ class PrivatBilBeregningRevurderingService(
 
         feilHvis(opphørsdato == null) {
             "Opphørsdato må være satt for å kunne opphøre"
-        }
-
-        brukerfeilHvis(opphørsdato.dayOfWeek != DayOfWeek.MONDAY) {
-            "Foreløpig støtter vi kun opphør av hele uker for daglige reiser med privat bil. Sett opphørsdato til en mandag"
         }
 
         val avkortedeReiser = forrigeRammevedtak.reiser.mapNotNull { it.avkortEtterDato(opphørsdato.minusDays(1)) }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatu
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.finnDagerInnenforPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilDag
@@ -110,7 +111,10 @@ class PrivatBilBeregningService(
         avklarteUkerForReise: List<AvklartKjørtUke>,
         brukersNavKontor: String?,
     ): BeregningsresultatForReisePrivatBil {
-        val avklarteDagerSomSkalBeregnes = avklarteUkerForReise.tilAvklartDagSomSkalBeregnes()
+        val avklarteDagerSomSkalBeregnes =
+            avklarteUkerForReise
+                .flatMap { it.dager }
+                .filter { it.avklartKjørtDagStatus != AvklartKjørtDagStatus.SLETTET }
 
         validerDagerErInnenforRammevedtak(
             rammeForReise = rammeForReise,
@@ -121,11 +125,7 @@ class PrivatBilBeregningService(
             reiseId = rammeForReise.reiseId,
             perioder =
                 rammeForReise.grunnlag.delperioder.flatMap { delperiode ->
-                    val avklarteDagerIDelperiode =
-                        avklarteDagerSomSkalBeregnes.finnDagerInnenforDelperiode(
-                            delperiode = delperiode,
-                            rammeForReise = rammeForReise,
-                        )
+                    val avklarteDagerIDelperiode = avklarteDagerSomSkalBeregnes.finnDagerInnenforPeriode(delperiode)
                     lagPerioderForDagerMedSammeSats(
                         dager = avklarteDagerIDelperiode,
                         delperiode = delperiode,
@@ -134,20 +134,6 @@ class PrivatBilBeregningService(
                 },
         )
     }
-
-    private fun List<AvklartKjørtUke>.tilAvklartDagSomSkalBeregnes(): List<AvklartKjørtDag> =
-        filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.SLETTET }
-            .flatMap { it.dager }
-            .filter { it.avklartKjørtDagStatus != AvklartKjørtDagStatus.SLETTET }
-
-    private fun List<AvklartKjørtDag>.finnDagerInnenforDelperiode(
-        delperiode: RammeForReiseMedPrivatBilDelperiode,
-        rammeForReise: RammeForReiseMedPrivatBil,
-    ): List<AvklartKjørtDag> =
-        filter { dag ->
-            rammeForReise.grunnlag.inneholder(dag.dato) &&
-                delperiode.fom <= dag.dato && dag.dato <= delperiode.tom
-        }
 
     private fun validerDagerErInnenforRammevedtak(
         rammeForReise: RammeForReiseMedPrivatBil,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
@@ -76,7 +77,8 @@ class PrivatBilBeregningService(
         brukersNavKontor: String?,
         forrigeReise: BeregningsresultatForReisePrivatBil,
     ): BeregningsresultatForReisePrivatBil {
-        val ukerSomSkalBeregnes = avklarteUkerForReise.filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.UENDRET }
+        val ukerSomSkalBeregnes =
+            avklarteUkerForReise.filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.UENDRET }
         val ukerSomSkalGjenbrukes =
             avklarteUkerForReise.filter {
                 it.avklartKjørtUkeStatus == AvklartKjørtUkeStatus.UENDRET
@@ -108,38 +110,50 @@ class PrivatBilBeregningService(
         avklarteUkerForReise: List<AvklartKjørtUke>,
         brukersNavKontor: String?,
     ): BeregningsresultatForReisePrivatBil {
-        val avklarteUkerSomSkalBeregnes = avklarteUkerForReise.filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.SLETTET }
+        val avklarteDagerSomSkalBeregnes = avklarteUkerForReise.tilAvklartDagSomSkalBeregnes()
 
-        // Kaster feil om det finnes godkjente dager utenfor rammevedtak
-        validerDagerErInnenforRammevedtak(rammeForReise, avklarteUkerSomSkalBeregnes)
-        val delperioder = rammeForReise.grunnlag.delperioder
+        validerDagerErInnenforRammevedtak(
+            rammeForReise = rammeForReise,
+            avklarteDagerForReise = avklarteDagerSomSkalBeregnes,
+        )
 
         return BeregningsresultatForReisePrivatBil(
             reiseId = rammeForReise.reiseId,
             perioder =
-                delperioder.flatMap { delperiode ->
-                    val dagerForDelperiode =
-                        avklarteUkerSomSkalBeregnes
-                            .flatMap { it.dager }
-                            .filter { dag ->
-                                rammeForReise.grunnlag.inneholder(dag.dato) &&
-                                    delperiode.fom <= dag.dato && dag.dato <= delperiode.tom
-                            }
+                rammeForReise.grunnlag.delperioder.flatMap { delperiode ->
+                    val avklarteDagerIDelperiode =
+                        avklarteDagerSomSkalBeregnes.finnDagerInnenforDelperiode(
+                            delperiode = delperiode,
+                            rammeForReise = rammeForReise,
+                        )
                     lagPerioderForDagerMedSammeSats(
-                        dagerForDelperiode,
-                        delperiode,
-                        brukersNavKontor,
+                        dager = avklarteDagerIDelperiode,
+                        delperiode = delperiode,
+                        brukersNavKontor = brukersNavKontor,
                     )
                 },
         )
     }
 
+    private fun List<AvklartKjørtUke>.tilAvklartDagSomSkalBeregnes(): List<AvklartKjørtDag> =
+        filter { it.avklartKjørtUkeStatus != AvklartKjørtUkeStatus.SLETTET }
+            .flatMap { it.dager }
+            .filter { it.avklartKjørtDagStatus != AvklartKjørtDagStatus.SLETTET }
+
+    private fun List<AvklartKjørtDag>.finnDagerInnenforDelperiode(
+        delperiode: RammeForReiseMedPrivatBilDelperiode,
+        rammeForReise: RammeForReiseMedPrivatBil,
+    ): List<AvklartKjørtDag> =
+        filter { dag ->
+            rammeForReise.grunnlag.inneholder(dag.dato) &&
+                delperiode.fom <= dag.dato && dag.dato <= delperiode.tom
+        }
+
     private fun validerDagerErInnenforRammevedtak(
         rammeForReise: RammeForReiseMedPrivatBil,
-        avklarteUkerForReise: List<AvklartKjørtUke>,
+        avklarteDagerForReise: List<AvklartKjørtDag>,
     ) {
-        avklarteUkerForReise
-            .flatMap { it.dager }
+        avklarteDagerForReise
             .filter { it.godkjentGjennomførtKjøring == GodkjentGjennomførtKjøring.JA }
             .forEach {
                 feilHvis(!rammeForReise.grunnlag.inneholder(it.dato)) {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/OpphørPrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/OpphørPrivatBilIntegrationTest.kt
@@ -7,22 +7,17 @@ import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
-import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
-import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
-import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.OpphørDagligReiseRequest
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
-import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 
 class OpphørPrivatBilIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
@@ -35,8 +30,9 @@ class OpphørPrivatBilIntegrationTest(
 
         val fom = 2 februar 2026
         val tom = 20 mars 2026
-        val opphørsdato = 9 mars 2026
+        val opphørsdato = 11 mars 2026
 
+        // Opprett førstegangsbehandling og send inn kjøreliste
         val førstegangsbehandlingContext =
             opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
                 defaultDagligReisePrivatBilTsoTestdata(fom, tom)
@@ -49,13 +45,15 @@ class OpphørPrivatBilIntegrationTest(
                             KjørtDag(dato = 9 februar 2026, parkeringsutgift = 50),
                             KjørtDag(dato = 16 februar 2026, parkeringsutgift = 50),
                             KjørtDag(dato = 23 februar 2026, parkeringsutgift = 50),
-                            KjørtDag(dato = 2 februar 2026, parkeringsutgift = 50),
-                            KjørtDag(dato = 9 februar 2026, parkeringsutgift = 50),
-                            KjørtDag(dato = 16 februar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 2 mars 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 9 mars 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 12 mars 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 16 mars 2026, parkeringsutgift = 50),
                         )
                 }
             }
 
+        // Behandle kjørelista
         val kjørelistebehandling =
             testoppsettService
                 .hentBehandlinger(førstegangsbehandlingContext.fagsakId)
@@ -63,6 +61,7 @@ class OpphørPrivatBilIntegrationTest(
         gjennomførKjørelisteBehandling(kjørelistebehandling)
         testoppsettService.settAndelerTilOkForBehandling(kjørelistebehandling.id)
 
+        // Opphør
         val revurderingId =
             opprettRevurderingOgGjennomførBehandlingsløp(
                 fraBehandlingId = førstegangsbehandlingContext.behandlingId,
@@ -89,43 +88,15 @@ class OpphørPrivatBilIntegrationTest(
         assertThat(beregningsresultatPrivatBil!!.reiser).hasSize(1)
 
         val ukerIReise = beregningsresultatPrivatBil.reiser.single().perioder
-        assertThat(ukerIReise).hasSize(5)
+        assertThat(ukerIReise).hasSize(6)
         assertThat(ukerIReise.maxOf { it.tom }).isEqualTo(opphørsdato.minusDays(1))
+
+        val dagerISisteUke = beregningsresultatPrivatBil.reiser.single().perioder.maxBy { it.fom }.grunnlag.dager
+        assertThat(dagerISisteUke).hasSize(1)
+        assertThat(dagerISisteUke.single().dato).isEqualTo(9 mars 2026)
+
 
         val andeler = tilkjentYtelseService.hentForBehandling(revurderingId).andelerTilkjentYtelse
         assertThat(andeler.maxOf { it.fom }).isBefore(opphørsdato.minusDays(1))
-    }
-
-    @Test
-    fun `skal kaste feil dersom opphør ikke skjer på en mandag`() {
-        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
-        every { unleashService.isEnabled(Toggle.KAN_OPPHØRE_PRIVAT_BIL) } returns true
-
-        val fom = 2 februar 2026
-        val tom = 20 mars 2026
-        val opphørsdato = 7 mars 2026
-
-        val førstegangsbehandlingContext =
-            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
-                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
-            }
-
-        val revurderingId =
-            opprettRevurderingOgGjennomførBehandlingsløp(
-                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                tilSteg = StegType.BEREGNE_YTELSE,
-            ) {}
-
-        kall.vedtak.apiRespons
-            .lagreOpphør(
-                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
-                behandlingId = revurderingId,
-                opphørDto =
-                    OpphørDagligReiseRequest(
-                        opphørsdato = opphørsdato,
-                        årsakerOpphør = listOf(ÅrsakOpphør.ANNET),
-                        begrunnelse = "Begrunnelse for opphør",
-                    ),
-            ).expectProblemDetail(HttpStatus.BAD_REQUEST, "Sett opphørsdato til en mandag")
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/OpphørPrivatBilIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/OpphørPrivatBilIntegrationTest.kt
@@ -91,10 +91,14 @@ class OpphørPrivatBilIntegrationTest(
         assertThat(ukerIReise).hasSize(6)
         assertThat(ukerIReise.maxOf { it.tom }).isEqualTo(opphørsdato.minusDays(1))
 
-        val dagerISisteUke = beregningsresultatPrivatBil.reiser.single().perioder.maxBy { it.fom }.grunnlag.dager
+        val dagerISisteUke =
+            beregningsresultatPrivatBil.reiser
+                .single()
+                .perioder
+                .maxBy { it.fom }
+                .grunnlag.dager
         assertThat(dagerISisteUke).hasSize(1)
         assertThat(dagerISisteUke.single().dato).isEqualTo(9 mars 2026)
-
 
         val andeler = tilkjentYtelseService.hentForBehandling(revurderingId).andelerTilkjentYtelse
         assertThat(andeler.maxOf { it.fom }).isBefore(opphørsdato.minusDays(1))

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatu
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UtfyltDagAutomatiskVurdering
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.markerSomSlettet
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammevedtakPrivatBil
@@ -56,7 +57,14 @@ class PrivatBilBeregningsresultatServiceTest {
         forrigeBeregningsresultat: BeregningsresultatPrivatBil? = null,
     ): BeregningsresultatPrivatBil {
         every { avklartKjørelisteService.hentAvklarteUkerForBehandling(behandlingId) } returns avklarteUker
-        return checkNotNull(beregningService.beregn(behandling, rammevedtak, brukersNavKontor, forrigeBeregningsresultat))
+        return checkNotNull(
+            beregningService.beregn(
+                behandling,
+                rammevedtak,
+                brukersNavKontor,
+                forrigeBeregningsresultat,
+            ),
+        )
     }
 
     @Test
@@ -622,7 +630,12 @@ class PrivatBilBeregningsresultatServiceTest {
         val tomRammevedtak = 15 februar 2026
         val delperiode = lagDelperiode(fomRammevedtak, tomRammevedtak)
         val rammevedtakPrivatBil =
-            rammevedtakPrivatBil(reiseId = reiseId, fom = fomRammevedtak, tom = tomRammevedtak, delperioder = listOf(delperiode))
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = fomRammevedtak,
+                tom = tomRammevedtak,
+                delperioder = listOf(delperiode),
+            )
 
         val kjøreliste1 =
             KjørelisteUtil.kjøreliste(
@@ -670,7 +683,12 @@ class PrivatBilBeregningsresultatServiceTest {
         val tomRammevedtak = 15 februar 2026
         val delperiode = lagDelperiode(fomRammevedtak, tomRammevedtak)
         val rammevedtakPrivatBil =
-            rammevedtakPrivatBil(reiseId = reiseId, fom = fomRammevedtak, tom = tomRammevedtak, delperioder = listOf(delperiode))
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = fomRammevedtak,
+                tom = tomRammevedtak,
+                delperioder = listOf(delperiode),
+            )
 
         val kjøreliste1 =
             KjørelisteUtil.kjøreliste(
@@ -724,7 +742,12 @@ class PrivatBilBeregningsresultatServiceTest {
         val tomRammevedtak = 8 februar 2026
         val delperiode = lagDelperiode(fomRammevedtak, tomRammevedtak)
         val rammevedtakPrivatBil =
-            rammevedtakPrivatBil(reiseId = reiseId, fom = fomRammevedtak, tom = tomRammevedtak, delperioder = listOf(delperiode))
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = fomRammevedtak,
+                tom = tomRammevedtak,
+                delperioder = listOf(delperiode),
+            )
 
         val kjøreliste =
             KjørelisteUtil.kjøreliste(
@@ -818,7 +841,12 @@ class PrivatBilBeregningsresultatServiceTest {
         val tomRammevedtak = 15 februar 2026
         val delperiode = lagDelperiode(fomRammevedtak, tomRammevedtak)
         val rammevedtakPrivatBil =
-            rammevedtakPrivatBil(reiseId = reiseId, fom = fomRammevedtak, tom = tomRammevedtak, delperioder = listOf(delperiode))
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = fomRammevedtak,
+                tom = tomRammevedtak,
+                delperioder = listOf(delperiode),
+            )
 
         val kjørelisteUke6 =
             KjørelisteUtil.kjøreliste(
@@ -826,18 +854,21 @@ class PrivatBilBeregningsresultatServiceTest {
                 periode = Datoperiode(2 februar 2026, 8 februar 2026),
                 kjørteDager = listOf(KjørelisteUtil.KjørtDag(2 februar 2026)),
             )
+        val kjørtDagUke7 = KjørelisteUtil.KjørtDag(9 februar 2026)
         val kjørelisteUke7 =
             KjørelisteUtil.kjøreliste(
                 reiseId = reiseId,
                 periode = Datoperiode(9 februar 2026, 15 februar 2026),
-                kjørteDager = listOf(KjørelisteUtil.KjørtDag(9 februar 2026)),
+                kjørteDager = listOf(kjørtDagUke7),
             )
 
         val ukeOK = avklarUkerFraKjøreliste(kjørelisteUke6).single()
+        val avklartKjørtUke7 = avklarUkerFraKjøreliste(kjørelisteUke7).single()
         val ukeSlettet =
-            avklarUkerFraKjøreliste(kjørelisteUke7)
-                .single()
-                .copy(avklartKjørtUkeStatus = AvklartKjørtUkeStatus.SLETTET)
+            avklartKjørtUke7.copy(
+                avklartKjørtUkeStatus = AvklartKjørtUkeStatus.SLETTET,
+                dager = avklartKjørtUke7.dager.markerSomSlettet(),
+            )
 
         val beregningsresultat = beregn(rammevedtakPrivatBil, listOf(ukeOK, ukeSlettet), brukersNavKontor)
 
@@ -852,7 +883,12 @@ class PrivatBilBeregningsresultatServiceTest {
         val tomRammevedtak = 8 februar 2026
         val delperiode = lagDelperiode(fomRammevedtak, tomRammevedtak)
         val rammevedtakPrivatBil =
-            rammevedtakPrivatBil(reiseId = reiseId, fom = fomRammevedtak, tom = tomRammevedtak, delperioder = listOf(delperiode))
+            rammevedtakPrivatBil(
+                reiseId = reiseId,
+                fom = fomRammevedtak,
+                tom = tomRammevedtak,
+                delperioder = listOf(delperiode),
+            )
 
         val kjøreliste =
             KjørelisteUtil.kjøreliste(
@@ -860,7 +896,8 @@ class PrivatBilBeregningsresultatServiceTest {
                 periode = Datoperiode(fomRammevedtak, tomRammevedtak),
                 kjørteDager = listOf(KjørelisteUtil.KjørtDag(fomRammevedtak)),
             )
-        val ukeMedUendretStatus = avklarUkerFraKjøreliste(kjøreliste).single().copy(avklartKjørtUkeStatus = AvklartKjørtUkeStatus.UENDRET)
+        val ukeMedUendretStatus =
+            avklarUkerFraKjøreliste(kjøreliste).single().copy(avklartKjørtUkeStatus = AvklartKjørtUkeStatus.UENDRET)
 
         val beregningsresultat =
             beregn(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Frem til nå har det vært en begrensning på at vi kun kan opphøre for daglig reise privat bil på mandag da vi ikke har slettemarkert på dag-nivå kun på uke-nivå. Denne endringen fliterer slik at vi ikke beregner på dager som er slettet.