### PR TITLE
 🐛 Tillat lesing av vilkår med bompenger/fergekostnad over 500 fra DB

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/dto/FaktaDagligReiseDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/dto/FaktaDagligReiseDto.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeDagligReise
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.FaktaDagligReise
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.FaktaOffentligTransport
@@ -69,22 +70,37 @@ data class FaktaDagligReisePrivatBilDto(
     override fun mapTilFakta(
         reiseId: ReiseId,
         adresse: String?,
-    ) = FaktaPrivatBil(
-        reiseId = reiseId,
-        reiseavstandEnVei = reiseavstandEnVei,
-        faktaDelperioder =
-            faktaDelperioder.map {
-                FaktaDelperiodePrivatBil(
-                    fom = it.fom,
-                    tom = it.tom,
-                    reisedagerPerUke = it.reisedagerPerUke,
-                    bompengerPerDag = it.bompengerPerDag,
-                    fergekostnadPerDag = it.fergekostnadPerDag,
-                )
-            },
-        adresse = adresse,
-        aktivitetId = aktivitetId,
-    )
+    ): FaktaPrivatBil {
+        validerBompengerOgFergekostnader()
+
+        return FaktaPrivatBil(
+            reiseId = reiseId,
+            reiseavstandEnVei = reiseavstandEnVei,
+            faktaDelperioder =
+                faktaDelperioder.map {
+                    FaktaDelperiodePrivatBil(
+                        fom = it.fom,
+                        tom = it.tom,
+                        reisedagerPerUke = it.reisedagerPerUke,
+                        bompengerPerDag = it.bompengerPerDag,
+                        fergekostnadPerDag = it.fergekostnadPerDag,
+                    )
+                },
+            adresse = adresse,
+            aktivitetId = aktivitetId,
+        )
+    }
+
+    private fun validerBompengerOgFergekostnader() {
+        faktaDelperioder.forEach { delperiode ->
+            brukerfeilHvis(delperiode.bompengerPerDag != null && delperiode.bompengerPerDag > BigDecimal(500)) {
+                "Skal du innvilge med bompenger høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet"
+            }
+            brukerfeilHvis(delperiode.fergekostnadPerDag != null && delperiode.fergekostnadPerDag > BigDecimal(500)) {
+                "Skal du innvilge med fergekostnader høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet"
+            }
+        }
+    }
 }
 
 data class FaktaDelperiodePrivatBilDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
@@ -88,12 +88,6 @@ data class FaktaDelperiodePrivatBil(
         brukerfeilHvis(fergekostnadPerDag != null && fergekostnadPerDag < BigDecimal.ZERO) {
             "Fergekostnaden må være større enn 0"
         }
-        brukerfeilHvis(bompengerPerDag != null && bompengerPerDag > BigDecimal(500)) {
-            "Skal du innvilge med bompenger høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet"
-        }
-        brukerfeilHvis(fergekostnadPerDag != null && fergekostnadPerDag > BigDecimal(500)) {
-            "Skal du innvilge med fergekostnader høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet"
-        }
     }
 }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårControllerTest.kt
@@ -4,6 +4,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.opprettOgTilordneOppgaveForBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.util.FileUtil
@@ -27,6 +28,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -179,6 +181,84 @@ class DagligReiseVilkårControllerTest : CleanDatabaseIntegrationTest() {
     }
 
     @Test
