### PR TITLE
Saksbehandlerrolle skrivetilgang

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
@@ -116,7 +116,6 @@ class BehandlingController(
     ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         henleggService.henleggBehandling(behandlingId, henlagt)
     }
 
@@ -136,7 +135,6 @@ class BehandlingController(
     ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         nullstillBehandlingService.nullstillBehandling(behandlingService.hentBehandling(behandlingId))
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/vent/SettPåVentController.kt
@@ -37,7 +37,6 @@ class SettPåVentController(
     ): StatusPåVentDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return settPåVentService.settPåVent(behandlingId, dto.tilDomene())
     }
 
@@ -48,7 +47,6 @@ class SettPåVentController(
     ): StatusPåVentDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE, validerTilordnetOppgave = false)
-        tilgangService.validerHarSaksbehandlerrolle()
         return settPåVentService.oppdaterSettPåVent(behandlingId, dto)
     }
 
@@ -59,7 +57,6 @@ class SettPåVentController(
     ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE, validerTilordnetOppgave = false)
-        tilgangService.validerHarSaksbehandlerrolle()
         taAvVentService.taAvVent(behandlingId, taAvVentDto)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandlingsflyt/StegController.kt
@@ -25,7 +25,6 @@ class StegController(
     ): StegFerdigstiltResponse {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return stegService.håndterSteg(behandlingId, request.steg).tilStegFerdigstiltResponse()
     }
