### PR TITLE
Utvid tidligste-endring logikk til å støtte utvidelse av privat-bil vilkår

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -14,8 +14,8 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDagligReiseOffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDagligReisePrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDelperiodePrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårFakta
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
@@ -255,37 +255,73 @@ data class TidligsteEndringIBehandlingUtleder(
             vilkårNå.erFremtidigUtgift != vilkårTidligereBehandling.erFremtidigUtgift ||
             vilkårNå.type != vilkårTidligereBehandling.type ||
             vilkårNå.resultat != vilkårTidligereBehandling.resultat ||
-            erVilkårFaktaEndret(vilkårNå.fakta, vilkårTidligereBehandling.fakta) ||
+            erVilkårFaktaEndret(vilkårNå, vilkårTidligereBehandling) ||
             harNyttSvarForSkalDekkeFaktiskeUtgifter(vilkårNå, vilkårTidligereBehandling)
 
     private fun erVilkårFaktaEndret(
-        faktaNå: VilkårFakta?,
-        faktaTidligere: VilkårFakta?,
+        vilkårNå: Vilkår,
+        vilkårTidligereBehandling: Vilkår,
     ): Boolean =
         when {
-            faktaNå is FaktaDagligReiseOffentligTransport && faktaTidligere is FaktaDagligReiseOffentligTransport -> {
+            vilkårNå.fakta is FaktaDagligReiseOffentligTransport &&
+                vilkårTidligereBehandling.fakta is FaktaDagligReiseOffentligTransport -> {
+                val faktaNå = vilkårNå.fakta
+                val faktaTidligere = vilkårTidligereBehandling.fakta
                 faktaNå.reisedagerPerUke != faktaTidligere.reisedagerPerUke ||
                     faktaNå.prisEnkelbillett != faktaTidligere.prisEnkelbillett ||
                     faktaNå.prisSyvdagersbillett != faktaTidligere.prisSyvdagersbillett ||
                     faktaNå.prisTrettidagersbillett != faktaTidligere.prisTrettidagersbillett
             }
 
-            faktaNå is FaktaDagligReisePrivatBil && faktaTidligere is FaktaDagligReisePrivatBil -> {
+            vilkårNå.fakta is FaktaDagligReisePrivatBil && vilkårTidligereBehandling.fakta is FaktaDagligReisePrivatBil -> {
+                val faktaNå = vilkårNå.fakta
+                val faktaTidligere = vilkårTidligereBehandling.fakta
+                val sammenligningsFom =
+                    maxOf(requireNotNull(vilkårNå.fom), requireNotNull(vilkårTidligereBehandling.fom))
+                val sammenligningsTom =
+                    minOf(requireNotNull(vilkårNå.tom), requireNotNull(vilkårTidligereBehandling.tom))
+
                 faktaNå.reiseavstandEnVei != faktaTidligere.reiseavstandEnVei ||
-                    faktaNå.faktaDelperioder.size != faktaTidligere.faktaDelperioder.size ||
-                    faktaNå.faktaDelperioder.zip(faktaTidligere.faktaDelperioder).any { (nå, tidligere) ->
-                        nå.fom != tidligere.fom ||
-                            nå.tom != tidligere.tom ||
-                            nå.reisedagerPerUke != tidligere.reisedagerPerUke ||
-                            nå.bompengerPerDag != tidligere.bompengerPerDag ||
-                            nå.fergekostnadPerDag != tidligere.fergekostnadPerDag
-                    }
+                    normaliserPrivatBilDelperioder(faktaNå, sammenligningsFom, sammenligningsTom) !=
+                    normaliserPrivatBilDelperioder(faktaTidligere, sammenligningsFom, sammenligningsTom)
             }
 
             else -> {
                 false
             }
         }
+
+    private fun normaliserPrivatBilDelperioder(
+        fakta: FaktaDagligReisePrivatBil,
+        fom: LocalDate,
+        tom: LocalDate,
+    ): List<FaktaDelperiodePrivatBil> =
+        fakta.faktaDelperioder
+            .mapNotNull { it.kuttTilPeriode(fom, tom) }
+            .sortedWith(
+                compareBy<FaktaDelperiodePrivatBil> { it.fom }
+                    .thenBy { it.tom }
+                    .thenBy { it.reisedagerPerUke }
+                    .thenBy { it.bompengerPerDag ?: -1 }
+                    .thenBy { it.fergekostnadPerDag ?: -1 },
+            )
+
+    private fun FaktaDelperiodePrivatBil.kuttTilPeriode(
+        fom: LocalDate?,
+        tom: LocalDate?,
+    ): FaktaDelperiodePrivatBil? {
+        val sammenligningsFom = maxOf(this.fom, fom ?: return null)
+        val sammenligningsTom = minOf(this.tom, tom ?: return null)
+
+        return if (sammenligningsFom <= sammenligningsTom) {
+            copy(
+                fom = sammenligningsFom,
+                tom = sammenligningsTom,
+            )
+        } else {
+            null
+        }
+    }
 
     /**
      * Dersom svar på om bruker har høyere utgifter pga. helsemessige årsaker endrer seg

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -195,9 +195,16 @@ data class TidligsteEndringIBehandlingUtleder(
                     .fjernSlettede()
                     .mapNotNull { it.wrapSomPeriode() }
                     .sortedWith(vilkårComparator),
-        ) { vilkårNå, vilkårTidligereBehandling ->
-            erVilkårEndret(vilkårNå.periodeType, vilkårTidligereBehandling.periodeType)
-        }
+            erEndret = { vilkårNå, vilkårTidligereBehandling ->
+                erVilkårEndret(vilkårNå.periodeType, vilkårTidligereBehandling.periodeType)
+            },
+            utledEndringsdatoVedEndretPeriode = { vilkårNå, vilkårTidligereBehandling ->
+                utledTidligsteEndringForVilkårFakta(
+                    vilkårNå = vilkårNå.periodeType,
+                    vilkårTidligereBehandling = vilkårTidligereBehandling.periodeType,
+                )
+            },
+        )
 
     private fun Iterable<Vilkår>.fjernSlettede() = this.filterNot { it.status == VilkårStatus.SLETTET }
 
@@ -365,10 +372,54 @@ data class TidligsteEndringIBehandlingUtleder(
         vedtaksperiode.målgruppe != tidligereVedtaksperiode.målgruppe ||
             vedtaksperiode.aktivitet != tidligereVedtaksperiode.aktivitet
 
+    private fun utledTidligsteEndringForVilkårFakta(
+        vilkårNå: Vilkår,
+        vilkårTidligereBehandling: Vilkår,
+    ): LocalDate? {
+        val faktaNå = vilkårNå.fakta
+        val faktaTidligere = vilkårTidligereBehandling.fakta
+        if (faktaNå !is FaktaDagligReisePrivatBil || faktaTidligere !is FaktaDagligReisePrivatBil) {
+            return null
+        }
+
+        val sammenligningsFom = maxOf(requireNotNull(vilkårNå.fom), requireNotNull(vilkårTidligereBehandling.fom))
+        val sammenligningsTom = minOf(requireNotNull(vilkårNå.tom), requireNotNull(vilkårTidligereBehandling.tom))
+
+        val delperioderNå = normaliserPrivatBilDelperioder(faktaNå, sammenligningsFom, sammenligningsTom)
+        val delperioderTidligere = normaliserPrivatBilDelperioder(faktaTidligere, sammenligningsFom, sammenligningsTom)
+
+        val antallDelperioder = min(delperioderNå.size, delperioderTidligere.size)
+        for (index in 0 until antallDelperioder) {
+            val delperiodeNå = delperioderNå[index]
+            val delperiodeTidligere = delperioderTidligere[index]
+            if (delperiodeNå != delperiodeTidligere) {
+                return if (delperiodeNå.harLikFakta(delperiodeTidligere) &&
+                    (delperiodeNå.fom != delperiodeTidligere.fom || delperiodeNå.tom != delperiodeTidligere.tom)
+                ) {
+                    minOf(delperiodeNå.tom, delperiodeTidligere.tom).plusDays(1)
+                } else {
+                    minOf(delperiodeNå.fom, delperiodeTidligere.fom)
+                }
+            }
+        }
+
+        return when {
+            delperioderNå.size > antallDelperioder -> delperioderNå[antallDelperioder].fom
+            delperioderTidligere.size > antallDelperioder -> delperioderTidligere[antallDelperioder].fom
+            else -> null
+        }
+    }
+
+    private fun FaktaDelperiodePrivatBil.harLikFakta(other: FaktaDelperiodePrivatBil): Boolean =
+        this.reisedagerPerUke == other.reisedagerPerUke &&
+            this.bompengerPerDag == other.bompengerPerDag &&
+            this.fergekostnadPerDag == other.fergekostnadPerDag
+
     private fun <T : Periode<LocalDate>> utledEndringIPeriode(
         perioderNå: List<T>,
         perioderTidligere: List<T>,
         erEndret: (T, T) -> Boolean,
+        utledEndringsdatoVedEndretPeriode: ((T, T) -> LocalDate?)? = null,
     ): LocalDate? {
         val antallPerioder = min(perioderNå.size, perioderTidligere.size)
 
@@ -379,7 +430,8 @@ data class TidligsteEndringIBehandlingUtleder(
                     val periodeTidligere = perioderTidligere[index]
 
                     if (periodeNå.fom != periodeTidligere.fom || erEndret(periodeNå, periodeTidligere)) {
-                        minOf(periodeNå.fom, periodeTidligere.fom)
+                        utledEndringsdatoVedEndretPeriode?.invoke(periodeNå, periodeTidligere)
+                            ?: minOf(periodeNå.fom, periodeTidligere.fom)
                     } else if (periodeNå.tom != periodeTidligere.tom) {
                         // Legger på en dag, da det først er fra dagen etter tom-datoen at det er en endring
                         minOf(periodeNå.tom, periodeTidligere.tom).plusDays(1)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.cucumber.Domenenøkkel
 import no.nav.tilleggsstonader.sak.cucumber.DomenenøkkelFelles
 import no.nav.tilleggsstonader.sak.cucumber.mapRad
+import no.nav.tilleggsstonader.sak.cucumber.parseBigDecimal
 import no.nav.tilleggsstonader.sak.cucumber.parseDato
 import no.nav.tilleggsstonader.sak.cucumber.parseEnum
 import no.nav.tilleggsstonader.sak.cucumber.parseInt
@@ -21,7 +22,11 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.DomenenøkkelPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDagligReisePrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDelperiodePrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -34,6 +39,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.GeneriskVilkårperiode
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
@@ -81,6 +87,10 @@ class UtledTidligsteEndringStepDefinitions {
 
     var vilkår = emptyList<Vilkår>()
     var vilkårForrigeBehandling = emptyList<Vilkår>()
+    var vilkårPrivatBil = emptyMap<Int, Vilkår>()
+    var vilkårPrivatBilForrigeBehandling = emptyMap<Int, Vilkår>()
+    var delperioderPrivatBil = emptyMap<Int, List<FaktaDelperiodePrivatBil>>()
+    var delperioderPrivatBilForrigeBehandling = emptyMap<Int, List<FaktaDelperiodePrivatBil>>()
 
     var aktiviteter = emptyList<GeneriskVilkårperiode<AktivitetFaktaOgVurdering>>()
     var aktiviteterForrigeBehandling = emptyList<GeneriskVilkårperiode<AktivitetFaktaOgVurdering>>()
@@ -106,6 +116,16 @@ class UtledTidligsteEndringStepDefinitions {
     @Gitt("følgende vilkår i revurdering - utledTidligsteEndring")
     fun `følgende vilkår i revurdering`(dataTable: DataTable) {
         vilkår = mapVilkår(dataTable, barnIder)
+    }
+
+    @Gitt("følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring")
+    fun `følgende vilkår for daglig reise med privat bil i forrige behandling`(dataTable: DataTable) {
+        vilkårPrivatBilForrigeBehandling = mapPrivatBilVilkår(dataTable)
+    }
+
+    @Gitt("følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring")
+    fun `følgende vilkår for daglig reise med privat bil i revurdering`(dataTable: DataTable) {
+        vilkårPrivatBil = mapPrivatBilVilkår(dataTable)
     }
 
     @Gitt("følgende aktiviteter i forrige behandling - utledTidligsteEndring")
@@ -138,12 +158,23 @@ class UtledTidligsteEndringStepDefinitions {
         vedtaksperioder = mapVedtaksperioder(dataTable)
     }
 
+    @Gitt("følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring")
+    fun `følgende delperioder for vilkår daglig reise med privat bil i forrige behandling`(dataTable: DataTable) {
+        delperioderPrivatBilForrigeBehandling = mapPrivatBilDelperioder(dataTable)
+    }
+
+    @Gitt("følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring")
+    fun `følgende delperioder for vilkår daglig reise med privat bil i revurdering`(dataTable: DataTable) {
+        delperioderPrivatBil = mapPrivatBilDelperioder(dataTable)
+    }
+
     @Når("utleder tidligste endring")
     fun `utleder tidligste endring`() {
         tidligsteEndring =
             TidligsteEndringIBehandlingUtleder(
-                vilkår = vilkår,
-                vilkårTidligereBehandling = vilkårForrigeBehandling,
+                vilkår = byggVilkårListe(vilkår, vilkårPrivatBil, delperioderPrivatBil),
+                vilkårTidligereBehandling =
+                    byggVilkårListe(vilkårForrigeBehandling, vilkårPrivatBilForrigeBehandling, delperioderPrivatBilForrigeBehandling),
                 vilkårsperioder = Vilkårperioder(aktiviteter = aktiviteter, målgrupper = målgrupper),
                 vilkårsperioderTidligereBehandling =
                     Vilkårperioder(
@@ -208,6 +239,66 @@ class UtledTidligsteEndringStepDefinitions {
             }
         }
     }
+
+    private fun mapPrivatBilVilkår(dataTable: DataTable): Map<Int, Vilkår> =
+        dataTable
+            .mapRad { rad ->
+                val reisenr = parseInt(DomenenøkkelPrivatBil.REISENR, rad)
+                reisenr to
+                    vilkår(
+                        behandlingId = BehandlingId.random(),
+                        fom = parseDato(DomenenøkkelFelles.FOM, rad),
+                        tom = parseDato(DomenenøkkelFelles.TOM, rad),
+                        resultat = parseEnum(TidligsteEndringFellesNøkler.RESULTAT, rad),
+                        type = VilkårType.DAGLIG_REISE,
+                        status = parseEnum(TidligsteEndringFellesNøkler.STATUS, rad),
+                        fakta = mapPrivatBilFakta(rad),
+                    )
+            }.toMap()
+
+    private fun mapPrivatBilFakta(rad: Map<String, String>) =
+        FaktaDagligReisePrivatBil(
+            reiseId = ReiseId.random(),
+            reiseavstandEnVei = parseBigDecimal(DomenenøkkelPrivatBil.REISEAVSTAND_EN_VEI, rad),
+            faktaDelperioder = emptyList(),
+            adresse = "Tiltaksveien 1",
+            aktivitetId = VilkårperiodeGlobalId.random(),
+        )
+
+    private fun mapPrivatBilDelperioder(dataTable: DataTable): Map<Int, List<FaktaDelperiodePrivatBil>> =
+        dataTable
+            .mapRad {
+                parseInt(DomenenøkkelPrivatBil.REISENR, it) to
+                    FaktaDelperiodePrivatBil(
+                        fom = parseDato(DomenenøkkelFelles.FOM, it),
+                        tom = parseDato(DomenenøkkelFelles.TOM, it),
+                        reisedagerPerUke = parseInt(DomenenøkkelPrivatBil.ANTALL_REISEDAGER_PER_UKE, it),
+                        bompengerPerDag = parseValgfriInt(DomenenøkkelPrivatBil.BOMPENGER, it),
+                        fergekostnadPerDag = parseValgfriInt(DomenenøkkelPrivatBil.FERGEKOSTNAD, it),
+                    )
+            }.groupBy { it.first }
+            .mapValues { it.value.map { it.second } }
+
+    private fun byggVilkårListe(
+        generiskeVilkår: List<Vilkår>,
+        privatBilVilkår: Map<Int, Vilkår>,
+        delperioder: Map<Int, List<FaktaDelperiodePrivatBil>>,
+    ): List<Vilkår> =
+        if (privatBilVilkår.isNotEmpty()) {
+            privatBilVilkår
+                .toSortedMap()
+                .map { (reisenr, vilkår) ->
+                    val fakta = vilkår.fakta as FaktaDagligReisePrivatBil
+                    vilkår.copy(
+                        fakta =
+                            fakta.copy(
+                                faktaDelperioder = delperioder[reisenr].orEmpty(),
+                            ),
+                    )
+                }.sortedBy { it.fom }
+        } else {
+            generiskeVilkår
+        }
 
     private fun mapAktiviteter(dataTable: DataTable) =
         dataTable.mapRad { rad ->

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -174,7 +174,11 @@ class UtledTidligsteEndringStepDefinitions {
             TidligsteEndringIBehandlingUtleder(
                 vilkår = byggVilkårListe(vilkår, vilkårPrivatBil, delperioderPrivatBil),
                 vilkårTidligereBehandling =
-                    byggVilkårListe(vilkårForrigeBehandling, vilkårPrivatBilForrigeBehandling, delperioderPrivatBilForrigeBehandling),
+                    byggVilkårListe(
+                        vilkårForrigeBehandling,
+                        vilkårPrivatBilForrigeBehandling,
+                        delperioderPrivatBilForrigeBehandling,
+                    ),
                 vilkårsperioder = Vilkårperioder(aktiviteter = aktiviteter, målgrupper = målgrupper),
                 vilkårsperioderTidligereBehandling =
                     Vilkårperioder(

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/vilkår_tidligste_endring.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/vilkår_tidligste_endring.feature
@@ -217,7 +217,7 @@ Egenskap: Utled tidligste endring av vilkår
 
       Så forvent følgende dato for tidligste endring: 24.02.2024
 
-  Scenario: Privat bil forkortes og delperiode forkortes
+    Scenario: Privat bil forkortes og delperiode forkortes
       Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
         | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | NY     |
@@ -227,8 +227,8 @@ Egenskap: Utled tidligste endring av vilkår
         | 1       | 01.01.2024 | 31.01.2024 | 5                         |
 
       Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
-        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
-        | 1       | 01.01.2024 | 20.01.2024 | 10           | OPPFYLT  | ENDRET  |
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 20.01.2024 | 10           | OPPFYLT  | ENDRET |
 
       Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Antall reisedager per uke |
@@ -238,7 +238,7 @@ Egenskap: Utled tidligste endring av vilkår
 
       Så forvent følgende dato for tidligste endring: 21.01.2024
 
-  Scenario: Privat bil forkortes og delperiode forsvinner
+    Scenario: Privat bil forkortes og delperiode forsvinner
       Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
         | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | NY     |
@@ -249,8 +249,8 @@ Egenskap: Utled tidligste endring av vilkår
         | 1       | 16.01.2024 | 31.01.2024 | 3                         |
 
       Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
-        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
-        | 1       | 01.01.2024 | 15.01.2024 | 10           | OPPFYLT  | ENDRET  |
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 15.01.2024 | 10           | OPPFYLT  | ENDRET |
 
       Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Antall reisedager per uke |
@@ -260,7 +260,7 @@ Egenskap: Utled tidligste endring av vilkår
 
       Så forvent følgende dato for tidligste endring: 16.01.2024
 
-  Scenario: Privat bil utvides og delperiode utvides
+    Scenario: Privat bil utvides og delperiode utvides
       Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
         | 1       | 01.01.2024 | 20.01.2024 | 10           | OPPFYLT  | NY     |
@@ -270,8 +270,8 @@ Egenskap: Utled tidligste endring av vilkår
         | 1       | 01.01.2024 | 20.01.2024 | 5                         |
 
       Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
-        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
-        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET  |
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET |
 
       Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Antall reisedager per uke |
@@ -281,7 +281,7 @@ Egenskap: Utled tidligste endring av vilkår
 
       Så forvent følgende dato for tidligste endring: 21.01.2024
 
-  Scenario: Privat bil utvides og ny delperiode kommer inn
+    Scenario: Privat bil utvides og ny delperiode kommer inn
       Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
         | 1       | 01.01.2024 | 15.01.2024 | 10           | OPPFYLT  | NY     |
@@ -291,8 +291,8 @@ Egenskap: Utled tidligste endring av vilkår
         | 1       | 01.01.2024 | 15.01.2024 | 5                         |
 
       Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
-        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
-        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET  |
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET |
 
       Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
         | Reisenr | Fom        | Tom        | Antall reisedager per uke |
@@ -302,3 +302,97 @@ Egenskap: Utled tidligste endring av vilkår
       Når utleder tidligste endring
 
       Så forvent følgende dato for tidligste endring: 16.01.2024
+
+    Scenario: Privat bil endrer bompenger i delperiode uten endring i overordnet vilkårsperiode
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 15.01.2024 | 10        | 5                         |
+        | 1       | 16.01.2024 | 31.01.2024 | 0         | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 15.01.2024 | 50        | 5                         |
+        | 1       | 16.01.2024 | 31.01.2024 | 0         | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.01.2024
+
+    Scenario: Privat bil flytter grense mellom to delperioder fra en uke til to uker
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 21.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 07.01.2024 | 10        | 5                         |
+        | 1       | 08.01.2024 | 21.01.2024 | 10        | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 21.01.2024 | 10           | OPPFYLT  | ENDRET |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 14.01.2024 | 10        | 5                         |
+        | 1       | 15.01.2024 | 21.01.2024 | 10        | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 08.01.2024
+
+    Scenario: Privat bil flytter grense mellom to delperioder fra to uker til en uke
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 21.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 14.01.2024 | 10        | 5                         |
+        | 1       | 15.01.2024 | 21.01.2024 | 10        | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 21.01.2024 | 10           | OPPFYLT  | ENDRET |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 07.01.2024 | 10        | 5                         |
+        | 1       | 08.01.2024 | 21.01.2024 | 10        | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 08.01.2024
+
+    Scenario: Privat bil endrer bompenger i delperiode 1 og 3
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 10.01.2024 | 10        | 5                         |
+        | 1       | 11.01.2024 | 20.01.2024 | 20        | 5                         |
+        | 1       | 21.01.2024 | 31.01.2024 | 30        | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Bompenger | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 10.01.2024 | 50        | 5                         |
+        | 1       | 11.01.2024 | 20.01.2024 | 20        | 5                         |
+        | 1       | 21.01.2024 | 31.01.2024 | 60        | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 01.01.2024

--- a/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/vilkår_tidligste_endring.feature
+++ b/src/test/resources/no/nav/tilleggsstonader/sak/tidligsteendring/vilkår_tidligste_endring.feature
@@ -216,3 +216,89 @@ Egenskap: Utled tidligste endring av vilkår
       Når utleder tidligste endring
 
       Så forvent følgende dato for tidligste endring: 24.02.2024
+
+  Scenario: Privat bil forkortes og delperiode forkortes
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 31.01.2024 | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
+        | 1       | 01.01.2024 | 20.01.2024 | 10           | OPPFYLT  | ENDRET  |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 20.01.2024 | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 21.01.2024
+
+  Scenario: Privat bil forkortes og delperiode forsvinner
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 15.01.2024 | 5                         |
+        | 1       | 16.01.2024 | 31.01.2024 | 3                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
+        | 1       | 01.01.2024 | 15.01.2024 | 10           | OPPFYLT  | ENDRET  |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 15.01.2024 | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 16.01.2024
+
+  Scenario: Privat bil utvides og delperiode utvides
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 20.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 20.01.2024 | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET  |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 31.01.2024 | 5                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 21.01.2024
+
+  Scenario: Privat bil utvides og ny delperiode kommer inn
+      Gitt følgende vilkår for daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status |
+        | 1       | 01.01.2024 | 15.01.2024 | 10           | OPPFYLT  | NY     |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i forrige behandling - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 15.01.2024 | 5                         |
+
+      Gitt følgende vilkår for daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Reiseavstand | Resultat | Status  |
+        | 1       | 01.01.2024 | 31.01.2024 | 10           | OPPFYLT  | ENDRET  |
+
+      Gitt følgende delperioder for vilkår daglig reise med privat bil i revurdering - utledTidligsteEndring
+        | Reisenr | Fom        | Tom        | Antall reisedager per uke |
+        | 1       | 01.01.2024 | 15.01.2024 | 5                         |
+        | 1       | 16.01.2024 | 31.01.2024 | 3                         |
+
+      Når utleder tidligste endring
+
+      Så forvent følgende dato for tidligste endring: 16.01.2024


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Tidligste-endring logikk for privat bil vilkår har i dag en mangel, da man ved endring av perioden, også vil endre delperioder. Delperioder ligger i faktaen, og generell logikk sier at om faktaen er endret, så er hele perioden endret - og tidligste-endring blir da satt til `fom`.