### PR TITLE
Utleder periode fra andel for privat-bil-andeler

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -20,8 +20,6 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatP
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import java.time.LocalDate
-import kotlin.collections.maxOf
-import kotlin.collections.minOf
 
 fun BeregningsresultatOffentligTransport.mapTilAndelTilkjentYtelse(saksbehandling: Saksbehandling): List<AndelTilkjentYtelse> =
     reiser
@@ -200,12 +198,22 @@ private fun finnPrivatBilPeriodeFraAndel(
     beregningsresultatPrivatBil: BeregningsresultatPrivatBil,
     andelTilkjentYtelse: AndelTilkjentYtelse,
 ): Datoperiode {
-    feilHvis(andelTilkjentYtelse.reiseId == null) {
-        "reiseId skal alltid være satt "
-    }
-    return beregningsresultatPrivatBil.reiser
-        .single { it.reiseId == andelTilkjentYtelse.reiseId }
-        .perioder
-        .single { periode -> andelTilkjentYtelse.fom.tilUkeIÅr() == periode.fom.tilUkeIÅr() }
-        .let { Datoperiode(it.fom, it.tom) }
+    val reiseId =
+        requireNotNull(andelTilkjentYtelse.reiseId) {
+            "Mangler reiseId på andel (fom=${andelTilkjentYtelse.fom})"
+        }
+
+    val uke = andelTilkjentYtelse.fom.tilUkeIÅr()
+
+    val reise =
+        beregningsresultatPrivatBil.reiser.singleOrNull { it.reiseId == reiseId }
+            ?: error("Finner ingen (eller flere) privatbilreiser for reiseId=$reiseId")
+
+    val periode =
+        reise.perioder.singleOrNull { it.fom.tilUkeIÅr() == uke }
+            ?: error(
+                "Finner ingen (eller flere) privatbilperioder for reiseId=$reiseId uke=$uke (andelFom=${andelTilkjentYtelse.fom})",
+            )
+
+    return Datoperiode(periode.fom, periode.tom)
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvisIkke
@@ -19,6 +20,8 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatP
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import java.time.LocalDate
+import kotlin.collections.maxOf
+import kotlin.collections.minOf
 
 fun BeregningsresultatOffentligTransport.mapTilAndelTilkjentYtelse(saksbehandling: Saksbehandling): List<AndelTilkjentYtelse> =
     reiser
@@ -166,17 +169,22 @@ fun finnTypeAndelFraTiltaksvariant(tiltaksvariant: TypeAktivitet): TypeAndel =
 fun finnPeriodeFraAndel(
     beregningsresultat: BeregningsresultatDagligReise,
     andelTilkjentYtelse: AndelTilkjentYtelse,
-): Datoperiode {
-    // TODO - må implementeres for privat bil også
-    val reiseperiodeMedSammeDatoSomAndel =
-        beregningsresultat.offentligTransport
-            ?.reiser
-            ?.flatMap { it.perioder }
-            ?.filter { it.grunnlag.fom.datoEllerNesteMandagHvisLørdagEllerSøndag() == andelTilkjentYtelse.fom }
-
-    if (reiseperiodeMedSammeDatoSomAndel == null) {
-        throw NotImplementedError("Det er kun implementert å finne periode fra andel for offentlig transport")
+): Datoperiode =
+    if (andelTilkjentYtelse.reiseId != null) {
+        finnPrivatBilPeriodeFraAndel(requireNotNull(beregningsresultat.privatBil), andelTilkjentYtelse)
+    } else {
+        finnOffentligTransportPeriodeFraAndel(requireNotNull(beregningsresultat.offentligTransport), andelTilkjentYtelse)
     }
+
+private fun finnOffentligTransportPeriodeFraAndel(
+    beregningsresultatOffentligTransport: BeregningsresultatOffentligTransport,
+    andelTilkjentYtelse: AndelTilkjentYtelse,
+): Datoperiode {
+    val reiseperiodeMedSammeDatoSomAndel =
+        beregningsresultatOffentligTransport
+            .reiser
+            .flatMap { it.perioder }
+            .filter { it.grunnlag.fom.datoEllerNesteMandagHvisLørdagEllerSøndag() == andelTilkjentYtelse.fom }
 
     if (reiseperiodeMedSammeDatoSomAndel.isEmpty()) {
         error("Finner ingen reiseperiode fra andel med fom ${andelTilkjentYtelse.fom}")
@@ -186,4 +194,18 @@ fun finnPeriodeFraAndel(
         fom = reiseperiodeMedSammeDatoSomAndel.minOf { it.grunnlag.fom },
         tom = reiseperiodeMedSammeDatoSomAndel.maxOf { it.grunnlag.tom },
     )
+}
+
+private fun finnPrivatBilPeriodeFraAndel(
+    beregningsresultatPrivatBil: BeregningsresultatPrivatBil,
+    andelTilkjentYtelse: AndelTilkjentYtelse,
+): Datoperiode {
+    feilHvis(andelTilkjentYtelse.reiseId == null) {
+        "reiseId skal alltid være satt "
+    }
+    return beregningsresultatPrivatBil.reiser
+        .single { it.reiseId == andelTilkjentYtelse.reiseId }
+        .perioder
+        .single { periode -> andelTilkjentYtelse.fom.tilUkeIÅr() == periode.fom.tilUkeIÅr() }
+        .let { Datoperiode(it.fom, it.tom) }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -169,7 +169,10 @@ fun finnPeriodeFraAndel(
     andelTilkjentYtelse: AndelTilkjentYtelse,
 ): Datoperiode =
     if (andelTilkjentYtelse.reiseId != null) {
-        finnPrivatBilPeriodeFraAndel(requireNotNull(beregningsresultat.privatBil), andelTilkjentYtelse)
+        feilHvis(beregningsresultat.privatBil == null) {
+            "Forventer at beregningsresultat for privat bil skal være satt når en andel har reiseId"
+        }
+        finnPrivatBilPeriodeFraAndel(beregningsresultat.privatBil, andelTilkjentYtelse)
     } else {
         finnOffentligTransportPeriodeFraAndel(requireNotNull(beregningsresultat.offentligTransport), andelTilkjentYtelse)
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/migrering/routing/SkjemaRoutingIntegrationTest.kt
@@ -345,6 +345,7 @@ class SkjemaRoutingIntegrationTest(
             val vedtak =
                 DagligReiseTestUtil.innvilgelse(
                     behandlingId = dagligReiseBehandling.id,
+                    rammevedtakPrivatBil = null,
                 )
             vedtakRepository.insert(vedtak)
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapperTest.kt
@@ -148,7 +148,7 @@ class DagligReiseAndelTilkjentYtelseMapperTest {
         @Nested
         inner class FinnPeriodeFraAndel {
             @Test
-            fun `finner periode fra andel`() {
+            fun `finner periode fra andel for offentlig transport`() {
                 val beregningsresultat = defaultInnvilgelseDagligReise.beregningsresultat
                 val andeler = beregningsresultat.offentligTransport!!.mapTilAndelTilkjentYtelse(saksbehandling)
 
@@ -167,6 +167,35 @@ class DagligReiseAndelTilkjentYtelseMapperTest {
                             .grunnlag.tom,
                     )
                 }
+            }
+
+            @Test
+            fun `finner periode fra andel for privat bil`() {
+                val beregningsresultat = defaultInnvilgelseDagligReise.beregningsresultat
+                val privatBil = requireNotNull(beregningsresultat.privatBil)
+                val andeler =
+                    privatBil.mapTilAndelTilkjentYtelse(
+                        saksbehandling = saksbehandling,
+                        rammevedtakPrivatBil = requireNotNull(defaultInnvilgelseDagligReise.rammevedtakPrivatBil),
+                    )
+
+                andeler
+                    .sortedBy { it.fom }
+                    .forEachIndexed { index, andelTilkjentYtelse ->
+                        val periodeFraAndel = finnPeriodeFraAndel(beregningsresultat, andelTilkjentYtelse)
+                        assertThat(periodeFraAndel.fom).isEqualTo(
+                            privatBil.reiser
+                                .first()
+                                .perioder[index]
+                                .fom,
+                        )
+                        assertThat(periodeFraAndel.tom).isEqualTo(
+                            privatBil.reiser
+                                .first()
+                                .perioder[index]
+                                .tom,
+                        )
+                    }
             }
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseTestUtil.kt
@@ -31,7 +31,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
-import java.time.Period
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import java.util.UUID.randomUUID
 
@@ -269,7 +269,7 @@ private fun rammevedtakPrivatBil(perioder: List<PrivatBilPeriode>) =
                         },
                     delperioder =
                         perioder.map { periode ->
-                            val dagerIperiode = Period.between(periode.fom, periode.tom.plusDays(1)).days
+                            val dagerIperiode = ChronoUnit.DAYS.between(periode.fom, periode.tom.plusDays(1)).toInt()
                             no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode(
                                 fom = periode.fom,
                                 tom = periode.tom,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseTestUtil.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.util.dummyReiseId
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
@@ -13,20 +14,49 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsgrunnlagO
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilDag
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilGrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatPrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakAvslag
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import java.time.LocalDate
+import java.time.Period
 import java.util.UUID
 import java.util.UUID.randomUUID
 
 object DagligReiseTestUtil {
+    private val defaultPrivatBilPerioder =
+        listOf(
+            PrivatBilPeriode(
+                fom = 3 januar 2024,
+                tom = 7 januar 2024,
+                stønadsbeløp = 100,
+            ),
+            PrivatBilPeriode(
+                fom = 8 januar 2024,
+                tom = 14 januar 2024,
+                stønadsbeløp = 200,
+            ),
+            PrivatBilPeriode(
+                fom = 15 januar 2024,
+                tom = 18 januar 2024,
+                stønadsbeløp = 300,
+            ),
+        )
+
+    val defaultRammevedtakPrivatBil = rammevedtakPrivatBil(perioder = defaultPrivatBilPerioder)
+
     val defaultVedtaksperioder =
         listOf(
             vedtaksperiode(
@@ -37,12 +67,12 @@ object DagligReiseTestUtil {
     val defaultBeregningsresultat =
         BeregningsresultatDagligReise(
             offentligTransport = beregningsresultatOffentligTransport(),
-            privatBil = null, // TODO
+            privatBil = beregningsresultatPrivatBil(perioder = defaultPrivatBilPerioder),
         )
     val defaultInnvilgelseDagligReise =
         InnvilgelseDagligReise(
             vedtaksperioder = defaultVedtaksperioder,
-            rammevedtakPrivatBil = null,
+            rammevedtakPrivatBil = defaultRammevedtakPrivatBil,
             beregningsresultat = defaultBeregningsresultat,
             beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
         )
@@ -61,6 +91,7 @@ object DagligReiseTestUtil {
         behandlingId: BehandlingId = BehandlingId.random(),
         vedtaksperioder: List<Vedtaksperiode> = defaultVedtaksperioder,
         beregningsresultat: BeregningsresultatDagligReise = defaultBeregningsresultat,
+        rammevedtakPrivatBil: RammevedtakPrivatBil? = if (beregningsresultat.privatBil != null) defaultRammevedtakPrivatBil else null,
     ) = GeneriskVedtak(
         behandlingId = behandlingId,
         type = TypeVedtak.INNVILGELSE,
@@ -68,7 +99,7 @@ object DagligReiseTestUtil {
             InnvilgelseDagligReise(
                 vedtaksperioder = vedtaksperioder,
                 beregningsresultat = beregningsresultat,
-                rammevedtakPrivatBil = null,
+                rammevedtakPrivatBil = rammevedtakPrivatBil,
                 beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
             ),
         gitVersjon = Applikasjonsversjon.versjon,
@@ -184,4 +215,89 @@ private fun vedtaksperiodeGrunnlag(
     aktivitet = aktivitet,
     målgruppe = målgruppe,
     antallReisedagerIVedtaksperioden = antallReisedagerIVedtaksperioden,
+)
+
+private fun beregningsresultatPrivatBil(perioder: List<PrivatBilPeriode>) =
+    BeregningsresultatPrivatBil(
+        reiser = listOf(beregningsresultatForReisePrivatBil(perioder = perioder)),
+    )
+
+private fun beregningsresultatForReisePrivatBil(
+    reiseId: ReiseId = dummyReiseId,
+    perioder: List<PrivatBilPeriode>,
+) = BeregningsresultatForReisePrivatBil(
+    reiseId = reiseId,
+    perioder = perioder.map { periode -> beregningsresultatForReisePrivatBilPeriode(periode) },
+)
+
+private fun beregningsresultatForReisePrivatBilPeriode(periode: PrivatBilPeriode) =
+    BeregningsresultatForReisePrivatBilPeriode(
+        fom = periode.fom,
+        tom = periode.tom,
+        grunnlag = beregningsresultatForReisePrivatBilGrunnlag(fom = periode.fom, stønadsbeløpForDag = periode.stønadsbeløp),
+        stønadsbeløp = periode.stønadsbeløp.toBigDecimal(),
+        brukersNavKontor = null,
+        fraTidligereVedtak = false,
+    )
+
+private fun beregningsresultatForReisePrivatBilGrunnlag(
+    fom: LocalDate = 1 januar 2024,
+    stønadsbeløpForDag: Int = 100,
+) = BeregningsresultatForReisePrivatBilGrunnlag(
+    dager =
+        listOf(
+            BeregningsresultatForReisePrivatBilDag(
+                dato = fom,
+                parkeringskostnad = 0,
+                dagsatsUtenParkering = stønadsbeløpForDag.toBigDecimal(),
+                stønadsbeløpForDag = stønadsbeløpForDag.toBigDecimal(),
+            ),
+        ),
+)
+
+private fun rammevedtakPrivatBil(perioder: List<PrivatBilPeriode>) =
+    RammevedtakPrivatBil(
+        reiser =
+            listOf(
+                rammeForReiseMedPrivatBil(
+                    reiseId = dummyReiseId,
+                    fom = perioder.first().fom,
+                    tom = perioder.last().tom,
+                    vedtaksperioder =
+                        perioder.map { periode ->
+                            DagligReiseTestUtil.vedtaksperiode(fom = periode.fom, tom = periode.tom)
+                        },
+                    delperioder =
+                        perioder.map { periode ->
+                            val dagerIperiode = Period.between(periode.fom, periode.tom.plusDays(1)).days
+                            no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode(
+                                fom = periode.fom,
+                                tom = periode.tom,
+                                reisedagerPerUke = 5,
+                                ekstrakostnader =
+                                    no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain
+                                        .RammeForReiseMedPrivatEkstrakostnader(
+                                            null,
+                                            null,
+                                        ),
+                                satser =
+                                    listOf(
+                                        no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilSatsForDelperiode(
+                                            fom = periode.fom,
+                                            tom = periode.tom,
+                                            satsBekreftetVedVedtakstidspunkt = true,
+                                            kilometersats = 2.94.toBigDecimal(),
+                                            dagsatsUtenParkering = (periode.stønadsbeløp / dagerIperiode).toBigDecimal(),
+                                        ),
+                                    ),
+                            )
+                        },
+                ),
+            ),
+    )
+
+private data class PrivatBilPeriode(
+    val fom: LocalDate,
+    val tom: LocalDate,
+    val stønadsbeløp: Int,
 )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseTestUtil.kt
@@ -20,6 +20,9 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatF
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatPrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilSatsForDelperiode
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatEkstrakostnader
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.domain.AvslagDagligReise
@@ -270,19 +273,18 @@ private fun rammevedtakPrivatBil(perioder: List<PrivatBilPeriode>) =
                     delperioder =
                         perioder.map { periode ->
                             val dagerIperiode = ChronoUnit.DAYS.between(periode.fom, periode.tom.plusDays(1)).toInt()
-                            no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode(
+                            RammeForReiseMedPrivatBilDelperiode(
                                 fom = periode.fom,
                                 tom = periode.tom,
                                 reisedagerPerUke = 5,
                                 ekstrakostnader =
-                                    no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain
-                                        .RammeForReiseMedPrivatEkstrakostnader(
-                                            null,
-                                            null,
-                                        ),
+                                    RammeForReiseMedPrivatEkstrakostnader(
+                                        null,
+                                        null,
+                                    ),
                                 satser =
                                     listOf(
-                                        no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilSatsForDelperiode(
+                                        RammeForReiseMedPrivatBilSatsForDelperiode(
                                             fom = periode.fom,
                                             tom = periode.tom,
                                             satsBekreftetVedVedtakstidspunkt = true,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vi må utlede hvilken periode en andel gjelder for når vi mottar hendelse `fagsysteminfo_behov` fra tilbakekreving. Vi har logikk for dette for offentlig transport (og alle andre stønadstyper), men ikke for privat bil. 

Andeler for privat bil har en reiseid, så vi vet hvilken reise det gjelder. Finnes en andel per kalenderuke for en reise med privat bil, så finner riktig periode ut fra uken.