### PR TITLE
Støtt overskridelse av reisedager i rammevedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -23,6 +23,8 @@ enum class Toggle(
 
     KAN_AUTOMATISK_BEHANDLE_KJØRELISTE("sak.automatisk-behandling-kjoreliste"),
 
+    KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK("sak.kan-overskride-antall-dager-i-rammevedtak"),
+
     BRUK_NYTT_FAGOMRADE_FOR_UTBETALING("sak.bruk-nytt-fagomrade-for-utbetaling"),
 
     SØKNAD_ROUTING_REISE_TIL_SAMLING("sak.soknad-routing.reise-til-samling"),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -2,12 +2,14 @@ package no.nav.tilleggsstonader.sak.privatbil.avklartedager
 
 import io.github.mikaojk.holiday.getNorwegianHolidays
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.libs.utils.dato.UkeIÅr
 import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.feilHvis
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteDag
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteId
@@ -29,6 +31,7 @@ class AvklartKjørelisteService(
     private val avklartKjørtUkeRepository: AvklartKjørtUkeRepository,
     private val kjørelisteService: KjørelisteService,
     private val behandlingService: BehandlingService,
+    private val unleashService: UnleashService,
 ) {
     fun hentAvklarteUkerForBehandling(behandlingId: BehandlingId): List<AvklartKjørtUke> =
         avklartKjørtUkeRepository.findByBehandlingId(behandlingId)
@@ -75,6 +78,7 @@ class AvklartKjørelisteService(
             ukeSomSkalOppdateres = eksisterendeUke.uke,
             rammevedtak = rammevedtak,
             innsendteKjørelisteDager = innsendteKjørelisteDager,
+            tillatOverskridelseRammevedtak = unleashService.isEnabled(Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK),
         )
 
         val nyAvklartKjørtUkeStatus = beregnNyStatus(behandlingId, eksisterendeUke, oppdaterteDager)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValidering.kt
@@ -24,9 +24,14 @@ fun validerOppdatertAvklartKjørtUke(
     ukeSomSkalOppdateres: UkeIÅr,
     rammevedtak: RammeForReiseMedPrivatBil,
     innsendteKjørelisteDager: List<KjørelisteDag>,
+    tillatOverskridelseRammevedtak: Boolean = false,
 ) {
     validerInnsendteDagerErInnenforUken(ukeSomSkalOppdateres, oppdaterteDager)
-    validerAntallDagerGodkjentInnenforRammevedtak(oppdaterteDager, rammevedtak)
+    validerAntallDagerGodkjentInnenforRammevedtak(
+        oppdaterteDager = oppdaterteDager,
+        rammevedtak = rammevedtak,
+        tillatOverskridelseRammevedtak = tillatOverskridelseRammevedtak,
+    )
 
     oppdaterteDager.forEach { oppdatertDag ->
         oppdatertDag.validerGyldigeVerdier()
@@ -39,7 +44,10 @@ fun validerOppdatertAvklartKjørtUke(
 private fun validerAntallDagerGodkjentInnenforRammevedtak(
     oppdaterteDager: List<AvklartKjørtDag>,
     rammevedtak: RammeForReiseMedPrivatBil,
+    tillatOverskridelseRammevedtak: Boolean,
 ) {
+    if (tillatOverskridelseRammevedtak) return
+
     val antallDagerSomDekkes = oppdaterteDager.count { it.godkjentGjennomførtKjøring == GodkjentGjennomførtKjøring.JA }
     val tilhørendeDelperiode =
         rammevedtak.finnDelperiodeForPeriode(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/OverskridAntallDagerIRammevedtakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/OverskridAntallDagerIRammevedtakIntegrationTest.kt
@@ -1,0 +1,119 @@
+package no.nav.tilleggsstonader.sak.privatbil
+
+import io.mockk.every
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingResultat
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
+import no.nav.tilleggsstonader.sak.infrastruktur.mocks.KafkaFake
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.forventAntallMeldingerPåTopic
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.TypeAvvikUke
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OverskridAntallDagerIRammevedtakIntegrationTest : IntegrationTest() {
+    @Test
+    fun `skal kunne overskride antall dager i rammevedtak når toggle er aktiv og utbetale behandling`() {
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+        every { unleashService.isEnabled(Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK) } returns false
+
+        val fom = 5 januar 2026
+        val tom = 11 januar 2026
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata(
+                    fom = fom,
+                    tom = tom,
+                    delperioder =
+                        listOf(
+                            FaktaDelperiodePrivatBilDto(
+                                fom = fom,
+                                tom = tom,
+                                reisedagerPerUke = 2,
+                                bompengerPerDag = null,
+                                fergekostnadPerDag = null,
+                            ),
+                        ),
+                )
+                sendInnKjøreliste {
+                    periode = Datoperiode(fom, tom)
+                    kjørteDager =
+                        listOf(
+                            KjørtDag(dato = 5 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 7 januar 2026, parkeringsutgift = 50),
+                            KjørtDag(dato = 9 januar 2026, parkeringsutgift = 50),
+                        )
+                }
+            }
+
+        val kjørelistebehandling =
+            testoppsettService
+                .hentBehandlinger(behandlingContext.fagsakId)
+                .single { it.type == BehandlingType.KJØRELISTE }
+
+        assertThat(kjørelistebehandling.erAktiv()).isTrue()
+        tilordneÅpenBehandlingOppgaveForBehandling(kjørelistebehandling.id)
+
+        val reisevurdering = kall.privatBil.hentReisevurderingForBehandling(kjørelistebehandling.id).single()
+        val ukeMedAvvik =
+            reisevurdering.uker.single {
+                it.avvik?.typeAvvik == TypeAvvikUke.FLERE_REISEDAGER_ENN_I_RAMMEVEDTAK
+            }
+        assertThat(ukeMedAvvik.status).isEqualTo(UkeStatus.AVVIK)
+
+        every { unleashService.isEnabled(Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK) } returns true
+
+        val oppdatertUke =
+            kall.privatBil.oppdaterUke(
+                behandlingId = kjørelistebehandling.id,
+                avklartUkeId = ukeMedAvvik.avklartUkeId!!,
+                avklarteDager =
+                    ukeMedAvvik.dager.map { dag ->
+                        val kjørelisteDag = dag.kjørelisteDag
+                        val harKjørt = kjørelisteDag?.harKjørt == true
+                        EndreAvklartDagRequest(
+                            dato = dag.dato,
+                            godkjentGjennomførtKjøring =
+                                if (harKjørt) {
+                                    GodkjentGjennomførtKjøring.JA
+                                } else {
+                                    GodkjentGjennomførtKjøring.NEI
+                                },
+                            parkeringsutgift = if (harKjørt) checkNotNull(kjørelisteDag).parkeringsutgift else null,
+                            begrunnelse = "Manuell vurdering av uke med avvik",
+                        )
+                    },
+            )
+
+        assertThat(oppdatertUke.status).isEqualTo(UkeStatus.OK_MANUELT)
+        assertThat(oppdatertUke.avvik?.typeAvvik).isEqualTo(TypeAvvikUke.FLERE_REISEDAGER_ENN_I_RAMMEVEDTAK)
+        assertThat(
+            oppdatertUke.dager.count {
+                it.avklartDag?.godkjentGjennomførtKjøring == GodkjentGjennomførtKjøring.JA
+            },
+        ).isEqualTo(3)
+
+        gjennomførKjørelisteBehandling(kjørelistebehandling)
+
+        val ferdigstiltBehandling = testoppsettService.hentBehandling(kjørelistebehandling.id)
+        assertThat(ferdigstiltBehandling.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
+        assertThat(ferdigstiltBehandling.resultat).isEqualTo(BehandlingResultat.INNVILGET)
+        KafkaFake
+            .sendteMeldinger()
+            .forventAntallMeldingerPåTopic(kafkaTopics.utbetaling, 1)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/OverskridAntallDagerIRammevedtakIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/OverskridAntallDagerIRammevedtakIntegrationTest.kt
@@ -25,10 +25,9 @@ import org.junit.jupiter.api.Test
 
 class OverskridAntallDagerIRammevedtakIntegrationTest : IntegrationTest() {
     @Test
-    fun `skal kunne overskride antall dager i rammevedtak når toggle er aktiv og utbetale behandling`() {
+    fun `skal kunne overskride antall dager i rammevedtak når toggle aktiveres ved manuell godkjenning og utbetale behandling`() {
         every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
         every { unleashService.isEnabled(Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK) } returns false
-
         val fom = 5 januar 2026
         val tom = 11 januar 2026
         val behandlingContext =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
@@ -5,11 +5,13 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteId
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteService
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
@@ -37,6 +39,7 @@ class AvklartKjørelisteServiceTest {
     private val kjørelisteService = mockk<KjørelisteService>()
     private val vedtakService = mockk<VedtakService>()
     private val behandlingService = mockk<BehandlingService>()
+    private val unleashService = mockk<UnleashService>()
 
     private val service =
         AvklartKjørelisteService(
@@ -44,6 +47,7 @@ class AvklartKjørelisteServiceTest {
             avklartKjørtUkeRepository = avklartKjørtUkeRepository,
             kjørelisteService = kjørelisteService,
             behandlingService = behandlingService,
+            unleashService = unleashService,
         )
 
     private val reiseId = ReiseId.random()
@@ -239,6 +243,7 @@ class AvklartKjørelisteServiceTest {
             )
         every { kjørelisteService.hentKjøreliste(eksisterendeUke.kjørelisteId) } returns innsendtKjøreliste
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
+        every { unleashService.isEnabled(Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK) } returns false
 
         val vedtakData =
             InnvilgelseDagligReise(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValideringTest.kt
@@ -128,6 +128,31 @@ class AvklartKjørelisteValideringTest {
         }
 
         @Test
+        fun `skal tillate overskridelse av antall godkjente dager når toggle er aktiv`() {
+            val oppdaterteDager =
+                listOf(
+                    avklartKjørtDag(mandag, GodkjentGjennomførtKjøring.JA),
+                    avklartKjørtDag(tirsdag, GodkjentGjennomførtKjøring.JA),
+                )
+            val kjørelisteDager =
+                listOf(
+                    kjørelisteDag(mandag, harKjørt = true),
+                    kjørelisteDag(tirsdag, harKjørt = true),
+                )
+            val ramme = rammeForReise(fom = mandag, tom = tirsdag, reisedagerPerUke = 1)
+
+            assertDoesNotThrow {
+                validerOppdatertAvklartKjørtUke(
+                    oppdaterteDager = oppdaterteDager,
+                    ukeSomSkalOppdateres = mandag.tilUkeIÅr(),
+                    rammevedtak = ramme,
+                    innsendteKjørelisteDager = kjørelisteDager,
+                    tillatOverskridelseRammevedtak = true,
+                )
+            }
+        }
+
+        @Test
         fun `skal kaste feil dersom antall godkjente dager overskrider rammevedtaket ved flere delperioder`() {
             val mandagUke1 = 5 januar 2026
             val søndagUke1 = 11 januar 2026


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legger til feature-toggle og valideringsstøtte for manuell godkjenning av flere kjøredager enn rammevedtaket. Inkluderer integrasjonstest og oppdaterte tester for validering/service.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29665