### PR TITLE
Avslag daglig reise etter rammevedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseSteg.kt
@@ -19,6 +19,7 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.AvslagDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseRequest
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.OpphørDagligReiseRequest
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.VedtakDagligReiseRequest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -48,7 +49,11 @@ class DagligReiseBeregnYtelseSteg(
         saksbehandling: Saksbehandling,
         kanBehandlePrivatBil: Boolean,
     ): StegType {
-        if (dagligReiseVedtakService.forrigeIverksatteBehandlingHarRammevedtakForPrivatBil(saksbehandling.forrigeIverksatteBehandlingId)) {
+        val gjelderAvslag = vedtakRepository.findByIdOrNull(saksbehandling.id)?.type == TypeVedtak.AVSLAG
+        val forrigeIverksatteBehandlingHarRammevedtakForPrivatBil =
+            dagligReiseVedtakService.forrigeIverksatteBehandlingHarRammevedtakForPrivatBil(saksbehandling.forrigeIverksatteBehandlingId)
+
+        if (forrigeIverksatteBehandlingHarRammevedtakForPrivatBil && !gjelderAvslag) {
             return StegType.KJØRELISTE
         }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførSteg.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/GjennomførSteg.kt
@@ -13,13 +13,18 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.dsl.BehandlingTestdataDsl
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tasks.kjørTasksKlareForProsessering
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.tilordneÅpenBehandlingOppgaveForBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.testdata.tilVedtaksperiodeDagligReiseDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.InnvilgelseTilsynBarnRequest
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnRequest
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.InnvilgelseBoutgifterRequest
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterRequest
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.AvslagDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseTsoRequest
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseTsrRequest
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.OpphørDagligReiseRequest
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerRequest
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerRequest
 import no.nav.tilleggsstonader.sak.vedtak.totrinnskontroll.dto.BeslutteVedtakDto
@@ -227,7 +232,43 @@ fun IntegrationTest.gjennomførBeregningStegKall(
                 )
         }
 
-        is OpprettAvslag -> TODO()
+        is OpprettAvslag ->
+            kall.vedtak.apiRespons
+                .lagreVedtak(
+                    stønadstype = stønadstype,
+                    behandlingId = behandlingId,
+                    typeVedtakPath = "avslag",
+                    vedtakDto =
+                        when (stønadstype) {
+                            Stønadstype.BARNETILSYN ->
+                                AvslagTilsynBarnDto(
+                                    årsakerAvslag = listOf(ÅrsakAvslag.ANNET),
+                                    begrunnelse = "begrunnelse",
+                                )
+
+                            Stønadstype.LÆREMIDLER ->
+                                AvslagLæremidlerDto(
+                                    årsakerAvslag = listOf(ÅrsakAvslag.ANNET),
+                                    begrunnelse = "begrunnelse",
+                                )
+
+                            Stønadstype.BOUTGIFTER ->
+                                AvslagBoutgifterDto(
+                                    årsakerAvslag = listOf(ÅrsakAvslag.ANNET),
+                                    begrunnelse = "begrunnelse",
+                                )
+
+                            Stønadstype.DAGLIG_REISE_TSO,
+                            Stønadstype.DAGLIG_REISE_TSR,
+                            ->
+                                AvslagDagligReiseDto(
+                                    årsakerAvslag = listOf(ÅrsakAvslag.ANNET),
+                                    begrunnelse = "begrunnelse",
+                                )
+
+                            Stønadstype.REISE_TIL_SAMLING_TSO -> TODO("AvslagReiseTilSamlingTsoRequest")
+                        },
+                )
         is OpprettOpphør ->
             kall.vedtak.apiRespons
                 .lagreOpphør(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/AvslagTilsynBarnIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/AvslagTilsynBarnIntegrationTest.kt
@@ -1,0 +1,41 @@
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.AvslagTilsynBarnDto
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AvslagTilsynBarnIntegrationTest : IntegrationTest() {
+    @Test
+    fun `skal gjennomføre avslag for tilsyn barn`() {
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN,
+            ) {
+                defaultTilsynBarnTestdata()
+                vedtak {
+                    avslag()
+                }
+            }
+
+        val behandling = kall.behandling.hent(behandlingContext.behandlingId)
+        assertThat(behandling.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
+        assertThat(behandling.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+
+        val avslag =
+            kall.vedtak
+                .hentVedtak(Stønadstype.BARNETILSYN, behandlingContext.behandlingId)
+                .expectOkWithBody<AvslagTilsynBarnDto>()
+
+        assertThat(avslag.årsakerAvslag).isEqualTo(listOf(ÅrsakAvslag.ANNET))
+        assertThat(avslag.begrunnelse).isEqualTo("begrunnelse")
+        assertThat(avslag.type).isEqualTo(TypeVedtak.AVSLAG)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/AvslagBoutgifterIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/AvslagBoutgifterIntegrationTest.kt
@@ -1,0 +1,41 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AvslagBoutgifterIntegrationTest : IntegrationTest() {
+    @Test
+    fun `skal gjennomføre avslag for boutgifter`() {
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BOUTGIFTER,
+            ) {
+                defaultBoutgifterTestdata()
+                vedtak {
+                    avslag()
+                }
+            }
+
+        val behandling = kall.behandling.hent(behandlingContext.behandlingId)
+        assertThat(behandling.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
+        assertThat(behandling.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+
+        val avslag =
+            kall.vedtak
+                .hentVedtak(Stønadstype.BOUTGIFTER, behandlingContext.behandlingId)
+                .expectOkWithBody<AvslagBoutgifterDto>()
+
+        assertThat(avslag.årsakerAvslag).isEqualTo(listOf(ÅrsakAvslag.ANNET))
+        assertThat(avslag.begrunnelse).isEqualTo("begrunnelse")
+        assertThat(avslag.type).isEqualTo(TypeVedtak.AVSLAG)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/AvslagDagligReiseIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/AvslagDagligReiseIntegrationTest.kt
@@ -1,0 +1,91 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise
+
+import io.mockk.every
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.AvslagDagligReiseDto
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AvslagDagligReiseIntegrationTest : IntegrationTest() {
+    @Test
+    fun `skal gjennomføre avslag for daglig reise tso`() {
+        assertAvslag(Stønadstype.DAGLIG_REISE_TSO) {
+            defaultDagligReiseTsoTestdata()
+        }
+    }
+
+    @Test
+    fun `skal gjennomføre avslag for daglig reise tsr`() {
+        assertAvslag(Stønadstype.DAGLIG_REISE_TSR) {
+            defaultDagligReiseTsrTestdata()
+        }
+    }
+
+    @Test
+    fun `skal innvilge daglig reise med privat bil og deretter avslå i revurdering`() {
+        every { unleashService.isEnabled(Toggle.KAN_BEHANDLE_PRIVAT_BIL) } returns true
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReisePrivatBilTsoTestdata()
+            }
+        assertThat(kall.privatBil.hentRammevedtak(førstegangsbehandlingContext.ident)).isNotEmpty
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            ) {
+                vedtak {
+                    avslag()
+                }
+            }
+
+        val avslag =
+            kall.vedtak
+                .hentVedtak(Stønadstype.DAGLIG_REISE_TSO, revurderingId)
+                .expectOkWithBody<AvslagDagligReiseDto>()
+
+        assertThat(avslag.årsakerAvslag).isEqualTo(listOf(ÅrsakAvslag.ANNET))
+        assertThat(avslag.begrunnelse).isEqualTo("begrunnelse")
+        assertThat(avslag.type).isEqualTo(TypeVedtak.AVSLAG)
+    }
+
+    private fun assertAvslag(
+        stønadstype: Stønadstype,
+        testdata: no.nav.tilleggsstonader.sak.integrasjonstest.dsl.BehandlingTestdataDsl.() -> Unit,
+    ) {
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = stønadstype,
+            ) {
+                testdata()
+                vedtak {
+                    avslag()
+                }
+            }
+
+        val behandling = kall.behandling.hent(behandlingContext.behandlingId)
+        assertThat(behandling.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
+        assertThat(behandling.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+
+        val avslag =
+            kall.vedtak
+                .hentVedtak(stønadstype, behandlingContext.behandlingId)
+                .expectOkWithBody<AvslagDagligReiseDto>()
+
+        assertThat(avslag.årsakerAvslag).isEqualTo(listOf(ÅrsakAvslag.ANNET))
+        assertThat(avslag.begrunnelse).isEqualTo("begrunnelse")
+        assertThat(avslag.type).isEqualTo(TypeVedtak.AVSLAG)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/AvslagLæremidlerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/AvslagLæremidlerIntegrationTest.kt
@@ -1,0 +1,41 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AvslagLæremidlerIntegrationTest : IntegrationTest() {
+    @Test
+    fun `skal gjennomføre avslag for læremidler`() {
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.LÆREMIDLER,
+            ) {
+                defaultLæremidlerTestdata()
+                vedtak {
+                    avslag()
+                }
+            }
+
+        val behandling = kall.behandling.hent(behandlingContext.behandlingId)
+        assertThat(behandling.status).isEqualTo(BehandlingStatus.FERDIGSTILT)
+        assertThat(behandling.steg).isEqualTo(StegType.BEHANDLING_FERDIGSTILT)
+
+        val avslag =
+            kall.vedtak
+                .hentVedtak(Stønadstype.LÆREMIDLER, behandlingContext.behandlingId)
+                .expectOkWithBody<AvslagLæremidlerDto>()
+
+        assertThat(avslag.årsakerAvslag).isEqualTo(listOf(ÅrsakAvslag.ANNET))
+        assertThat(avslag.begrunnelse).isEqualTo("begrunnelse")
+        assertThat(avslag.type).isEqualTo(TypeVedtak.AVSLAG)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Er i dag ikke mulig å avslå om forrige iverksatte behandling har et rammevedtak for privat bil, da neste steg blir satt til KJØRELISTE.