### PR TITLE
🐛 Sett type vedtak til innvilgelse når kopierer vedtak for kjøreliste

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/Beregningsplan.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/Beregningsplan.kt
@@ -25,6 +25,7 @@ data class Beregningsplan internal constructor(
             Beregningsomfang.ALLE_PERIODER -> null
             Beregningsomfang.FRA_DATO -> fraDato
             Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT -> error("beregnFra-dato er ikke relevant for $omfang")
+            Beregningsomfang.KUN_NYE_KJORELISTE_UKER -> null
         }
 
     fun legacyTidligsteEndring(): LocalDate? =
@@ -32,6 +33,7 @@ data class Beregningsplan internal constructor(
             Beregningsomfang.ALLE_PERIODER -> null
             Beregningsomfang.FRA_DATO -> tidligsteEndring ?: fraDato
             Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT -> null
+            Beregningsomfang.KUN_NYE_KJORELISTE_UKER -> null
         }
 }
 
@@ -39,4 +41,5 @@ enum class Beregningsomfang {
     ALLE_PERIODER,
     FRA_DATO,
     GJENBRUK_FORRIGE_RESULTAT,
+    KUN_NYE_KJORELISTE_UKER,
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
@@ -7,6 +7,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
@@ -134,6 +135,9 @@ class DagligReiseVedtakService(
         vedtakRepository.insert(
             eksisterendeVedtak.copy(
                 behandlingId = nyBehandlingId,
+                type = TypeVedtak.INNVILGELSE,
+                data = eksisterendeVedtak.data.tilInnvilgelseForKjøreliste(),
+                opphørsdato = null,
             ),
         )
     }
@@ -165,3 +169,19 @@ class DagligReiseVedtakService(
         return vedtakRepository.harRammevedtak(listOf(forrigeIverksatteBehandlingId))
     }
 }
+
+private fun InnvilgelseEllerOpphørDagligReise.tilInnvilgelseForKjøreliste(): InnvilgelseDagligReise =
+    when (this) {
+        is InnvilgelseDagligReise ->
+            copy(
+                beregningsplan = Beregningsplan(Beregningsomfang.KUN_NYE_KJORELISTE_UKER),
+            )
+
+        is OpphørDagligReise ->
+            InnvilgelseDagligReise(
+                beregningsresultat = beregningsresultat,
+                rammevedtakPrivatBil = rammevedtakPrivatBil,
+                vedtaksperioder = vedtaksperioder,
+                beregningsplan = Beregningsplan(Beregningsomfang.KUN_NYE_KJORELISTE_UKER),
+            )
+    }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakServiceTest.kt
@@ -2,12 +2,22 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
+import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakRepository
+import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
+import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
+import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
+import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.Optional
 
 class DagligReiseVedtakServiceTest {
     private val vedtakRepository = mockk<VedtakRepository>()
@@ -55,5 +65,44 @@ class DagligReiseVedtakServiceTest {
             )
 
         assertThat(harRammevedtak).isFalse
+    }
+
+    @Test
+    fun `skal gjenbruke opphørsvedtak som innvilgelse for kjøreliste`() {
+        val forrigeBehandlingId = BehandlingId.random()
+        val nyBehandlingId = BehandlingId.random()
+        val eksisterendeVedtak =
+            GeneriskVedtak(
+                behandlingId = forrigeBehandlingId,
+                type = TypeVedtak.OPPHØR,
+                data =
+                    OpphørDagligReise(
+                        vedtaksperioder = DagligReiseTestUtil.defaultVedtaksperioder,
+                        beregningsresultat = DagligReiseTestUtil.defaultBeregningsresultat,
+                        rammevedtakPrivatBil = DagligReiseTestUtil.defaultRammevedtakPrivatBil,
+                        årsaker = listOf(ÅrsakOpphør.ANNET),
+                        begrunnelse = "opphør",
+                        beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, LocalDate.of(2025, 1, 1)),
+                    ),
+                gitVersjon = "123",
+                tidligsteEndring = null,
+                opphørsdato = null,
+            )
+        val lagretVedtak = slot<GeneriskVedtak<*>>()
+
+        every { vedtakRepository.findById(forrigeBehandlingId) } returns Optional.of(eksisterendeVedtak)
+        every { vedtakRepository.insert(capture(lagretVedtak)) } answers { firstArg() }
+
+        dagligReiseVedtakService.gjenbrukVedtak(
+            forrigeIverksatteBehandlingId = forrigeBehandlingId,
+            nyBehandlingId = nyBehandlingId,
+        )
+
+        assertThat(lagretVedtak.captured.type).isEqualTo(TypeVedtak.INNVILGELSE)
+        assertThat(lagretVedtak.captured.data).isInstanceOf(InnvilgelseDagligReise::class.java)
+        assertThat((lagretVedtak.captured.data as InnvilgelseDagligReise).vedtaksperioder)
+            .isEqualTo(eksisterendeVedtak.data.vedtaksperioder)
+        assertThat((lagretVedtak.captured.data as InnvilgelseDagligReise).beregningsplan.omfang)
+            .isEqualTo(Beregningsomfang.KUN_NYE_KJORELISTE_UKER)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.simulering.SimuleringService
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
@@ -16,7 +17,6 @@ import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 import java.util.Optional
 
 class DagligReiseVedtakServiceTest {
@@ -82,7 +82,7 @@ class DagligReiseVedtakServiceTest {
                         rammevedtakPrivatBil = DagligReiseTestUtil.defaultRammevedtakPrivatBil,
                         årsaker = listOf(ÅrsakOpphør.ANNET),
                         begrunnelse = "opphør",
-                        beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, LocalDate.of(2025, 1, 1)),
+                        beregningsplan = Beregningsplan(Beregningsomfang.FRA_DATO, 1 januar 2025),
                     ),
                 gitVersjon = "123",
                 tidligsteEndring = null,


### PR DESCRIPTION
Hvis vi kopierer et vedtak som er et opphør vil det se ut som invilgelsen av kjørelista er et opphør. Dette er forvirrende i fronend der vi låser muligheten til å redigere uker ved opphør og i databasen ved debugging.

Setter også beregningsomfang til kun nye uker og beren fra til null slik at disse verdiene også blir rett og ikke skaper forrvirring ved debugging
