### PR TITLE
🐛 Støtt at to vedtaksperioder med samme aktivitet og målgruppe til sammen kan dekke en kjøreliste uke

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
@@ -95,6 +95,27 @@ inline fun brukerfeilHvisIkke(
     brukerfeilHvis(!boolean, httpStatus, sensitivFeilmelding) { lazyMessage() }
 }
 
+inline fun <T> List<T>.singleEllerFeil(
+    httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    noinline sensitivFeilmelding: (() -> String)? = null,
+    lazyMessage: () -> String,
+): T =
+    when (size) {
+        1 -> this[0]
+        else -> throw Feil(
+            message = lazyMessage(),
+            frontendFeilmelding = sensitivFeilmelding?.invoke() ?: lazyMessage(),
+            httpStatus = httpStatus,
+        )
+    }
+
+inline fun <T> Iterable<T>.singleEllerFeil(
+    predicate: (T) -> Boolean,
+    httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    noinline sensitivFeilmelding: (() -> String)? = null,
+    lazyMessage: () -> String,
+): T = filter(predicate).singleEllerFeil(httpStatus, sensitivFeilmelding, lazyMessage)
+
 class ManglerTilgang(
     val melding: String,
     val frontendFeilmelding: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/exception/Feil.kt
@@ -96,7 +96,7 @@ inline fun brukerfeilHvisIkke(
 }
 
 inline fun <T> List<T>.singleEllerFeil(
-    httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
     noinline sensitivFeilmelding: (() -> String)? = null,
     lazyMessage: () -> String,
 ): T =
@@ -111,7 +111,7 @@ inline fun <T> List<T>.singleEllerFeil(
 
 inline fun <T> Iterable<T>.singleEllerFeil(
     predicate: (T) -> Boolean,
-    httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+    httpStatus: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR,
     noinline sensitivFeilmelding: (() -> String)? = null,
     lazyMessage: () -> String,
 ): T = filter(predicate).singleEllerFeil(httpStatus, sensitivFeilmelding, lazyMessage)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseAndelTilkjentYtelseMapper.kt
@@ -63,13 +63,12 @@ fun BeregningsresultatPrivatBil.mapTilAndelTilkjentYtelse(
             reise.perioder
                 .map { periode ->
                     val fom = periode.fom
-                    val vedtaksperiode = rammevedtakForReise.grunnlag.vedtaksperiodeForPeriode(periode)
 
                     lagAndelForDagligReise(
                         saksbehandling = saksbehandling,
                         fomUkedag = fom.iDagHvisMandagEllerForrigeMandag(),
                         beløp = periode.stønadsbeløp.avrundetStønadsbeløp().toInt(),
-                        målgruppe = vedtaksperiode.målgruppe,
+                        målgruppe = rammevedtakForReise.finnMålgruppeForReiseperiode(periode),
                         tiltaksvariant = rammevedtakForReise.tiltaksvariant,
                         brukersNavKontor = periode.brukersNavKontor,
                         reiseId = reise.reiseId, // Skal kun opprette andeler for privat-bil med reiseId

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammevedtakPrivatBil.kt
@@ -4,8 +4,11 @@ import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.kontrakter.felles.KopierPeriode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.periode.avkortFraOgMed
+import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.singleEllerFeil
 import no.nav.tilleggsstonader.sak.util.validerUkentligeDelperioderErSammenhengendeInnenforOverordnetPeriode
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
+import no.nav.tilleggsstonader.sak.vedtak.domain.mergeSammenhengende
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import java.math.BigDecimal
@@ -33,6 +36,14 @@ data class RammeForReiseMedPrivatBil(
             grunnlag = avkortetGrunnlag,
         )
     }
+
+    fun finnMålgruppeForReiseperiode(reiseperiode: BeregningsresultatForReisePrivatBilPeriode): FaktiskMålgruppe =
+        grunnlag.vedtaksperioder
+            .mergeSammenhengende()
+            .singleEllerFeil(
+                predicate = { it.inneholder(reiseperiode) },
+            ) { "Kan ikke finne målgruppe for reiseperioden. Forventer nøyaktig en vedtaksperiode for reiseperioden." }
+            .målgruppe
 }
 
 data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
@@ -54,8 +65,6 @@ data class RammeForReiseMedPrivatBilBeregningsgrunnlag(
         fom: LocalDate,
         tom: LocalDate,
     ): RammeForReiseMedPrivatBilBeregningsgrunnlag = this.copy(fom = fom, tom = tom)
-
-    fun vedtaksperiodeForPeriode(periode: Periode<LocalDate>) = vedtaksperioder.single { it.inneholder(periode) }
 
     fun avkortEtterDato(maksTom: LocalDate): RammeForReiseMedPrivatBilBeregningsgrunnlag? {
         if (maksTom < fom) return null

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammeForReiseMedPrivatBilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammeForReiseMedPrivatBilTest.kt
@@ -1,0 +1,43 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain
+
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
+import no.nav.tilleggsstonader.sak.util.vedtaksperiode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class RammeForReiseMedPrivatBilTest {
+    @Test
+    fun `finnMålgruppeForReiseperiode returnerer målgruppe når beregningsuke spenner over to sammenhengende vedtaksperioder med lik målgruppe og aktivitet`() {
+        val ukeFom = 6 januar 2025
+        val ukeTom = 12 januar 2025
+
+        val reise =
+            rammeForReiseMedPrivatBil(
+                fom = ukeFom,
+                tom = ukeTom,
+                vedtaksperioder =
+                    listOf(
+                        // Grensen mellom periodene (9. og 10. jan) faller midt i beregningsuken
+                        vedtaksperiode(fom = 1 januar 2025, tom = 9 januar 2025, målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE),
+                        vedtaksperiode(fom = 10 januar 2025, tom = 19 januar 2025, målgruppe = FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE),
+                    ),
+            )
+
+        val reiseperiode =
+            BeregningsresultatForReisePrivatBilPeriode(
+                fom = ukeFom,
+                tom = ukeTom,
+                grunnlag = BeregningsresultatForReisePrivatBilGrunnlag(dager = emptyList()),
+                stønadsbeløp = BigDecimal.ZERO,
+                brukersNavKontor = null,
+                fraTidligereVedtak = false,
+            )
+
+        val målgruppe = reise.finnMålgruppeForReiseperiode(reiseperiode)
+
+        assertThat(målgruppe).isEqualTo(FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE)
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammeForReiseMedPrivatBilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/domain/RammeForReiseMedPrivatBilTest.kt
@@ -10,7 +10,7 @@ import java.math.BigDecimal
 
 class RammeForReiseMedPrivatBilTest {
     @Test
-    fun `finnMålgruppeForReiseperiode returnerer målgruppe når beregningsuke spenner over to sammenhengende vedtaksperioder med lik målgruppe og aktivitet`() {
+    fun `finner rett målgruppe når beregningsuke går over to sammenhengende vedtaksperioder`() {
         val ukeFom = 6 januar 2025
         val ukeTom = 12 januar 2025
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi har en feil i prod hvor en kjøreliste uke er dekket av to vedtaksperioder. Vi forventer kun en vedtaksperiode per kjøreliste uke så vi kaster feil og får ikke behandlet kjørelista.

Feilende sak: https://nav-it.slack.com/archives/C05LT2KJL6B/p1782470266754749