@@ -37,7 +36,6 @@ class StegController(
     ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         stegService.resetSteg(behandlingId, request.steg)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/brevmottaker/BrevmottakereController.kt
@@ -37,7 +37,6 @@ class BrevmottakereController(
     ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return brevmottakereService.lagreBrevmottakere(behandlingId, brevmottakere)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/KjørelisteBehandlingBrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/kjørelistebrev/KjørelisteBehandlingBrevController.kt
@@ -26,7 +26,6 @@ class KjørelisteBehandlingBrevController(
     ): KjørelistebrevResponseDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val brev =
             kjørelisteBehandlingBrevService.oppdaterBegrunnelseOgGenererBrev(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/mellomlager/BrevMellomlagerController.kt
@@ -26,7 +26,6 @@ class BrevMellomlagerController(
     ): BehandlingId {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return mellomlagringBrevService.mellomlagreBrev(
             behandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/BrevController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/brev/vedtaksbrev/BrevController.kt
@@ -31,7 +31,6 @@ class BrevController(
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
 
         tilgangService.validerSkrivetilgangTilBehandling(saksbehandling.id, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return Base64.getEncoder().encode(brevService.lagSaksbehandlerBrev(saksbehandling, request.html))
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -34,7 +34,6 @@ class ReisevurderingController(
     ): List<ReisevurderingPrivatBilDto> {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerLesetilgangTilBehandling(behandlingId)
-        tilgangService.validerHarSaksbehandlerrolle() // TODO: Trengs denne når vi har den over?
 
         val behandling = behandlingService.hentBehandling(behandlingId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -57,7 +57,6 @@ class ReisevurderingController(
     ): UkeVurderingDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle() // TODO: Trengs denne når vi har den over?
 
         behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangService.kt
@@ -84,6 +84,7 @@ class TilgangService(
         feilHvis(event == AuditLoggerEvent.ACCESS) {
             "AuditLoggerEvent.ACCESS er ikke gyldig for skrivetilgangskontroll"
         }
+        validerHarSaksbehandlerrolle()
 
         val saksbehandling = hentCachedBehandling(behandlingId)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/totrinnskontroll/TotrinnskontrollController.kt
@@ -63,7 +63,6 @@ class TotrinnskontrollController(
     ): StatusTotrinnskontrollDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE, validerTilordnetOppgave = false)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         angreSendTilBeslutterService.angreSendTilBeslutter(behandlingId)
         return totrinnskontrollService.hentTotrinnskontrollStatus(behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/VilkårController.kt
@@ -41,7 +41,6 @@ class VilkårController(
     ): VilkårDto {
         tilgangService.settBehandlingsdetaljerForRequest(svarPåVilkårDto.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(svarPåVilkårDto.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         try {
             return vilkårService.oppdaterVilkår(svarPåVilkårDto).tilDto()
         } catch (e: Exception) {
@@ -61,7 +60,6 @@ class VilkårController(
     ): VilkårDto {
         tilgangService.settBehandlingsdetaljerForRequest(opprettVilkårDto.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(opprettVilkårDto.behandlingId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return vilkårService.opprettNyttVilkår(opprettVilkårDto).tilDto()
     }
@@ -72,7 +70,6 @@ class VilkårController(
     ): SlettVilkårResponse {
         tilgangService.settBehandlingsdetaljerForRequest(request.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(request.behandlingId, AuditLoggerEvent.DELETE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return vilkårService.slettVilkår(request).tilDto()
     }
@@ -83,7 +80,6 @@ class VilkårController(
     ): VilkårDto {
         tilgangService.settBehandlingsdetaljerForRequest(request.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(request.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return vilkårService.settVilkårTilSkalIkkeVurderes(request)
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårController.kt
@@ -56,7 +56,6 @@ class DagligReiseVilkårController(
     ): VilkårDagligReiseDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return dagligReiseVilkårService
             .opprettNyttVilkår(
@@ -73,7 +72,6 @@ class DagligReiseVilkårController(
     ): VilkårDagligReiseDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return dagligReiseVilkårService
             .oppdaterVilkår(
@@ -91,7 +89,6 @@ class DagligReiseVilkårController(
     ): SlettVilkårResultatDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.DELETE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return dagligReiseVilkårService
             .slettVilkår(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårController.kt
@@ -52,7 +52,6 @@ class ReiseTilSamlingVilkårController(
     ): VilkårReiseTilSamlingDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return reiseTilSamlingVilkårService
             .opprettNyttVilkår(
@@ -69,7 +68,6 @@ class ReiseTilSamlingVilkårController(
     ): VilkårReiseTilSamlingDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return reiseTilSamlingVilkårService
             .oppdaterVilkår(
@@ -87,7 +85,6 @@ class ReiseTilSamlingVilkårController(
     ): SlettVilkårResultatDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.DELETE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return reiseTilSamlingVilkårService
             .slettVilkår(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/VilkårperiodeController.kt
@@ -46,7 +46,6 @@ class VilkårperiodeController(
     ) {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         vilkårperiodeGrunnlagService.oppdaterGrunnlag(behandlingId, oppdaterGrunnlag?.hentFom)
     }
@@ -57,7 +56,6 @@ class VilkårperiodeController(
     ): LagreVilkårperiodeResponse {
         tilgangService.settBehandlingsdetaljerForRequest(vilkårperiode.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.opprettVilkårperiode(vilkårperiode)
         return LagreVilkårperiodeResponse(periode = periode.tilDto())
@@ -70,7 +68,6 @@ class VilkårperiodeController(
     ): LagreVilkårperiodeResponse {
         tilgangService.settBehandlingsdetaljerForRequest(vilkårperiode.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(vilkårperiode.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.oppdaterVilkårperiode(id, vilkårperiode)
         return LagreVilkårperiodeResponse(periode = periode.tilDto())
@@ -83,7 +80,6 @@ class VilkårperiodeController(
     ): LagreVilkårperiodeResponse {
         tilgangService.settBehandlingsdetaljerForRequest(slettVikårperiode.behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(slettVikårperiode.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val periode = vilkårperiodeService.slettVilkårperiode(id, slettVikårperiode)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tilgang/TilgangServiceTest.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ManglerTilgang
 import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.RolleConfig
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockUnleashService
+import no.nav.tilleggsstonader.sak.opplysninger.oppgave.OppgaveService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.PdlSøker
@@ -39,10 +40,20 @@ internal class TilgangServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val fagsakService = mockk<FagsakService>()
     private val fagsakPersonService = mockk<FagsakPersonService>()
+    private val oppgaveService = mockk<OppgaveService>()
     private val cacheManager = ConcurrentMapCacheManager()
     private val kode6Gruppe = "kode6"
     private val kode7Gruppe = "kode7"
-    private val rolleConfig = RolleConfig("", "", "", kode6 = kode6Gruppe, kode7 = kode7Gruppe, "", "")
+    private val rolleConfig =
+        RolleConfig(
+            beslutterRolle = "beslutter",
+            saksbehandlerRolle = "saksbehandler",
+            veilederRolle = "veileder",
+            kode6 = kode6Gruppe,
+            kode7 = kode7Gruppe,
+            egenAnsatt = "egenAnsatt",
+            utvikler = "utvikler",
+        )
     private val tilgangService =
         TilgangService(
             tilgangskontrollService = tilgangskontrollService,
@@ -53,7 +64,7 @@ internal class TilgangServiceTest {
             cacheManager = cacheManager,
             auditLogger = mockk(relaxed = true),
             behandlingLogService = mockk(),
-            oppgaveService = mockk(),
+            oppgaveService = oppgaveService,
             unleashService = mockUnleashService(),
         )
     private val mocketPersonIdent = "12345"
@@ -68,6 +79,7 @@ internal class TilgangServiceTest {
         every { fagsakPersonService.hentAktivIdent(fagsak.fagsakPersonId) } returns fagsak.hentAktivIdent()
         every { behandlingService.hentSaksbehandling(behandling.id) } returns saksbehandling(fagsak, behandling)
         every { fagsakService.hentFagsak(fagsak.id) } returns fagsak
+        every { oppgaveService.hentÅpenBehandlingsoppgave(behandling.id) } returns null
     }
 
     @AfterEach
@@ -175,6 +187,28 @@ internal class TilgangServiceTest {
 
             verify(exactly = 1) { behandlingService.hentSaksbehandling(behandling.id) }
             verify(exactly = 2) { tilgangskontrollService.sjekkTilgangTilStønadstype(any(), any(), any()) }
+        }
+    }
+
+    @Nested
+    inner class ValiderSkrivetilgangTilBehandling {
+        @Test
+        fun `skal kaste ManglerTilgang dersom bruker mangler saksbehandlerrolle`() {
+            mockBrukerContext("A", groups = emptyList())
+
+            assertThatThrownBy {
+                tilgangService.validerSkrivetilgangTilBehandling(behandling.id, AuditLoggerEvent.UPDATE)
+            }.isInstanceOf(ManglerTilgang::class.java)
+        }
+
+        @Test
+        fun `skal ikke feile når bruker har saksbehandlerrolle og tilgang til behandling`() {
+            mockBrukerContext("A", groups = listOf(rolleConfig.saksbehandlerRolle))
+            every { tilgangskontrollService.sjekkTilgangTilStønadstype(any(), any(), any()) } returns Tilgang(true)
+
+            assertDoesNotThrow {
+                tilgangService.validerSkrivetilgangTilBehandling(behandling.id, AuditLoggerEvent.UPDATE, validerTilordnetOppgave = false)
+            }
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vi kaller eksplisitt sjekk av saksbehandler-rolle i alle endepunkt som skriver til en behandling, i tillegg til en validering for om saksbehandler har skrivetilgang.

Merger sjekk av saksbehandler-rolle inn i `validerSkrivetilgangTilBehandling`, slik at vi slipper å eksplisitt sjekke saksbehandler-rolle i alle skrive-endepunkt.