### PR TITLE
Legg til visning av behandling_endret-hendelser for tilbakekreving

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/BehandlingController.kt
@@ -21,6 +21,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.sikkerhet.BehandlerRolle
 import no.nav.tilleggsstonader.sak.opplysninger.grunnlag.FaktaGrunnlagService
 import no.nav.tilleggsstonader.sak.opplysninger.tilordnetSaksbehandler.TilordnetSaksbehandlerService
 import no.nav.tilleggsstonader.sak.opplysninger.tilordnetSaksbehandler.dto.tilDto
+import no.nav.tilleggsstonader.sak.tilbakekreving.TilbakekrevinghendelseService
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.http.HttpStatus
@@ -45,6 +46,7 @@ class BehandlingController(
     private val tilgangService: TilgangService,
     private val nullstillBehandlingService: NullstillBehandlingService,
     private val tilordnetSaksbehandlerService: TilordnetSaksbehandlerService,
+    private val tilbakekrevinghendelseService: TilbakekrevinghendelseService,
 ) {
     @GetMapping("{behandlingId}")
     fun hentBehandling(
@@ -65,6 +67,7 @@ class BehandlingController(
         return saksbehandling.tilDto(
             tilordnetSaksbehandler = tilordnetSaksbehandler,
             harÅpenKjørelistebehandling = harÅpenKjørelistebehandling,
+            harTilbakekrevingSak = tilbakekrevinghendelseService.harHendelserForBehandling(behandlingId),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/BehandlingDto.kt
@@ -47,7 +47,7 @@ fun Saksbehandling.tilDto(
     tilordnetSaksbehandler: TilordnetSaksbehandlerDto,
     harÅpenKjørelistebehandling: Boolean,
     harTilbakekrevingSak: Boolean,
-    ): BehandlingDto =
+): BehandlingDto =
     BehandlingDto(
         id = this.id,
         forrigeIverksatteBehandlingId = this.forrigeIverksatteBehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/dto/BehandlingDto.kt
@@ -40,12 +40,14 @@ data class BehandlingDto(
     val nyeOpplysningerMetadata: NyeOpplysningerMetadata?,
     val harÅpenKjørelistebehandling: Boolean,
     val tilordnetSaksbehandler: TilordnetSaksbehandlerDto,
+    val harTilbakekrevingSak: Boolean,
 )
 
 fun Saksbehandling.tilDto(
     tilordnetSaksbehandler: TilordnetSaksbehandlerDto,
     harÅpenKjørelistebehandling: Boolean,
-): BehandlingDto =
+    harTilbakekrevingSak: Boolean,
+    ): BehandlingDto =
     BehandlingDto(
         id = this.id,
         forrigeIverksatteBehandlingId = this.forrigeIverksatteBehandlingId,
@@ -68,6 +70,7 @@ fun Saksbehandling.tilDto(
         nyeOpplysningerMetadata = this.nyeOpplysningerMetadata,
         harÅpenKjørelistebehandling = harÅpenKjørelistebehandling,
         tilordnetSaksbehandler = tilordnetSaksbehandler,
+        harTilbakekrevingSak = harTilbakekrevingSak,
     )
 
 fun Behandling.tilBehandlingJournalDto(): BehandlingTilJournalføringDto =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/unleash/Toggle.kt
@@ -19,6 +19,8 @@ enum class Toggle(
 
     OPPRETT_OPPGAVE_TILBAKEKREVING("sak.opprett-oppgave-tilbakekreving"),
 
+    KAN_VISE_TILBAKEKREVING("sak.kan-vise-tilbakekreving"),
+
     KAN_BEHANDLE_PRIVAT_BIL("sak.daglig-reise-privat-bil"),
 
     KAN_AUTOMATISK_BEHANDLE_KJØRELISTE("sak.automatisk-behandling-kjoreliste"),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingHendelseController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingHendelseController.kt
@@ -1,0 +1,27 @@
+package no.nav.tilleggsstonader.sak.tilbakekreving
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.tilbakekreving.dto.TilbakekrevingHendelseDto
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/api/tilbakekreving"])
+@ProtectedWithClaims(issuer = "azuread")
+class TilbakekrevingHendelseController(
+    private val tilbakekrevinghendelseService: TilbakekrevinghendelseService,
+    private val tilgangService: TilgangService,
+) {
+    @GetMapping("{behandlingId}/hendelser")
+    fun hentBehandlingEndretHendelser(
+        @PathVariable behandlingId: BehandlingId,
+    ): List<TilbakekrevingHendelseDto> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
+        tilgangService.validerLesetilgangTilBehandling(behandlingId)
+        return tilbakekrevinghendelseService.hentBehandlingEndretHendelser(behandlingId)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevinghendelseRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevinghendelseRepository.kt
@@ -9,4 +9,6 @@ interface TilbakekrevinghendelseRepository :
     RepositoryInterface<TilbakekrevingHendelse, Long>,
     InsertUpdateRepository<TilbakekrevingHendelse> {
     fun findAllByBehandlingId(behandlingId: BehandlingId): List<TilbakekrevingHendelse>
+
+    fun existsByBehandlingId(behandlingId: BehandlingId): Boolean
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevinghendelseService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevinghendelseService.kt
@@ -1,13 +1,18 @@
 package no.nav.tilleggsstonader.sak.tilbakekreving
 
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.tilbakekreving.domene.TilbakekrevingHendelse
 import no.nav.tilleggsstonader.sak.tilbakekreving.domene.Tilbakekrevingsstatus
+import no.nav.tilleggsstonader.sak.tilbakekreving.dto.TilbakekrevingHendelseDto
+import no.nav.tilleggsstonader.sak.tilbakekreving.dto.tilDto
 import org.springframework.stereotype.Service
 
 @Service
 class TilbakekrevinghendelseService(
     private val tilbakekrevinghendelseRepository: TilbakekrevinghendelseRepository,
+    private val unleashService: UnleashService,
 ) {
     fun persisterHendelse(
         behandlingId: BehandlingId,
@@ -23,6 +28,17 @@ class TilbakekrevinghendelseService(
 
     fun hentHendelserForBehandling(behandlingId: BehandlingId): List<TilbakekrevingHendelse> =
         tilbakekrevinghendelseRepository.findAllByBehandlingId(behandlingId)
+
+    fun harHendelserForBehandling(behandlingId: BehandlingId): Boolean =
+        unleashService.isEnabled(Toggle.KAN_VISE_TILBAKEKREVING) &&
+            tilbakekrevinghendelseRepository.existsByBehandlingId(behandlingId)
+
+    fun hentBehandlingEndretHendelser(behandlingId: BehandlingId): List<TilbakekrevingHendelseDto> =
+        hentHendelserForBehandling(behandlingId)
+            .map { it.hendelse }
+            .filterIsInstance<Tilbakekrevingsstatus>()
+            .sortedBy { it.hendelseOpprettet }
+            .map { it.tilDto() }
 
     fun harMottattHendelseMedStatus(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/domene/Tilbakekrevingstatus.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/domene/Tilbakekrevingstatus.kt
@@ -24,6 +24,7 @@ data class Tilbakekrevingsstatus(
     val tilbakekrevingFom: LocalDate,
     val tilbakekrevingTom: LocalDate,
     val tilbakekrevingBehandlingId: String,
+    val saksbehandlingURL: String? = null,
 ) : TilbakekrevingJson {
     val type: String = "status"
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/dto/TilbakekrevingHendelseDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/dto/TilbakekrevingHendelseDto.kt
@@ -1,0 +1,31 @@
+package no.nav.tilleggsstonader.sak.tilbakekreving.dto
+
+import no.nav.tilleggsstonader.sak.tilbakekreving.domene.Tilbakekrevingsstatus
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class TilbakekrevingHendelseDto(
+    val hendelseOpprettet: LocalDateTime,
+    val sakOpprettet: LocalDateTime,
+    val varselSendtTidspunkt: LocalDate?,
+    val behandlingstatus: String,
+    val totaltFeilutbetaltBeløp: BigDecimal,
+    val tilbakekrevingFom: LocalDate,
+    val tilbakekrevingTom: LocalDate,
+    val tilbakekrevingBehandlingId: String,
+    val saksbehandlingURL: String?,
+)
+
+fun Tilbakekrevingsstatus.tilDto(): TilbakekrevingHendelseDto =
+    TilbakekrevingHendelseDto(
+        hendelseOpprettet = this.hendelseOpprettet,
+        sakOpprettet = this.sakOpprettet,
+        varselSendtTidspunkt = this.varselSendtTidspunkt,
+        behandlingstatus = this.behandlingstatus,
+        totaltFeilutbetaltBeløp = this.totaltFeilutbetaltBeløp,
+        tilbakekrevingFom = this.tilbakekrevingFom,
+        tilbakekrevingTom = this.tilbakekrevingTom,
+        tilbakekrevingBehandlingId = this.tilbakekrevingBehandlingId,
+        saksbehandlingURL = this.saksbehandlingURL,
+    )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/hendelse/TilbakekrevingBehandlingEndret.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/hendelse/TilbakekrevingBehandlingEndret.kt
@@ -36,6 +36,7 @@ data class TilbakekrevingBehandlingEndret(
             tilbakekrevingFom = tilbakekreving.fullstendigPeriode.fom,
             tilbakekrevingTom = tilbakekreving.fullstendigPeriode.tom,
             tilbakekrevingBehandlingId = tilbakekreving.behandlingId,
+            saksbehandlingURL = tilbakekreving.saksbehandlingURL,
         )
 
     companion object {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/Kall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/Kall.kt
@@ -17,6 +17,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.SettPåVentK
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.SimuleringKall
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.SkjemaRoutingKall
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.StegKall
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.TilbakekrevingKall
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.TotrinnskontrollKall
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.VedtakKall
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.VilkårDagligReiseKall
@@ -42,6 +43,7 @@ class Kall(
     val simulering = SimuleringKall(testklient)
     val steg = StegKall(testklient)
     val skjemaRouting = SkjemaRoutingKall(testklient)
+    val tilbakekreving = TilbakekrevingKall(testklient)
     val totrinnskontroll = TotrinnskontrollKall(testklient)
     val vedtak = VedtakKall(testklient)
     val vilkår = VilkårKall(testklient)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/TilbakekrevingKall.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/integrasjonstest/extensions/kall/TilbakekrevingKall.kt
@@ -1,0 +1,19 @@
+package no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.integrasjonstest.Testklient
+import no.nav.tilleggsstonader.sak.tilbakekreving.dto.TilbakekrevingHendelseDto
+
+class TilbakekrevingKall(
+    private val testklient: Testklient,
+) {
+    fun hentHendelser(behandlingId: BehandlingId): List<TilbakekrevingHendelseDto> =
+        apiRespons.hentHendelser(behandlingId).expectOkWithBody()
+
+    // Gir tilgang til "rå"-endepunktet slik at tester kan skrive egne assertions på responsen.
+    val apiRespons = TilbakekrevingApi()
+
+    inner class TilbakekrevingApi {
+        fun hentHendelser(behandlingId: BehandlingId) = testklient.get("/api/tilbakekreving/$behandlingId/hendelser")
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingForBehandlingIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tilbakekreving/TilbakekrevingForBehandlingIntegrationTest.kt
@@ -1,0 +1,131 @@
+package no.nav.tilleggsstonader.sak.tilbakekreving
+
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mai
+import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.infrastruktur.unleash.mockIsEnabled
+import no.nav.tilleggsstonader.sak.tilbakekreving.domene.Tilbakekrevingsstatus
+import no.nav.tilleggsstonader.sak.util.behandling
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+class TilbakekrevingForBehandlingIntegrationTest : CleanDatabaseIntegrationTest() {
+    @Autowired
+    lateinit var tilbakekrevinghendelseService: TilbakekrevinghendelseService
+
+    @Nested
+    inner class HentTilbakekrevingHendelser {
+        @Test
+        fun `henter tom liste når det ikke finnes hendelser på behandlingen`() {
+            val behandling = opprettBehandling()
+
+            val hendelser = kall.tilbakekreving.hentHendelser(behandling.id)
+
+            assertThat(hendelser).isEmpty()
+        }
+
+        @Test
+        fun `henter hendelser sortert på hendelseOpprettet`() {
+            val behandling = opprettBehandling()
+
+            val eldsteHendelseOpprettet = (1 januar 2025).atTime(10, 0)
+            val nyesteHendelseOpprettet = (1 februar 2025).atTime(10, 0)
+
+            persisterHendelse(behandling.id, nyesteHendelseOpprettet, "TIL_BEHANDLING")
+            persisterHendelse(behandling.id, eldsteHendelseOpprettet, "OPPRETTET")
+
+            val hendelser = kall.tilbakekreving.hentHendelser(behandling.id)
+
+            assertThat(hendelser.map { it.behandlingstatus }).containsExactly("OPPRETTET", "TIL_BEHANDLING")
+        }
+
+        @Test
+        fun `henter hendelser med alle felter`() {
+            val behandling = opprettBehandling()
+
+            val hendelseOpprettet = (1 januar 2025).atTime(10, 0)
+            persisterHendelse(behandling.id, hendelseOpprettet, "TIL_BEHANDLING")
+
+            val hendelse = kall.tilbakekreving.hentHendelser(behandling.id).single()
+
+            assertThat(hendelse.hendelseOpprettet).isEqualTo(hendelseOpprettet)
+            assertThat(hendelse.sakOpprettet).isEqualTo(hendelseOpprettet)
+            assertThat(hendelse.varselSendtTidspunkt).isNull()
+            assertThat(hendelse.behandlingstatus).isEqualTo("TIL_BEHANDLING")
+            assertThat(hendelse.totaltFeilutbetaltBeløp).isEqualByComparingTo(BigDecimal("10000"))
+            assertThat(hendelse.tilbakekrevingFom).isEqualTo(1 januar 2025)
+            assertThat(hendelse.tilbakekrevingTom).isEqualTo(31 mai 2025)
+            assertThat(hendelse.tilbakekrevingBehandlingId).isEqualTo("tilbakekreving-1")
+            assertThat(hendelse.saksbehandlingURL).isEqualTo("http://localhost/tilbakekreving-1")
+        }
+
+        @Test
+        fun `henter kun hendelser tilknyttet behandlingen i forespørselen`() {
+            val behandling = opprettBehandling()
+            val annenBehandling = opprettBehandling(stønadstype = Stønadstype.BARNETILSYN)
+
+            persisterHendelse(annenBehandling.id, LocalDateTime.now(), "TIL_BEHANDLING")
+
+            assertThat(kall.tilbakekreving.hentHendelser(behandling.id)).isEmpty()
+            assertThat(kall.tilbakekreving.hentHendelser(annenBehandling.id)).hasSize(1)
+        }
+    }
+
+    @Nested
+    inner class HarTilbakekrevingSak {
+        @Test
+        fun `behandling har ikke tilbakekrevingssak når det ikke finnes hendelser`() {
+            val behandling = opprettBehandling()
+
+            assertThat(kall.behandling.hent(behandling.id).harTilbakekrevingSak).isFalse()
+        }
+
+        @Test
+        fun `behandling har tilbakekrevingssak når det finnes hendelser`() {
+            val behandling = opprettBehandling()
+            persisterHendelse(behandling.id, LocalDateTime.now(), "TIL_BEHANDLING")
+
+            assertThat(kall.behandling.hent(behandling.id).harTilbakekrevingSak).isTrue()
+        }
+
+        @Test
+        fun `behandling har ikke tilbakekrevingssak når feature-toggle er av selv om det finnes hendelser`() {
+            val behandling = opprettBehandling()
+            persisterHendelse(behandling.id, LocalDateTime.now(), "TIL_BEHANDLING")
+
+            unleashService.mockIsEnabled(Toggle.KAN_VISE_TILBAKEKREVING, false)
+
+            assertThat(kall.behandling.hent(behandling.id).harTilbakekrevingSak).isFalse()
+        }
+    }
+
+    private fun opprettBehandling(stønadstype: Stønadstype = Stønadstype.LÆREMIDLER) =
+        testoppsettService.opprettBehandlingMedFagsak(behandling(), stønadstype = stønadstype)
+
+    private fun persisterHendelse(
+        behandlingId: BehandlingId,
+        hendelseOpprettet: LocalDateTime,
+        behandlingstatus: String,
+    ) = tilbakekrevinghendelseService.persisterHendelse(
+        behandlingId,
+        Tilbakekrevingsstatus(
+            hendelseOpprettet = hendelseOpprettet,
+            sakOpprettet = hendelseOpprettet,
+            varselSendtTidspunkt = null,
+            behandlingstatus = behandlingstatus,
+            totaltFeilutbetaltBeløp = BigDecimal("10000"),
+            tilbakekrevingFom = 1 januar 2025,
+            tilbakekrevingTom = 31 mai 2025,
+            tilbakekrevingBehandlingId = "tilbakekreving-1",
+            saksbehandlingURL = "http://localhost/tilbakekreving-1",
+        ),
+    )
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Frontend: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/1219

For å kunne teste mot tilbakekreving enklere enn å måtte slå opp i databasen og manuelt lese kafka-topics...

Eksponerer tilbakekrevingshendelser (behandling_endret) på en behandling slik at frontend kan vise dem i en egen fane.

- BehandlingDto får nytt flagg harTilbakekrevingSak som er true når det finnes tilbakekrevingshendelser på behandlingen og feature-toggelen KAN_VISE_TILBAKEKREVING er på.
- Ny feature-toggle KAN_VISE_TILBAKEKREVING (sak.kan-vise-tilbakekreving).
- Nytt endepunkt GET /api/tilbakekreving/{behandlingId}/hendelser som returnerer hendelsene sortert på hendelseOpprettet.
- TilbakekrevinghendelseService får harHendelserForBehandling (gated på toggle) og hentBehandlingEndretHendelser.
- TilbakekrevinghendelseRepository får existsByBehandlingId.
- Domenet Tilbakekrevingsstatus utvides med nullable saksbehandlingURL som mappes fra behandling_endret-hendelsen. Nullable for å håndtere eksisterende innslag uten feltet.
- Ny integrasjonstest for service-logikken og toggle-gating.
