### PR TITLE
Juster simulering-varsel til å ta høyde for om en fagsak utbetales med nytt fagområde

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/FagsakService.kt
@@ -91,14 +91,7 @@ class FagsakService(
                 .map { it.tilFagsakMedPerson() }
                 .associateBy { it.stønadstype }
 
-        return Fagsaker(
-            barnetilsyn = fagsaker[Stønadstype.BARNETILSYN],
-            læremidler = fagsaker[Stønadstype.LÆREMIDLER],
-            boutgifter = fagsaker[Stønadstype.BOUTGIFTER],
-            dagligReiseTso = fagsaker[Stønadstype.DAGLIG_REISE_TSO],
-            dagligReiseTsr = fagsaker[Stønadstype.DAGLIG_REISE_TSR],
-            reiseTilSamlingTso = fagsaker[Stønadstype.REISE_TIL_SAMLING_TSO],
-        )
+        return Fagsaker(fagsaker)
     }
 
     fun erLøpende(fagsakId: FagsakId): Boolean = fagsakRepository.harLøpendeUtbetaling(fagsakId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
@@ -1,6 +1,8 @@
 package no.nav.tilleggsstonader.sak.fagsak.domain
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.kontrakter.felles.gjelderDagligReise
+import no.nav.tilleggsstonader.kontrakter.felles.gjelderReiseTilSamling
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.Sporbar
@@ -10,22 +12,32 @@ import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
 
 data class Fagsaker(
-    val barnetilsyn: Fagsak?,
-    val læremidler: Fagsak?,
-    val boutgifter: Fagsak?,
-    val dagligReiseTso: Fagsak?,
-    val dagligReiseTsr: Fagsak?,
-    val reiseTilSamlingTso: Fagsak?,
+    private val fagsaker: Map<Stønadstype, Fagsak>,
 ) {
-    fun alleFagsaker() =
-        listOfNotNull(
-            barnetilsyn,
-            læremidler,
-            boutgifter,
-            dagligReiseTso,
-            dagligReiseTsr,
-            reiseTilSamlingTso,
-        )
+    val barnetilsyn: Fagsak? = fagsaker[Stønadstype.BARNETILSYN]
+    val læremidler: Fagsak? = fagsaker[Stønadstype.LÆREMIDLER]
+    val boutgifter: Fagsak? = fagsaker[Stønadstype.BOUTGIFTER]
+    val dagligReiseTso: Fagsak? = fagsaker[Stønadstype.DAGLIG_REISE_TSO]
+    val dagligReiseTsr: Fagsak? = fagsaker[Stønadstype.DAGLIG_REISE_TSR]
+    val reiseTilSamlingTso: Fagsak? = fagsaker[Stønadstype.REISE_TIL_SAMLING_TSO]
+
+    fun alleFagsaker() = fagsaker.values
+
+    fun alleFagsakerMedUtbetalingPåGammeltFagområde() =
+        alleFagsaker().filter {
+            it.utbetalPåNyttFagområde != null &&
+                !it.utbetalPåNyttFagområde
+        }
+
+    fun alleFagsakerAvStønadstypeUavhengigAvTema(stønadstype: Stønadstype) =
+        when (stønadstype) {
+            Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR -> fagsaker.values.filter { it.stønadstype.gjelderDagligReise() }
+            Stønadstype.REISE_TIL_SAMLING_TSO -> fagsaker.values.filter { it.stønadstype.gjelderReiseTilSamling() }
+            Stønadstype.BARNETILSYN,
+            Stønadstype.LÆREMIDLER,
+            Stønadstype.BOUTGIFTER,
+            -> alleFagsaker().filter { it.stønadstype == stønadstype }
+        }
 }
 
 data class Fagsak(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/fagsak/domain/Fagsak.kt
@@ -16,7 +16,17 @@ data class Fagsaker(
     val dagligReiseTso: Fagsak?,
     val dagligReiseTsr: Fagsak?,
     val reiseTilSamlingTso: Fagsak?,
-)
+) {
+    fun alleFagsaker() =
+        listOfNotNull(
+            barnetilsyn,
+            læremidler,
+            boutgifter,
+            dagligReiseTso,
+            dagligReiseTsr,
+            reiseTilSamlingTso,
+        )
+}
 
 data class Fagsak(
     val id: FagsakId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
@@ -1,10 +1,6 @@
 package no.nav.tilleggsstonader.sak.utbetaling.simulering
 
-import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
-import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
@@ -14,12 +10,10 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.domain.Simuleringsresul
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.kontrakt.SimuleringResponseDto
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.utbetaling.utsjekk.utbetaling.UtbetalingV3Mapper
-import no.nav.tilleggsstonader.sak.util.forrigeVirkedag
 import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 
 @Service
 class SimuleringService(
@@ -28,8 +22,6 @@ class SimuleringService(
     private val tilkjentYtelseService: TilkjentYtelseService,
     private val tilgangService: TilgangService,
     private val utbetalingV3Mapper: UtbetalingV3Mapper,
-    private val fagsakService: FagsakService,
-    private val behandlingService: BehandlingService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -74,59 +66,5 @@ class SimuleringService(
                 tilkjentYtelse.andelerTilkjentYtelse,
             ),
         )
-    }
-
-    fun lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId: BehandlingId): String? {
-        val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
-        feilHvis(fagsak.utbetalPåNyttFagområde == null) {
-            "Forventer at utbetalPåNyttFagområde skal være satt på fagsaken"
-        }
-        val alleFagsaker =
-            fagsakService
-                .finnFagsakerForFagsakPersonId(fagsak.fagsakPersonId)
-
-        val skalVarsleOmNyligeUtbetalingerInnenforSammeFagområde =
-            if (fagsak.utbetalPåNyttFagområde) {
-                // Motregnes kun "innad" i stønadstypen og da uavhengig av tema
-                finnesFagsakMedIverksatteAndelerInnenforPeriode(
-                    fagsaker = alleFagsaker.alleFagsakerAvStønadstypeUavhengigAvTema(fagsak.stønadstype),
-                    periode = Datoperiode(LocalDate.now(), LocalDate.now()),
-                )
-            } else {
-                // Motregnes mot alle andre fagsaker som også utbetaler på gammelt fagområde. Også en ventedag før utbetaling
-                finnesFagsakMedIverksatteAndelerInnenforPeriode(
-                    fagsaker = alleFagsaker.alleFagsakerMedUtbetalingPåGammeltFagområde(),
-                    periode = Datoperiode(LocalDate.now().forrigeVirkedag(), LocalDate.now()),
-                )
-            }
-
-        return if (skalVarsleOmNyligeUtbetalingerInnenforSammeFagområde) {
-            "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
-        } else {
-            null
-        }
-    }
-
-    private fun finnesFagsakMedIverksatteAndelerInnenforPeriode(
-        fagsaker: List<Fagsak>,
-        periode: Datoperiode,
-    ): Boolean {
-        return fagsaker.any { relevantFagsak ->
-
-            val behandlingId =
-                behandlingService
-                    .finnSisteIverksatteBehandling(relevantFagsak.id)
-                    ?.id ?: return@any false
-
-            val tilkjentYtelse =
-                tilkjentYtelseService.hentForBehandling(behandlingId)
-
-            tilkjentYtelse.andelerTilkjentYtelse.any { andel ->
-                val iverksettingDato =
-                    andel.iverksetting?.iverksettingTidspunkt?.toLocalDate()
-
-                iverksettingDato != null && periode.inneholder(iverksettingDato)
-            }
-        }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.SimuleringClient
@@ -98,7 +99,7 @@ class SimuleringService(
                 )
 
             Stønadstype.BOUTGIFTER, Stønadstype.LÆREMIDLER, Stønadstype.BARNETILSYN ->
-                håndterTilsynbarnLæremidlerBoutgifterVarsel(alleFagsaker)
+                håndterTilsynbarnLæremidlerBoutgifterVarsel(fagsak, alleFagsaker)
         }
     }
 
