### PR TITLE
Presisjon task.trigger_tid

### DIFF
--- a/src/main/resources/db/migration/V141__task_triggertid_nøyaktighet.sql
+++ b/src/main/resources/db/migration/V141__task_triggertid_nøyaktighet.sql
@@ -1,0 +1,1 @@
+ALTER TABLE task ALTER COLUMN trigger_tid TYPE TIMESTAMP(6);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legger til migrering for å endre på presisjon til kolonnen trigger_tid på tabellen task fordi lav presisjon fører til at tasker ikke blir kjørt i integrasjonstester (for oss med rask mac 🤓)

Er spesifikt `fun IntegrationTest.opprettOgTilordneOppgaveForBehandling(...)` som feiler. Denne oppretter en task og forsøker å kjøre den umiddelbart. Millisekund-presisjon fører til at task-rammeverket ikke plukker den opp (gjør oppslag type `select * from task where trigger_tid < :triggerTid`).