### PR TITLE
🩹 Legg til Flyway-migrering som retter beregningsplan for kjørelistevedtak

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
@@ -138,6 +138,7 @@ class DagligReiseVedtakService(
                 type = TypeVedtak.INNVILGELSE,
                 data = eksisterendeVedtak.data.tilInnvilgelseForKjøreliste(),
                 opphørsdato = null,
+                tidligsteEndring = null
             ),
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakService.kt
@@ -138,7 +138,7 @@ class DagligReiseVedtakService(
                 type = TypeVedtak.INNVILGELSE,
                 data = eksisterendeVedtak.data.tilInnvilgelseForKjøreliste(),
                 opphørsdato = null,
-                tidligsteEndring = null
+                tidligsteEndring = null,
             ),
         )
     }

--- a/src/main/resources/db/migration/V140__rett_beregningsplan_kjoreliste.sql
+++ b/src/main/resources/db/migration/V140__rett_beregningsplan_kjoreliste.sql
@@ -1,0 +1,12 @@
+-- Kjørelistebehandlinger skal alltid bruke beregningsomfang KUN_NYE_KJORELISTE_UKER
+-- uten fraDato/tidligsteEndring.
+UPDATE vedtak v
+SET data = jsonb_set(
+        v.data,
+        '{beregningsplan}',
+        jsonb_build_object('omfang', 'KUN_NYE_KJORELISTE_UKER')
+    ),
+    tidligste_endring = NULL
+FROM behandling b
+WHERE v.behandling_id = b.id
+  AND b.type = 'KJØRELISTE';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? 
Kjørelistebehandlinger styres ikke av beregn-fra dato, men av kjørelisteuker. Eksisterende data kunne inneholde arv av feil beregningsplan og datoer. Setter beregningsplan til KUN_NYE_KJORELISTE_UKER for alle kjørelistevedtak.

 Migreringen oppdaterer alle kjørelistevedtak slik at:
 - `beregningsplan.omfang = KUN_NYE_KJORELISTE_UKER`
 - `beregningsplan.fraDato` fjernes
 - `beregningsplan.tidligsteEndring` fjernes
 - `vedtak.tidligste_endring` settes til `NULL`
 
Endringen gjelder migrering av data etter denne endringen:
https://github.com/navikt/tilleggsstonader-sak/pull/1294

> Hvis vi kopierer et vedtak som er et opphør vil det se ut som invilgelsen av kjørelista er et opphør. Dette er forvirrende i fronend der vi låser muligheten til å redigere uker ved opphør og i databasen ved debugging.
> 
> Setter også beregningsomfang til kun nye uker og beren fra til null slik at disse verdiene også blir rett og ikke skaper forrvirring ved debugging