### PR TITLE
🐛 Retuner `null` hvis oppsummer privat bil beregning endepunkt kalles på en behandling som ikke gjelder daglig reise

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -137,7 +137,7 @@ class DagligReiseVedtakController(
         tilgangService.validerLesetilgangTilBehandling(behandlingId)
 
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
-        if(!behandling.stønadstype.gjelderDagligReise()){
+        if (!behandling.stønadstype.gjelderDagligReise()) {
             return null
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -132,9 +132,14 @@ class DagligReiseVedtakController(
     @GetMapping("{behandlingId}/privat-bil/oppsummer-beregning")
     fun hentOppsummertBeregning(
         @PathVariable behandlingId: BehandlingId,
-    ): PrivatBilOppsummertBeregningDto {
+    ): PrivatBilOppsummertBeregningDto? {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerLesetilgangTilBehandling(behandlingId)
+
+        val behandling = behandlingService.hentSaksbehandling(behandlingId)
+        if(!behandling.stønadstype.gjelderDagligReise()){
+            return null
+        }
 
         val vedtaksdata = vedtakService.hentVedtak<InnvilgelseEllerOpphørDagligReise>(behandlingId).data
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kalle dette endepunktet når vi lager brev for å fylle ut utbetalingstabell for privat bil kjøreliste. For å holde logikken enkel i frontend kalles endepunktet for alle stønadstyper, men retunerer null hvis det ikke er relevant for stønadstypen.

