### PR TITLE
Gi gradle mer minne under bygging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-kotlin.daemon.jvmargs=-Xmx4g
-org.gradle.jvmargs=-Xmx4g
+kotlin.daemon.jvmargs=-Xmx5g
+org.gradle.jvmargs=-Xmx5g
 org.gradle.configuration-cache=true


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Bygget feiler sporadisk på lokal maskin da det ikke er allokert nok minne. Endringen allokerer mer minne til gradle under bygging.