+    fun `skal kunne hente vilkår med bompenger over 500 fra databasen men ikke lagre nye verdier over 500`() {
+        val fom = 1 januar 2026
+        val tom = 31 januar 2026
+
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+                tilSteg = StegType.VILKÅR,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTso(fom = fom, tom = tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom = fom, tom = tom)
+                    }
+                }
+            }
+
+        val aktivitet =
+            kall.vilkårperiode
+                .hentForBehandling(behandlingContext.behandlingId)
+                .vilkårperioder.aktiviteter
+                .single()
+
+        val nyttVilkår =
+            LagreVilkårDagligReiseDto(
+                fom = fom,
+                tom = tom,
+                adresse = "Tiltaksveien 1",
+                reiseId = dummyReiseId,
+                svar = svarPrivatBil,
+                fakta = faktaPrivatBil(aktivitet = aktivitet),
+            )
+
+        val opprettetVilkår = kall.vilkårDagligReise.opprettVilkår(behandlingContext.behandlingId, nyttVilkår)
+
+        jdbcTemplate.update(
+            """
+            UPDATE vilkar
+            SET fakta = jsonb_set(
+                CAST(fakta AS jsonb),
+                '{faktaDelperioder,0,bompengerPerDag}',
+                to_jsonb(CAST(:bompengerPerDag AS numeric)),
+                true
+            )
+            WHERE id = :vilkarId
+            """.trimIndent(),
+            mapOf(
+                "bompengerPerDag" to BigDecimal("5023"),
+                "vilkarId" to opprettetVilkår.id.id,
+            ),
+        )
+
+        val vilkårFraDb = kall.vilkårDagligReise.hentVilkår(behandlingContext.behandlingId).single()
+        val fakta = vilkårFraDb.fakta as FaktaDagligReisePrivatBilDto
+        assertThat(fakta.faktaDelperioder.single().bompengerPerDag).isEqualTo(BigDecimal("5023"))
+
+        val oppdatertVilkår =
+            nyttVilkår.copy(
+                fakta =
+                    faktaPrivatBil(
+                        aktivitet = aktivitet,
+                        bompengerPerDag = BigDecimal("501"),
+                    ),
+            )
+
+        kall.vilkårDagligReise.apiRespons
+            .oppdaterVilkår(oppdatertVilkår, opprettetVilkår.id, behandlingContext.behandlingId)
+            .expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail = "Skal du innvilge med bompenger høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet",
+            )
+    }
+
+    @Test
     fun `skal kunne lagre ned et vilkår med fakta UBESTEMT med adresse og reiseId om vilkår ikke er oppfylt`() {
         val svarAvstandIkkeOppfylt =
             mapOf(
@@ -227,6 +307,8 @@ class DagligReiseVilkårControllerTest : CleanDatabaseIntegrationTest() {
         reiseavstandEnVei: BigDecimal = BigDecimal("10"),
         fom: LocalDate = 1 januar 2026,
         tom: LocalDate = 31 januar 2026,
+        bompengerPerDag: BigDecimal? = null,
+        fergekostnadPerDag: BigDecimal? = null,
         aktivitet: VilkårperiodeDto,
     ) = FaktaDagligReisePrivatBilDto(
         reiseavstandEnVei = reiseavstandEnVei,
@@ -236,8 +318,8 @@ class DagligReiseVilkårControllerTest : CleanDatabaseIntegrationTest() {
                     fom = fom,
                     tom = tom,
                     reisedagerPerUke = 5,
-                    bompengerPerDag = null,
-                    fergekostnadPerDag = null,
+                    bompengerPerDag = bompengerPerDag,
+                    fergekostnadPerDag = fergekostnadPerDag,
                 ),
             ),
         aktivitetId = aktivitet.globalId,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/domain/FaktaDagligReiseTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/domain/FaktaDagligReiseTest.kt
@@ -3,6 +3,8 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.util.faktaOffentligTransport
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDagligReisePrivatBilDto
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDelperiodePrivatBilDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDelperiodePrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
@@ -191,98 +193,6 @@ class FaktaDagligReiseTest {
         }
 
         @Test
-        fun `skal kaste feil hvis bompenger er høyere enn 500`() {
-            val feil =
-                assertThrows<ApiFeil> {
-                    FaktaPrivatBil(
-                        reiseId = ReiseId.random(),
-                        adresse = "Tiltaksveien 1",
-                        faktaDelperioder =
-                            listOf(
-                                FaktaDelperiodePrivatBil(
-                                    fom = LocalDate.now(),
-                                    tom = LocalDate.now().plusDays(10),
-                                    reisedagerPerUke = 4,
-                                    bompengerPerDag = BigDecimal("501"),
-                                    fergekostnadPerDag = null,
-                                ),
-                            ),
-                        reiseavstandEnVei = BigDecimal(10),
-                        aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID()),
-                    )
-                }
-            assertThat(
-                feil.message,
-            ).isEqualTo("Skal du innvilge med bompenger høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet")
-        }
-
-        @Test
-        fun `skal kaste feil hvis fergekostnad er høyere enn 500`() {
-            val feil =
-                assertThrows<ApiFeil> {
-                    FaktaPrivatBil(
-                        reiseId = ReiseId.random(),
-                        adresse = "Tiltaksveien 1",
-                        faktaDelperioder =
-                            listOf(
-                                FaktaDelperiodePrivatBil(
-                                    fom = LocalDate.now(),
-                                    tom = LocalDate.now().plusDays(10),
-                                    reisedagerPerUke = 4,
-                                    bompengerPerDag = null,
-                                    fergekostnadPerDag = BigDecimal("501"),
-                                ),
-                            ),
-                        reiseavstandEnVei = BigDecimal(10),
-                        aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID()),
-                    )
-                }
-            assertThat(
-                feil.message,
-            ).isEqualTo("Skal du innvilge med fergekostnader høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet")
-        }
-
-        @Test
-        fun `skal ikke kaste feil hvis bompenger er nøyaktig 500`() {
-            FaktaPrivatBil(
-                reiseId = ReiseId.random(),
-                adresse = "Tiltaksveien 1",
-                faktaDelperioder =
-                    listOf(
-                        FaktaDelperiodePrivatBil(
-                            fom = LocalDate.now(),
-                            tom = LocalDate.now().plusDays(10),
-                            reisedagerPerUke = 4,
-                            bompengerPerDag = BigDecimal("500"),
-                            fergekostnadPerDag = null,
-                        ),
-                    ),
-                reiseavstandEnVei = BigDecimal(10),
-                aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID()),
-            )
-        }
-
-        @Test
-        fun `skal ikke kaste feil hvis fergekostnad er nøyaktig 500`() {
-            FaktaPrivatBil(
-                reiseId = ReiseId.random(),
-                adresse = "Tiltaksveien 1",
-                faktaDelperioder =
-                    listOf(
-                        FaktaDelperiodePrivatBil(
-                            fom = LocalDate.now(),
-                            tom = LocalDate.now().plusDays(10),
-                            reisedagerPerUke = 4,
-                            bompengerPerDag = null,
-                            fergekostnadPerDag = BigDecimal("500"),
-                        ),
-                    ),
-                reiseavstandEnVei = BigDecimal(10),
-                aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID()),
-            )
-        }
-
-        @Test
         fun `skal kaste feil hvis negativ reiseavstand`() {
             val feil =
                 assertThrows<ApiFeil> {
@@ -353,5 +263,56 @@ class FaktaDagligReiseTest {
                 }
             assertThat(feil.message).isEqualTo("Reisedager per uke kan ikke være mer enn 7")
         }
+    }
+
+    @Nested
+    inner class FaktaDelperiodePrivatBilDtoValidering {
+        @Test
+        fun `skal kaste feil hvis bompenger er høyere enn 500`() {
+            val feil =
+                assertThrows<ApiFeil> {
+                    faktaPrivatBilDto(
+                        bompengerPerDag = BigDecimal("501"),
+                    ).mapTilFakta(reiseId = ReiseId.random(), adresse = "Tiltaksveien 1")
+                }
+
+            assertThat(
+                feil.message,
+            ).isEqualTo("Skal du innvilge med bompenger høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet")
+        }
+
+        @Test
+        fun `skal kaste feil hvis fergekostnad er høyere enn 500`() {
+            val feil =
+                assertThrows<ApiFeil> {
+                    faktaPrivatBilDto(
+                        fergekostnadPerDag = BigDecimal("501"),
+                    ).mapTilFakta(reiseId = ReiseId.random(), adresse = "Tiltaksveien 1")
+                }
+
+            assertThat(
+                feil.message,
+            ).isEqualTo("Skal du innvilge med fergekostnader høyere enn 500kr må du ta kontakt med Tilleggsstønader-temet")
+        }
+
+        private fun faktaPrivatBilDto(
+            bompengerPerDag: BigDecimal? = null,
+            fergekostnadPerDag: BigDecimal? = null,
+        ) = FaktaDagligReisePrivatBilDto(
+            reiseavstandEnVei = BigDecimal("10"),
+            faktaDelperioder =
+                listOf(
+                    FaktaDelperiodePrivatBilDto(
+                        fom = LocalDate.now(),
+                        tom = LocalDate.now().plusDays(10),
+                        reisedagerPerUke = 4,
+                        bompengerPerDag = bompengerPerDag,
+                        fergekostnadPerDag = fergekostnadPerDag,
+                    ),
+                ),
+            aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID()),
+            adresse = "Tiltaksveien 1",
+            aktivitetType = "TILTAK",
+        )
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
 Etter endringen som innførte maksgrense på 500 kr for bompenger/fergekostnad, ble samme validering kjørt ved deserialisering av eksisterende vilkår fra databasen.  Det gjorde at enkelte behandlinger ikke kunne åpnes. Nå tillater vi lesing av alle eksisterende vilkår, men ikke lagring av vilkår med bompnger/fergekostnad over 500kr.

Knyttet til denne feilen i prod:
https://nav-it.slack.com/archives/C05LT2KJL6B/p1782472067051409
 
