### PR TITLE
legg til opphørsvalidering av vedtak som er endret før opphørsdato

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -160,12 +160,17 @@ data class TidligsteEndringIBehandlingUtleder(
      * Returnerer null hvis det ikke er noen endringer.
      */
     fun utledTidligsteEndring(): TidligsteEndringResultat? {
+        val endringerForvilkår = utledTidligsteEndringForVilkår()
+        val endringerForAktiviteter = utledTidligsteEndringForAktiviteter()
+        val endringerForMålgrupper = utledTidligsteEndringForMålgrupper()
+        val endringerForVedtaksperioder = utledTidligsteEndringForVedtaksperioder()
+
         val tidligsteEndring =
             listOfNotNull(
-                utledTidligsteEndringForVilkår(),
-                utledTidligsteEndringForAktiviteter(),
-                utledTidligsteEndringForMålgrupper(),
-                utledTidligsteEndringForVedtaksperioder(),
+                endringerForvilkår,
+                endringerForAktiviteter,
+                endringerForMålgrupper,
+                endringerForVedtaksperioder,
             ).minOrNull()
 
         return tidligsteEndring?.let {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -160,17 +160,12 @@ data class TidligsteEndringIBehandlingUtleder(
      * Returnerer null hvis det ikke er noen endringer.
      */
     fun utledTidligsteEndring(): TidligsteEndringResultat? {
-        val endringerForvilkår = utledTidligsteEndringForVilkår()
-        val endringerForAktiviteter = utledTidligsteEndringForAktiviteter()
-        val endringerForMålgrupper = utledTidligsteEndringForMålgrupper()
-        val endringerForVedtaksperioder = utledTidligsteEndringForVedtaksperioder()
-
         val tidligsteEndring =
             listOfNotNull(
-                endringerForvilkår,
-                endringerForAktiviteter,
-                endringerForMålgrupper,
-                endringerForVedtaksperioder,
+                utledTidligsteEndringForVilkår(),
+                utledTidligsteEndringForAktiviteter(),
+                utledTidligsteEndringForMålgrupper(),
+                utledTidligsteEndringForVedtaksperioder(),
             ).minOrNull()
 
         return tidligsteEndring?.let {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -35,7 +35,7 @@ class OpphørValideringService(
         val vilkår = vilkårService.hentVilkår(saksbehandling.id)
         val vilkårperioder = vilkårsperiodeService.hentVilkårperioder(saksbehandling.id)
 
-        validerIngenEndringerIVilkårFørOpphørsdato(
+        validerIngenEndringerIVilkårEllerVilkårperioderFørOpphørsdato(
             behandlingId = saksbehandling.id,
             opphørsdato = opphørsdato,
         )
@@ -88,8 +88,7 @@ class OpphørValideringService(
         }
     }
 
-    // TODO Oppdater navn
-    private fun validerIngenEndringerIVilkårFørOpphørsdato(
+    private fun validerIngenEndringerIVilkårEllerVilkårperioderFørOpphørsdato(
         behandlingId: BehandlingId,
         opphørsdato: LocalDate,
     ) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.sak.vedtak
 
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
@@ -23,6 +25,8 @@ import java.time.YearMonth
 class OpphørValideringService(
     private val vilkårsperiodeService: VilkårperiodeService,
     private val vilkårService: VilkårService,
+    private val vedtakService: VedtakService,
+    private val utledTidligsteEndringService: UtledTidligsteEndringService,
 ) {
     fun validerVilkårperioder(
         saksbehandling: Saksbehandling,
@@ -30,7 +34,13 @@ class OpphørValideringService(
     ) {
         val vilkår = vilkårService.hentVilkår(saksbehandling.id)
         val vilkårperioder = vilkårsperiodeService.hentVilkårperioder(saksbehandling.id)
+        val vedtaksperioder = vedtakService.hentVedtaksperioder(saksbehandling.id)
 
+        validerIngenEndringerIVilkårFørOpphørsdato(
+            behandlingId = saksbehandling.id,
+            vedtaksperioder = vedtaksperioder,
+            opphørsdato = opphørsdato,
+        )
         validerIngenNyeOppfylteVilkårEllerVilkårperioder(vilkår, vilkårperioder)
         validerIngenEndredePerioderMedTomEtterOpphørsdato(
             vilkårperioder,
@@ -77,6 +87,21 @@ class OpphørValideringService(
 
         brukerfeilHvis(senesteTomIForrigeVedtaksperioder < opphørsdato) {
             "Opphør er et ugyldig valg fordi ønsket opphørsdato ikke korter ned vedtaket."
+        }
+    }
+
+    private fun validerIngenEndringerIVilkårFørOpphørsdato(
+        behandlingId: BehandlingId,
+        vedtaksperioder: List<Vedtaksperiode>,
+        opphørsdato: LocalDate
+    ) {
+        val tidligsteEndring = utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+            behandlingId = behandlingId,
+            vedtaksperioder = vedtaksperioder
+        )
+
+        brukerfeilHvis(tidligsteEndring != null && tidligsteEndring < opphørsdato) {
+            "Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato"
         }
     }
 
@@ -127,7 +152,9 @@ class OpphørValideringService(
         }
     }
 
-    private fun Vilkårperiode.erOppfyltOgEndret(): Boolean = (status == Vilkårstatus.ENDRET) && (resultat == ResultatVilkårperiode.OPPFYLT)
+    private fun Vilkårperiode.erOppfyltOgEndret(): Boolean =
+        (status == Vilkårstatus.ENDRET) && (resultat == ResultatVilkårperiode.OPPFYLT)
 
-    private fun Vilkår.erOppfyltOgEndret(): Boolean = (status == VilkårStatus.ENDRET) && (resultat == Vilkårsresultat.OPPFYLT)
+    private fun Vilkår.erOppfyltOgEndret(): Boolean =
+        (status == VilkårStatus.ENDRET) && (resultat == Vilkårsresultat.OPPFYLT)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
+import no.nav.tilleggsstonader.sak.util.norskFormat
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
@@ -25,7 +26,6 @@ import java.time.YearMonth
 class OpphørValideringService(
     private val vilkårsperiodeService: VilkårperiodeService,
     private val vilkårService: VilkårService,
-    private val vedtakService: VedtakService,
     private val utledTidligsteEndringService: UtledTidligsteEndringService,
 ) {
     fun validerVilkårperioder(
@@ -34,11 +34,9 @@ class OpphørValideringService(
     ) {
         val vilkår = vilkårService.hentVilkår(saksbehandling.id)
         val vilkårperioder = vilkårsperiodeService.hentVilkårperioder(saksbehandling.id)
-        val vedtaksperioder = vedtakService.hentVedtaksperioder(saksbehandling.id)
 
         validerIngenEndringerIVilkårFørOpphørsdato(
             behandlingId = saksbehandling.id,
-            vedtaksperioder = vedtaksperioder,
             opphørsdato = opphørsdato,
         )
         validerIngenNyeOppfylteVilkårEllerVilkårperioder(vilkår, vilkårperioder)
@@ -90,19 +88,18 @@ class OpphørValideringService(
         }
     }
 
+    // TODO Oppdater navn
     private fun validerIngenEndringerIVilkårFørOpphørsdato(
         behandlingId: BehandlingId,
-        vedtaksperioder: List<Vedtaksperiode>,
         opphørsdato: LocalDate,
     ) {
         val tidligsteEndring =
-            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+            utledTidligsteEndringService.utledTidligsteEndringIgnorerVedtaksperioder(
                 behandlingId = behandlingId,
-                vedtaksperioder = vedtaksperioder,
             )
 
-        brukerfeilHvis(tidligsteEndring != null && tidligsteEndring < opphørsdato) {
-            "Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato"
+        brukerfeilHvis(tidligsteEndring != null && tidligsteEndring <= opphørsdato) {
+            "Opphør er et ugyldig vedtaksresultat fordi opphørsdato er etter eller lik tidligste endring (${tidligsteEndring?.norskFormat()})"
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -93,12 +93,13 @@ class OpphørValideringService(
     private fun validerIngenEndringerIVilkårFørOpphørsdato(
         behandlingId: BehandlingId,
         vedtaksperioder: List<Vedtaksperiode>,
-        opphørsdato: LocalDate
+        opphørsdato: LocalDate,
     ) {
-        val tidligsteEndring = utledTidligsteEndringService.utledTidligsteEndringForBeregning(
-            behandlingId = behandlingId,
-            vedtaksperioder = vedtaksperioder
-        )
+        val tidligsteEndring =
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandlingId = behandlingId,
+                vedtaksperioder = vedtaksperioder,
+            )
 
         brukerfeilHvis(tidligsteEndring != null && tidligsteEndring < opphørsdato) {
             "Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato"
@@ -152,9 +153,7 @@ class OpphørValideringService(
         }
     }
 
-    private fun Vilkårperiode.erOppfyltOgEndret(): Boolean =
-        (status == Vilkårstatus.ENDRET) && (resultat == ResultatVilkårperiode.OPPFYLT)
+    private fun Vilkårperiode.erOppfyltOgEndret(): Boolean = (status == Vilkårstatus.ENDRET) && (resultat == ResultatVilkårperiode.OPPFYLT)
 
-    private fun Vilkår.erOppfyltOgEndret(): Boolean =
-        (status == VilkårStatus.ENDRET) && (resultat == Vilkårsresultat.OPPFYLT)
+    private fun Vilkår.erOppfyltOgEndret(): Boolean = (status == VilkårStatus.ENDRET) && (resultat == Vilkårsresultat.OPPFYLT)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -35,15 +35,15 @@ class OpphørValideringService(
         val vilkår = vilkårService.hentVilkår(saksbehandling.id)
         val vilkårperioder = vilkårsperiodeService.hentVilkårperioder(saksbehandling.id)
 
-        validerIngenEndringerIVilkårEllerVilkårperioderFørOpphørsdato(
-            behandlingId = saksbehandling.id,
-            opphørsdato = opphørsdato,
-        )
         validerIngenNyeOppfylteVilkårEllerVilkårperioder(vilkår, vilkårperioder)
         validerIngenEndredePerioderMedTomEtterOpphørsdato(
             vilkårperioder,
             vilkår,
             opphørsdato,
+        )
+        validerIngenEndringerIVilkårEllerVilkårperioderFørOpphørsdato(
+            behandlingId = saksbehandling.id,
+            opphørsdato = opphørsdato,
         )
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/testdata/VilkårperiodeMapper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/testdata/VilkårperiodeMapper.kt
@@ -89,6 +89,5 @@ private fun FaktaOgVurderingerDto.tilFaktaOgSvarDto(): FaktaOgSvarDto =
                 svarUtgifterDekketAvAnnetRegelverk = this.utgifterDekketAvAnnetRegelverk?.svar,
             )
 
-        // Hvorfor er denne TODO og ikke bare exhaustive?
-        else -> TODO()
+        else -> TODO("FaktaOgVurderingerDto.tilFaktaOgSvarDto() ikke implementert for ${this::class.simpleName}")
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/testdata/VilkårperiodeMapper.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/testdata/VilkårperiodeMapper.kt
@@ -4,9 +4,11 @@ import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.AktivitetBarnetilsynFaktaOgVurderingerDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.AktivitetDagligReiseTsoFaktaOgVurderingerDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.AktivitetDagligReiseTsrFaktaOgVurderingerDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.AktivitetLæremidlerFaktaOgVurderingerDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBarnetilsynDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetDagligReiseTsoDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetDagligReiseTsrDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetLæremidlerDto
@@ -66,6 +68,13 @@ private fun FaktaOgVurderingerDto.tilFaktaOgSvarDto(): FaktaOgSvarDto =
             )
         }
 
+        is AktivitetBarnetilsynFaktaOgVurderingerDto -> {
+            FaktaOgSvarAktivitetBarnetilsynDto(
+                aktivitetsdager = this.aktivitetsdager,
+                svarLønnet = this.lønnet?.svar,
+            )
+        }
+
         is MålgruppeFaktaOgVurderingerDto -> {
             FaktaOgSvarMålgruppeDto(
                 svarMedlemskap = this.medlemskap?.svar,
@@ -80,5 +89,6 @@ private fun FaktaOgVurderingerDto.tilFaktaOgSvarDto(): FaktaOgSvarDto =
                 svarUtgifterDekketAvAnnetRegelverk = this.utgifterDekketAvAnnetRegelverk?.svar,
             )
 
+        // Hvorfor er denne TODO og ikke bare exhaustive?
         else -> TODO()
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceTest.kt
@@ -7,14 +7,15 @@ import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.tidligsteendring.UtledTidligsteEndringService
 import no.nav.tilleggsstonader.sak.util.fagsakBoutgifter
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.beregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.beregning.TilsynBarnBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil.vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
@@ -34,6 +35,8 @@ import java.time.YearMonth
 class OpphørValideringServiceTest {
     private val vilkårperiodeService = mockk<VilkårperiodeService>()
     private val vilkårService = mockk<VilkårService>()
+    private val vedtakService = mockk<VedtakService>()
+    private val utledTidligsteEndringService = mockk<UtledTidligsteEndringService>()
     private val tilsynBarnBeregningService = mockk<TilsynBarnBeregningService>()
 
     val måned = YearMonth.of(2025, 1)
@@ -52,7 +55,8 @@ class OpphørValideringServiceTest {
         saksbehandling(
             type = BehandlingType.REVURDERING,
         )
-    val opphørValideringService = OpphørValideringService(vilkårperiodeService, vilkårService)
+    val opphørValideringService =
+        OpphørValideringService(vilkårperiodeService, vilkårService, vedtakService, utledTidligsteEndringService)
     val vilkår =
         vilkår(
             behandlingId = saksbehandling.id,
@@ -89,10 +93,12 @@ class OpphørValideringServiceTest {
     fun setUp() {
         every { vilkårService.hentVilkår(saksbehandling.id) } returns listOf(vilkår)
         every { vilkårperiodeService.hentVilkårperioder(any()) } returns
-            Vilkårperioder(
-                målgrupper = listOf(målgruppe),
-                aktiviteter = listOf(aktivitet),
-            )
+                Vilkårperioder(
+                    målgrupper = listOf(målgruppe),
+                    aktiviteter = listOf(aktivitet),
+                )
+        every { vedtakService.hentVedtaksperioder(any()) } returns listOf(vedtaksperiode(fom, tom))
+        every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(any(), any()) } returns null
         every { tilsynBarnBeregningService.beregn(any(), any(), any(), any()) } returns beregningsresultat
     }
 
@@ -158,10 +164,10 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved nye oppfylte målgrupper`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                Vilkårperioder(
-                    målgrupper = listOf(målgruppe.copy(status = Vilkårstatus.NY)),
-                    aktiviteter = listOf(aktivitet),
-                )
+                    Vilkårperioder(
+                        målgrupper = listOf(målgruppe.copy(status = Vilkårstatus.NY)),
+                        aktiviteter = listOf(aktivitet),
+                    )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -171,10 +177,10 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved nye oppfylte aktivteter`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                Vilkårperioder(
-                    målgrupper = listOf(målgruppe),
-                    aktiviteter = listOf(aktivitet.copy(status = Vilkårstatus.NY)),
-                )
+                    Vilkårperioder(
+                        målgrupper = listOf(målgruppe),
+                        aktiviteter = listOf(aktivitet.copy(status = Vilkårstatus.NY)),
+                    )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -184,16 +190,16 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved målgruppe flyttet til etter opphørt dato`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                Vilkårperioder(
-                    målgrupper =
-                        listOf(
-                            målgruppe.copy(
-                                tom = LocalDate.now().plusMonths(2),
-                                status = Vilkårstatus.ENDRET,
+                    Vilkårperioder(
+                        målgrupper =
+                            listOf(
+                                målgruppe.copy(
+                                    tom = LocalDate.now().plusMonths(2),
+                                    status = Vilkårstatus.ENDRET,
+                                ),
                             ),
-                        ),
-                    aktiviteter = listOf(aktivitet),
-                )
+                        aktiviteter = listOf(aktivitet),
+                    )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -203,16 +209,16 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved aktivitet flyttet til etter opphørt dato`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                Vilkårperioder(
-                    målgrupper = listOf(målgruppe),
-                    aktiviteter =
-                        listOf(
-                            aktivitet.copy(
-                                tom = måned.plusMonths(1).atEndOfMonth(),
-                                status = Vilkårstatus.ENDRET,
+                    Vilkårperioder(
+                        målgrupper = listOf(målgruppe),
+                        aktiviteter =
+                            listOf(
+                                aktivitet.copy(
+                                    tom = måned.plusMonths(1).atEndOfMonth(),
+                                    status = Vilkårstatus.ENDRET,
+                                ),
                             ),
-                        ),
-                )
+                    )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -222,12 +228,12 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved vilkår flyttet til etter opphørt dato`() {
             every { vilkårService.hentVilkår(saksbehandling.id) } returns
-                listOf(
-                    vilkår.copy(
-                        status = VilkårStatus.ENDRET,
-                        tom = YearMonth.from(opphørsdato).plusMonths(1).atEndOfMonth(),
-                    ),
-                )
+                    listOf(
+                        vilkår.copy(
+                            status = VilkårStatus.ENDRET,
+                            tom = YearMonth.from(opphørsdato).plusMonths(1).atEndOfMonth(),
+                        ),
+                    )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -237,12 +243,12 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster ikke feil ved vilkår flyttet til etter opphørt dato men er i samme måned`() {
             every { vilkårService.hentVilkår(saksbehandling.id) } returns
-                listOf(
-                    vilkår.copy(
-                        status = VilkårStatus.ENDRET,
-                        tom = YearMonth.from(opphørsdato).atEndOfMonth(),
-                    ),
-                )
+                    listOf(
+                        vilkår.copy(
+                            status = VilkårStatus.ENDRET,
+                            tom = YearMonth.from(opphørsdato).atEndOfMonth(),
+                        ),
+                    )
 
             assertThatCode {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -281,12 +287,12 @@ class OpphørValideringServiceTest {
     @Test
     fun `Kaster feil ved vilkår flyttet til etter opphørt dato for boutgifter`() {
         every { vilkårService.hentVilkår(saksbehandlingBoutgifter.id) } returns
-            listOf(
-                vilkårBoutgifter.copy(
-                    status = VilkårStatus.ENDRET,
-                    tom = YearMonth.from(opphørsdato).atEndOfMonth(),
-                ),
-            )
+                listOf(
+                    vilkårBoutgifter.copy(
+                        status = VilkårStatus.ENDRET,
+                        tom = YearMonth.from(opphørsdato).atEndOfMonth(),
+                    ),
+                )
 
         assertThatThrownBy {
             opphørValideringService.validerVilkårperioder(saksbehandlingBoutgifter, opphørsdato)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceTest.kt
@@ -93,10 +93,10 @@ class OpphørValideringServiceTest {
     fun setUp() {
         every { vilkårService.hentVilkår(saksbehandling.id) } returns listOf(vilkår)
         every { vilkårperiodeService.hentVilkårperioder(any()) } returns
-                Vilkårperioder(
-                    målgrupper = listOf(målgruppe),
-                    aktiviteter = listOf(aktivitet),
-                )
+            Vilkårperioder(
+                målgrupper = listOf(målgruppe),
+                aktiviteter = listOf(aktivitet),
+            )
         every { vedtakService.hentVedtaksperioder(any()) } returns listOf(vedtaksperiode(fom, tom))
         every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(any(), any()) } returns null
         every { tilsynBarnBeregningService.beregn(any(), any(), any(), any()) } returns beregningsresultat
@@ -164,10 +164,10 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved nye oppfylte målgrupper`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                    Vilkårperioder(
-                        målgrupper = listOf(målgruppe.copy(status = Vilkårstatus.NY)),
-                        aktiviteter = listOf(aktivitet),
-                    )
+                Vilkårperioder(
+                    målgrupper = listOf(målgruppe.copy(status = Vilkårstatus.NY)),
+                    aktiviteter = listOf(aktivitet),
+                )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -177,10 +177,10 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved nye oppfylte aktivteter`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                    Vilkårperioder(
-                        målgrupper = listOf(målgruppe),
-                        aktiviteter = listOf(aktivitet.copy(status = Vilkårstatus.NY)),
-                    )
+                Vilkårperioder(
+                    målgrupper = listOf(målgruppe),
+                    aktiviteter = listOf(aktivitet.copy(status = Vilkårstatus.NY)),
+                )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -190,16 +190,16 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved målgruppe flyttet til etter opphørt dato`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                    Vilkårperioder(
-                        målgrupper =
-                            listOf(
-                                målgruppe.copy(
-                                    tom = LocalDate.now().plusMonths(2),
-                                    status = Vilkårstatus.ENDRET,
-                                ),
+                Vilkårperioder(
+                    målgrupper =
+                        listOf(
+                            målgruppe.copy(
+                                tom = LocalDate.now().plusMonths(2),
+                                status = Vilkårstatus.ENDRET,
                             ),
-                        aktiviteter = listOf(aktivitet),
-                    )
+                        ),
+                    aktiviteter = listOf(aktivitet),
+                )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -209,16 +209,16 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved aktivitet flyttet til etter opphørt dato`() {
             every { vilkårperiodeService.hentVilkårperioder(saksbehandling.id) } returns
-                    Vilkårperioder(
-                        målgrupper = listOf(målgruppe),
-                        aktiviteter =
-                            listOf(
-                                aktivitet.copy(
-                                    tom = måned.plusMonths(1).atEndOfMonth(),
-                                    status = Vilkårstatus.ENDRET,
-                                ),
+                Vilkårperioder(
+                    målgrupper = listOf(målgruppe),
+                    aktiviteter =
+                        listOf(
+                            aktivitet.copy(
+                                tom = måned.plusMonths(1).atEndOfMonth(),
+                                status = Vilkårstatus.ENDRET,
                             ),
-                    )
+                        ),
+                )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -228,12 +228,12 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster feil ved vilkår flyttet til etter opphørt dato`() {
             every { vilkårService.hentVilkår(saksbehandling.id) } returns
-                    listOf(
-                        vilkår.copy(
-                            status = VilkårStatus.ENDRET,
-                            tom = YearMonth.from(opphørsdato).plusMonths(1).atEndOfMonth(),
-                        ),
-                    )
+                listOf(
+                    vilkår.copy(
+                        status = VilkårStatus.ENDRET,
+                        tom = YearMonth.from(opphørsdato).plusMonths(1).atEndOfMonth(),
+                    ),
+                )
 
             assertThatThrownBy {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -243,12 +243,12 @@ class OpphørValideringServiceTest {
         @Test
         fun `Kaster ikke feil ved vilkår flyttet til etter opphørt dato men er i samme måned`() {
             every { vilkårService.hentVilkår(saksbehandling.id) } returns
-                    listOf(
-                        vilkår.copy(
-                            status = VilkårStatus.ENDRET,
-                            tom = YearMonth.from(opphørsdato).atEndOfMonth(),
-                        ),
-                    )
+                listOf(
+                    vilkår.copy(
+                        status = VilkårStatus.ENDRET,
+                        tom = YearMonth.from(opphørsdato).atEndOfMonth(),
+                    ),
+                )
 
             assertThatCode {
                 opphørValideringService.validerVilkårperioder(saksbehandling, opphørsdato)
@@ -287,12 +287,12 @@ class OpphørValideringServiceTest {
     @Test
     fun `Kaster feil ved vilkår flyttet til etter opphørt dato for boutgifter`() {
         every { vilkårService.hentVilkår(saksbehandlingBoutgifter.id) } returns
-                listOf(
-                    vilkårBoutgifter.copy(
-                        status = VilkårStatus.ENDRET,
-                        tom = YearMonth.from(opphørsdato).atEndOfMonth(),
-                    ),
-                )
+            listOf(
+                vilkårBoutgifter.copy(
+                    status = VilkårStatus.ENDRET,
+                    tom = YearMonth.from(opphørsdato).atEndOfMonth(),
+                ),
+            )
 
         assertThatThrownBy {
             opphørValideringService.validerVilkårperioder(saksbehandlingBoutgifter, opphørsdato)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringServiceTest.kt
@@ -56,7 +56,7 @@ class OpphørValideringServiceTest {
             type = BehandlingType.REVURDERING,
         )
     val opphørValideringService =
-        OpphørValideringService(vilkårperiodeService, vilkårService, vedtakService, utledTidligsteEndringService)
+        OpphørValideringService(vilkårperiodeService, vilkårService, utledTidligsteEndringService)
     val vilkår =
         vilkår(
             behandlingId = saksbehandling.id,
@@ -98,7 +98,7 @@ class OpphørValideringServiceTest {
                 aktiviteter = listOf(aktivitet),
             )
         every { vedtakService.hentVedtaksperioder(any()) } returns listOf(vedtaksperiode(fom, tom))
-        every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(any(), any()) } returns null
+        every { utledTidligsteEndringService.utledTidligsteEndringIgnorerVedtaksperioder(any()) } returns null
         every { tilsynBarnBeregningService.beregn(any(), any(), any(), any()) } returns beregningsresultat
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
@@ -258,23 +259,21 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     defaultTilsynBarnTestdata(fom = fom, tom = tom)
                 }
 
+            testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
             val behandlingId =
                 opprettRevurderingOgGjennomførBehandlingsløp(
                     fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                    tilSteg = StegType.BEREGNE_YTELSE,
                 ) {
                     aktivitet {
                         oppdaterTomPåEnesteAktivitet(tom = fom.toYearMonth().atEndOfMonth())
                     }
+                    vedtak {
+                        opphør(
+                            opphørsdato = 31 januar 2025,
+                        )
+                    }
                 }
-
-            kall.vedtak.apiRespons
-                .lagreOpphør(
-                    stønadstype = Stønadstype.BARNETILSYN,
-                    behandlingId = behandlingId,
-                    opphørDto = opphørDto(opphørsdato = 31 januar 2025),
-                ).expectStatus()
-                .isOk()
 
             val vedtak =
                 kall.vedtak
@@ -282,8 +281,8 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     .expectOkWithBody<OpphørTilsynBarnResponse>()
 
             assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
-            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ENDRING_UTGIFTER)
-            assertThat(vedtak.begrunnelse).isEqualTo("Endring i utgifter")
+            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+            assertThat(vedtak.begrunnelse).isEqualTo("annet")
         }
 
         /**
@@ -337,7 +336,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
         @Test
         fun `skal ikke kunne opphøre dersom utgifter endres før opphørsdato`() {
             val fom = 1 januar 2025
-            val tom = 28 februar 2025
+            val tom = 31 mars 2025
 
             val førstegangsbehandlingContext =
                 opprettBehandlingOgGjennomførBehandlingsløp(
@@ -361,7 +360,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                         opprett {
                             passBarn(
                                 fom = fom.toYearMonth().plusMonths(1),
-                                tom = tom.toYearMonth().plusMonths(1),
+                                tom = tom.toYearMonth(),
                                 utgift = 1000,
                             )
                         }
@@ -381,7 +380,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                                     behandlingId = behandlingId,
                                     delvilkårsett = delvilkårsett,
                                     fom = fom.plusMonths(1),
-                                    tom = tom,
+                                    tom = 28 februar 2025,
                                     utgift = 500,
                                     erFremtidigUtgift = erFremtidigUtgift,
                                     offentligTransport = null,
@@ -397,7 +396,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     behandlingId = revurderingId,
                     opphørDto =
                         opphørDto(
-                            opphørsdato = 15 februar 2025,
+                            opphørsdato = 1 mars 2025,
                         ),
                 ).expectProblemDetail(
                     forventetStatus = HttpStatus.BAD_REQUEST,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -14,6 +14,8 @@ import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.resetMock
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
@@ -23,20 +25,19 @@ import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.util.toYearMonth
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.beregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
-import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
-import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
@@ -51,7 +52,6 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterEach
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
@@ -201,9 +202,12 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                         utbetalingsdato = april.atDay(3),
                     ),
                 )
-            assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "endretTid")
-                .containsExactlyElementsOf(forventedeAndeler)
+            assertThat(
+                tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList(),
+            ).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                "id",
+                "endretTid",
+            ).containsExactlyElementsOf(forventedeAndeler)
         }
 
         @Test
@@ -226,9 +230,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
             }
 
             val beregningsresultat =
-                vedtakService
-                    .hentVedtak<InnvilgelseTilsynBarn>(behandling.id)
-                    .data.beregningsresultat
+                vedtakService.hentVedtak<InnvilgelseTilsynBarn>(behandling.id).data.beregningsresultat
             with(beregningsresultat.perioder.single()) {
                 with(this.grunnlag.vedtaksperiodeGrunnlag.single()) {
                     assertThat(this.vedtaksperiode.fom).isEqualTo(juni.atDay(1))
@@ -246,81 +248,42 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
     inner class Opphør {
         @Test
         fun `skal lagre vedtak`() {
-            val beløpsperioderJanuar =
-                listOf(Beløpsperiode(dato = LocalDate.of(2023, 1, 2), beløp = 1000, målgruppe = NEDSATT_ARBEIDSEVNE))
-            val beløpsperiodeFebruar =
-                listOf(Beløpsperiode(dato = LocalDate.of(2023, 2, 1), beløp = 2000, målgruppe = NEDSATT_ARBEIDSEVNE))
-            val beregningsresultatJanuar =
-                beregningsresultatForMåned(beløpsperioder = beløpsperioderJanuar, måned = YearMonth.of(2023, 1))
-            val beregningsresultatFebruar =
-                beregningsresultatForMåned(beløpsperioder = beløpsperiodeFebruar, måned = YearMonth.of(2023, 2))
+            val fom = 1 januar 2025
+            val tom = 28 februar 2025
 
-            val vedtakBeregningsresultatFørstegangsbehandling =
-                BeregningsresultatTilsynBarn(
-                    perioder =
-                        listOf(
-                            beregningsresultatJanuar,
-                            beregningsresultatFebruar,
-                        ),
-                )
+            val førstegangsbehandlingContext =
+                opprettBehandlingOgGjennomførBehandlingsløp(
+                    stønadstype = Stønadstype.BARNETILSYN,
+                ) {
+                    defaultTilsynBarnTestdata(fom = fom, tom = tom)
+                }
 
-            val vedtaksperiode =
-                Vedtaksperiode(
-                    id = UUID.randomUUID(),
-                    fom = LocalDate.of(2023, 1, 2),
-                    tom = LocalDate.of(2023, 2, 28),
-                    målgruppe = NEDSATT_ARBEIDSEVNE,
-                    aktivitet = AktivitetType.TILTAK,
-                )
+            val behandlingId =
+                opprettRevurderingOgGjennomførBehandlingsløp(
+                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                    tilSteg = StegType.BEREGNE_YTELSE,
+                ) {
+                    aktivitet {
+                        oppdaterTomPåEnesteAktivitet(tom = fom.toYearMonth().atEndOfMonth())
+                    }
+                }
 
-            testoppsettService.lagVedtak(
-                behandling = behandling,
-                beregningsresultat = vedtakBeregningsresultatFørstegangsbehandling,
-                vedtaksperioder = listOf(vedtaksperiode),
-            )
-            testoppsettService.ferdigstillBehandling(behandling = behandling)
+            kall.vedtak.apiRespons
+                .lagreOpphør(
+                    stønadstype = Stønadstype.BARNETILSYN,
+                    behandlingId = behandlingId,
+                    opphørDto = opphørDto(opphørsdato = LocalDate.of(2025, 1, 31)),
+                ).expectStatus()
+                .isOk()
 
-            val behandlingForOpphør =
-                testoppsettService.opprettRevurdering(
-                    forrigeBehandling = behandling,
-                    fagsak = fagsak,
-                )
-            val saksbehandlingForOpphør = saksbehandling(behandling = behandlingForOpphør)
-            val aktivitetForOpphør =
-                aktivitet(
-                    behandlingForOpphør.id,
-                    fom = LocalDate.of(2023, 1, 2),
-                    tom = LocalDate.of(2023, 1, 31),
-                    status = Vilkårstatus.ENDRET,
-                )
-            val målgruppeForOpphør =
-                målgruppe.copy(behandlingId = behandlingForOpphør.id, status = Vilkårstatus.UENDRET)
+            val vedtak =
+                kall.vedtak
+                    .hentVedtak(Stønadstype.BARNETILSYN, behandlingId)
+                    .expectOkWithBody<OpphørTilsynBarnResponse>()
 
-            vilkårperiodeRepository.insert(aktivitetForOpphør)
-            vilkårperiodeRepository.insert(målgruppeForOpphør)
-            lagVilkårForPeriode(saksbehandlingForOpphør, januar, februar, 100, status = VilkårStatus.UENDRET)
-
-            val vedtakDto = opphørDto(opphørsdato = LocalDate.of(2023, 2, 1))
-            steg.utførOgReturnerNesteSteg(saksbehandlingForOpphør, vedtakDto)
-
-            val vedtak = repository.findByIdOrThrow(saksbehandlingForOpphør.id).withTypeOrThrow<OpphørTilsynBarn>()
-
-            val tilkjentYtelse =
-                tilkjentYtelseRepository.findByBehandlingId(saksbehandlingForOpphør.id)!!.andelerTilkjentYtelse
-
-            val forventetVedtaksperioderForOpphør = vedtaksperiode.copy(tom = LocalDate.of(2023, 1, 31))
-
-            assertThat(vedtak.behandlingId).isEqualTo(saksbehandlingForOpphør.id)
             assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
-            assertThat(vedtak.data.årsaker).containsExactly(ÅrsakOpphør.ENDRING_UTGIFTER)
-            assertThat(vedtak.data.begrunnelse).isEqualTo("Endring i utgifter")
-            assertThat(
-                vedtak.data.beregningsresultat.perioder
-                    .single(),
-            ).isEqualTo(beregningsresultatJanuar)
-            assertThat(tilkjentYtelse).hasSize(1)
-            assertThat(vedtak.data.vedtaksperioder).isEqualTo(listOf(forventetVedtaksperioderForOpphør))
-            assertThat(vedtak.gitVersjon).isEqualTo(Applikasjonsversjon.versjon)
+            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ENDRING_UTGIFTER)
+            assertThat(vedtak.begrunnelse).isEqualTo("Endring i utgifter")
         }
 
         /**
@@ -380,10 +343,29 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                 opprettBehandlingOgGjennomførBehandlingsløp(
                     stønadstype = Stønadstype.BARNETILSYN,
                 ) {
-                    defaultTilsynBarnTestdata(
-                        fom = fom,
-                        tom = tom,
-                    )
+                    aktivitet {
+                        opprett {
+                            aktivitetTiltakTilsynBarn(
+                                fom = fom,
+                                tom = tom,
+                                aktivitetsdager = 4,
+                            )
+                        }
+                    }
+                    målgruppe {
+                        opprett {
+                            målgruppeAAP(fom, tom)
+                        }
+                    }
+                    vilkår {
+                        opprett {
+                            passBarn(
+                                fom = fom.toYearMonth().plusMonths(1),
+                                tom = tom.toYearMonth().plusMonths(1),
+                                utgift = 1000,
+                            )
+                        }
+                    }
                 }
 
             val revurderingId =
@@ -398,8 +380,8 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                                     id = id,
                                     behandlingId = behandlingId,
                                     delvilkårsett = delvilkårsett,
-                                    fom = fom,
-                                    tom = januar.withYear(2025).atEndOfMonth(),
+                                    fom = fom.plusMonths(1),
+                                    tom = tom,
                                     utgift = 500,
                                     erFremtidigUtgift = erFremtidigUtgift,
                                     offentligTransport = null,
@@ -415,13 +397,14 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     behandlingId = revurderingId,
                     opphørDto =
                         opphørDto(
-                            opphørsdato = 1 februar 2025,
+                            opphørsdato = 15 februar 2025,
                         ),
-                ).expectStatus()
-                .isBadRequest()
-                .expectBody()
-                .jsonPath("$.detail")
-                .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
+                ).expectProblemDetail(
+                    forventetStatus = HttpStatus.BAD_REQUEST,
+                    forventetDetail =
+                        "Opphør er et ugyldig vedtaksresultat fordi " +
+                            "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
+                )
         }
     }
 
@@ -547,10 +530,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
         }
 
         private fun hentBeregningsresultat(behandlingId: BehandlingId): BeregningsresultatTilsynBarn =
-            vedtakService
-                .hentVedtak<InnvilgelseTilsynBarn>(behandlingId)
-                .data
-                .beregningsresultat
+            vedtakService.hentVedtak<InnvilgelseTilsynBarn>(behandlingId).data.beregningsresultat
 
         private fun assertHarPerioderForJanuarOgFebruar(beregningsresultat: List<BeregningsresultatForMåned>) {
             with(beregningsresultat[0].grunnlag.vedtaksperiodeGrunnlag.single()) {
@@ -643,9 +623,12 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     )
                 }
 
-            assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "endretTid")
-                .containsExactlyElementsOf(forventedeAndeler)
+            assertThat(
+                tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList(),
+            ).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                "id",
+                "endretTid",
+            ).containsExactlyElementsOf(forventedeAndeler)
         }
 
         @Test
@@ -687,9 +670,12 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     beløp = beløp1DagUtgift100,
                     type = TypeAndel.TILSYN_BARN_ENSLIG_FORSØRGER,
                 )
-            assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "endretTid")
-                .containsExactlyElementsOf(listOf(forventetAndel))
+            assertThat(
+                tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList(),
+            ).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                "id",
+                "endretTid",
+            ).containsExactlyElementsOf(listOf(forventetAndel))
         }
 
         @Test
@@ -730,9 +716,12 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     beløp = beløp1DagUtgift100,
                     type = TypeAndel.TILSYN_BARN_ETTERLATTE,
                 )
-            assertThat(tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList())
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "endretTid")
-                .containsExactlyElementsOf(listOf(forventetAndel))
+            assertThat(
+                tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id)!!.andelerTilkjentYtelse.toList(),
+            ).usingRecursiveFieldByFieldElementComparatorIgnoringFields(
+                "id",
+                "endretTid",
+            ).containsExactlyElementsOf(listOf(forventetAndel))
         }
     }
 
@@ -760,9 +749,5 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
     private fun finnTotalbeløp(
         dagsats: BigDecimal,
         antallDager: Int,
-    ): Int =
-        dagsats
-            .multiply(antallDager.toBigDecimal())
-            .setScale(0, RoundingMode.HALF_UP)
-            .toInt()
+    ): Int = dagsats.multiply(antallDager.toBigDecimal()).setScale(0, RoundingMode.HALF_UP).toInt()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -1,24 +1,15 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
-import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.libs.utils.dato.februar
-import no.nav.tilleggsstonader.libs.utils.dato.januar
-import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
-import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.resetMock
-import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
-import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
-import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
-import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
@@ -26,26 +17,20 @@ import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
-import no.nav.tilleggsstonader.sak.util.toYearMonth
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.innvilgelseDto
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatForMåned
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.BeregningsresultatTilsynBarn
-import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseTilsynBarn
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
-import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppe
@@ -54,13 +39,11 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
@@ -242,168 +225,6 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     assertThat(this.dato).isEqualTo(juni.atDay(3))
                 }
             }
-        }
-    }
-
-    @Nested
-    inner class Opphør {
-        @Test
-        fun `skal lagre vedtak`() {
-            val fom = 1 januar 2025
-            val tom = 28 februar 2025
-
-            val førstegangsbehandlingContext =
-                opprettBehandlingOgGjennomførBehandlingsløp(
-                    stønadstype = Stønadstype.BARNETILSYN,
-                ) {
-                    defaultTilsynBarnTestdata(fom = fom, tom = tom)
-                }
-
-            testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
-
-            val behandlingId =
-                opprettRevurderingOgGjennomførBehandlingsløp(
-                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                ) {
-                    aktivitet {
-                        oppdaterTomPåEnesteAktivitet(tom = fom.toYearMonth().atEndOfMonth())
-                    }
-                    vedtak {
-                        opphør(
-                            opphørsdato = 31 januar 2025,
-                        )
-                    }
-                }
-
-            val vedtak =
-                kall.vedtak
-                    .hentVedtak(Stønadstype.BARNETILSYN, behandlingId)
-                    .expectOkWithBody<OpphørTilsynBarnResponse>()
-
-            assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
-            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
-            assertThat(vedtak.begrunnelse).isEqualTo("annet")
-        }
-
-        /**
-         * I tilfeller der AAP opphører 2 februar 2025 som er en søndag, så revurderer man fra og med 3 februar 2025.
-         * I dette tilfelle kommer det finnes en beløpsperiode for 1 og 2 februar, med beløp 0kr.
-         * Problemet her er at dato i [Beløpsperiode] er 3 januar, då den settes til første ukesdagen i perioden.
-         * Så hadde vi tidligere validering at det ikke finnes noen beløpsperioder fra og med revurder-fra.
-         * Nå validerer vi kun at det ikke finnes noen beløpsperioder med et beløp større enn 0kr
-         */
-        @Test
-        fun `skal kunne opphøre første mandag i måneden der det finnes helgdager før mandagen`() {
-            val januar = januar.withYear(2025)
-            val februar = februar.withYear(2025)
-            val aktivitet = vilkårperiodeRepository.insert(aktivitet.copy(tom = februar.atEndOfMonth()))
-            val målgruppe = vilkårperiodeRepository.insert(målgruppe.copy(tom = februar.atEndOfMonth()))
-            lagVilkårForPeriode(saksbehandling, januar, februar, 100)
-
-            val element =
-                VedtaksperiodeDto(
-                    id = UUID.randomUUID(),
-                    fom = januar.atDay(1),
-                    tom = februar.atEndOfMonth(),
-                    målgruppeType = NEDSATT_ARBEIDSEVNE,
-                    aktivitetType = AktivitetType.TILTAK,
-                )
-            val innvilgelse = innvilgelseDto(listOf(element))
-            steg.utførOgReturnerNesteSteg(saksbehandling, innvilgelse)
-
-            testoppsettService.ferdigstillBehandling(behandling = behandling)
-
-            val behandlingForOpphør =
-                testoppsettService
-                    .opprettRevurdering(
-                        forrigeBehandling = behandling,
-                        fagsak = fagsak,
-                    ).let { saksbehandling(behandling = it) }
-
-            val aktivitetForOpphør = aktivitet.kopierTilBehandling(behandlingForOpphør.id)
-            val målgruppeForOpphør = målgruppe.kopierTilBehandling(behandlingForOpphør.id)
-
-            vilkårperiodeRepository.insert(aktivitetForOpphør)
-            vilkårperiodeRepository.insert(målgruppeForOpphør)
-            lagVilkårForPeriode(behandlingForOpphør, januar, februar, 100, status = VilkårStatus.UENDRET)
-
-            val vedtakDto = opphørDto(opphørsdato = LocalDate.of(2025, 2, 3))
-            assertThatCode {
-                steg.utførOgReturnerNesteSteg(behandlingForOpphør, vedtakDto)
-            }.doesNotThrowAnyException()
-        }
-
-        @Test
-        fun `skal ikke kunne opphøre dersom utgifter endres før opphørsdato`() {
-            val fom = 1 januar 2025
-            val tom = 31 mars 2025
-
-            val førstegangsbehandlingContext =
-                opprettBehandlingOgGjennomførBehandlingsløp(
-                    stønadstype = Stønadstype.BARNETILSYN,
-                ) {
-                    aktivitet {
-                        opprett {
-                            aktivitetTiltakTilsynBarn(
-                                fom = fom,
-                                tom = tom,
-                                aktivitetsdager = 4,
-                            )
-                        }
-                    }
-                    målgruppe {
-                        opprett {
-                            målgruppeAAP(fom, tom)
-                        }
-                    }
-                    vilkår {
-                        opprett {
-                            passBarn(
-                                fom = fom.toYearMonth().plusMonths(1),
-                                tom = tom.toYearMonth(),
-                                utgift = 1000,
-                            )
-                        }
-                    }
-                }
-
-            val revurderingId =
-                opprettRevurderingOgGjennomførBehandlingsløp(
-                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                    tilSteg = StegType.BEREGNE_YTELSE,
-                ) {
-                    vilkår {
-                        oppdater { vilkårsvurdering ->
-                            with(vilkårsvurdering.vilkårsett.single()) {
-                                SvarPåVilkårDto(
-                                    id = id,
-                                    behandlingId = behandlingId,
-                                    delvilkårsett = delvilkårsett,
-                                    fom = fom.plusMonths(1),
-                                    tom = 28 februar 2025,
-                                    utgift = 500,
-                                    erFremtidigUtgift = erFremtidigUtgift,
-                                    offentligTransport = null,
-                                )
-                            }
-                        }
-                    }
-                }
-
-            kall.vedtak.apiRespons
-                .lagreOpphør(
-                    stønadstype = Stønadstype.BARNETILSYN,
-                    behandlingId = revurderingId,
-                    opphørDto =
-                        opphørDto(
-                            opphørsdato = 1 mars 2025,
-                        ),
-                ).expectProblemDetail(
-                    forventetStatus = HttpStatus.BAD_REQUEST,
-                    forventetDetail =
-                        "Opphør er et ugyldig vedtaksresultat fordi " +
-                            "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
-                )
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -412,7 +412,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                 stønadstype = Stønadstype.BARNETILSYN,
                 behandlingId = revurderingId,
                 opphørDto = opphørDto(
-                    opphørsdato = LocalDate.of(2025, 2, 1)
+                    opphørsdato = 1 februar 2025
                 ),
             ).expectStatus().isBadRequest().expectBody().jsonPath("$.detail")
                 .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
@@ -456,8 +456,20 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
             val behandling = testoppsettService.hentSaksbehandling(behandlingId)
 
             val vedtaksperiode = vedtaksperiode.copy(fom = januar.atDay(1), tom = februar.atEndOfMonth())
-            vilkårperiodeRepository.insert(aktivitet(behandlingId = behandlingId, fom = januar.atDay(1), tom = april.atEndOfMonth()))
-            vilkårperiodeRepository.insert(målgruppe(behandlingId = behandlingId, fom = januar.atDay(1), tom = april.atEndOfMonth()))
+            vilkårperiodeRepository.insert(
+                aktivitet(
+                    behandlingId = behandlingId,
+                    fom = januar.atDay(1),
+                    tom = april.atEndOfMonth()
+                )
+            )
+            vilkårperiodeRepository.insert(
+                målgruppe(
+                    behandlingId = behandlingId,
+                    fom = januar.atDay(1),
+                    tom = april.atEndOfMonth()
+                )
+            )
             lagVilkårForPeriode(behandling, januar, februar, 100)
             steg.utførOgReturnerNesteSteg(behandling, innvilgelseDto(listOf(vedtaksperiode)))
         }
@@ -479,8 +491,20 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     målgruppeType = NEDSATT_ARBEIDSEVNE,
                     aktivitetType = AktivitetType.TILTAK,
                 )
-            vilkårperiodeRepository.insert(aktivitet(behandlingId = behandling.id, fom = januar.atDay(1), tom = april.atEndOfMonth()))
-            vilkårperiodeRepository.insert(målgruppe(behandlingId = behandling.id, fom = januar.atDay(1), tom = april.atEndOfMonth()))
+            vilkårperiodeRepository.insert(
+                aktivitet(
+                    behandlingId = behandling.id,
+                    fom = januar.atDay(1),
+                    tom = april.atEndOfMonth()
+                )
+            )
+            vilkårperiodeRepository.insert(
+                målgruppe(
+                    behandlingId = behandling.id,
+                    fom = januar.atDay(1),
+                    tom = april.atEndOfMonth()
+                )
+            )
             lagVilkårForPeriode(behandling, januar, april, 100)
             steg.utførOgReturnerNesteSteg(behandling, innvilgelseDto(listOf(vedtaksperiodeJanFeb, vedtaksperiodeMars)))
         }
@@ -555,8 +579,20 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
         fun setUp() {
             val faktaOgVurderingUføretrygd = faktaOgVurderingMålgruppe(type = MålgruppeType.UFØRETRYGD)
             val faktaOgVurderingNedsattArbeidsevne = faktaOgVurderingMålgruppe(type = MålgruppeType.NEDSATT_ARBEIDSEVNE)
-            vilkårperiodeRepository.insert(aktivitet(behandlingId = behandling.id, fom = januar.atDay(1), tom = april.atEndOfMonth()))
-            vilkårperiodeRepository.insert(målgruppe(behandlingId = behandling.id, fom = januar.atDay(1), tom = april.atEndOfMonth()))
+            vilkårperiodeRepository.insert(
+                aktivitet(
+                    behandlingId = behandling.id,
+                    fom = januar.atDay(1),
+                    tom = april.atEndOfMonth()
+                )
+            )
+            vilkårperiodeRepository.insert(
+                målgruppe(
+                    behandlingId = behandling.id,
+                    fom = januar.atDay(1),
+                    tom = april.atEndOfMonth()
+                )
+            )
             vilkårperiodeRepository.insert(
                 målgruppe(
                     behandlingId = behandling.id,
@@ -581,7 +617,11 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
         fun `skal mappe nedsatt arbeidsevne til riktig TypeAndel`() {
             val vedtaksperioder =
                 listOf(
-                    vedtaksperiode.copy(fom = januar.atDay(2), tom = januar.atDay(2), målgruppeType = NEDSATT_ARBEIDSEVNE),
+                    vedtaksperiode.copy(
+                        fom = januar.atDay(2),
+                        tom = januar.atDay(2),
+                        målgruppeType = NEDSATT_ARBEIDSEVNE
+                    ),
                 )
 
             val vedtakDto = innvilgelseDto(vedtaksperioder)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -376,45 +376,51 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
             val fom = 1 januar 2025
             val tom = 28 februar 2025
 
-            val førstegangsbehandlingContext = opprettBehandlingOgGjennomførBehandlingsløp(
-                stønadstype = Stønadstype.BARNETILSYN
-            ) {
-                defaultTilsynBarnTestdata(
-                    fom = fom,
-                    tom = tom,
-                )
-            }
+            val førstegangsbehandlingContext =
+                opprettBehandlingOgGjennomførBehandlingsløp(
+                    stønadstype = Stønadstype.BARNETILSYN,
+                ) {
+                    defaultTilsynBarnTestdata(
+                        fom = fom,
+                        tom = tom,
+                    )
+                }
 
-            val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
-                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                tilSteg = StegType.BEREGNE_YTELSE
-            ) {
-                vilkår {
-                    oppdater { vilkårsvurdering ->
-                        with(vilkårsvurdering.vilkårsett.single()) {
-                            SvarPåVilkårDto(
-                                id = id,
-                                behandlingId = behandlingId,
-                                delvilkårsett = delvilkårsett,
-                                fom = fom,
-                                tom = januar.withYear(2025).atEndOfMonth(),
-                                utgift = 500,
-                                erFremtidigUtgift = erFremtidigUtgift,
-                                offentligTransport = null,
-                            )
+            val revurderingId =
+                opprettRevurderingOgGjennomførBehandlingsløp(
+                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                    tilSteg = StegType.BEREGNE_YTELSE,
+                ) {
+                    vilkår {
+                        oppdater { vilkårsvurdering ->
+                            with(vilkårsvurdering.vilkårsett.single()) {
+                                SvarPåVilkårDto(
+                                    id = id,
+                                    behandlingId = behandlingId,
+                                    delvilkårsett = delvilkårsett,
+                                    fom = fom,
+                                    tom = januar.withYear(2025).atEndOfMonth(),
+                                    utgift = 500,
+                                    erFremtidigUtgift = erFremtidigUtgift,
+                                    offentligTransport = null,
+                                )
+                            }
                         }
                     }
                 }
-            }
 
-
-            kall.vedtak.apiRespons.lagreOpphør(
-                stønadstype = Stønadstype.BARNETILSYN,
-                behandlingId = revurderingId,
-                opphørDto = opphørDto(
-                    opphørsdato = 1 februar 2025
-                ),
-            ).expectStatus().isBadRequest().expectBody().jsonPath("$.detail")
+            kall.vedtak.apiRespons
+                .lagreOpphør(
+                    stønadstype = Stønadstype.BARNETILSYN,
+                    behandlingId = revurderingId,
+                    opphørDto =
+                        opphørDto(
+                            opphørsdato = 1 februar 2025,
+                        ),
+                ).expectStatus()
+                .isBadRequest()
+                .expectBody()
+                .jsonPath("$.detail")
                 .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
         }
     }
@@ -460,15 +466,15 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                 aktivitet(
                     behandlingId = behandlingId,
                     fom = januar.atDay(1),
-                    tom = april.atEndOfMonth()
-                )
+                    tom = april.atEndOfMonth(),
+                ),
             )
             vilkårperiodeRepository.insert(
                 målgruppe(
                     behandlingId = behandlingId,
                     fom = januar.atDay(1),
-                    tom = april.atEndOfMonth()
-                )
+                    tom = april.atEndOfMonth(),
+                ),
             )
             lagVilkårForPeriode(behandling, januar, februar, 100)
             steg.utførOgReturnerNesteSteg(behandling, innvilgelseDto(listOf(vedtaksperiode)))
@@ -495,15 +501,15 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                 aktivitet(
                     behandlingId = behandling.id,
                     fom = januar.atDay(1),
-                    tom = april.atEndOfMonth()
-                )
+                    tom = april.atEndOfMonth(),
+                ),
             )
             vilkårperiodeRepository.insert(
                 målgruppe(
                     behandlingId = behandling.id,
                     fom = januar.atDay(1),
-                    tom = april.atEndOfMonth()
-                )
+                    tom = april.atEndOfMonth(),
+                ),
             )
             lagVilkårForPeriode(behandling, januar, april, 100)
             steg.utførOgReturnerNesteSteg(behandling, innvilgelseDto(listOf(vedtaksperiodeJanFeb, vedtaksperiodeMars)))
@@ -583,15 +589,15 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                 aktivitet(
                     behandlingId = behandling.id,
                     fom = januar.atDay(1),
-                    tom = april.atEndOfMonth()
-                )
+                    tom = april.atEndOfMonth(),
+                ),
             )
             vilkårperiodeRepository.insert(
                 målgruppe(
                     behandlingId = behandling.id,
                     fom = januar.atDay(1),
-                    tom = april.atEndOfMonth()
-                )
+                    tom = april.atEndOfMonth(),
+                ),
             )
             vilkårperiodeRepository.insert(
                 målgruppe(
@@ -620,7 +626,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                     vedtaksperiode.copy(
                         fom = januar.atDay(2),
                         tom = januar.atDay(2),
-                        målgruppeType = NEDSATT_ARBEIDSEVNE
+                        målgruppeType = NEDSATT_ARBEIDSEVNE,
                     ),
                 )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -272,7 +272,7 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
                 .lagreOpphør(
                     stønadstype = Stønadstype.BARNETILSYN,
                     behandlingId = behandlingId,
-                    opphørDto = opphørDto(opphørsdato = LocalDate.of(2025, 1, 31)),
+                    opphørDto = opphørDto(opphørsdato = 31 januar 2025),
                 ).expectStatus()
                 .isOk()
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnBeregnYtelseStegIntegrationTest.kt
@@ -1,15 +1,21 @@
 package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.barn.BehandlingBarn
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.resetMock
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TypeAndel
@@ -37,6 +43,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårReposit
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetTilsynBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingMålgruppe
@@ -362,6 +369,53 @@ class TilsynBarnBeregnYtelseStegIntegrationTest : CleanDatabaseIntegrationTest()
             assertThatCode {
                 steg.utførOgReturnerNesteSteg(behandlingForOpphør, vedtakDto)
             }.doesNotThrowAnyException()
+        }
+
+        @Test
+        fun `skal ikke kunne opphøre dersom utgifter endres før opphørsdato`() {
+            val fom = 1 januar 2025
+            val tom = 28 februar 2025
+
+            val førstegangsbehandlingContext = opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN
+            ) {
+                defaultTilsynBarnTestdata(
+                    fom = fom,
+                    tom = tom,
+                )
+            }
+
+            val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE
+            ) {
+                vilkår {
+                    oppdater { vilkårsvurdering ->
+                        with(vilkårsvurdering.vilkårsett.single()) {
+                            SvarPåVilkårDto(
+                                id = id,
+                                behandlingId = behandlingId,
+                                delvilkårsett = delvilkårsett,
+                                fom = fom,
+                                tom = januar.withYear(2025).atEndOfMonth(),
+                                utgift = 500,
+                                erFremtidigUtgift = erFremtidigUtgift,
+                                offentligTransport = null,
+                            )
+                        }
+                    }
+                }
+            }
+
+
+            kall.vedtak.apiRespons.lagreOpphør(
+                stønadstype = Stønadstype.BARNETILSYN,
+                behandlingId = revurderingId,
+                opphørDto = opphørDto(
+                    opphørsdato = LocalDate.of(2025, 2, 1)
+                ),
+            ).expectStatus().isBadRequest().expectBody().jsonPath("$.detail")
+                .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnOpphørIntegrationTest.kt
@@ -1,0 +1,179 @@
+package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
+import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.toYearMonth
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnResponse
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class TilsynBarnOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
+    @Test
+    fun `skal lagre vedtak`() {
+        val fom = 1 januar 2025
+        val tom = 28 februar 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN,
+            ) {
+                defaultTilsynBarnTestdata(fom = fom, tom = tom)
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            ) {
+                aktivitet {
+                    oppdaterTomPåEnesteAktivitet(tom = fom.toYearMonth().atEndOfMonth())
+                }
+                vedtak {
+                    opphør(
+                        opphørsdato = 31 januar 2025,
+                    )
+                }
+            }
+
+        val vedtak =
+            kall.vedtak
+                .hentVedtak(Stønadstype.BARNETILSYN, behandlingId)
+                .expectOkWithBody<OpphørTilsynBarnResponse>()
+
+        assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
+        assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+        assertThat(vedtak.begrunnelse).isEqualTo("annet")
+    }
+
+    /**
+     * I tilfeller der AAP opphører 2 februar 2025 som er en søndag, så revurderer man fra og med 3 februar 2025.
+     * I dette tilfelle kommer det finnes en beløpsperiode for 1 og 2 februar, med beløp 0kr.
+     * Problemet her er at dato i [Beløpsperiode] er 3 januar, då den settes til første ukesdagen i perioden.
+     * Så hadde vi tidligere validering at det ikke finnes noen beløpsperioder fra og med revurder-fra.
+     * Nå validerer vi kun at det ikke finnes noen beløpsperioder med et beløp større enn 0kr
+     */
+    @Test
+    fun `skal kunne opphøre første mandag i måneden der det finnes helgdager før mandagen`() {
+        val fom = 1 januar 2025
+        val tom = 28 februar 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN,
+            ) {
+                defaultTilsynBarnTestdata(fom = fom, tom = tom)
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            ) {
+                vedtak {
+                    opphør(
+                        opphørsdato = 3 februar 2025,
+                    )
+                }
+            }
+
+        kall.vedtak
+            .hentVedtak(
+                stønadstype = Stønadstype.BARNETILSYN,
+                behandlingId = behandlingId,
+            ).expectOkWithBody<OpphørTilsynBarnResponse>()
+            .also { vedtak ->
+                assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
+                assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+                assertThat(vedtak.begrunnelse).isEqualTo("annet")
+            }
+    }
+
+    @Test
+    fun `skal ikke kunne opphøre dersom utgifter endres før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTilsynBarn(
+                            fom = fom,
+                            tom = tom,
+                            aktivitetsdager = 4,
+                        )
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        passBarn(
+                            fom = fom.toYearMonth().plusMonths(1),
+                            tom = tom.toYearMonth(),
+                            utgift = 1000,
+                        )
+                    }
+                }
+            }
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                vilkår {
+                    oppdater { vilkårsvurdering ->
+                        with(vilkårsvurdering.vilkårsett.single()) {
+                            SvarPåVilkårDto(
+                                id = id,
+                                behandlingId = behandlingId,
+                                delvilkårsett = delvilkårsett,
+                                fom = fom.plusMonths(1),
+                                tom = 28 februar 2025,
+                                utgift = 500,
+                                erFremtidigUtgift = erFremtidigUtgift,
+                                offentligTransport = null,
+                            )
+                        }
+                    }
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.BARNETILSYN,
+                behandlingId = revurderingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 1 mars 2025,
+                    ),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -130,7 +130,6 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         OpphørValideringService(
             vilkårsperiodeService = vilkårperiodeServiceMock,
             vilkårService = vilkårService,
-            vedtakService = vedtakService,
             utledTidligsteEndringService = utledTidligsteEndringService,
         )
     val steg =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -82,57 +82,66 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     val vedtakRepositoryFake = VedtakRepositoryFake()
     val tilkjentYtelseRepositoryFake = TilkjentYtelseRepositoryFake()
     val behandlingServiceMock = mockk<BehandlingService>()
-    val utledTidligsteEndringService = mockk<UtledTidligsteEndringService> {
-        every { utledTidligsteEndringForBeregning(any(), any()) } returns null
-    }
-    val beregningsplanUtleder = BeregningsplanUtleder(utledTidligsteEndringService)
-    val vilkårperiodeServiceMock = mockk<VilkårperiodeService>().apply {
-        every { hentVilkårperioder(any()) } answers {
-            val vilkårsperioder =
-                vilkårperiodeRepositoryFake.findByBehandlingId(BehandlingId(firstArg<UUID>())).sorted()
-            Vilkårperioder(
-                målgrupper = vilkårsperioder.ofType<MålgruppeFaktaOgVurdering>(),
-                aktiviteter = vilkårsperioder.ofType<AktivitetFaktaOgVurdering>(),
-            )
+    val utledTidligsteEndringService =
+        mockk<UtledTidligsteEndringService> {
+            every { utledTidligsteEndringForBeregning(any(), any()) } returns null
         }
-    }
-    val vilkårService = VilkårService(
-        behandlingService = behandlingServiceMock,
-        vilkårRepository = vilkårRepositoryFake,
-        barnService = mockk(relaxed = true),
-    )
+    val beregningsplanUtleder = BeregningsplanUtleder(utledTidligsteEndringService)
+    val vilkårperiodeServiceMock =
+        mockk<VilkårperiodeService>().apply {
+            every { hentVilkårperioder(any()) } answers {
+                val vilkårsperioder =
+                    vilkårperiodeRepositoryFake.findByBehandlingId(BehandlingId(firstArg<UUID>())).sorted()
+                Vilkårperioder(
+                    målgrupper = vilkårsperioder.ofType<MålgruppeFaktaOgVurdering>(),
+                    aktiviteter = vilkårsperioder.ofType<AktivitetFaktaOgVurdering>(),
+                )
+            }
+        }
+    val vilkårService =
+        VilkårService(
+            behandlingService = behandlingServiceMock,
+            vilkårRepository = vilkårRepositoryFake,
+            barnService = mockk(relaxed = true),
+        )
     val boutgifterUtgiftService = BoutgifterUtgiftService(vilkårService = vilkårService)
-    val vedtakService = VedtakService(
-        vedtakRepository = vedtakRepositoryFake,
-    )
-    val vedtaksperiodeValideringService = VedtaksperiodeValideringService(
-        vilkårperiodeService = vilkårperiodeServiceMock,
-    )
+    val vedtakService =
+        VedtakService(
+            vedtakRepository = vedtakRepositoryFake,
+        )
+    val vedtaksperiodeValideringService =
+        VedtaksperiodeValideringService(
+            vilkårperiodeService = vilkårperiodeServiceMock,
+        )
     val simuleringServiceMock = mockk<SimuleringService>(relaxed = true)
 
-    val satsBoutgifterService = SatsBoutgifterService(
-        satsBoutgifterProvider = SatsBoutgifterProvider(),
-    )
-    val beregningService = BoutgifterBeregningService(
-        boutgifterUtgiftService = boutgifterUtgiftService,
-        vedtaksperiodeValideringService = vedtaksperiodeValideringService,
-        vedtakRepository = vedtakRepositoryFake,
-        satsBoutgifterService = satsBoutgifterService,
-    )
-    val opphørValideringService = OpphørValideringService(
-        vilkårsperiodeService = vilkårperiodeServiceMock,
-        vilkårService = vilkårService,
-        vedtakService = vedtakService,
-        utledTidligsteEndringService = utledTidligsteEndringService,
-    )
-    val steg = BoutgifterBeregnYtelseSteg(
-        beregningService = beregningService,
-        opphørValideringService = opphørValideringService,
-        beregningsplanUtleder = beregningsplanUtleder,
-        vedtakRepository = vedtakRepositoryFake,
-        tilkjentYtelseService = TilkjentYtelseService(tilkjentYtelseRepositoryFake),
-        simuleringService = simuleringServiceMock,
-    )
+    val satsBoutgifterService =
+        SatsBoutgifterService(
+            satsBoutgifterProvider = SatsBoutgifterProvider(),
+        )
+    val beregningService =
+        BoutgifterBeregningService(
+            boutgifterUtgiftService = boutgifterUtgiftService,
+            vedtaksperiodeValideringService = vedtaksperiodeValideringService,
+            vedtakRepository = vedtakRepositoryFake,
+            satsBoutgifterService = satsBoutgifterService,
+        )
+    val opphørValideringService =
+        OpphørValideringService(
+            vilkårsperiodeService = vilkårperiodeServiceMock,
+            vilkårService = vilkårService,
+            vedtakService = vedtakService,
+            utledTidligsteEndringService = utledTidligsteEndringService,
+        )
+    val steg =
+        BoutgifterBeregnYtelseSteg(
+            beregningService = beregningService,
+            opphørValideringService = opphørValideringService,
+            beregningsplanUtleder = beregningsplanUtleder,
+            vedtakRepository = vedtakRepositoryFake,
+            tilkjentYtelseService = TilkjentYtelseService(tilkjentYtelseRepositoryFake),
+            simuleringService = simuleringServiceMock,
+        )
 
     var feil: Exception? = null
 
@@ -166,16 +175,18 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         utgifterData: DataTable,
     ) {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
-        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns dummyBehandling(
-            behandlingId = behandlingId,
-            steg = StegType.VILKÅR,
-        )
+        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
+            dummyBehandling(
+                behandlingId = behandlingId,
+                steg = StegType.VILKÅR,
+            )
 
-        val opprettVilkårDto = mapOpprettVilkårDto(
-            typeBoutgift = typeBoutgift,
-            behandlingId = behandlingId,
-            utgifterData = utgifterData,
-        )
+        val opprettVilkårDto =
+            mapOpprettVilkårDto(
+                typeBoutgift = typeBoutgift,
+                behandlingId = behandlingId,
+                utgifterData = utgifterData,
+            )
 
         opprettVilkårDto.forEach { vilkårService.opprettNyttVilkår(it) }
     }
@@ -184,19 +195,20 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         typeBoutgift: TypeBoutgift,
         behandlingId: BehandlingId,
         utgifterData: DataTable,
-    ): List<OpprettVilkårDto> = utgifterData.mapRad { rad ->
-        val delvilkår = mapDelvilkår(rad, typeBoutgift)
-        OpprettVilkårDto(
-            vilkårType = typeBoutgift.tilVilkårType(),
-            behandlingId = behandlingId,
-            delvilkårsett = delvilkår,
-            fom = parseDato(DomenenøkkelFelles.FOM, rad),
-            tom = parseDato(DomenenøkkelFelles.TOM, rad),
-            utgift = parseInt(BoutgifterDomenenøkkel.UTGIFT, rad),
-            erFremtidigUtgift = false,
-            offentligTransport = null,
-        )
-    }
+    ): List<OpprettVilkårDto> =
+        utgifterData.mapRad { rad ->
+            val delvilkår = mapDelvilkår(rad, typeBoutgift)
+            OpprettVilkårDto(
+                vilkårType = typeBoutgift.tilVilkårType(),
+                behandlingId = behandlingId,
+                delvilkårsett = delvilkår,
+                fom = parseDato(DomenenøkkelFelles.FOM, rad),
+                tom = parseDato(DomenenøkkelFelles.TOM, rad),
+                utgift = parseInt(BoutgifterDomenenøkkel.UTGIFT, rad),
+                erFremtidigUtgift = false,
+                offentligTransport = null,
+            )
+        }
 
     private fun mapDelvilkår(
         rad: Map<String, String>,
@@ -225,10 +237,11 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     ) {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
 
-        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns dummyBehandling(
-            behandlingId = behandlingId,
-            steg = StegType.BEREGNE_YTELSE,
-        )
+        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
+            dummyBehandling(
+                behandlingId = behandlingId,
+                steg = StegType.BEREGNE_YTELSE,
+            )
         val vedtaksperioder = mapVedtaksperioder(dataTable).map { it.tilDto() }
 
         kjørMedFeilkontekst {
@@ -261,11 +274,12 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val utgifter = boutgifterUtgiftService.hentUtgifterTilBeregning(behandlingId)
         val perioderBeregningsresultat = mapBeregningsresultat(dataTable, utgifter)
         val vedtaksperiode = mapVedtaksperioder(dataTable)
-        val vedtak = innvilgelseBoutgifter(
-            behandlingId = behandlingId,
-            vedtaksperioder = vedtaksperiode,
-            beregningsresultat = BeregningsresultatBoutgifter(perioderBeregningsresultat),
-        )
+        val vedtak =
+            innvilgelseBoutgifter(
+                behandlingId = behandlingId,
+                vedtaksperioder = vedtaksperiode,
+                beregningsresultat = BeregningsresultatBoutgifter(perioderBeregningsresultat),
+            )
         vedtakRepositoryFake.insert(vedtak)
     }
 
@@ -301,7 +315,8 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
 
         every {
             utledTidligsteEndringService.utledTidligsteEndringForBeregning(
-                behandlingId, any()
+                behandlingId,
+                any(),
             )
         } returns tidligsteEndring
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -33,7 +33,6 @@ import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.BeregningsplanUtleder
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
-import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.BoutgifterTestUtil.innvilgelseBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterUtgiftService
@@ -107,10 +106,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
             barnService = mockk(relaxed = true),
         )
     val boutgifterUtgiftService = BoutgifterUtgiftService(vilkårService = vilkårService)
-    val vedtakService =
-        VedtakService(
-            vedtakRepository = vedtakRepositoryFake,
-        )
+
     val vedtaksperiodeValideringService =
         VedtaksperiodeValideringService(
             vilkårperiodeService = vilkårperiodeServiceMock,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -82,66 +82,57 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     val vedtakRepositoryFake = VedtakRepositoryFake()
     val tilkjentYtelseRepositoryFake = TilkjentYtelseRepositoryFake()
     val behandlingServiceMock = mockk<BehandlingService>()
-    val utledTidligsteEndringService =
-        mockk<UtledTidligsteEndringService> {
-            every { utledTidligsteEndringForBeregning(any(), any()) } returns null
-        }
+    val utledTidligsteEndringService = mockk<UtledTidligsteEndringService> {
+        every { utledTidligsteEndringForBeregning(any(), any()) } returns null
+    }
     val beregningsplanUtleder = BeregningsplanUtleder(utledTidligsteEndringService)
-    val vilkårperiodeServiceMock =
-        mockk<VilkårperiodeService>().apply {
-            every { hentVilkårperioder(any()) } answers {
-                val vilkårsperioder =
-                    vilkårperiodeRepositoryFake.findByBehandlingId(BehandlingId(firstArg<UUID>())).sorted()
-                Vilkårperioder(
-                    målgrupper = vilkårsperioder.ofType<MålgruppeFaktaOgVurdering>(),
-                    aktiviteter = vilkårsperioder.ofType<AktivitetFaktaOgVurdering>(),
-                )
-            }
+    val vilkårperiodeServiceMock = mockk<VilkårperiodeService>().apply {
+        every { hentVilkårperioder(any()) } answers {
+            val vilkårsperioder =
+                vilkårperiodeRepositoryFake.findByBehandlingId(BehandlingId(firstArg<UUID>())).sorted()
+            Vilkårperioder(
+                målgrupper = vilkårsperioder.ofType<MålgruppeFaktaOgVurdering>(),
+                aktiviteter = vilkårsperioder.ofType<AktivitetFaktaOgVurdering>(),
+            )
         }
-    val vilkårService =
-        VilkårService(
-            behandlingService = behandlingServiceMock,
-            vilkårRepository = vilkårRepositoryFake,
-            barnService = mockk(relaxed = true),
-        )
+    }
+    val vilkårService = VilkårService(
+        behandlingService = behandlingServiceMock,
+        vilkårRepository = vilkårRepositoryFake,
+        barnService = mockk(relaxed = true),
+    )
     val boutgifterUtgiftService = BoutgifterUtgiftService(vilkårService = vilkårService)
     val vedtakService = VedtakService(
         vedtakRepository = vedtakRepositoryFake,
     )
-    val vedtaksperiodeValideringService =
-        VedtaksperiodeValideringService(
-            vilkårperiodeService = vilkårperiodeServiceMock,
-        )
+    val vedtaksperiodeValideringService = VedtaksperiodeValideringService(
+        vilkårperiodeService = vilkårperiodeServiceMock,
+    )
     val simuleringServiceMock = mockk<SimuleringService>(relaxed = true)
 
-    val satsBoutgifterService =
-        SatsBoutgifterService(
-            satsBoutgifterProvider = SatsBoutgifterProvider(),
-        )
-    val beregningService =
-        BoutgifterBeregningService(
-            boutgifterUtgiftService = boutgifterUtgiftService,
-            vedtaksperiodeValideringService = vedtaksperiodeValideringService,
-            vedtakRepository = vedtakRepositoryFake,
-            satsBoutgifterService = satsBoutgifterService,
-        )
-    val opphørValideringService =
-        OpphørValideringService(
-            vilkårsperiodeService = vilkårperiodeServiceMock,
-            vilkårService = vilkårService,
-            vedtakService = vedtakService,
-            utledTidligsteEndringService = utledTidligsteEndringService,
-        )
-    val steg =
-        BoutgifterBeregnYtelseSteg(
-            beregningService =
-                beregningService,
-            opphørValideringService = opphørValideringService,
-            beregningsplanUtleder = beregningsplanUtleder,
-            vedtakRepository = vedtakRepositoryFake,
-            tilkjentYtelseService = TilkjentYtelseService(tilkjentYtelseRepositoryFake),
-            simuleringService = simuleringServiceMock,
-        )
+    val satsBoutgifterService = SatsBoutgifterService(
+        satsBoutgifterProvider = SatsBoutgifterProvider(),
+    )
+    val beregningService = BoutgifterBeregningService(
+        boutgifterUtgiftService = boutgifterUtgiftService,
+        vedtaksperiodeValideringService = vedtaksperiodeValideringService,
+        vedtakRepository = vedtakRepositoryFake,
+        satsBoutgifterService = satsBoutgifterService,
+    )
+    val opphørValideringService = OpphørValideringService(
+        vilkårsperiodeService = vilkårperiodeServiceMock,
+        vilkårService = vilkårService,
+        vedtakService = vedtakService,
+        utledTidligsteEndringService = utledTidligsteEndringService,
+    )
+    val steg = BoutgifterBeregnYtelseSteg(
+        beregningService = beregningService,
+        opphørValideringService = opphørValideringService,
+        beregningsplanUtleder = beregningsplanUtleder,
+        vedtakRepository = vedtakRepositoryFake,
+        tilkjentYtelseService = TilkjentYtelseService(tilkjentYtelseRepositoryFake),
+        simuleringService = simuleringServiceMock,
+    )
 
     var feil: Exception? = null
 
@@ -175,18 +166,16 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         utgifterData: DataTable,
     ) {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
-        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
-                dummyBehandling(
-                    behandlingId = behandlingId,
-                    steg = StegType.VILKÅR,
-                )
+        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns dummyBehandling(
+            behandlingId = behandlingId,
+            steg = StegType.VILKÅR,
+        )
 
-        val opprettVilkårDto =
-            mapOpprettVilkårDto(
-                typeBoutgift = typeBoutgift,
-                behandlingId = behandlingId,
-                utgifterData = utgifterData,
-            )
+        val opprettVilkårDto = mapOpprettVilkårDto(
+            typeBoutgift = typeBoutgift,
+            behandlingId = behandlingId,
+            utgifterData = utgifterData,
+        )
 
         opprettVilkårDto.forEach { vilkårService.opprettNyttVilkår(it) }
     }
@@ -195,29 +184,26 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         typeBoutgift: TypeBoutgift,
         behandlingId: BehandlingId,
         utgifterData: DataTable,
-    ): List<OpprettVilkårDto> =
-        utgifterData.mapRad { rad ->
-            val delvilkår = mapDelvilkår(rad, typeBoutgift)
-            OpprettVilkårDto(
-                vilkårType = typeBoutgift.tilVilkårType(),
-                behandlingId = behandlingId,
-                delvilkårsett = delvilkår,
-                fom = parseDato(DomenenøkkelFelles.FOM, rad),
-                tom = parseDato(DomenenøkkelFelles.TOM, rad),
-                utgift = parseInt(BoutgifterDomenenøkkel.UTGIFT, rad),
-                erFremtidigUtgift = false,
-                offentligTransport = null,
-            )
-        }
+    ): List<OpprettVilkårDto> = utgifterData.mapRad { rad ->
+        val delvilkår = mapDelvilkår(rad, typeBoutgift)
+        OpprettVilkårDto(
+            vilkårType = typeBoutgift.tilVilkårType(),
+            behandlingId = behandlingId,
+            delvilkårsett = delvilkår,
+            fom = parseDato(DomenenøkkelFelles.FOM, rad),
+            tom = parseDato(DomenenøkkelFelles.TOM, rad),
+            utgift = parseInt(BoutgifterDomenenøkkel.UTGIFT, rad),
+            erFremtidigUtgift = false,
+            offentligTransport = null,
+        )
+    }
 
     private fun mapDelvilkår(
         rad: Map<String, String>,
         typeBoutgift: TypeBoutgift,
     ): List<DelvilkårDto> {
         val harHøyereUtgifter =
-            parseValgfriBoolean(BoutgifterDomenenøkkel.HØYERE_UTGIFTER, rad)
-                ?.takeIf { it }
-                ?.let { SvarId.JA }
+            parseValgfriBoolean(BoutgifterDomenenøkkel.HØYERE_UTGIFTER, rad)?.takeIf { it }?.let { SvarId.JA }
                 ?: SvarId.NEI
         return when (typeBoutgift) {
             TypeBoutgift.UTGIFTER_OVERNATTING -> oppfylteDelvilkårUtgifterOvernatting(harHøyereUtgifter)
@@ -239,11 +225,10 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     ) {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
 
-        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
-                dummyBehandling(
-                    behandlingId = behandlingId,
-                    steg = StegType.BEREGNE_YTELSE,
-                )
+        every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns dummyBehandling(
+            behandlingId = behandlingId,
+            steg = StegType.BEREGNE_YTELSE,
+        )
         val vedtaksperioder = mapVedtaksperioder(dataTable).map { it.tilDto() }
 
         kjørMedFeilkontekst {
@@ -276,12 +261,11 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val utgifter = boutgifterUtgiftService.hentUtgifterTilBeregning(behandlingId)
         val perioderBeregningsresultat = mapBeregningsresultat(dataTable, utgifter)
         val vedtaksperiode = mapVedtaksperioder(dataTable)
-        val vedtak =
-            innvilgelseBoutgifter(
-                behandlingId = behandlingId,
-                vedtaksperioder = vedtaksperiode,
-                beregningsresultat = BeregningsresultatBoutgifter(perioderBeregningsresultat),
-            )
+        val vedtak = innvilgelseBoutgifter(
+            behandlingId = behandlingId,
+            vedtaksperioder = vedtaksperiode,
+            beregningsresultat = BeregningsresultatBoutgifter(perioderBeregningsresultat),
+        )
         vedtakRepositoryFake.insert(vedtak)
     }
 
@@ -317,8 +301,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
 
         every {
             utledTidligsteEndringService.utledTidligsteEndringForBeregning(
-                behandlingId,
-                any()
+                behandlingId, any()
             )
         } returns tidligsteEndring
 
@@ -357,10 +340,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val forventedeAndeler = mapAndeler(dataTable)
 
         val andeler =
-            tilkjentYtelseRepositoryFake
-                .findByBehandlingId(behandlingId)!!
-                .andelerTilkjentYtelse
-                .sortedBy { it.fom }
+            tilkjentYtelseRepositoryFake.findByBehandlingId(behandlingId)!!.andelerTilkjentYtelse.sortedBy { it.fom }
 
         verifiserAtListerErLike(faktisk = andeler.map { ForenkletAndel(it) }, forventet = forventedeAndeler)
     }
@@ -393,10 +373,7 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     }
 
     private fun hentVedtak(behandlingId: BehandlingId): InnvilgelseEllerOpphørBoutgifter =
-        vedtakRepositoryFake
-            .findByIdOrThrow(behandlingId)
-            .withTypeOrThrow<InnvilgelseEllerOpphørBoutgifter>()
-            .data
+        vedtakRepositoryFake.findByIdOrThrow(behandlingId).withTypeOrThrow<InnvilgelseEllerOpphørBoutgifter>().data
 
     private fun dummyBehandling(
         behandlingId: BehandlingId,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -85,7 +85,9 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     val utledTidligsteEndringService =
         mockk<UtledTidligsteEndringService> {
             every { utledTidligsteEndringForBeregning(any(), any()) } returns null
+            every { utledTidligsteEndringIgnorerVedtaksperioder(any()) } returns null
         }
+
     val beregningsplanUtleder = BeregningsplanUtleder(utledTidligsteEndringService)
     val vilkårperiodeServiceMock =
         mockk<VilkårperiodeService>().apply {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterBeregnYtelseStegStepDefinitions.kt
@@ -33,6 +33,7 @@ import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.BeregningsplanUtleder
 import no.nav.tilleggsstonader.sak.vedtak.OpphørValideringService
+import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.BoutgifterTestUtil.innvilgelseBoutgifter
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterBeregningService
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning.BoutgifterUtgiftService
@@ -104,6 +105,9 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
             barnService = mockk(relaxed = true),
         )
     val boutgifterUtgiftService = BoutgifterUtgiftService(vilkårService = vilkårService)
+    val vedtakService = VedtakService(
+        vedtakRepository = vedtakRepositoryFake,
+    )
     val vedtaksperiodeValideringService =
         VedtaksperiodeValideringService(
             vilkårperiodeService = vilkårperiodeServiceMock,
@@ -125,11 +129,13 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         OpphørValideringService(
             vilkårsperiodeService = vilkårperiodeServiceMock,
             vilkårService = vilkårService,
+            vedtakService = vedtakService,
+            utledTidligsteEndringService = utledTidligsteEndringService,
         )
     val steg =
         BoutgifterBeregnYtelseSteg(
             beregningService =
-            beregningService,
+                beregningService,
             opphørValideringService = opphørValideringService,
             beregningsplanUtleder = beregningsplanUtleder,
             vedtakRepository = vedtakRepositoryFake,
@@ -170,10 +176,10 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
     ) {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
         every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
-            dummyBehandling(
-                behandlingId = behandlingId,
-                steg = StegType.VILKÅR,
-            )
+                dummyBehandling(
+                    behandlingId = behandlingId,
+                    steg = StegType.VILKÅR,
+                )
 
         val opprettVilkårDto =
             mapOpprettVilkårDto(
@@ -234,10 +240,10 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val behandlingId = testIdTilBehandlingId.getValue(behandlingIdTall)
 
         every { behandlingServiceMock.hentSaksbehandling(any<BehandlingId>()) } returns
-            dummyBehandling(
-                behandlingId = behandlingId,
-                steg = StegType.BEREGNE_YTELSE,
-            )
+                dummyBehandling(
+                    behandlingId = behandlingId,
+                    steg = StegType.BEREGNE_YTELSE,
+                )
         val vedtaksperioder = mapVedtaksperioder(dataTable).map { it.tilDto() }
 
         kjørMedFeilkontekst {
@@ -309,7 +315,12 @@ class BoutgifterBeregnYtelseStegStepDefinitions {
         val tidligsteEndring = parseDato(tidligsteEndringStr)
         val vedtaksperioder = mapVedtaksperioder(vedtaksperiodeData).map { it.tilDto() }
 
-        every { utledTidligsteEndringService.utledTidligsteEndringForBeregning(behandlingId, any()) } returns tidligsteEndring
+        every {
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandlingId,
+                any()
+            )
+        } returns tidligsteEndring
 
         kjørMedFeilkontekst {
             steg.utførSteg(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterOpphørIntegrationTest.kt
@@ -1,0 +1,130 @@
+package no.nav.tilleggsstonader.sak.vedtak.boutgifter
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
+import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class BoutgifterOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
+    @Test
+    fun `skal lagre og hente opphør`() {
+        val fom = 1 januar 2025
+        val tom = 28 februar 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BOUTGIFTER,
+            ) {
+                defaultBoutgifterTestdata(
+                    fom = fom,
+                    tom = tom,
+                )
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            ) {
+                vedtak {
+                    opphør(
+                        årsaker = listOf(ÅrsakOpphør.ANNET),
+                        begrunnelse = "Statsbudsjettet er tomt",
+                        opphørsdato = tom.minusDays(10),
+                    )
+                }
+            }
+
+        val vedtak =
+            kall.vedtak
+                .hentVedtak(Stønadstype.BOUTGIFTER, revurderingId)
+                .expectOkWithBody<OpphørBoutgifterResponse>()
+
+        assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
+        assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+        assertThat(vedtak.begrunnelse).isEqualTo("Statsbudsjettet er tomt")
+    }
+
+    @Test
+    fun `skal ikke kunne lagre opphør ved endringer i vedtak før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BOUTGIFTER,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakBoutgifter(fom, tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        løpendeutgifterEnBolig(fom.plusMonths(1).tilFørsteDagIMåneden(), tom)
+                    }
+                }
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                vilkår {
+                    oppdater { vilkårsvurdering ->
+                        with(vilkårsvurdering.vilkårsett.single()) {
+                            SvarPåVilkårDto(
+                                id = id,
+                                behandlingId = behandlingId,
+                                delvilkårsett = delvilkårsett,
+                                fom = fom.plusMonths(1).tilFørsteDagIMåneden(),
+                                tom = 28 februar 2025,
+                                utgift = utgift,
+                                erFremtidigUtgift = erFremtidigUtgift,
+                                offentligTransport = null,
+                            )
+                        }
+                    }
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.BOUTGIFTER,
+                behandlingId = behandlingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 1 mars 2025,
+                    ),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakControllerTest.kt
@@ -17,7 +17,6 @@ import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterRequest
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
@@ -114,32 +113,29 @@ class BoutgifterVedtakControllerTest : CleanDatabaseIntegrationTest() {
                     )
                 }
 
+            testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
             val revurderingId =
                 opprettRevurderingOgGjennomførBehandlingsløp(
                     fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                    tilSteg = StegType.BEREGNE_YTELSE,
-                ) {}
+                ) {
+                    vedtak {
+                        opphør(
+                            årsaker = listOf(ÅrsakOpphør.ANNET),
+                            begrunnelse = "Statsbudsjettet er tomt",
+                            opphørsdato = tom.minusDays(10),
+                        )
+                    }
+                }
 
-            val opphørVedtak =
-                OpphørBoutgifterRequest(
-                    årsakerOpphør = listOf(ÅrsakOpphør.ANNET),
-                    begrunnelse = "Statsbudsjettet er tomt",
-                    opphørsdato = tom.minusDays(10),
-                )
-
-            kall.vedtak.apiRespons
-                .lagreOpphør(Stønadstype.BOUTGIFTER, revurderingId, opphørVedtak)
-                .expectStatus()
-                .isOk()
-
-            val lagretDto =
+            val vedtak =
                 kall.vedtak
                     .hentVedtak(Stønadstype.BOUTGIFTER, revurderingId)
                     .expectOkWithBody<OpphørBoutgifterResponse>()
 
-            assertThat(lagretDto.årsakerOpphør).isEqualTo(opphørVedtak.årsakerOpphør)
-            assertThat(lagretDto.begrunnelse).isEqualTo(opphørVedtak.begrunnelse)
-            assertThat(lagretDto.type).isEqualTo(TypeVedtak.OPPHØR)
+            assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
+            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+            assertThat(vedtak.begrunnelse).isEqualTo("Statsbudsjettet er tomt")
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakControllerTest.kt
@@ -1,39 +1,37 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
-import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkEmpty
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.opprettOgTilordneOppgaveForBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.InnvilgelseBoutgifterRequest
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterRequest
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
-import no.nav.tilleggsstonader.sak.vedtak.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeRepository
-import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.felles.Vilkårstatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
-import java.util.UUID
 
 class BoutgifterVedtakControllerTest : CleanDatabaseIntegrationTest() {
     @Autowired
@@ -45,7 +43,8 @@ class BoutgifterVedtakControllerTest : CleanDatabaseIntegrationTest() {
     val dummyFom: LocalDate = LocalDate.now()
     val dummyTom: LocalDate = LocalDate.now().plusDays(7)
     val dummyFagsak = fagsak(stønadstype = Stønadstype.BOUTGIFTER)
-    val dummyBehandling = behandling(fagsak = dummyFagsak, steg = StegType.BEREGNE_YTELSE, status = BehandlingStatus.UTREDES)
+    val dummyBehandling =
+        behandling(fagsak = dummyFagsak, steg = StegType.BEREGNE_YTELSE, status = BehandlingStatus.UTREDES)
 
     val vedtaksperiode = vedtaksperiode(fom = dummyFom, tom = dummyTom)
     val aktivitet = aktivitet(dummyBehandling.id, fom = dummyFom, tom = dummyTom)
@@ -102,61 +101,43 @@ class BoutgifterVedtakControllerTest : CleanDatabaseIntegrationTest() {
     inner class Opphør {
         @Test
         fun `skal lagre og hente opphør`() {
-            val opphørsdato = dummyFom.plusDays(4)
-            kall.vedtak.lagreInnvilgelse(
-                Stønadstype.BOUTGIFTER,
-                dummyBehandling.id,
-                InnvilgelseBoutgifterRequest(listOf(vedtaksperiode.tilDto())),
-            )
-            testoppsettService.ferdigstillBehandling(dummyBehandling)
+            val fom = 1 januar 2025
+            val tom = 28 februar 2025
 
-            val revurdering =
-                testoppsettService.opprettRevurdering(
-                    forrigeBehandling = dummyBehandling,
-                    fagsak = dummyFagsak,
-                )
-            opprettOgTilordneOppgaveForBehandling(revurdering.id)
+            val førstegangsbehandlingContext =
+                opprettBehandlingOgGjennomførBehandlingsløp(
+                    stønadstype = Stønadstype.BOUTGIFTER,
+                ) {
+                    defaultBoutgifterTestdata(
+                        fom = fom,
+                        tom = tom,
+                    )
+                }
 
-            vilkårRepository.insert(
-                vilkår.copy(
-                    fom = dummyFom,
-                    tom = opphørsdato.minusDays(1),
-                    id = VilkårId.random(),
-                    behandlingId = revurdering.id,
-                    status = VilkårStatus.ENDRET,
-                ),
-            )
-
-            vilkårperiodeRepository.insert(
-                aktivitet.copy(
-                    id = UUID.randomUUID(),
-                    behandlingId = revurdering.id,
-                    status = Vilkårstatus.UENDRET,
-                ),
-            )
-            vilkårperiodeRepository.insert(
-                målgruppe.copy(
-                    id = UUID.randomUUID(),
-                    behandlingId = revurdering.id,
-                    status = Vilkårstatus.UENDRET,
-                ),
-            )
+            val revurderingId =
+                opprettRevurderingOgGjennomførBehandlingsløp(
+                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                    tilSteg = StegType.BEREGNE_YTELSE,
+                ) {}
 
             val opphørVedtak =
                 OpphørBoutgifterRequest(
                     årsakerOpphør = listOf(ÅrsakOpphør.ANNET),
                     begrunnelse = "Statsbudsjettet er tomt",
-                    opphørsdato = opphørsdato,
+                    opphørsdato = tom.minusDays(10),
                 )
 
-            kall.vedtak.lagreOpphør(Stønadstype.BOUTGIFTER, revurdering.id, opphørVedtak)
+            kall.vedtak.apiRespons
+                .lagreOpphør(Stønadstype.BOUTGIFTER, revurderingId, opphørVedtak)
+                .expectStatus()
+                .isOk()
 
             val lagretDto =
                 kall.vedtak
-                    .hentVedtak(Stønadstype.BOUTGIFTER, revurdering.id)
+                    .hentVedtak(Stønadstype.BOUTGIFTER, revurderingId)
                     .expectOkWithBody<OpphørBoutgifterResponse>()
 
-            assertThat((lagretDto).årsakerOpphør).isEqualTo(opphørVedtak.årsakerOpphør)
+            assertThat(lagretDto.årsakerOpphør).isEqualTo(opphørVedtak.årsakerOpphør)
             assertThat(lagretDto.begrunnelse).isEqualTo(opphørVedtak.begrunnelse)
             assertThat(lagretDto.type).isEqualTo(TypeVedtak.OPPHØR)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterVedtakControllerTest.kt
@@ -1,25 +1,19 @@
 package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.libs.utils.dato.februar
-import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkEmpty
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.opprettOgTilordneOppgaveForBehandling
-import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
-import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.util.vilkår
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.AvslagBoutgifterDto
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
-import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
@@ -93,49 +87,6 @@ class BoutgifterVedtakControllerTest : CleanDatabaseIntegrationTest() {
             assertThat(lagretDto.årsakerAvslag).isEqualTo(avslag.årsakerAvslag)
             assertThat(lagretDto.begrunnelse).isEqualTo(avslag.begrunnelse)
             assertThat(lagretDto.type).isEqualTo(TypeVedtak.AVSLAG)
-        }
-    }
-
-    @Nested
-    inner class Opphør {
-        @Test
-        fun `skal lagre og hente opphør`() {
-            val fom = 1 januar 2025
-            val tom = 28 februar 2025
-
-            val førstegangsbehandlingContext =
-                opprettBehandlingOgGjennomførBehandlingsløp(
-                    stønadstype = Stønadstype.BOUTGIFTER,
-                ) {
-                    defaultBoutgifterTestdata(
-                        fom = fom,
-                        tom = tom,
-                    )
-                }
-
-            testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
-
-            val revurderingId =
-                opprettRevurderingOgGjennomførBehandlingsløp(
-                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                ) {
-                    vedtak {
-                        opphør(
-                            årsaker = listOf(ÅrsakOpphør.ANNET),
-                            begrunnelse = "Statsbudsjettet er tomt",
-                            opphørsdato = tom.minusDays(10),
-                        )
-                    }
-                }
-
-            val vedtak =
-                kall.vedtak
-                    .hentVedtak(Stønadstype.BOUTGIFTER, revurderingId)
-                    .expectOkWithBody<OpphørBoutgifterResponse>()
-
-            assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
-            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
-            assertThat(vedtak.begrunnelse).isEqualTo("Statsbudsjettet er tomt")
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.juni
 import no.nav.tilleggsstonader.libs.utils.dato.mars
@@ -9,11 +10,15 @@ import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.util.lagreDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDagligReiseOffentligTransportDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 
 class DagligReiseBeregnYtelseStegIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
@@ -54,4 +59,49 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
         assertThat(andelerOpphør.size).isNotEqualTo(andelerFørstegangsbehandling.size)
         assertThat(andelerOpphør.maxByOrNull { it.tom }!!.tom).isBeforeOrEqualTo(14 mars 2025)
     }
+
+    @Test
+    fun `skal ikke kunne opphøre dersom pris er endret før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 28 februar 2025
+
+        val førstegangsbehandlingContext = opprettBehandlingOgGjennomførBehandlingsløp(
+            stønadstype = Stønadstype.DAGLIG_REISE_TSO
+        ) {
+            defaultDagligReiseTsoTestdata(fom = fom, tom = tom)
+        }
+
+        val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
+            fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            tilSteg = StegType.BEREGNE_YTELSE
+        ) {
+            vilkår {
+                oppdaterDagligReise { vilkårDagligReise, _ ->
+                    vilkårDagligReise.single().id to
+                            lagreDagligReiseDto(
+                                fom = fom,
+                                tom = tom,
+                                fakta =
+                                    FaktaDagligReiseOffentligTransportDto(
+                                        reisedagerPerUke = 3,
+                                        prisEnkelbillett = 40,
+                                        prisSyvdagersbillett = null,
+                                        prisTrettidagersbillett = 1200,
+                                    ),
+                            )
+                }
+            }
+        }
+
+        kall.vedtak.apiRespons.lagreOpphør(
+            stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            behandlingId = revurderingId,
+            opphørDto = opphørDto(
+                opphørsdato = LocalDate.of(2025, 2, 1)
+            ),
+        ).expectStatus().isBadRequest().expectBody().jsonPath("$.detail")
+            .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
+    }
+
+
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -109,7 +109,9 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
                     ),
             ).expectProblemDetail(
                 forventetStatus = HttpStatus.BAD_REQUEST,
-                forventetDetail = "Opphør er et ugyldig vedtaksresultat fordi opphørsdato er etter eller lik tidligste endring (01.01.2025)",
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.01.2025)",
             )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -25,28 +25,37 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
 ) : IntegrationTest() {
     @Test
     fun `skal kunne opphøre`() {
-        val førstegangsbehandlingContext = opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
-            defaultDagligReiseTsoTestdata(2 januar 2025, 6 juni 2025)
-        }
-
-        val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
-            førstegangsbehandlingContext.behandlingId, tilSteg = StegType.SIMULERING
-        ) {
-            vedtak {
-                opphør(opphørsdato = 15 mars 2025)
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
+                defaultDagligReiseTsoTestdata(2 januar 2025, 6 juni 2025)
             }
-        }
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                vedtak {
+                    opphør(opphørsdato = 15 mars 2025)
+                }
+            }
 
         val beregningsresultat = vedtakService.hentVedtak<OpphørDagligReise>(revurderingId).data.beregningsresultat
         assertThat(
-            beregningsresultat.offentligTransport!!.reiser[0].perioder.maxByOrNull {
-                it.grunnlag.tom
-            }!!.grunnlag.tom,
+            beregningsresultat.offentligTransport!!
+                .reiser[0]
+                .perioder
+                .maxByOrNull {
+                    it.grunnlag.tom
+                }!!
+                .grunnlag.tom,
         ).isEqualTo(14 mars 2025)
 
-        val andelerFørstegangsbehandling = tilkjentYtelseService.hentForBehandling(
-            førstegangsbehandlingContext.behandlingId,
-        ).andelerTilkjentYtelse
+        val andelerFørstegangsbehandling =
+            tilkjentYtelseService
+                .hentForBehandling(
+                    førstegangsbehandlingContext.behandlingId,
+                ).andelerTilkjentYtelse
         val andelerOpphør = tilkjentYtelseService.hentForBehandling(revurderingId).andelerTilkjentYtelse
 
         assertThat(andelerOpphør.size).isNotEqualTo(andelerFørstegangsbehandling.size)
@@ -58,40 +67,48 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
         val fom = 1 januar 2025
         val tom = 28 februar 2025
 
-        val førstegangsbehandlingContext = opprettBehandlingOgGjennomførBehandlingsløp(
-            stønadstype = Stønadstype.DAGLIG_REISE_TSO
-        ) {
-            defaultDagligReiseTsoTestdata(fom = fom, tom = tom)
-        }
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                defaultDagligReiseTsoTestdata(fom = fom, tom = tom)
+            }
 
-        val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
-            fraBehandlingId = førstegangsbehandlingContext.behandlingId, tilSteg = StegType.BEREGNE_YTELSE
-        ) {
-            vilkår {
-                oppdaterDagligReise { vilkårDagligReise, _ ->
-                    vilkårDagligReise.single().id to lagreDagligReiseDto(
-                        fom = fom,
-                        tom = tom,
-                        fakta = FaktaDagligReiseOffentligTransportDto(
-                            reisedagerPerUke = 3,
-                            prisEnkelbillett = 40,
-                            prisSyvdagersbillett = null,
-                            prisTrettidagersbillett = 1200,
-                        ),
-                    )
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                vilkår {
+                    oppdaterDagligReise { vilkårDagligReise, _ ->
+                        vilkårDagligReise.single().id to
+                            lagreDagligReiseDto(
+                                fom = fom,
+                                tom = tom,
+                                fakta =
+                                    FaktaDagligReiseOffentligTransportDto(
+                                        reisedagerPerUke = 3,
+                                        prisEnkelbillett = 40,
+                                        prisSyvdagersbillett = null,
+                                        prisTrettidagersbillett = 1200,
+                                    ),
+                            )
+                    }
                 }
             }
-        }
 
-        kall.vedtak.apiRespons.lagreOpphør(
-            stønadstype = Stønadstype.DAGLIG_REISE_TSO,
-            behandlingId = revurderingId,
-            opphørDto = opphørDto(
-                opphørsdato = 1 februar 2025
-            ),
-        ).expectStatus().isBadRequest().expectBody().jsonPath("$.detail")
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+                behandlingId = revurderingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 1 februar 2025,
+                    ),
+            ).expectStatus()
+            .isBadRequest()
+            .expectBody()
+            .jsonPath("$.detail")
             .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
     }
-
-
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.libs.utils.dato.juni
 import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.IntegrationTest
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
@@ -18,6 +19,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.Fakta
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 
 class DagligReiseBeregnYtelseStegIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
@@ -105,10 +107,9 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
                     opphørDto(
                         opphørsdato = 1 februar 2025,
                     ),
-            ).expectStatus()
-            .isBadRequest()
-            .expectBody()
-            .jsonPath("$.detail")
-            .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail = "Opphør er et ugyldig vedtaksresultat fordi opphørsdato er etter eller lik tidligste endring (01.01.2025)",
+            )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -18,7 +18,6 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.Fakta
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import java.time.LocalDate
 
 class DagligReiseBeregnYtelseStegIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
@@ -26,34 +25,28 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
 ) : IntegrationTest() {
     @Test
     fun `skal kunne opphøre`() {
-        val førstegangsbehandlingContext =
-            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
-                defaultDagligReiseTsoTestdata(2 januar 2025, 6 juni 2025)
-            }
+        val førstegangsbehandlingContext = opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
+            defaultDagligReiseTsoTestdata(2 januar 2025, 6 juni 2025)
+        }
 
-        val revurderingId =
-            opprettRevurderingOgGjennomførBehandlingsløp(førstegangsbehandlingContext.behandlingId, tilSteg = StegType.SIMULERING) {
-                vedtak {
-                    opphør(opphørsdato = 15 mars 2025)
-                }
+        val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
+            førstegangsbehandlingContext.behandlingId, tilSteg = StegType.SIMULERING
+        ) {
+            vedtak {
+                opphør(opphørsdato = 15 mars 2025)
             }
+        }
 
         val beregningsresultat = vedtakService.hentVedtak<OpphørDagligReise>(revurderingId).data.beregningsresultat
         assertThat(
-            beregningsresultat.offentligTransport!!
-                .reiser[0]
-                .perioder
-                .maxByOrNull {
-                    it.grunnlag.tom
-                }!!
-                .grunnlag.tom,
+            beregningsresultat.offentligTransport!!.reiser[0].perioder.maxByOrNull {
+                it.grunnlag.tom
+            }!!.grunnlag.tom,
         ).isEqualTo(14 mars 2025)
 
-        val andelerFørstegangsbehandling =
-            tilkjentYtelseService
-                .hentForBehandling(
-                    førstegangsbehandlingContext.behandlingId,
-                ).andelerTilkjentYtelse
+        val andelerFørstegangsbehandling = tilkjentYtelseService.hentForBehandling(
+            førstegangsbehandlingContext.behandlingId,
+        ).andelerTilkjentYtelse
         val andelerOpphør = tilkjentYtelseService.hentForBehandling(revurderingId).andelerTilkjentYtelse
 
         assertThat(andelerOpphør.size).isNotEqualTo(andelerFørstegangsbehandling.size)
@@ -72,23 +65,20 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
         }
 
         val revurderingId = opprettRevurderingOgGjennomførBehandlingsløp(
-            fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-            tilSteg = StegType.BEREGNE_YTELSE
+            fraBehandlingId = førstegangsbehandlingContext.behandlingId, tilSteg = StegType.BEREGNE_YTELSE
         ) {
             vilkår {
                 oppdaterDagligReise { vilkårDagligReise, _ ->
-                    vilkårDagligReise.single().id to
-                            lagreDagligReiseDto(
-                                fom = fom,
-                                tom = tom,
-                                fakta =
-                                    FaktaDagligReiseOffentligTransportDto(
-                                        reisedagerPerUke = 3,
-                                        prisEnkelbillett = 40,
-                                        prisSyvdagersbillett = null,
-                                        prisTrettidagersbillett = 1200,
-                                    ),
-                            )
+                    vilkårDagligReise.single().id to lagreDagligReiseDto(
+                        fom = fom,
+                        tom = tom,
+                        fakta = FaktaDagligReiseOffentligTransportDto(
+                            reisedagerPerUke = 3,
+                            prisEnkelbillett = 40,
+                            prisSyvdagersbillett = null,
+                            prisTrettidagersbillett = 1200,
+                        ),
+                    )
                 }
             }
         }
@@ -97,7 +87,7 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
             stønadstype = Stønadstype.DAGLIG_REISE_TSO,
             behandlingId = revurderingId,
             opphørDto = opphørDto(
-                opphørsdato = LocalDate.of(2025, 2, 1)
+                opphørsdato = 1 februar 2025
             ),
         ).expectStatus().isBadRequest().expectBody().jsonPath("$.detail")
             .isEqualTo("Opphør er et ugyldig vedtaksresultat fordi det er endringer i vilkår før opphørsdato")

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseBeregnYtelseStegIntegrationTest.kt
@@ -67,13 +67,30 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
     @Test
     fun `skal ikke kunne opphøre dersom pris er endret før opphørsdato`() {
         val fom = 1 januar 2025
-        val tom = 28 februar 2025
+        val tom = 31 mars 2025
 
         val førstegangsbehandlingContext =
             opprettBehandlingOgGjennomførBehandlingsløp(
                 stønadstype = Stønadstype.DAGLIG_REISE_TSO,
             ) {
-                defaultDagligReiseTsoTestdata(fom = fom, tom = tom)
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTso(fom, tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        offentligTransport(
+                            fom = fom.plusMonths(1),
+                            tom = tom,
+                        )
+                    }
+                }
             }
 
         val revurderingId =
@@ -85,8 +102,8 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
                     oppdaterDagligReise { vilkårDagligReise, _ ->
                         vilkårDagligReise.single().id to
                             lagreDagligReiseDto(
-                                fom = fom,
-                                tom = tom,
+                                fom = fom.plusMonths(1),
+                                tom = 28 februar 2025,
                                 fakta =
                                     FaktaDagligReiseOffentligTransportDto(
                                         reisedagerPerUke = 3,
@@ -105,13 +122,13 @@ class DagligReiseBeregnYtelseStegIntegrationTest(
                 behandlingId = revurderingId,
                 opphørDto =
                     opphørDto(
-                        opphørsdato = 1 februar 2025,
+                        opphørsdato = 1 mars 2025,
                     ),
             ).expectProblemDetail(
                 forventetStatus = HttpStatus.BAD_REQUEST,
                 forventetDetail =
                     "Opphør er et ugyldig vedtaksresultat fordi " +
-                        "opphørsdato er etter eller lik tidligste endring (01.01.2025)",
+                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
             )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseOpphørIntegrationTest.kt
@@ -5,7 +5,7 @@ import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.juni
 import no.nav.tilleggsstonader.libs.utils.dato.mars
-import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 
-class DagligReiseBeregnYtelseStegIntegrationTest(
+class DagligReiseOpphørIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
     @Autowired private val tilkjentYtelseService: TilkjentYtelseService,
-) : IntegrationTest() {
+) : CleanDatabaseIntegrationTest() {
     @Test
     fun `skal kunne opphøre`() {
         val førstegangsbehandlingContext =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
@@ -5,7 +5,11 @@ import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.libs.utils.dato.august
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
@@ -16,9 +20,9 @@ import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseLæremidler
-import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
@@ -101,20 +105,18 @@ class LæremidlerBeregnYtelseStegTest : CleanDatabaseIntegrationTest() {
     inner class Opphør {
         @Test
         fun `skal lagre vedtak`() {
-            val vedtaksperiode = vedtaksperiodeDto(id = UUID.randomUUID(), fom = fom, tom = tom)
-            val innvilgelse = InnvilgelseLæremidlerRequest(vedtaksperioder = listOf(vedtaksperiode))
+            val førstegangsbehandlingContext =
+                opprettBehandlingOgGjennomførBehandlingsløp(
+                    stønadstype = Stønadstype.LÆREMIDLER,
+                ) {
+                    defaultLæremidlerTestdata(fom = fom, tom = tom)
+                }
 
-            vilkårperiodeRepository.insertAll(listOf(målgruppe, aktivitet))
-
-            steg.utførSteg(saksbehandling, innvilgelse)
-
-            testoppsettService.ferdigstillBehandling(behandling = behandling)
-            val behandlingForOpphør =
-                testoppsettService
-                    .opprettRevurdering(
-                        forrigeBehandling = behandling,
-                        fagsak = fagsak,
-                    ).let { testoppsettService.hentSaksbehandling(it.id) }
+            val revurderingId =
+                opprettRevurderingOgGjennomførBehandlingsløp(
+                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                    tilSteg = StegType.BEREGNE_YTELSE,
+                ) {}
 
             val opphør =
                 OpphørLæremidlerRequest(
@@ -122,16 +124,25 @@ class LæremidlerBeregnYtelseStegTest : CleanDatabaseIntegrationTest() {
                     begrunnelse = "en begrunnelse",
                     opphørsdato = LocalDate.of(2025, 2, 1),
                 )
-            steg.utførSteg(behandlingForOpphør, opphør)
 
-            val vedtak = repository.findByIdOrThrow(behandlingForOpphør.id).withTypeOrThrow<OpphørLæremidler>()
-            assertThat(vedtak.behandlingId).isEqualTo(behandlingForOpphør.id)
+            kall.vedtak.apiRespons
+                .lagreOpphør(
+                    stønadstype = Stønadstype.LÆREMIDLER,
+                    behandlingId = revurderingId,
+                    opphørDto = opphør,
+                ).expectStatus()
+                .isOk()
+
+            val vedtak =
+                kall.vedtak
+                    .hentVedtak(Stønadstype.BOUTGIFTER, revurderingId)
+                    .expectOkWithBody<OpphørBoutgifterResponse>()
+
             assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
-            with(vedtak.data.vedtaksperioder.single()) {
+            with(vedtak.vedtaksperioder.single()) {
                 assertThat(this.fom).isEqualTo(fom)
                 assertThat(this.tom).isEqualTo(LocalDate.of(2025, 1, 31))
             }
-            assertThat(vedtak.gitVersjon).isEqualTo(Applikasjonsversjon.versjon)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
@@ -3,13 +3,9 @@ package no.nav.tilleggsstonader.sak.vedtak.læremidler
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.libs.utils.dato.august
-import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
-import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
-import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
-import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.Satstype
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.TilkjentYtelseRepository
@@ -24,11 +20,9 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
-import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil.vedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerRequest
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerResponse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
@@ -97,45 +91,6 @@ class LæremidlerBeregnYtelseStegTest : CleanDatabaseIntegrationTest() {
                 assertThat(this.tom).isEqualTo(tom)
             }
             assertThat(vedtak.gitVersjon).isEqualTo(Applikasjonsversjon.versjon)
-        }
-    }
-
-    @Nested
-    inner class Opphør {
-        @Test
-        fun `skal lagre vedtak`() {
-            val førstegangsbehandlingContext =
-                opprettBehandlingOgGjennomførBehandlingsløp(
-                    stønadstype = Stønadstype.LÆREMIDLER,
-                ) {
-                    defaultLæremidlerTestdata(fom = fom, tom = tom)
-                }
-
-            testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
-
-            val revurderingId =
-                opprettRevurderingOgGjennomførBehandlingsløp(
-                    fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                ) {
-                    vedtak {
-                        opphør(
-                            opphørsdato = 1 februar 2025,
-                        )
-                    }
-                }
-
-            val vedtak =
-                kall.vedtak
-                    .hentVedtak(Stønadstype.LÆREMIDLER, revurderingId)
-                    .expectOkWithBody<OpphørLæremidlerResponse>()
-
-            assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
-            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
-            assertThat(vedtak.begrunnelse).isEqualTo("annet")
-            with(vedtak.vedtaksperioder.single()) {
-                assertThat(this.fom).isEqualTo(fom)
-                assertThat(this.tom).isEqualTo(31 januar 2025)
-            }
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerBeregnYtelseStegTest.kt
@@ -3,9 +3,9 @@ package no.nav.tilleggsstonader.sak.vedtak.læremidler
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.libs.utils.dato.august
+import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
-import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
@@ -20,7 +20,6 @@ import no.nav.tilleggsstonader.sak.util.fagsak
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
-import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseLæremidler
 import no.nav.tilleggsstonader.sak.vedtak.domain.VedtakUtil.withTypeOrThrow
@@ -29,7 +28,7 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.LæremidlerTestUtil.vedtaksperiodeDto
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.AvslagLæremidlerDto
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.InnvilgelseLæremidlerRequest
-import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerRequest
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerResponse
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.aktivitet
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.faktaOgVurderingAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeTestUtil.målgruppe
@@ -112,36 +111,30 @@ class LæremidlerBeregnYtelseStegTest : CleanDatabaseIntegrationTest() {
                     defaultLæremidlerTestdata(fom = fom, tom = tom)
                 }
 
+            testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
             val revurderingId =
                 opprettRevurderingOgGjennomførBehandlingsløp(
                     fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-                    tilSteg = StegType.BEREGNE_YTELSE,
-                ) {}
-
-            val opphør =
-                OpphørLæremidlerRequest(
-                    årsakerOpphør = listOf(ÅrsakOpphør.ANNET),
-                    begrunnelse = "en begrunnelse",
-                    opphørsdato = LocalDate.of(2025, 2, 1),
-                )
-
-            kall.vedtak.apiRespons
-                .lagreOpphør(
-                    stønadstype = Stønadstype.LÆREMIDLER,
-                    behandlingId = revurderingId,
-                    opphørDto = opphør,
-                ).expectStatus()
-                .isOk()
+                ) {
+                    vedtak {
+                        opphør(
+                            opphørsdato = 1 februar 2025,
+                        )
+                    }
+                }
 
             val vedtak =
                 kall.vedtak
-                    .hentVedtak(Stønadstype.BOUTGIFTER, revurderingId)
-                    .expectOkWithBody<OpphørBoutgifterResponse>()
+                    .hentVedtak(Stønadstype.LÆREMIDLER, revurderingId)
+                    .expectOkWithBody<OpphørLæremidlerResponse>()
 
             assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
+            assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+            assertThat(vedtak.begrunnelse).isEqualTo("annet")
             with(vedtak.vedtaksperioder.single()) {
                 assertThat(this.fom).isEqualTo(fom)
-                assertThat(this.tom).isEqualTo(LocalDate.of(2025, 1, 31))
+                assertThat(this.tom).isEqualTo(31 januar 2025)
             }
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerOpphørIntegrationTest.kt
@@ -1,0 +1,107 @@
+package no.nav.tilleggsstonader.sak.vedtak.læremidler
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.april
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
+import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
+import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class LæremidlerOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
+    @Test
+    fun `skal lagre vedtak`() {
+        val fom = 1 januar 2025
+        val tom = 30 april 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.LÆREMIDLER,
+            ) {
+                defaultLæremidlerTestdata(fom = fom, tom = tom)
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+            ) {
+                vedtak {
+                    opphør(
+                        opphørsdato = 1 februar 2025,
+                    )
+                }
+            }
+
+        val vedtak =
+            kall.vedtak
+                .hentVedtak(Stønadstype.LÆREMIDLER, revurderingId)
+                .expectOkWithBody<OpphørLæremidlerResponse>()
+
+        assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
+        assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
+        assertThat(vedtak.begrunnelse).isEqualTo("annet")
+        with(vedtak.vedtaksperioder.single()) {
+            assertThat(this.fom).isEqualTo(fom)
+            assertThat(this.tom).isEqualTo(31 januar 2025)
+        }
+    }
+
+    @Test
+    fun `skal ikke kunne opphøre med endringer i vilkårperiode før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.LÆREMIDLER,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetUtdanningLæremidler(fom, tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                målgruppe {
+                    oppdaterTomPåEnesteMålgruppe(28 februar 2025)
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.LÆREMIDLER,
+                behandlingId = behandlingId,
+                opphørDto = opphørDto(opphørsdato = 1 mars 2025),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
+            )
+    }
+}


### PR DESCRIPTION
Kan være en idé å legge til en integrasjonstest for hver stønadstype, hvis det er ønskelig så gønnær jeg på. 

### Hvorfor er denne endringen nødvendig? ✨

Slik at vi ikke opphører med endringer som gjør at beregninger blir vanskelige. Ellerno 🤔

Edit: slik at vi ikke opphører med endringer som gjør at beregning vil gi et annet resultat (pluss/minus) dersom det innvilges i ettertid.