@@ -111,9 +112,19 @@ class SimuleringService(
         }
     }
 
-    fun håndterTilsynbarnLæremidlerBoutgifterVarsel(alleFagsaker: Fagsaker): String? {
+    private fun håndterTilsynbarnLæremidlerBoutgifterVarsel(
+        fagsak: Fagsak,
+        fagsaker: Fagsaker,
+    ): String? {
+        val utbetalPåNyttFagområde =
+            fagsak.utbetalPåNyttFagområde
+                ?: feil("Mangler verdi for utbetalPåNyttFagområde på fagsak=${fagsak.id}")
         val relevanteFagsaker =
-            listOfNotNull(alleFagsaker.barnetilsyn, alleFagsaker.læremidler, alleFagsaker.boutgifter)
+            if (utbetalPåNyttFagområde) {
+                listOf(fagsak)
+            } else {
+                fagsaker.alleFagsaker().filter { it.utbetalPåNyttFagområde == false }
+            }
         val periode = Datoperiode(LocalDate.now().forrigeVirkedag(), LocalDate.now())
         return if (erVarselRelevantForTilsynBarnLæremidlerBoutgifter(relevanteFagsaker, periode)) {
             "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringService.kt
@@ -1,14 +1,11 @@
 package no.nav.tilleggsstonader.sak.utbetaling.simulering
 
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
-import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.fagsak.FagsakService
 import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
-import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.utbetaling.iverksetting.SimuleringClient
@@ -79,84 +76,38 @@ class SimuleringService(
         )
     }
 
-    fun skalSendeVarsel(behandlingId: BehandlingId): String? {
+    fun lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId: BehandlingId): String? {
         val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
+        feilHvis(fagsak.utbetalPåNyttFagområde == null) {
+            "Forventer at utbetalPåNyttFagområde skal være satt på fagsaken"
+        }
         val alleFagsaker =
             fagsakService
                 .finnFagsakerForFagsakPersonId(fagsak.fagsakPersonId)
-        return when (fagsak.stønadstype) {
-            Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR ->
-                håndterVarselForStønaderMedEgetFagområde(
-                    listOfNotNull(
-                        alleFagsaker.dagligReiseTso,
-                        alleFagsaker.dagligReiseTsr,
-                    ),
+
+        val skalVarsleOmNyligeUtbetalingerInnenforSammeFagområde =
+            if (fagsak.utbetalPåNyttFagområde) {
+                // Motregnes kun "innad" i stønadstypen og da uavhengig av tema
+                finnesFagsakMedIverksatteAndelerInnenforPeriode(
+                    fagsaker = alleFagsaker.alleFagsakerAvStønadstypeUavhengigAvTema(fagsak.stønadstype),
+                    periode = Datoperiode(LocalDate.now(), LocalDate.now()),
                 )
-
-            Stønadstype.REISE_TIL_SAMLING_TSO ->
-                håndterVarselForStønaderMedEgetFagområde(
-                    listOfNotNull(alleFagsaker.reiseTilSamlingTso),
-                )
-
-            Stønadstype.BOUTGIFTER, Stønadstype.LÆREMIDLER, Stønadstype.BARNETILSYN ->
-                håndterTilsynbarnLæremidlerBoutgifterVarsel(fagsak, alleFagsaker)
-        }
-    }
-
-    fun håndterVarselForStønaderMedEgetFagområde(relevanteFagsaker: List<Fagsak>): String? {
-        val dagensDato = LocalDate.now()
-        return if (erVarselRelevant(relevanteFagsaker, dagensDato)) {
-            "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
-        } else {
-            null
-        }
-    }
-
-    private fun håndterTilsynbarnLæremidlerBoutgifterVarsel(
-        fagsak: Fagsak,
-        fagsaker: Fagsaker,
-    ): String? {
-        val utbetalPåNyttFagområde =
-            fagsak.utbetalPåNyttFagområde
-                ?: feil("Mangler verdi for utbetalPåNyttFagområde på fagsak=${fagsak.id}")
-        val relevanteFagsaker =
-            if (utbetalPåNyttFagområde) {
-                listOf(fagsak)
             } else {
-                fagsaker.alleFagsaker().filter { it.utbetalPåNyttFagområde == false }
+                // Motregnes mot alle andre fagsaker som også utbetaler på gammelt fagområde. Også en ventedag før utbetaling
+                finnesFagsakMedIverksatteAndelerInnenforPeriode(
+                    fagsaker = alleFagsaker.alleFagsakerMedUtbetalingPåGammeltFagområde(),
+                    periode = Datoperiode(LocalDate.now().forrigeVirkedag(), LocalDate.now()),
+                )
             }
-        val periode = Datoperiode(LocalDate.now().forrigeVirkedag(), LocalDate.now())
-        return if (erVarselRelevantForTilsynBarnLæremidlerBoutgifter(relevanteFagsaker, periode)) {
+
+        return if (skalVarsleOmNyligeUtbetalingerInnenforSammeFagområde) {
             "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
         } else {
             null
         }
     }
 
-    private fun erVarselRelevant(
-        fagsaker: List<Fagsak>,
-        dagensDato: LocalDate,
-    ): Boolean {
-        return fagsaker.any { relevantFagsak ->
-
-            val behandlingId =
-                behandlingService
-                    .finnSisteIverksatteBehandling(relevantFagsak.id)
-                    ?.id ?: return@any false
-
-            val tilkjentYtelse =
-                tilkjentYtelseService.hentForBehandling(behandlingId)
-
-            tilkjentYtelse.andelerTilkjentYtelse.any { andel ->
-                val iverksettingDato =
-                    andel.iverksetting?.iverksettingTidspunkt?.toLocalDate()
-
-                iverksettingDato?.isEqual(dagensDato) == true
-            }
-        }
-    }
-
-    private fun erVarselRelevantForTilsynBarnLæremidlerBoutgifter(
+    private fun finnesFagsakMedIverksatteAndelerInnenforPeriode(
         fagsaker: List<Fagsak>,
         periode: Datoperiode,
     ): Boolean {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegService.kt
@@ -27,7 +27,7 @@ class SimuleringStegService(
             if (saksbehandling.steg == StegType.SIMULERING) {
                 stegService.håndterSteg(saksbehandling.id, StegType.SIMULERING)
             }
-            val varsel = simuleringService.skalSendeVarsel(saksbehandling.id)
+            val varsel = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(saksbehandling.id)
 
             return simuleringService.hentLagretSimulering(saksbehandling.id)?.tilDto()?.copy(varsel = varsel)
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegService.kt
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 class SimuleringStegService(
     private val stegService: StegService,
     private val simuleringService: SimuleringService,
+    private val varselVedMotregningISimuleringService: VarselVedMotregningISimuleringService,
     private val tilgangService: TilgangService,
 ) {
     @Transactional
@@ -27,7 +28,7 @@ class SimuleringStegService(
             if (saksbehandling.steg == StegType.SIMULERING) {
                 stegService.håndterSteg(saksbehandling.id, StegType.SIMULERING)
             }
-            val varsel = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(saksbehandling.id)
+            val varsel = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(saksbehandling.id)
 
             return simuleringService.hentLagretSimulering(saksbehandling.id)?.tilDto()?.copy(varsel = varsel)
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/VarselVedMotregningISimuleringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/VarselVedMotregningISimuleringService.kt
@@ -1,0 +1,69 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsak
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.util.forrigeVirkedag
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class VarselVedMotregningISimuleringService(
+    private val behandlingService: BehandlingService,
+    private val fagsakService: FagsakService,
+    private val tilkjentYtelseService: TilkjentYtelseService,
+) {
+    fun lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId: BehandlingId): String? {
+        val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
+        feilHvis(fagsak.utbetalPåNyttFagområde == null) {
+            "Forventer at utbetalPåNyttFagområde skal være satt på fagsaken"
+        }
+        val alleFagsaker =
+            fagsakService.finnFagsakerForFagsakPersonId(fagsak.fagsakPersonId)
+
+        val skalVarsleOmNyligeUtbetalingerInnenforSammeFagområde =
+            if (fagsak.utbetalPåNyttFagområde) {
+                finnesFagsakMedIverksatteAndelerInnenforPeriode(
+                    fagsaker = alleFagsaker.alleFagsakerAvStønadstypeUavhengigAvTema(fagsak.stønadstype),
+                    periode = Datoperiode(LocalDate.now(), LocalDate.now()),
+                )
+            } else {
+                finnesFagsakMedIverksatteAndelerInnenforPeriode(
+                    fagsaker = alleFagsaker.alleFagsakerMedUtbetalingPåGammeltFagområde(),
+                    periode = Datoperiode(LocalDate.now().forrigeVirkedag(), LocalDate.now()),
+                )
+            }
+
+        return if (skalVarsleOmNyligeUtbetalingerInnenforSammeFagområde) {
+            "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
+        } else {
+            null
+        }
+    }
+
+    private fun finnesFagsakMedIverksatteAndelerInnenforPeriode(
+        fagsaker: List<Fagsak>,
+        periode: Datoperiode,
+    ): Boolean {
+        return fagsaker.any { relevantFagsak ->
+            val behandlingId =
+                behandlingService
+                    .finnSisteIverksatteBehandling(relevantFagsak.id)
+                    ?.id ?: return@any false
+
+            val tilkjentYtelse =
+                tilkjentYtelseService.hentForBehandling(behandlingId)
+
+            tilkjentYtelse.andelerTilkjentYtelse.any { andel ->
+                val iverksettingDato =
+                    andel.iverksetting?.iverksettingTidspunkt?.toLocalDate()
+
+                iverksettingDato != null && periode.inneholder(iverksettingDato)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingsoversiktServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingsoversiktServiceTest.kt
@@ -91,14 +91,7 @@ class BehandlingsoversiktServiceTest {
     @BeforeEach
     fun setUp() {
         every { fagsakService.finnFagsakerForFagsakPersonId(fagsak.fagsakPersonId) } returns
-            Fagsaker(
-                barnetilsyn = fagsak,
-                læremidler = null,
-                boutgifter = null,
-                dagligReiseTso = null,
-                dagligReiseTsr = null,
-                reiseTilSamlingTso = null,
-            )
+            Fagsaker(mapOf(fagsak.stønadstype to fagsak))
         every { behandlingRepository.findByFagsakId(fagsakId = fagsak.id) } returns listOf(behandling)
         every { fagsakService.erLøpende(fagsak.id) } returns true
         every { vedtakService.hentVedtak(any()) } answers { vedtak }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/klage/KlageServiceTest.kt
@@ -139,14 +139,7 @@ internal class KlageServiceTest {
         @Test
         internal fun `skal returnere tomme lister dersom eksternFagsakId ikke eksisterer`() {
             every { fagsakService.finnFagsakerForFagsakPersonId(fagsakPersonId) } returns
-                Fagsaker(
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                )
+                Fagsaker(emptyMap())
 
             val klager = klageService.hentBehandlinger(fagsakPersonId)
 
@@ -281,7 +274,7 @@ internal class KlageServiceTest {
             )
         }
 
-        private fun fagsaker() = Fagsaker(fagsak, null, null, null, null, null)
+        private fun fagsaker() = Fagsaker(mapOf(fagsak.stønadstype to fagsak))
 
         private fun klageBehandlingDto(
             resultat: BehandlingResultat? = null,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -33,6 +33,7 @@ import no.nav.tilleggsstonader.sak.util.fagsakpersoner
 import no.nav.tilleggsstonader.sak.util.forrigeVirkedag
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tools.jackson.module.kotlin.readValue
@@ -64,7 +65,7 @@ internal class SimuleringServiceTest {
         )
 
     private val personIdent = "12345678901"
-    private val fagsak = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
+    private val fagsak = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = true)
 
     @BeforeEach
     internal fun setUp() {
@@ -180,8 +181,14 @@ internal class SimuleringServiceTest {
     @Test
     fun `skal sende varsel for daglig reise når iverksetting er idag`() {
         val behandlingId = behandling(fagsak).id
-        val fagsakDagligReiseTso = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO)
-        val fagsakDagligReiseTsr = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR)
+        val fagsakDagligReiseTso =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO).copy(
+                utbetalPåNyttFagområde = true,
+            )
+        val fagsakDagligReiseTsr =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR).copy(
+                utbetalPåNyttFagområde = true,
+            )
         val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
 
         val alleFagsaker =
@@ -225,10 +232,16 @@ internal class SimuleringServiceTest {
     }
 
     @Test
-    fun `skal sende varsel for daglig reise når iverksetting er ikke er ida`() {
+    fun `skal sende varsel for daglig reise når iverksetting ikke er i dag`() {
         val behandlingId = behandling(fagsak).id
-        val fagsakDagligReiseTso = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO)
-        val fagsakDagligReiseTsr = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR)
+        val fagsakDagligReiseTso =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO).copy(
+                utbetalPåNyttFagområde = true,
+            )
+        val fagsakDagligReiseTsr =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR).copy(
+                utbetalPåNyttFagområde = true,
+            )
 
         val alleFagsaker =
             Fagsaker(
@@ -271,11 +284,17 @@ internal class SimuleringServiceTest {
     }
 
     @Test
-    fun `skal sende varsel for tilsynbarn når dato er innenfor periode`() {
+    fun `skal sende varsel for tilsynbarn når dato er innenfor periode og det utbetales på gammelt fagområde`() {
         val behandlingId = behandling(fagsak).id
 
-        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
-        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
+        val fagsakTilsynbarn =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
+                utbetalPåNyttFagområde = false,
+            )
+        val fagsakLæremidler =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
+                utbetalPåNyttFagområde = false,
+            )
 
         val alleFagsaker =
             Fagsaker(
@@ -319,10 +338,13 @@ internal class SimuleringServiceTest {
     }
 
     @Test
-    fun `skal ikke sende varsel for tilsynbarn når dato er utenfor periode`() {
+    fun `skal ikke sende varsel for tilsynbarn når dato er utenfor periode og det utbetales på gammelt fagområde`() {
         val behandlingId = behandling(fagsak).id
 
-        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
+        val fagsakTilsynbarn =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
+                utbetalPåNyttFagområde = false,
+            )
 
         val alleFagsaker =
             Fagsaker(
@@ -361,6 +383,102 @@ internal class SimuleringServiceTest {
         val resultat = simuleringService.skalSendeVarsel(behandlingId)
 
         assertThat(resultat).isNull()
+    }
+
+    @Test
+    fun `skal kun sjekke samme fagsak for tilsynbarn når nytt fagområde brukes`() {
+        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = true)
+        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = false)
+        val behandlingId = behandling(fagsakTilsynbarn).id
+
+        val alleFagsaker =
+            Fagsaker(
+                barnetilsyn = fagsakTilsynbarn,
+                læremidler = fagsakLæremidler,
+                boutgifter = null,
+                dagligReiseTso = null,
+                dagligReiseTsr = null,
+                reiseTilSamlingTso = null,
+            )
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns behandling(fagsakLæremidler)
+
+        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+
+        assertThat(resultat).isNull()
+    }
+
+    @Test
+    fun `skal sjekke alle fagsaker med gammelt fagområde`() {
+        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = false)
+        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = true)
+        val fagsakBoutgifter = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BOUTGIFTER).copy(utbetalPåNyttFagområde = true)
+        val fagsakDagligReise =
+            fagsak(
+                fagsakpersoner(setOf(personIdent)),
+                Stønadstype.DAGLIG_REISE_TSO,
+            ).copy(utbetalPåNyttFagområde = false)
+        val behandlingId = behandling(fagsakTilsynbarn).id
+
+        val alleFagsaker =
+            Fagsaker(
+                barnetilsyn = fagsakTilsynbarn,
+                læremidler = fagsakLæremidler,
+                boutgifter = fagsakBoutgifter,
+                dagligReiseTso = fagsakDagligReise,
+                dagligReiseTsr = null,
+                reiseTilSamlingTso = null,
+            )
+        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
+        val behandlingDagligReise = behandling(fagsakDagligReise)
+        val idag = LocalDate.now()
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakBoutgifter.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakDagligReise.id) } returns behandlingDagligReise
+        every { tilkjentYtelseService.hentForBehandling(behandlingDagligReise.id) } returns
+            tilkjentYtelse(
+                behandlingId = behandlingDagligReise.id,
+                andeler =
+                    listOf(
+                        tilkjentYtelse(behandlingId = behandlingDagligReise.id).andelerTilkjentYtelse.first().copy(
+                            iverksetting =
+                                mockk {
+                                    every { iverksettingTidspunkt } returns idag.atStartOfDay()
+                                },
+                        ),
+                    ).toTypedArray(),
+            )
+
+        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+
+        assertThat(resultat).isEqualTo(varselTekst)
+    }
+
+    @Test
+    fun `skal feile når utbetalPåNyttFagområde mangler for tilsynbarn læremidler og boutgifter`() {
+        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
+        val behandlingId = behandling(fagsakTilsynbarn).id
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns
+            Fagsaker(
+                barnetilsyn = fagsakTilsynbarn,
+                læremidler = null,
+                boutgifter = null,
+                dagligReiseTso = null,
+                dagligReiseTsr = null,
+                reiseTilSamlingTso = null,
+            )
+
+        assertThatThrownBy { simuleringService.skalSendeVarsel(behandlingId) }
+            .hasMessageContaining("Mangler verdi for utbetalPåNyttFagområde")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -192,14 +192,7 @@ internal class SimuleringServiceTest {
         val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
 
         val alleFagsaker =
-            Fagsaker(
-                barnetilsyn = null,
-                læremidler = null,
-                boutgifter = null,
-                dagligReiseTso = fagsakDagligReiseTso,
-                dagligReiseTsr = fagsakDagligReiseTsr,
-                reiseTilSamlingTso = null,
-            )
+            Fagsaker(listOf(fagsakDagligReiseTso, fagsakDagligReiseTsr).associateBy { it.stønadstype })
         val idag = LocalDate.now()
 
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakDagligReiseTso
@@ -226,7 +219,7 @@ internal class SimuleringServiceTest {
 
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
 
-        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
 
         assertThat(resultat).isEqualTo(varselTekst)
     }
@@ -243,15 +236,7 @@ internal class SimuleringServiceTest {
                 utbetalPåNyttFagområde = true,
             )
 
-        val alleFagsaker =
-            Fagsaker(
-                barnetilsyn = null,
-                læremidler = null,
-                boutgifter = null,
-                dagligReiseTso = fagsakDagligReiseTso,
-                dagligReiseTsr = fagsakDagligReiseTsr,
-                reiseTilSamlingTso = null,
-            )
+        val alleFagsaker = Fagsaker(listOf(fagsakDagligReiseTso, fagsakDagligReiseTsr).associateBy { it.stønadstype })
         val idag = LocalDate.now()
 
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakDagligReiseTso
@@ -278,7 +263,7 @@ internal class SimuleringServiceTest {
 
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
 
-        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
 
         assertThat(resultat).isNull()
     }
@@ -297,14 +282,7 @@ internal class SimuleringServiceTest {
             )
 
         val alleFagsaker =
-            Fagsaker(
-                barnetilsyn = fagsakTilsynbarn,
-                læremidler = fagsakLæremidler,
-                boutgifter = null,
-                dagligReiseTso = null,
-                dagligReiseTsr = null,
-                reiseTilSamlingTso = null,
-            )
+            Fagsaker(listOf(fagsakTilsynbarn, fagsakLæremidler).associateBy { it.stønadstype })
         val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
 
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
@@ -332,7 +310,7 @@ internal class SimuleringServiceTest {
 
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
 
-        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
 
         assertThat(resultat).isEqualTo(varselTekst)
     }
@@ -346,15 +324,7 @@ internal class SimuleringServiceTest {
                 utbetalPåNyttFagområde = false,
             )
 
-        val alleFagsaker =
-            Fagsaker(
-                barnetilsyn = fagsakTilsynbarn,
-                læremidler = null,
-                boutgifter = null,
-                dagligReiseTso = null,
-                dagligReiseTsr = null,
-                reiseTilSamlingTso = null,
-            )
+        val alleFagsaker = Fagsaker(mapOf(fagsakTilsynbarn.stønadstype to fagsakTilsynbarn))
 
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
         every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
@@ -380,7 +350,7 @@ internal class SimuleringServiceTest {
 
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
 
-        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
 
         assertThat(resultat).isNull()
     }
@@ -391,22 +361,14 @@ internal class SimuleringServiceTest {
         val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = false)
         val behandlingId = behandling(fagsakTilsynbarn).id
 
-        val alleFagsaker =
-            Fagsaker(
-                barnetilsyn = fagsakTilsynbarn,
-                læremidler = fagsakLæremidler,
-                boutgifter = null,
-                dagligReiseTso = null,
-                dagligReiseTsr = null,
-                reiseTilSamlingTso = null,
-            )
+        val alleFagsaker = Fagsaker(listOf(fagsakTilsynbarn, fagsakLæremidler).associateBy { it.stønadstype })
 
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
         every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
         every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
         every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns behandling(fagsakLæremidler)
 
-        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
 
         assertThat(resultat).isNull()
     }
@@ -425,12 +387,12 @@ internal class SimuleringServiceTest {
 
         val alleFagsaker =
             Fagsaker(
-                barnetilsyn = fagsakTilsynbarn,
-                læremidler = fagsakLæremidler,
-                boutgifter = fagsakBoutgifter,
-                dagligReiseTso = fagsakDagligReise,
-                dagligReiseTsr = null,
-                reiseTilSamlingTso = null,
+                listOf(
+                    fagsakTilsynbarn,
+                    fagsakLæremidler,
+                    fagsakBoutgifter,
+                    fagsakDagligReise,
+                ).associateBy { it.stønadstype },
             )
         val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
         val behandlingDagligReise = behandling(fagsakDagligReise)
@@ -456,7 +418,7 @@ internal class SimuleringServiceTest {
                     ).toTypedArray(),
             )
 
-        val resultat = simuleringService.skalSendeVarsel(behandlingId)
+        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
 
         assertThat(resultat).isEqualTo(varselTekst)
     }
@@ -468,17 +430,10 @@ internal class SimuleringServiceTest {
 
         every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
         every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns
-            Fagsaker(
-                barnetilsyn = fagsakTilsynbarn,
-                læremidler = null,
-                boutgifter = null,
-                dagligReiseTso = null,
-                dagligReiseTsr = null,
-                reiseTilSamlingTso = null,
-            )
+            Fagsaker(mapOf(fagsakTilsynbarn.stønadstype to fagsakTilsynbarn))
 
-        assertThatThrownBy { simuleringService.skalSendeVarsel(behandlingId) }
-            .hasMessageContaining("Mangler verdi for utbetalPåNyttFagområde")
+        assertThatThrownBy { simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId) }
+            .hasMessageContaining("Forventer at utbetalPåNyttFagområde skal være satt på fagsaken")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -292,7 +292,7 @@ internal class SimuleringServiceTest {
                 utbetalPåNyttFagområde = false,
             )
         val fagsakLæremidler =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(
                 utbetalPåNyttFagområde = false,
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringServiceTest.kt
@@ -7,10 +7,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
-import no.nav.tilleggsstonader.sak.fagsak.FagsakService
-import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import no.nav.tilleggsstonader.sak.utbetaling.fagomrade.FagsakUtbetalingsvalgService
@@ -33,7 +30,6 @@ import no.nav.tilleggsstonader.sak.util.fagsakpersoner
 import no.nav.tilleggsstonader.sak.util.forrigeVirkedag
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tools.jackson.module.kotlin.readValue
@@ -43,8 +39,6 @@ import no.nav.tilleggsstonader.sak.utbetaling.simulering.kontrakt.SimuleringDeta
 
 internal class SimuleringServiceTest {
     private val simuleringClient = mockk<SimuleringClient>()
-    private val behandlingService = mockk<BehandlingService>()
-    private val fagsakService = mockk<FagsakService>()
     private val simuleringsresultatRepository = mockk<SimuleringsresultatRepository>()
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
     private val tilgangService = mockk<TilgangService>()
@@ -60,8 +54,6 @@ internal class SimuleringServiceTest {
             tilkjentYtelseService = tilkjentYtelseService,
             tilgangService = tilgangService,
             utbetalingV3Mapper = utbetalingV3Mapper,
-            behandlingService = behandlingService,
-            fagsakService = fagsakService,
         )
 
     private val personIdent = "12345678901"
@@ -69,8 +61,6 @@ internal class SimuleringServiceTest {
 
     @BeforeEach
     internal fun setUp() {
-        every { fagsakService.hentFagsak(any()) } returns fagsak
-        every { fagsakService.fagsakMedOppdatertPersonIdent(any()) } returns fagsak
         every { tilgangService.validerHarSaksbehandlerrolle() } just Runs
         every { tilgangService.harTilgangTilRolle(any()) } returns true
         every { fagsakUtbetalingIdService.hentEllerOpprettUtbetalingId(any(), any(), any()) } answers {
@@ -107,7 +97,6 @@ internal class SimuleringServiceTest {
                 behandlingId = saksbehandling.id,
                 data = SimuleringJson(mockk(), mockk()),
             )
-        every { behandlingService.hentBehandling(any()) } returns behandling
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
         every { simuleringsresultatRepository.deleteById(any()) } just Runs
         every { simuleringsresultatRepository.insert(any()) } returns simuleringsresultat
@@ -166,7 +155,6 @@ internal class SimuleringServiceTest {
         every { simuleringClient.simuler(any()) } returns
             jsonMapper.readValue(readFile("mock/iverksett/simuleringsresultat.json"))
 
-        every { behandlingService.hentBehandling(any()) } returns behandling
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
         every { simuleringsresultatRepository.deleteById(any()) } just Runs
 
@@ -179,274 +167,13 @@ internal class SimuleringServiceTest {
     }
 
     @Test
-    fun `skal sende varsel for daglig reise når iverksetting er idag`() {
-        val behandlingId = behandling(fagsak).id
-        val fagsakDagligReiseTso =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO).copy(
-                utbetalPåNyttFagområde = true,
-            )
-        val fagsakDagligReiseTsr =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR).copy(
-                utbetalPåNyttFagområde = true,
-            )
-        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
-
-        val alleFagsaker =
-            Fagsaker(listOf(fagsakDagligReiseTso, fagsakDagligReiseTsr).associateBy { it.stønadstype })
-        val idag = LocalDate.now()
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakDagligReiseTso
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
-
-        val behandling = behandling(fagsakDagligReiseTso)
-        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
-
-        val tilkjentYtelse =
-            tilkjentYtelse(
-                behandlingId = behandling.id,
-                andeler =
-                    listOf(
-                        tilkjentYtelse(
-                            behandlingId = behandlingId,
-                        ).andelerTilkjentYtelse.first().copy(
-                            iverksetting =
-                                mockk {
-                                    every { iverksettingTidspunkt } returns idag.atStartOfDay()
-                                },
-                        ),
-                    ).toTypedArray(),
-            )
-
-        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
-
-        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
-
-        assertThat(resultat).isEqualTo(varselTekst)
-    }
-
-    @Test
-    fun `skal sende varsel for daglig reise når iverksetting ikke er i dag`() {
-        val behandlingId = behandling(fagsak).id
-        val fagsakDagligReiseTso =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO).copy(
-                utbetalPåNyttFagområde = true,
-            )
-        val fagsakDagligReiseTsr =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR).copy(
-                utbetalPåNyttFagområde = true,
-            )
-
-        val alleFagsaker = Fagsaker(listOf(fagsakDagligReiseTso, fagsakDagligReiseTsr).associateBy { it.stønadstype })
-        val idag = LocalDate.now()
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakDagligReiseTso
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
-
-        val behandling = behandling(fagsakDagligReiseTso)
-        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
-
-        val tilkjentYtelse =
-            tilkjentYtelse(
-                behandlingId = behandling.id,
-                andeler =
-                    listOf(
-                        tilkjentYtelse(
-                            behandlingId = behandlingId,
-                        ).andelerTilkjentYtelse.first().copy(
-                            iverksetting =
-                                mockk {
-                                    every { iverksettingTidspunkt } returns idag.atStartOfDay().minusDays(10)
-                                },
-                        ),
-                    ).toTypedArray(),
-            )
-
-        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
-
-        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
-
-        assertThat(resultat).isNull()
-    }
-
-    @Test
-    fun `skal sende varsel for tilsynbarn når dato er innenfor periode og det utbetales på gammelt fagområde`() {
-        val behandlingId = behandling(fagsak).id
-
-        val fagsakTilsynbarn =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
-                utbetalPåNyttFagområde = false,
-            )
-        val fagsakLæremidler =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(
-                utbetalPåNyttFagområde = false,
-            )
-
-        val alleFagsaker =
-            Fagsaker(listOf(fagsakTilsynbarn, fagsakLæremidler).associateBy { it.stønadstype })
-        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
-
-        val behandling = behandling(fagsakTilsynbarn)
-        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
-        val idag = LocalDate.now()
-
-        val datoInnenfor = idag.forrigeVirkedag()
-
-        val tilkjentYtelse =
-            tilkjentYtelse(
-                behandlingId = behandling.id,
-                andeler =
-                    listOf(
-                        tilkjentYtelse(behandlingId = behandlingId).andelerTilkjentYtelse.first().copy(
-                            iverksetting =
-                                mockk {
-                                    every { iverksettingTidspunkt } returns datoInnenfor.atStartOfDay()
-                                },
-                        ),
-                    ).toTypedArray(),
-            )
-
-        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
-
-        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
-
-        assertThat(resultat).isEqualTo(varselTekst)
-    }
-
-    @Test
-    fun `skal ikke sende varsel for tilsynbarn når dato er utenfor periode og det utbetales på gammelt fagområde`() {
-        val behandlingId = behandling(fagsak).id
-
-        val fagsakTilsynbarn =
-            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
-                utbetalPåNyttFagområde = false,
-            )
-
-        val alleFagsaker = Fagsaker(mapOf(fagsakTilsynbarn.stønadstype to fagsakTilsynbarn))
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
-
-        val behandling = behandling(fagsakTilsynbarn)
-        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
-        val idag = LocalDate.now()
-        val datoUtenfor = idag.forrigeVirkedag().minusDays(10)
-
-        val tilkjentYtelse =
-            tilkjentYtelse(
-                behandlingId = behandling.id,
-                andeler =
-                    listOf(
-                        tilkjentYtelse(behandlingId = behandlingId).andelerTilkjentYtelse.first().copy(
-                            iverksetting =
-                                mockk {
-                                    every { iverksettingTidspunkt } returns datoUtenfor.atStartOfDay()
-                                },
-                        ),
-                    ).toTypedArray(),
-            )
-
-        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
-
-        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
-
-        assertThat(resultat).isNull()
-    }
-
-    @Test
-    fun `skal kun sjekke samme fagsak for tilsynbarn når nytt fagområde brukes`() {
-        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = true)
-        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = false)
-        val behandlingId = behandling(fagsakTilsynbarn).id
-
-        val alleFagsaker = Fagsaker(listOf(fagsakTilsynbarn, fagsakLæremidler).associateBy { it.stønadstype })
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns behandling(fagsakLæremidler)
-
-        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
-
-        assertThat(resultat).isNull()
-    }
-
-    @Test
-    fun `skal sjekke alle fagsaker med gammelt fagområde`() {
-        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = false)
-        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = true)
-        val fagsakBoutgifter = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BOUTGIFTER).copy(utbetalPåNyttFagområde = true)
-        val fagsakDagligReise =
-            fagsak(
-                fagsakpersoner(setOf(personIdent)),
-                Stønadstype.DAGLIG_REISE_TSO,
-            ).copy(utbetalPåNyttFagområde = false)
-        val behandlingId = behandling(fagsakTilsynbarn).id
-
-        val alleFagsaker =
-            Fagsaker(
-                listOf(
-                    fagsakTilsynbarn,
-                    fagsakLæremidler,
-                    fagsakBoutgifter,
-                    fagsakDagligReise,
-                ).associateBy { it.stønadstype },
-            )
-        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
-        val behandlingDagligReise = behandling(fagsakDagligReise)
-        val idag = LocalDate.now()
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns null
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakBoutgifter.id) } returns null
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakDagligReise.id) } returns behandlingDagligReise
-        every { tilkjentYtelseService.hentForBehandling(behandlingDagligReise.id) } returns
-            tilkjentYtelse(
-                behandlingId = behandlingDagligReise.id,
-                andeler =
-                    listOf(
-                        tilkjentYtelse(behandlingId = behandlingDagligReise.id).andelerTilkjentYtelse.first().copy(
-                            iverksetting =
-                                mockk {
-                                    every { iverksettingTidspunkt } returns idag.atStartOfDay()
-                                },
-                        ),
-                    ).toTypedArray(),
-            )
-
-        val resultat = simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
-
-        assertThat(resultat).isEqualTo(varselTekst)
-    }
-
-    @Test
-    fun `skal feile når utbetalPåNyttFagområde mangler for tilsynbarn læremidler og boutgifter`() {
-        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
-        val behandlingId = behandling(fagsakTilsynbarn).id
-
-        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
-        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns
-            Fagsaker(mapOf(fagsakTilsynbarn.stønadstype to fagsakTilsynbarn))
-
-        assertThatThrownBy { simuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId) }
-            .hasMessageContaining("Forventer at utbetalPåNyttFagområde skal være satt på fagsaken")
-    }
-
-    @Test
     fun `forrigeVirkedag skal gi riktig dag`() {
-        // Mandag -> forrige virkedag er Fredag
         assertThat(LocalDate.of(2026, 3, 30).dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
         assertThat(LocalDate.of(2026, 3, 30).forrigeVirkedag()).isEqualTo(LocalDate.of(2026, 3, 27))
 
-        // Sondag -> forrige virkedag er Fredag
         assertThat(LocalDate.of(2026, 3, 29).dayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
         assertThat(LocalDate.of(2026, 3, 29).forrigeVirkedag()).isEqualTo(LocalDate.of(2026, 3, 27))
 
-        // Onsdag -> forrige virkedag er Tirsdag
         assertThat(LocalDate.of(2026, 3, 25).dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
         assertThat(LocalDate.of(2026, 3, 25).forrigeVirkedag()).isEqualTo(LocalDate.of(2026, 3, 24))
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegServiceTest.kt
@@ -20,12 +20,14 @@ import java.util.UUID
 class SimuleringStegServiceTest {
     val stegService = mockk<StegService>()
     val simuleringService = mockk<SimuleringService>()
+    val varselVedMotregningISimuleringService = mockk<VarselVedMotregningISimuleringService>()
     val tilgangService = mockk<TilgangService>()
 
     val simuleringStegService =
         SimuleringStegService(
             stegService = stegService,
             simuleringService = simuleringService,
+            varselVedMotregningISimuleringService = varselVedMotregningISimuleringService,
             tilgangService = tilgangService,
         )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/VarselVedMotregningISimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/VarselVedMotregningISimuleringServiceTest.kt
@@ -1,0 +1,305 @@
+package no.nav.tilleggsstonader.sak.utbetaling.simulering
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.fagsak.domain.Fagsaker
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.fagsakpersoner
+import no.nav.tilleggsstonader.sak.util.forrigeVirkedag
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+internal class VarselVedMotregningISimuleringServiceTest {
+    private val behandlingService = mockk<BehandlingService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
+
+    private val varselVedMotregningISimuleringService =
+        VarselVedMotregningISimuleringService(
+            behandlingService = behandlingService,
+            fagsakService = fagsakService,
+            tilkjentYtelseService = tilkjentYtelseService,
+        )
+
+    private val personIdent = "12345678901"
+    private val fagsak = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = true)
+
+    @Test
+    fun `skal sende varsel for daglig reise når iverksetting er idag`() {
+        val behandlingId = behandling(fagsak).id
+        val fagsakDagligReiseTso =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO).copy(
+                utbetalPåNyttFagområde = true,
+            )
+        val fagsakDagligReiseTsr =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR).copy(
+                utbetalPåNyttFagområde = true,
+            )
+        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
+
+        val alleFagsaker =
+            Fagsaker(listOf(fagsakDagligReiseTso, fagsakDagligReiseTsr).associateBy { it.stønadstype })
+        val idag = LocalDate.now()
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakDagligReiseTso
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+
+        val behandling = behandling(fagsakDagligReiseTso)
+        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
+
+        val tilkjentYtelse =
+            tilkjentYtelse(
+                behandlingId = behandling.id,
+                andeler =
+                    listOf(
+                        tilkjentYtelse(
+                            behandlingId = behandlingId,
+                        ).andelerTilkjentYtelse.first().copy(
+                            iverksetting =
+                                mockk {
+                                    every { iverksettingTidspunkt } returns idag.atStartOfDay()
+                                },
+                        ),
+                    ).toTypedArray(),
+            )
+
+        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
+
+        val resultat = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
+
+        assertThat(resultat).isEqualTo(varselTekst)
+    }
+
+    @Test
+    fun `skal sende varsel for daglig reise når iverksetting ikke er i dag`() {
+        val behandlingId = behandling(fagsak).id
+        val fagsakDagligReiseTso =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSO).copy(
+                utbetalPåNyttFagområde = true,
+            )
+        val fagsakDagligReiseTsr =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.DAGLIG_REISE_TSR).copy(
+                utbetalPåNyttFagområde = true,
+            )
+
+        val alleFagsaker = Fagsaker(listOf(fagsakDagligReiseTso, fagsakDagligReiseTsr).associateBy { it.stønadstype })
+        val idag = LocalDate.now()
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakDagligReiseTso
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+
+        val behandling = behandling(fagsakDagligReiseTso)
+        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
+
+        val tilkjentYtelse =
+            tilkjentYtelse(
+                behandlingId = behandling.id,
+                andeler =
+                    listOf(
+                        tilkjentYtelse(
+                            behandlingId = behandlingId,
+                        ).andelerTilkjentYtelse.first().copy(
+                            iverksetting =
+                                mockk {
+                                    every { iverksettingTidspunkt } returns idag.atStartOfDay().minusDays(10)
+                                },
+                        ),
+                    ).toTypedArray(),
+            )
+
+        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
+
+        val resultat = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
+
+        assertThat(resultat).isNull()
+    }
+
+    @Test
+    fun `skal sende varsel for tilsynbarn når dato er innenfor periode og det utbetales på gammelt fagområde`() {
+        val behandlingId = behandling(fagsak).id
+
+        val fagsakTilsynbarn =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
+                utbetalPåNyttFagområde = false,
+            )
+        val fagsakLæremidler =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(
+                utbetalPåNyttFagområde = false,
+            )
+
+        val alleFagsaker =
+            Fagsaker(listOf(fagsakTilsynbarn, fagsakLæremidler).associateBy { it.stønadstype })
+        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+
+        val behandling = behandling(fagsakTilsynbarn)
+        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
+        val idag = LocalDate.now()
+
+        val datoInnenfor = idag.forrigeVirkedag()
+
+        val tilkjentYtelse =
+            tilkjentYtelse(
+                behandlingId = behandling.id,
+                andeler =
+                    listOf(
+                        tilkjentYtelse(behandlingId = behandlingId).andelerTilkjentYtelse.first().copy(
+                            iverksetting =
+                                mockk {
+                                    every { iverksettingTidspunkt } returns datoInnenfor.atStartOfDay()
+                                },
+                        ),
+                    ).toTypedArray(),
+            )
+
+        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
+
+        val resultat = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
+
+        assertThat(resultat).isEqualTo(varselTekst)
+    }
+
+    @Test
+    fun `skal ikke sende varsel for tilsynbarn når dato er utenfor periode og det utbetales på gammelt fagområde`() {
+        val behandlingId = behandling(fagsak).id
+
+        val fagsakTilsynbarn =
+            fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(
+                utbetalPåNyttFagområde = false,
+            )
+
+        val alleFagsaker = Fagsaker(mapOf(fagsakTilsynbarn.stønadstype to fagsakTilsynbarn))
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+
+        val behandling = behandling(fagsakTilsynbarn)
+        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling
+        val idag = LocalDate.now()
+        val datoUtenfor = idag.forrigeVirkedag().minusDays(10)
+
+        val tilkjentYtelse =
+            tilkjentYtelse(
+                behandlingId = behandling.id,
+                andeler =
+                    listOf(
+                        tilkjentYtelse(behandlingId = behandlingId).andelerTilkjentYtelse.first().copy(
+                            iverksetting =
+                                mockk {
+                                    every { iverksettingTidspunkt } returns datoUtenfor.atStartOfDay()
+                                },
+                        ),
+                    ).toTypedArray(),
+            )
+
+        every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
+
+        val resultat = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
+
+        assertThat(resultat).isNull()
+    }
+
+    @Test
+    fun `skal kun sjekke samme fagsak for tilsynbarn når nytt fagområde brukes`() {
+        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = true)
+        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = false)
+        val behandlingId = behandling(fagsakTilsynbarn).id
+
+        val alleFagsaker = Fagsaker(listOf(fagsakTilsynbarn, fagsakLæremidler).associateBy { it.stønadstype })
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns behandling(fagsakLæremidler)
+
+        val resultat = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
+
+        assertThat(resultat).isNull()
+    }
+
+    @Test
+    fun `skal sjekke alle fagsaker med gammelt fagområde`() {
+        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN).copy(utbetalPåNyttFagområde = false)
+        val fagsakLæremidler = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.LÆREMIDLER).copy(utbetalPåNyttFagområde = true)
+        val fagsakBoutgifter = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BOUTGIFTER).copy(utbetalPåNyttFagområde = true)
+        val fagsakDagligReise =
+            fagsak(
+                fagsakpersoner(setOf(personIdent)),
+                Stønadstype.DAGLIG_REISE_TSO,
+            ).copy(utbetalPåNyttFagområde = false)
+        val behandlingId = behandling(fagsakTilsynbarn).id
+
+        val alleFagsaker =
+            Fagsaker(
+                listOf(
+                    fagsakTilsynbarn,
+                    fagsakLæremidler,
+                    fagsakBoutgifter,
+                    fagsakDagligReise,
+                ).associateBy { it.stønadstype },
+            )
+        val varselTekst = "Forrige vedtak har enda ikke blitt registrert i økonomisystemet. Simuleringen kan derfor være unøyaktig"
+        val behandlingDagligReise = behandling(fagsakDagligReise)
+        val idag = LocalDate.now()
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns alleFagsaker
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakTilsynbarn.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakLæremidler.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakBoutgifter.id) } returns null
+        every { behandlingService.finnSisteIverksatteBehandling(fagsakDagligReise.id) } returns behandlingDagligReise
+        every { tilkjentYtelseService.hentForBehandling(behandlingDagligReise.id) } returns
+            tilkjentYtelse(
+                behandlingId = behandlingDagligReise.id,
+                andeler =
+                    listOf(
+                        tilkjentYtelse(behandlingId = behandlingDagligReise.id).andelerTilkjentYtelse.first().copy(
+                            iverksetting =
+                                mockk {
+                                    every { iverksettingTidspunkt } returns idag.atStartOfDay()
+                                },
+                        ),
+                    ).toTypedArray(),
+            )
+
+        val resultat = varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId)
+
+        assertThat(resultat).isEqualTo(varselTekst)
+    }
+
+    @Test
+    fun `skal feile når utbetalPåNyttFagområde mangler for tilsynbarn læremidler og boutgifter`() {
+        val fagsakTilsynbarn = fagsak(fagsakpersoner(setOf(personIdent)), Stønadstype.BARNETILSYN)
+        val behandlingId = behandling(fagsakTilsynbarn).id
+
+        every { fagsakService.hentFagsakForBehandling(any()) } returns fagsakTilsynbarn
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns
+            Fagsaker(mapOf(fagsakTilsynbarn.stønadstype to fagsakTilsynbarn))
+
+        assertThatThrownBy { varselVedMotregningISimuleringService.lagEvtVarselForUtbetalingerPåFagsakerISammeFagområde(behandlingId) }
+            .hasMessageContaining("Forventer at utbetalPåNyttFagområde skal være satt på fagsaken")
+    }
+
+    @Test
+    fun `forrigeVirkedag skal gi riktig dag`() {
+        assertThat(LocalDate.of(2026, 3, 30).dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+        assertThat(LocalDate.of(2026, 3, 30).forrigeVirkedag()).isEqualTo(LocalDate.of(2026, 3, 27))
+
+        assertThat(LocalDate.of(2026, 3, 29).dayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
+        assertThat(LocalDate.of(2026, 3, 29).forrigeVirkedag()).isEqualTo(LocalDate.of(2026, 3, 27))
+
+        assertThat(LocalDate.of(2026, 3, 25).dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+        assertThat(LocalDate.of(2026, 3, 25).forrigeVirkedag()).isEqualTo(LocalDate.of(2026, 3, 24))
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Fagsaker med ulike tilleggsstønader motregnes ikke mot hverandre når fagsaken sine utbetalinger bruker nytt fagområde hos økonomi. Justerer derfor varsling vi i dag har for å si fra til saksbehandler at simuleringen kan inneholde beløp fra andre fagsaker som nylig har hatt utbetalinger :eyes:

Ref https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-26216