### PR TITLE
✨ Slå sammen gammelt og nytt rammevedtak i reisevudering og marker uker med ny, uendret eller slettet.

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -79,6 +79,7 @@ class ReisevurderingController(
         return lagUkeVurderingDto(
             uke = oppdatertAvklartUke.uke,
             datoer = oppdatertAvklartUke.alleDatoer(),
+            gjeldendeDatoerForUke = oppdatertAvklartUke.alleDatoer(),
             avklartUke = oppdatertAvklartUke,
             kjøreliste = kjøreliste,
             erUkeSlettet = false,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -1,9 +1,11 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.ekstern.stønad.DagligReisePrivatBilService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilMapper.lagUkeVurderingDto
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
@@ -15,8 +17,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
-import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
-import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilMapper.lagUkeVurderingDto
 
 @RestController
 @RequestMapping(path = ["/api/kjoreliste"])

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -4,8 +4,6 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.ekstern.stønad.DagligReisePrivatBilService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
-import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilMapper.tilReisevurderingDto
-import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilMapper.tilUkeVurderingDto
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
@@ -17,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
+import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
+import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilMapper.lagUkeVurderingDto
 
 @RestController
 @RequestMapping(path = ["/api/kjoreliste"])
@@ -39,14 +39,26 @@ class ReisevurderingController(
         val behandling = behandlingService.hentBehandling(behandlingId)
 
         val kjørelister = kjørelisteService.hentForFagsakId(behandling.fagsakId)
-        val reiserIRammevedtak =
+        val reiserIGjeldendeRammevedtak = dagligReisePrivatBilService.hentRammevedtakForBehandlingId(behandlingId)?.reiser
+        val reiserIForrigeRammevedtak =
             behandling.forrigeIverksatteBehandlingId
                 ?.let { dagligReisePrivatBilService.hentRammevedtakForBehandlingId(it)?.reiser }
         val avklarteUker = avklartKjørelisteService.hentAvklarteUkerForBehandling(behandlingId)
+        val alleReiseIder =
+            ((reiserIGjeldendeRammevedtak ?: emptyList()) + (reiserIForrigeRammevedtak ?: emptyList()))
+                .map { it.reiseId }
+                .distinct()
 
-        return reiserIRammevedtak?.map { reise ->
-            reise.tilReisevurderingDto(avklarteUker = avklarteUker, kjørelister = kjørelister)
-        } ?: emptyList()
+        return alleReiseIder.map { reiseId ->
+            val gjeldendeReise = reiserIGjeldendeRammevedtak?.singleOrNull { it.reiseId == reiseId }
+            val forrigeReise = reiserIForrigeRammevedtak?.singleOrNull { it.reiseId == reiseId }
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = forrigeReise,
+                avklarteUker = avklarteUker,
+                kjørelister = kjørelister,
+            )
+        }
     }
 
     @PutMapping("{behandlingId}/{ukeId}")
@@ -64,6 +76,12 @@ class ReisevurderingController(
         val oppdatertAvklartUke = avklartKjørelisteService.oppdaterAvklartUke(behandlingId, ukeId, avklarteDager)
         val kjøreliste = kjørelisteService.hentKjøreliste(oppdatertAvklartUke.kjørelisteId)
 
-        return oppdatertAvklartUke.tilUkeVurderingDto(kjøreliste = kjøreliste)
+        return lagUkeVurderingDto(
+            uke = oppdatertAvklartUke.uke,
+            datoer = oppdatertAvklartUke.alleDatoer(),
+            avklartUke = oppdatertAvklartUke,
+            kjøreliste = kjøreliste,
+            endringIRammevedtakStatus = UkeEndringIRammevedtakStatus.UENDRET,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -81,7 +81,7 @@ class ReisevurderingController(
             datoer = oppdatertAvklartUke.alleDatoer(),
             avklartUke = oppdatertAvklartUke,
             kjøreliste = kjøreliste,
-            endringIRammevedtakStatus = UkeEndringIRammevedtakStatus.UENDRET,
+            erUkeSlettet = false,
         )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
@@ -41,6 +41,7 @@ data class AvvikUke(
 data class DagDto(
     val dato: LocalDate,
     val ukedag: String, // avklar om faktisk trenger, eller om frontend skal mappe ut fra dag
+    val erDagSlettet: Boolean,
     val kjørelisteDag: KjørelisteDagDto?,
     val avklartDag: AvklartDagDto?,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 
 data class ReisevurderingPrivatBilDto(
     val reiseId: ReiseId,
-    val rammevedtak: RammeForReiseMedPrivatBilDto,
+    val rammevedtak: RammeForReiseMedPrivatBilDto?,
     val forrigeRammevedtak: RammeForReiseMedPrivatBilDto?,
     val uker: List<UkeVurderingDto>,
 )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 data class ReisevurderingPrivatBilDto(
     val reiseId: ReiseId,
     val rammevedtak: RammeForReiseMedPrivatBilDto,
+    val forrigeRammevedtak: RammeForReiseMedPrivatBilDto?,
     val uker: List<UkeVurderingDto>,
 )
 
@@ -22,6 +23,7 @@ data class UkeVurderingDto(
     val ukenummer: Int,
     val fraDato: LocalDate,
     val tilDato: LocalDate,
+    val endringIRammevedtakStatus: UkeEndringIRammevedtakStatus,
     val status: UkeStatus,
     val avvik: AvvikUke?,
     val behandletDato: LocalDate?,
@@ -31,6 +33,12 @@ data class UkeVurderingDto(
     val avklartKjørtUkeStatus: AvklartKjørtUkeStatus?, // null hvis avklartKjørtUke ikke finnes
     val dager: List<DagDto>,
 )
+
+enum class UkeEndringIRammevedtakStatus {
+    NY,
+    SLETTET,
+    UENDRET,
+}
 
 data class AvvikUke(
     val typeAvvik: TypeAvvikUke,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilDto.kt
@@ -23,7 +23,7 @@ data class UkeVurderingDto(
     val ukenummer: Int,
     val fraDato: LocalDate,
     val tilDato: LocalDate,
-    val endringIRammevedtakStatus: UkeEndringIRammevedtakStatus,
+    val erUkeSlettet: Boolean,
     val status: UkeStatus,
     val avvik: AvvikUke?,
     val behandletDato: LocalDate?,
@@ -33,12 +33,6 @@ data class UkeVurderingDto(
     val avklartKjørtUkeStatus: AvklartKjørtUkeStatus?, // null hvis avklartKjørtUke ikke finnes
     val dager: List<DagDto>,
 )
-
-enum class UkeEndringIRammevedtakStatus {
-    NY,
-    SLETTET,
-    UENDRET,
-}
 
 data class AvvikUke(
     val typeAvvik: TypeAvvikUke,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
+import java.time.LocalDate
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
@@ -8,7 +9,6 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.tilDto
-import java.time.LocalDate
 
 object ReisevurderingPrivatBilMapper {
     fun tilReisevurderingDto(
@@ -38,15 +38,14 @@ object ReisevurderingPrivatBilMapper {
     }
 
     /**
-     * For kjørelistebehandling er ikke rammevedtaket beregnet enda, så da må vi bruke forrige rammevedtak som grunnlag for reisevurderingen.
-     * For "vanlig" revurdering er rammevedtaket for denne behandlingen beregnet, så da bruker vi det i reisevurderingen.
+     * Bruker gammelt rammevedtak som grunnlag for reisevuderingen hvis hele reisen er slettet
      */
     fun finnRammevedtakForReiseVurdering(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
         forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
     ): RammeForReiseMedPrivatBil =
         gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise
-            ?: feil("Kan ikke lagre reisevudering. Mangler rammevedtak for reise")
+        ?: feil("Kan ikke lagre reisevudering. Mangler rammevedtak for reise")
 
     private fun lagUkeVurderingerDto(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -76,12 +76,7 @@ object ReisevurderingPrivatBilMapper {
                 datoer = datoerForUke,
                 avklartUke = avklartUke,
                 kjøreliste = kjørelisteForUke,
-                endringIRammevedtakStatus =
-                    finnEndringIRammevedtakStatus(
-                        uke,
-                        gjeldendeUker,
-                        forrigeUker,
-                    ),
+                erUkeSlettet = erUkeSlettet(uke, gjeldendeUker, forrigeUker),
             )
         }
     }
@@ -91,13 +86,13 @@ object ReisevurderingPrivatBilMapper {
         datoer: List<LocalDate>,
         avklartUke: AvklartKjørtUke?,
         kjøreliste: Kjøreliste?,
-        endringIRammevedtakStatus: UkeEndringIRammevedtakStatus,
+        erUkeSlettet: Boolean,
     ): UkeVurderingDto =
         UkeVurderingDto(
             ukenummer = uke.ukenummer,
             fraDato = datoer.min(),
             tilDato = datoer.max(),
-            endringIRammevedtakStatus = endringIRammevedtakStatus,
+            erUkeSlettet = erUkeSlettet,
             status = avklartUke?.status ?: UkeStatus.IKKE_MOTTATT_KJØRELISTE,
             avvik = avklartUke?.typeAvvik?.let { AvvikUke(typeAvvik = it) },
             behandletDato = avklartUke?.behandletDato,
@@ -149,20 +144,12 @@ object ReisevurderingPrivatBilMapper {
             avklartKjørtDagStatus = avklartKjørtDagStatus,
         )
 
-    private fun finnEndringIRammevedtakStatus(
+    private fun erUkeSlettet(
         uke: UkeIÅr,
         gjeldendeUker: Map<UkeIÅr, List<LocalDate>>,
         forrigeUker: Map<UkeIÅr, List<LocalDate>>,
-    ): UkeEndringIRammevedtakStatus {
-        if (gjeldendeUker.isEmpty()) return UkeEndringIRammevedtakStatus.SLETTET
-
-        val finnesIGjeldende = gjeldendeUker.containsKey(uke)
-        val finnesIForrige = forrigeUker.containsKey(uke)
-
-        return when {
-            finnesIGjeldende && !finnesIForrige -> UkeEndringIRammevedtakStatus.NY
-            !finnesIGjeldende && finnesIForrige -> UkeEndringIRammevedtakStatus.SLETTET
-            else -> UkeEndringIRammevedtakStatus.UENDRET
-        }
+    ): Boolean {
+        if (gjeldendeUker.isEmpty()) return true
+        return !gjeldendeUker.containsKey(uke) && forrigeUker.containsKey(uke)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -9,6 +9,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.tilDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 
 object ReisevurderingPrivatBilMapper {
     fun tilReisevurderingDto(
@@ -17,8 +18,8 @@ object ReisevurderingPrivatBilMapper {
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
     ): ReisevurderingPrivatBilDto {
-        val rammevedtak =
-            finnRammevedtakForReiseVurdering(
+        val reiseId =
+            finnReiseId(
                 gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
                 forrigeRammevedtakForReise = forrigeRammevedtakForReise,
             )
@@ -30,22 +31,22 @@ object ReisevurderingPrivatBilMapper {
                 kjørelister = kjørelister,
             )
         return ReisevurderingPrivatBilDto(
-            reiseId = rammevedtak.reiseId,
-            rammevedtak = rammevedtak.tilDto(),
+            reiseId = reiseId,
+            rammevedtak = gjeldendeRammevedtakForReise?.tilDto(),
             forrigeRammevedtak = forrigeRammevedtakForReise?.tilDto(),
             uker = ukeVurderingerDto,
         )
     }
 
     /**
-     * Bruker gammelt rammevedtak som grunnlag for reisevuderingen hvis hele reisen er slettet
+     * Bruker gammelt rammevedtak for å finne ReiseId hvis hele reisen er slettet
      */
-    fun finnRammevedtakForReiseVurdering(
+    private fun finnReiseId(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
         forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
-    ): RammeForReiseMedPrivatBil =
-        gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise
-        ?: feil("Kan ikke lagre reisevudering. Mangler rammevedtak for reise")
+    ): ReiseId =
+        gjeldendeRammevedtakForReise?.reiseId ?: forrigeRammevedtakForReise?.reiseId
+        ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
 
     private fun lagUkeVurderingerDto(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
@@ -53,7 +54,10 @@ object ReisevurderingPrivatBilMapper {
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
     ): List<UkeVurderingDto> {
-        val reise = finnRammevedtakForReiseVurdering(gjeldendeRammevedtakForReise, forrigeRammevedtakForReise)
+        val reiseId = finnReiseId(
+            gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
+            forrigeRammevedtakForReise = forrigeRammevedtakForReise
+        )
         val gjeldendeUker = gjeldendeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val forrigeUker = forrigeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val sammenslåtteUker =
@@ -63,7 +67,7 @@ object ReisevurderingPrivatBilMapper {
 
         return sammenslåtteUker.map { uke ->
             val datoerForUke = (gjeldendeUker[uke].orEmpty() + forrigeUker[uke].orEmpty()).distinct().sorted()
-            val avklartUke = avklarteUker.singleOrNull { it.reiseId == reise.reiseId && it.uke == uke }
+            val avklartUke = avklarteUker.singleOrNull { it.reiseId == reiseId && it.uke == uke }
             val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
 
             lagUkeVurderingDto(
@@ -74,7 +78,6 @@ object ReisevurderingPrivatBilMapper {
                 endringIRammevedtakStatus =
                     finnEndringIRammevedtakStatus(
                         uke,
-                        gjeldendeRammevedtakForReise != null,
                         gjeldendeUker,
                         forrigeUker,
                     ),
@@ -147,11 +150,10 @@ object ReisevurderingPrivatBilMapper {
 
     private fun finnEndringIRammevedtakStatus(
         uke: UkeIÅr,
-        harGjeldendeRammevedtak: Boolean,
         gjeldendeUker: Map<UkeIÅr, List<LocalDate>>,
         forrigeUker: Map<UkeIÅr, List<LocalDate>>,
     ): UkeEndringIRammevedtakStatus {
-        if (!harGjeldendeRammevedtak) return UkeEndringIRammevedtakStatus.UENDRET
+        if (gjeldendeUker.isEmpty()) return UkeEndringIRammevedtakStatus.SLETTET
 
         val finnesIGjeldende = gjeldendeUker.containsKey(uke)
         val finnesIForrige = forrigeUker.containsKey(uke)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -38,8 +38,8 @@ object ReisevurderingPrivatBilMapper {
     }
 
     /**
-     * For kjørelistebehandling er ikke rammevedtaket beregnet enda, så da må vi bruke forrgie rammevedtak som grunnlag for reisevurderingen
-     * For "vanlig" revudering er rammevedtaket for denne behandlingen beregnet, så da bruker vi det i reisevuderingen
+     * For kjørelistebehandling er ikke rammevedtaket beregnet enda, så da må vi bruke forrige rammevedtak som grunnlag for reisevurderingen.
+     * For "vanlig" revurdering er rammevedtaket for denne behandlingen beregnet, så da bruker vi det i reisevurderingen.
      */
     fun finnRammevedtakForReiseVurdering(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
@@ -54,7 +54,7 @@ object ReisevurderingPrivatBilMapper {
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
     ): List<UkeVurderingDto> {
-        val reise = gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise ?: error("Mangler rammevedtak for reise")
+        val reise = finnRammevedtakForReiseVurdering(gjeldendeRammevedtakForReise, forrigeRammevedtakForReise)
         val gjeldendeUker = gjeldendeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val forrigeUker = forrigeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val sammenslåtteUker =
@@ -63,7 +63,7 @@ object ReisevurderingPrivatBilMapper {
                 .sortedBy { (gjeldendeUker[it] ?: forrigeUker[it]).orEmpty().min() }
 
         return sammenslåtteUker.map { uke ->
-            val datoerForUke = (gjeldendeUker[uke].orEmpty() + forrigeUker[uke].orEmpty()).distinct()
+            val datoerForUke = (gjeldendeUker[uke].orEmpty() + forrigeUker[uke].orEmpty()).distinct().sorted()
             val avklartUke = avklarteUker.singleOrNull { it.reiseId == reise.reiseId && it.uke == uke }
             val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -64,13 +64,15 @@ object ReisevurderingPrivatBilMapper {
         val sammenslåtteUker = (gjeldendeUker.keys + forrigeUker.keys).distinct().sorted()
 
         return sammenslåtteUker.map { uke ->
-            val datoerForUke = (gjeldendeUker[uke].orEmpty() + forrigeUker[uke].orEmpty()).distinct().sorted()
+            val gjeldendeDatoerForUke = gjeldendeUker[uke].orEmpty()
+            val datoerForUke = (gjeldendeDatoerForUke + forrigeUker[uke].orEmpty()).distinct().sorted()
             val avklartUke = avklarteUker.singleOrNull { it.reiseId == reiseId && it.uke == uke }
             val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
 
             lagUkeVurderingDto(
                 uke = uke,
                 datoer = datoerForUke,
+                gjeldendeDatoerForUke = gjeldendeDatoerForUke,
                 avklartUke = avklartUke,
                 kjøreliste = kjørelisteForUke,
                 erUkeSlettet = erUkeSlettet(uke, gjeldendeUker, forrigeUker),
@@ -81,6 +83,7 @@ object ReisevurderingPrivatBilMapper {
     fun lagUkeVurderingDto(
         uke: UkeIÅr,
         datoer: List<LocalDate>,
+        gjeldendeDatoerForUke: List<LocalDate>,
         avklartUke: AvklartKjørtUke?,
         kjøreliste: Kjøreliste?,
         erUkeSlettet: Boolean,
@@ -101,6 +104,7 @@ object ReisevurderingPrivatBilMapper {
                 datoer.map { dato ->
                     lagDagDto(
                         dato = dato,
+                        gjeldendeDatoerForUke = gjeldendeDatoerForUke,
                         kjørelisteForUke = kjøreliste,
                         avklartUke = avklartUke,
                     )
@@ -109,12 +113,14 @@ object ReisevurderingPrivatBilMapper {
 
     private fun lagDagDto(
         dato: LocalDate,
+        gjeldendeDatoerForUke: List<LocalDate>,
         kjørelisteForUke: Kjøreliste?,
         avklartUke: AvklartKjørtUke?,
     ): DagDto =
         DagDto(
             dato = dato,
             ukedag = dato.dayOfWeek.name,
+            erDagSlettet = !gjeldendeDatoerForUke.contains(dato),
             kjørelisteDag =
                 kjørelisteForUke
                     ?.data
@@ -145,8 +151,5 @@ object ReisevurderingPrivatBilMapper {
         uke: UkeIÅr,
         gjeldendeUker: Map<UkeIÅr, List<LocalDate>>,
         forrigeUker: Map<UkeIÅr, List<LocalDate>>,
-    ): Boolean {
-        if (gjeldendeUker.isEmpty()) return true
-        return !gjeldendeUker.containsKey(uke) && forrigeUker.containsKey(uke)
-    }
+    ): Boolean = !gjeldendeUker.containsKey(uke) && forrigeUker.containsKey(uke)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
-import java.time.LocalDate
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
@@ -9,6 +8,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.tilDto
+import java.time.LocalDate
 
 object ReisevurderingPrivatBilMapper {
     fun tilReisevurderingDto(
@@ -17,21 +17,23 @@ object ReisevurderingPrivatBilMapper {
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
     ): ReisevurderingPrivatBilDto {
-        val rammevedtak = finnRammevedtakForReiseVurdering(
-            gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
-            forrigeRammevedtakForReise = forrigeRammevedtakForReise
-        )
-        val ukeVurderingerDto = lagUkeVurderingerDto(
-            gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
-            forrigeRammevedtakForReise = forrigeRammevedtakForReise,
-            avklarteUker = avklarteUker,
-            kjørelister = kjørelister
-        )
+        val rammevedtak =
+            finnRammevedtakForReiseVurdering(
+                gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
+                forrigeRammevedtakForReise = forrigeRammevedtakForReise,
+            )
+        val ukeVurderingerDto =
+            lagUkeVurderingerDto(
+                gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
+                forrigeRammevedtakForReise = forrigeRammevedtakForReise,
+                avklarteUker = avklarteUker,
+                kjørelister = kjørelister,
+            )
         return ReisevurderingPrivatBilDto(
             reiseId = rammevedtak.reiseId,
             rammevedtak = rammevedtak.tilDto(),
             forrigeRammevedtak = forrigeRammevedtakForReise?.tilDto(),
-            uker = ukeVurderingerDto
+            uker = ukeVurderingerDto,
         )
     }
 
@@ -42,8 +44,9 @@ object ReisevurderingPrivatBilMapper {
     fun finnRammevedtakForReiseVurdering(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
         forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
-    ): RammeForReiseMedPrivatBil = gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise
-    ?: feil("Kan ikke lagre reisevudering. Mangler rammevedtak for reise")
+    ): RammeForReiseMedPrivatBil =
+        gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise
+            ?: feil("Kan ikke lagre reisevudering. Mangler rammevedtak for reise")
 
     private fun lagUkeVurderingerDto(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
@@ -99,13 +102,14 @@ object ReisevurderingPrivatBilMapper {
             kjørelisteId = kjøreliste?.id,
             avklartUkeId = avklartUke?.id,
             avklartKjørtUkeStatus = avklartUke?.avklartKjørtUkeStatus,
-            dager = datoer.map { dato ->
-                lagDagDto(
-                    dato = dato,
-                    kjørelisteForUke = kjøreliste,
-                    avklartUke = avklartUke
-                )
-            },
+            dager =
+                datoer.map { dato ->
+                    lagDagDto(
+                        dato = dato,
+                        kjørelisteForUke = kjøreliste,
+                        avklartUke = avklartUke,
+                    )
+                },
         )
 
     private fun lagDagDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
-import java.time.LocalDate
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
@@ -10,6 +9,7 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import java.time.LocalDate
 
 object ReisevurderingPrivatBilMapper {
     fun tilReisevurderingDto(
@@ -46,7 +46,7 @@ object ReisevurderingPrivatBilMapper {
         forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
     ): ReiseId =
         gjeldendeRammevedtakForReise?.reiseId ?: forrigeRammevedtakForReise?.reiseId
-        ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
+            ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
 
     private fun lagUkeVurderingerDto(
         gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
@@ -54,10 +54,11 @@ object ReisevurderingPrivatBilMapper {
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
     ): List<UkeVurderingDto> {
-        val reiseId = finnReiseId(
-            gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
-            forrigeRammevedtakForReise = forrigeRammevedtakForReise
-        )
+        val reiseId =
+            finnReiseId(
+                gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
+                forrigeRammevedtakForReise = forrigeRammevedtakForReise,
+            )
         val gjeldendeUker = gjeldendeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val forrigeUker = forrigeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val sammenslåtteUker =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -1,46 +1,97 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
-import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
+import java.time.LocalDate
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.alleDatoerGruppertPåUke
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.tilDto
-import java.time.LocalDate
 
 object ReisevurderingPrivatBilMapper {
-    fun RammeForReiseMedPrivatBil.tilReisevurderingDto(
+    fun tilReisevurderingDto(
+        gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
+        forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
-    ): ReisevurderingPrivatBilDto =
-        ReisevurderingPrivatBilDto(
-            reiseId = reiseId,
-            rammevedtak = tilDto(),
-            uker =
-                grunnlag
-                    .alleDatoerGruppertPåUke()
-                    .map { (uke, datoer) ->
-                        val avklartUke = avklarteUker.singleOrNull { it.reiseId == reiseId && it.uke == uke }
-                        val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
-                        lagUkeVurderingDto(uke = uke, datoer = datoer, avklartUke = avklartUke, kjøreliste = kjørelisteForUke)
-                    },
+    ): ReisevurderingPrivatBilDto {
+        val rammevedtak = finnRammevedtakForReiseVurdering(
+            gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
+            forrigeRammevedtakForReise = forrigeRammevedtakForReise
         )
+        val ukeVurderingerDto = lagUkeVurderingerDto(
+            gjeldendeRammevedtakForReise = gjeldendeRammevedtakForReise,
+            forrigeRammevedtakForReise = forrigeRammevedtakForReise,
+            avklarteUker = avklarteUker,
+            kjørelister = kjørelister
+        )
+        return ReisevurderingPrivatBilDto(
+            reiseId = rammevedtak.reiseId,
+            rammevedtak = rammevedtak.tilDto(),
+            forrigeRammevedtak = forrigeRammevedtakForReise?.tilDto(),
+            uker = ukeVurderingerDto
+        )
+    }
 
-    fun AvklartKjørtUke.tilUkeVurderingDto(kjøreliste: Kjøreliste?): UkeVurderingDto =
-        lagUkeVurderingDto(uke = uke, datoer = alleDatoer(), avklartUke = this, kjøreliste = kjøreliste)
+    /**
+     * For kjørelistebehandling er ikke rammevedtaket beregnet enda, så da må vi bruke forrgie rammevedtak som grunnlag for reisevurderingen
+     * For "vanlig" revudering er rammevedtaket for denne behandlingen beregnet, så da bruker vi det i reisevuderingen
+     */
+    fun finnRammevedtakForReiseVurdering(
+        gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
+        forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
+    ): RammeForReiseMedPrivatBil = gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise
+    ?: feil("Kan ikke lagre reisevudering. Mangler rammevedtak for reise")
 
-    private fun lagUkeVurderingDto(
+    private fun lagUkeVurderingerDto(
+        gjeldendeRammevedtakForReise: RammeForReiseMedPrivatBil?,
+        forrigeRammevedtakForReise: RammeForReiseMedPrivatBil?,
+        avklarteUker: List<AvklartKjørtUke>,
+        kjørelister: List<Kjøreliste>,
+    ): List<UkeVurderingDto> {
+        val reise = gjeldendeRammevedtakForReise ?: forrigeRammevedtakForReise ?: error("Mangler rammevedtak for reise")
+        val gjeldendeUker = gjeldendeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
+        val forrigeUker = forrigeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
+        val sammenslåtteUker =
+            (gjeldendeUker.keys + forrigeUker.keys)
+                .distinct()
+                .sortedBy { (gjeldendeUker[it] ?: forrigeUker[it]).orEmpty().min() }
+
+        return sammenslåtteUker.map { uke ->
+            val datoerForUke = (gjeldendeUker[uke].orEmpty() + forrigeUker[uke].orEmpty()).distinct()
+            val avklartUke = avklarteUker.singleOrNull { it.reiseId == reise.reiseId && it.uke == uke }
+            val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
+
+            lagUkeVurderingDto(
+                uke = uke,
+                datoer = datoerForUke,
+                avklartUke = avklartUke,
+                kjøreliste = kjørelisteForUke,
+                endringIRammevedtakStatus =
+                    finnEndringIRammevedtakStatus(
+                        uke,
+                        gjeldendeRammevedtakForReise != null,
+                        gjeldendeUker,
+                        forrigeUker,
+                    ),
+            )
+        }
+    }
+
+    fun lagUkeVurderingDto(
         uke: UkeIÅr,
         datoer: List<LocalDate>,
         avklartUke: AvklartKjørtUke?,
         kjøreliste: Kjøreliste?,
+        endringIRammevedtakStatus: UkeEndringIRammevedtakStatus,
     ): UkeVurderingDto =
         UkeVurderingDto(
             ukenummer = uke.ukenummer,
             fraDato = datoer.min(),
             tilDato = datoer.max(),
+            endringIRammevedtakStatus = endringIRammevedtakStatus,
             status = avklartUke?.status ?: UkeStatus.IKKE_MOTTATT_KJØRELISTE,
             avvik = avklartUke?.typeAvvik?.let { AvvikUke(typeAvvik = it) },
             behandletDato = avklartUke?.behandletDato,
@@ -48,7 +99,13 @@ object ReisevurderingPrivatBilMapper {
             kjørelisteId = kjøreliste?.id,
             avklartUkeId = avklartUke?.id,
             avklartKjørtUkeStatus = avklartUke?.avklartKjørtUkeStatus,
-            dager = datoer.map { dato -> lagDagDto(dato = dato, kjørelisteForUke = kjøreliste, avklartUke = avklartUke) },
+            dager = datoer.map { dato ->
+                lagDagDto(
+                    dato = dato,
+                    kjørelisteForUke = kjøreliste,
+                    avklartUke = avklartUke
+                )
+            },
         )
 
     private fun lagDagDto(
@@ -84,4 +141,22 @@ object ReisevurderingPrivatBilMapper {
             parkeringsutgift = parkeringsutgift,
             avklartKjørtDagStatus = avklartKjørtDagStatus,
         )
+
+    private fun finnEndringIRammevedtakStatus(
+        uke: UkeIÅr,
+        harGjeldendeRammevedtak: Boolean,
+        gjeldendeUker: Map<UkeIÅr, List<LocalDate>>,
+        forrigeUker: Map<UkeIÅr, List<LocalDate>>,
+    ): UkeEndringIRammevedtakStatus {
+        if (!harGjeldendeRammevedtak) return UkeEndringIRammevedtakStatus.UENDRET
+
+        val finnesIGjeldende = gjeldendeUker.containsKey(uke)
+        val finnesIForrige = forrigeUker.containsKey(uke)
+
+        return when {
+            finnesIGjeldende && !finnesIForrige -> UkeEndringIRammevedtakStatus.NY
+            !finnesIGjeldende && finnesIForrige -> UkeEndringIRammevedtakStatus.SLETTET
+            else -> UkeEndringIRammevedtakStatus.UENDRET
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -61,10 +61,7 @@ object ReisevurderingPrivatBilMapper {
             )
         val gjeldendeUker = gjeldendeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
         val forrigeUker = forrigeRammevedtakForReise?.grunnlag?.alleDatoerGruppertPåUke().orEmpty()
-        val sammenslåtteUker =
-            (gjeldendeUker.keys + forrigeUker.keys)
-                .distinct()
-                .sortedBy { (gjeldendeUker[it] ?: forrigeUker[it]).orEmpty().min() }
+        val sammenslåtteUker = (gjeldendeUker.keys + forrigeUker.keys).distinct().sorted()
 
         return sammenslåtteUker.map { uke ->
             val datoerForUke = (gjeldendeUker[uke].orEmpty() + forrigeUker[uke].orEmpty()).distinct().sorted()

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -27,7 +27,7 @@ class ReisevurderingPrivatBilMapperTest {
 
         assertThat(dto.rammevedtak?.reiseId).isEqualTo(gjeldendeReise.reiseId)
         assertThat(dto.forrigeRammevedtak).isNull()
-        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.NY }
+        assertThat(dto.uker).allMatch { !it.erUkeSlettet }
     }
 
     @Test
@@ -49,7 +49,7 @@ class ReisevurderingPrivatBilMapperTest {
             )
 
         assertThat(dto.reiseId).isEqualTo(forrigeReise.reiseId)
-        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.SLETTET }
+        assertThat(dto.uker).allMatch { it.erUkeSlettet }
     }
 
     @Test
@@ -71,11 +71,11 @@ class ReisevurderingPrivatBilMapperTest {
             )
 
         assertThat(dto.reiseId).isEqualTo(forrigeReise.reiseId)
-        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.SLETTET }
+        assertThat(dto.uker).allMatch { it.erUkeSlettet }
     }
 
     @Test
-    fun `sammenslåtte uker markeres med ny, slettet og uendret`() {
+    fun `sammenslåtte uker - kun slettet hvis ikke i gjeldende rammevedtak`() {
         val reiseId = ReiseId.random()
         val gjeldendeReise =
             rammeForReiseMedPrivatBil(
@@ -98,10 +98,10 @@ class ReisevurderingPrivatBilMapperTest {
                 kjørelister = emptyList(),
             )
 
-        val statusPerUke = dto.uker.associate { it.ukenummer to it.endringIRammevedtakStatus }
-        assertThat(statusPerUke).containsEntry(2, UkeEndringIRammevedtakStatus.NY)
-        assertThat(statusPerUke).containsEntry(3, UkeEndringIRammevedtakStatus.UENDRET)
-        assertThat(statusPerUke).containsEntry(4, UkeEndringIRammevedtakStatus.SLETTET)
+        val slettetPerUke = dto.uker.associate { it.ukenummer to it.erUkeSlettet }
+        assertThat(slettetPerUke).containsEntry(2, false) // kun i gjeldende
+        assertThat(slettetPerUke).containsEntry(3, false) // i begge
+        assertThat(slettetPerUke).containsEntry(4, true) // kun i forrige
         assertThat(dto.forrigeRammevedtak).isNotNull
         assertThat(dto.forrigeRammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -25,13 +25,13 @@ class ReisevurderingPrivatBilMapperTest {
                 kjørelister = emptyList(),
             )
 
-        assertThat(dto.rammevedtak.reiseId).isEqualTo(gjeldendeReise.reiseId)
+        assertThat(dto.rammevedtak?.reiseId).isEqualTo(gjeldendeReise.reiseId)
         assertThat(dto.forrigeRammevedtak).isNull()
         assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.NY }
     }
 
     @Test
-    fun `kun forrige rammevedtak gir kun uendrede uker`() {
+    fun `kun forrige rammevedtak uten gjeldende vedtak gir kun uendrede uker`() {
         val reiseId = ReiseId.random()
         val forrigeReise =
             rammeForReiseMedPrivatBil(
@@ -48,8 +48,30 @@ class ReisevurderingPrivatBilMapperTest {
                 kjørelister = emptyList(),
             )
 
-        assertThat(dto.rammevedtak.reiseId).isEqualTo(forrigeReise.reiseId)
+        assertThat(dto.rammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
         assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.UENDRET }
+    }
+
+    @Test
+    fun `hel reise slettet fra gjeldende vedtak gir kun slettede uker`() {
+        val reiseId = ReiseId.random()
+        val forrigeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 19 januar 2025,
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = null,
+                forrigeRammevedtakForReise = forrigeReise,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+            )
+
+        assertThat(dto.rammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
+        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.SLETTET }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -1,0 +1,86 @@
+package no.nav.tilleggsstonader.sak.privatbil
+
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ReisevurderingPrivatBilMapperTest {
+    @Test
+    fun `kun gjeldende rammevedtak gir kun nye uker`() {
+        val reiseId = ReiseId.random()
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 19 januar 2025,
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = null,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+            )
+
+        assertThat(dto.rammevedtak.reiseId).isEqualTo(gjeldendeReise.reiseId)
+        assertThat(dto.forrigeRammevedtak).isNull()
+        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.NY }
+    }
+
+    @Test
+    fun `kun forrige rammevedtak gir kun uendrede uker`() {
+        val reiseId = ReiseId.random()
+        val forrigeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 19 januar 2025,
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = null,
+                forrigeRammevedtakForReise = forrigeReise,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+            )
+
+        assertThat(dto.rammevedtak.reiseId).isEqualTo(forrigeReise.reiseId)
+        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.UENDRET }
+    }
+
+    @Test
+    fun `sammenslåtte uker markeres med ny, slettet og uendret`() {
+        val reiseId = ReiseId.random()
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025, // uke 2
+                tom = 19 januar 2025, // uke 3
+            )
+        val forrigeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 13 januar 2025, // uke 3
+                tom = 26 januar 2025, // uke 4
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = forrigeReise,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+            )
+
+        val statusPerUke = dto.uker.associate { it.ukenummer to it.endringIRammevedtakStatus }
+        assertThat(statusPerUke).containsEntry(2, UkeEndringIRammevedtakStatus.NY)
+        assertThat(statusPerUke).containsEntry(3, UkeEndringIRammevedtakStatus.UENDRET)
+        assertThat(statusPerUke).containsEntry(4, UkeEndringIRammevedtakStatus.SLETTET)
+        assertThat(dto.forrigeRammevedtak).isNotNull
+        assertThat(dto.forrigeRammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -31,7 +31,7 @@ class ReisevurderingPrivatBilMapperTest {
     }
 
     @Test
-    fun `kun forrige rammevedtak uten gjeldende vedtak gir kun uendrede uker`() {
+    fun `kun forrige rammevedtak uten gjeldende vedtak gir kun slettede uker`() {
         val reiseId = ReiseId.random()
         val forrigeReise =
             rammeForReiseMedPrivatBil(
@@ -48,8 +48,8 @@ class ReisevurderingPrivatBilMapperTest {
                 kjørelister = emptyList(),
             )
 
-        assertThat(dto.rammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
-        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.UENDRET }
+        assertThat(dto.reiseId).isEqualTo(forrigeReise.reiseId)
+        assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.SLETTET }
     }
 
     @Test
@@ -70,7 +70,7 @@ class ReisevurderingPrivatBilMapperTest {
                 kjørelister = emptyList(),
             )
 
-        assertThat(dto.rammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
+        assertThat(dto.reiseId).isEqualTo(forrigeReise.reiseId)
         assertThat(dto.uker).allMatch { it.endringIRammevedtakStatus == UkeEndringIRammevedtakStatus.SLETTET }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -28,6 +28,7 @@ class ReisevurderingPrivatBilMapperTest {
         assertThat(dto.rammevedtak?.reiseId).isEqualTo(gjeldendeReise.reiseId)
         assertThat(dto.forrigeRammevedtak).isNull()
         assertThat(dto.uker).allMatch { !it.erUkeSlettet }
+        assertThat(dto.uker.flatMap { it.dager }).allMatch { !it.erDagSlettet }
     }
 
     @Test
@@ -50,6 +51,7 @@ class ReisevurderingPrivatBilMapperTest {
 
         assertThat(dto.reiseId).isEqualTo(forrigeReise.reiseId)
         assertThat(dto.uker).allMatch { it.erUkeSlettet }
+        assertThat(dto.uker.flatMap { it.dager }).allMatch { it.erDagSlettet }
     }
 
     @Test
@@ -72,6 +74,7 @@ class ReisevurderingPrivatBilMapperTest {
 
         assertThat(dto.reiseId).isEqualTo(forrigeReise.reiseId)
         assertThat(dto.uker).allMatch { it.erUkeSlettet }
+        assertThat(dto.uker.flatMap { it.dager }).allMatch { it.erDagSlettet }
     }
 
     @Test
@@ -104,5 +107,48 @@ class ReisevurderingPrivatBilMapperTest {
         assertThat(slettetPerUke).containsEntry(4, true) // kun i forrige
         assertThat(dto.forrigeRammevedtak).isNotNull
         assertThat(dto.forrigeRammevedtak?.reiseId).isEqualTo(forrigeReise.reiseId)
+
+        // Dager i uke 2 og 3 er ikke slettet, dager i uke 4 er slettet (uke kun i forrige)
+        val dagerPerUke = dto.uker.associate { it.ukenummer to it.dager }
+        assertThat(dagerPerUke[2]?.map { it.erDagSlettet }).allMatch { !it }
+        assertThat(dagerPerUke[3]?.map { it.erDagSlettet }).allMatch { !it }
+        assertThat(dagerPerUke[4]?.map { it.erDagSlettet }).allMatch { it }
+    }
+
+    @Test
+    fun `dager slettet innen uke - kun dager fjernet fra gjeldende rammevedtak er slettet`() {
+        val reiseId = ReiseId.random()
+        // gjeldende starter onsdag (8 jan) — mandag og tirsdag i uke 2 er fjernet
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 8 januar 2025, // onsdag uke 2
+                tom = 10 januar 2025, // fredag uke 2
+            )
+        val forrigeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025, // mandag uke 2
+                tom = 10 januar 2025, // fredag uke 2
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = forrigeReise,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+            )
+
+        assertThat(dto.uker).hasSize(1)
+        val uke2 = dto.uker.single()
+        assertThat(uke2.erUkeSlettet).isFalse()
+
+        val dagSlettetPerDato = uke2.dager.associate { it.dato to it.erDagSlettet }
+        assertThat(dagSlettetPerDato[6 januar 2025]).isTrue() // mandag — slettet
+        assertThat(dagSlettetPerDato[7 januar 2025]).isTrue() // tirsdag — slettet
+        assertThat(dagSlettetPerDato[8 januar 2025]).isFalse() // onsdag — i gjeldende
+        assertThat(dagSlettetPerDato[9 januar 2025]).isFalse() // torsdag — i gjeldende
+        assertThat(dagSlettetPerDato[10 januar 2025]).isFalse() // fredag — i gjeldende
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Tidligere har vi alltid brukt rammevetaket fra forrgie behandlig for å lage reisevuderingen. Dette henger igjeg fra før vi hadde kopiering av dataog vi ikke hadde noe rammevedtak i en kjørelistebehandling og man må derfor hente ut rammevedtaket fra forrige behandling og beregning. Når vi skal revurdere rammevedtaket gjør dette at forandringen i rammevedtaket ikke kommer tydlig frem. 

Endringen finner derfor diffen mellom gammelt og nytt rammevedtak og legger dette til som en status.

Frontend: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/1198

