### PR TITLE
🐛 Fikser for validering av opphør

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -97,8 +97,8 @@ class OpphørValideringService(
                 behandlingId = behandlingId,
             )
 
-        brukerfeilHvis(tidligsteEndring != null && tidligsteEndring <= opphørsdato) {
-            "Opphør er et ugyldig vedtaksresultat fordi opphørsdato er etter eller lik tidligste endring (${tidligsteEndring?.norskFormat()})"
+        brukerfeilHvis(tidligsteEndring != null && tidligsteEndring < opphørsdato) {
+            "Opphør er et ugyldig vedtaksresultat fordi opphørsdato (${opphørsdato.norskFormat()}) er etter tidligste endring (${tidligsteEndring?.norskFormat()})"
         }
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/OpphørValideringService.kt
@@ -41,10 +41,10 @@ class OpphørValideringService(
             vilkår,
             opphørsdato,
         )
-//        validerIngenEndringerIVilkårEllerVilkårperioderFørOpphørsdato(
-//            behandlingId = saksbehandling.id,
-//            opphørsdato = opphørsdato,
-//        )
+        validerIngenEndringerIVilkårEllerVilkårperioderFørOpphørsdato(
+            behandlingId = saksbehandling.id,
+            opphørsdato = opphørsdato,
+        )
     }
 
     fun validerIngenUtbetalingEtterOpphørsdato(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnOpphørIntegrationTest.kt
@@ -3,17 +3,23 @@ package no.nav.tilleggsstonader.sak.vedtak.barnetilsyn
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.util.toYearMonth
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.domain.Beløpsperiode
 import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.dto.OpphørTilsynBarnResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 
 class TilsynBarnOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
     @Test
@@ -98,76 +104,76 @@ class TilsynBarnOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
             }
     }
 
-//    @Test
-//    fun `skal ikke kunne opphøre dersom utgifter endres før opphørsdato`() {
-//        val fom = 1 januar 2025
-//        val tom = 31 mars 2025
-//
-//        val førstegangsbehandlingContext =
-//            opprettBehandlingOgGjennomførBehandlingsløp(
-//                stønadstype = Stønadstype.BARNETILSYN,
-//            ) {
-//                aktivitet {
-//                    opprett {
-//                        aktivitetTiltakTilsynBarn(
-//                            fom = fom,
-//                            tom = tom,
-//                            aktivitetsdager = 4,
-//                        )
-//                    }
-//                }
-//                målgruppe {
-//                    opprett {
-//                        målgruppeAAP(fom, tom)
-//                    }
-//                }
-//                vilkår {
-//                    opprett {
-//                        passBarn(
-//                            fom = fom.toYearMonth().plusMonths(1),
-//                            tom = tom.toYearMonth(),
-//                            utgift = 1000,
-//                        )
-//                    }
-//                }
-//            }
-//
-//        val revurderingId =
-//            opprettRevurderingOgGjennomførBehandlingsløp(
-//                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-//                tilSteg = StegType.BEREGNE_YTELSE,
-//            ) {
-//                vilkår {
-//                    oppdater { vilkårsvurdering ->
-//                        with(vilkårsvurdering.vilkårsett.single()) {
-//                            SvarPåVilkårDto(
-//                                id = id,
-//                                behandlingId = behandlingId,
-//                                delvilkårsett = delvilkårsett,
-//                                fom = fom.plusMonths(1),
-//                                tom = 28 februar 2025,
-//                                utgift = 500,
-//                                erFremtidigUtgift = erFremtidigUtgift,
-//                                offentligTransport = null,
-//                            )
-//                        }
-//                    }
-//                }
-//            }
-//
-//        kall.vedtak.apiRespons
-//            .lagreOpphør(
-//                stønadstype = Stønadstype.BARNETILSYN,
-//                behandlingId = revurderingId,
-//                opphørDto =
-//                    opphørDto(
-//                        opphørsdato = 1 mars 2025,
-//                    ),
-//            ).expectProblemDetail(
-//                forventetStatus = HttpStatus.BAD_REQUEST,
-//                forventetDetail =
-//                    "Opphør er et ugyldig vedtaksresultat fordi " +
-//                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
-//            )
-//    }
+    @Test
+    fun `skal ikke kunne opphøre dersom utgifter endres før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTilsynBarn(
+                            fom = fom,
+                            tom = tom,
+                            aktivitetsdager = 4,
+                        )
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        passBarn(
+                            fom = fom.toYearMonth().plusMonths(1),
+                            tom = tom.toYearMonth(),
+                            utgift = 1000,
+                        )
+                    }
+                }
+            }
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                vilkår {
+                    oppdater { vilkårsvurdering ->
+                        with(vilkårsvurdering.vilkårsett.single()) {
+                            SvarPåVilkårDto(
+                                id = id,
+                                behandlingId = behandlingId,
+                                delvilkårsett = delvilkårsett,
+                                fom = fom.plusMonths(1),
+                                tom = 28 februar 2025,
+                                utgift = 500,
+                                erFremtidigUtgift = erFremtidigUtgift,
+                                offentligTransport = null,
+                            )
+                        }
+                    }
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.BARNETILSYN,
+                behandlingId = revurderingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 1 mars 2025,
+                    ),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
+            )
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/barnetilsyn/TilsynBarnOpphørIntegrationTest.kt
@@ -45,7 +45,7 @@ class TilsynBarnOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
                 }
                 vedtak {
                     opphør(
-                        opphørsdato = 31 januar 2025,
+                        opphørsdato = 1 februar 2025,
                     )
                 }
             }
@@ -58,6 +58,46 @@ class TilsynBarnOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
         assertThat(vedtak.type).isEqualTo(TypeVedtak.OPPHØR)
         assertThat(vedtak.årsakerOpphør).containsExactly(ÅrsakOpphør.ANNET)
         assertThat(vedtak.begrunnelse).isEqualTo("annet")
+    }
+
+    @Test
+    fun `skal ikke lagre vedtak hvis dato for opphør er etter endring`() {
+        val fom = 1 januar 2025
+        val tom = 28 februar 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BARNETILSYN,
+            ) {
+                defaultTilsynBarnTestdata(fom = fom, tom = tom)
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                aktivitet {
+                    oppdaterTomPåEnesteAktivitet(tom = fom.toYearMonth().atEndOfMonth())
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.BARNETILSYN,
+                behandlingId = behandlingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 2 februar 2025,
+                    ),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato (02.02.2025) er etter tidligste endring (01.02.2025)",
+            )
     }
 
     /**
@@ -173,7 +213,7 @@ class TilsynBarnOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
                 forventetStatus = HttpStatus.BAD_REQUEST,
                 forventetDetail =
                     "Opphør er et ugyldig vedtaksresultat fordi " +
-                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
+                        "opphørsdato (01.03.2025) er etter tidligste endring (01.02.2025)",
             )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterOpphørIntegrationTest.kt
@@ -118,13 +118,13 @@ class BoutgifterOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
                 behandlingId = behandlingId,
                 opphørDto =
                     opphørDto(
-                        opphørsdato = 1 mars 2025,
+                        opphørsdato = 2 mars 2025,
                     ),
             ).expectProblemDetail(
                 forventetStatus = HttpStatus.BAD_REQUEST,
                 forventetDetail =
                     "Opphør er et ugyldig vedtaksresultat fordi " +
-                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
+                        "opphørsdato (02.03.2025) er etter tidligste endring (01.03.2025)",
             )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/BoutgifterOpphørIntegrationTest.kt
@@ -3,15 +3,22 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.tilFørsteDagIMåneden
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
 import no.nav.tilleggsstonader.sak.vedtak.boutgifter.dto.OpphørBoutgifterResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dto.SvarPåVilkårDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 
 class BoutgifterOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
     @Test
@@ -54,70 +61,70 @@ class BoutgifterOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
         assertThat(vedtak.begrunnelse).isEqualTo("Statsbudsjettet er tomt")
     }
 
-//    @Test
-//    fun `skal ikke kunne lagre opphør ved endringer i vedtak før opphørsdato`() {
-//        val fom = 1 januar 2025
-//        val tom = 31 mars 2025
-//
-//        val førstegangsbehandlingContext =
-//            opprettBehandlingOgGjennomførBehandlingsløp(
-//                stønadstype = Stønadstype.BOUTGIFTER,
-//            ) {
-//                aktivitet {
-//                    opprett {
-//                        aktivitetTiltakBoutgifter(fom, tom)
-//                    }
-//                }
-//                målgruppe {
-//                    opprett {
-//                        målgruppeAAP(fom, tom)
-//                    }
-//                }
-//                vilkår {
-//                    opprett {
-//                        løpendeutgifterEnBolig(fom.plusMonths(1).tilFørsteDagIMåneden(), tom)
-//                    }
-//                }
-//            }
-//
-//        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
-//
-//        val behandlingId =
-//            opprettRevurderingOgGjennomførBehandlingsløp(
-//                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-//                tilSteg = StegType.BEREGNE_YTELSE,
-//            ) {
-//                vilkår {
-//                    oppdater { vilkårsvurdering ->
-//                        with(vilkårsvurdering.vilkårsett.single()) {
-//                            SvarPåVilkårDto(
-//                                id = id,
-//                                behandlingId = behandlingId,
-//                                delvilkårsett = delvilkårsett,
-//                                fom = fom.plusMonths(1).tilFørsteDagIMåneden(),
-//                                tom = 28 februar 2025,
-//                                utgift = utgift,
-//                                erFremtidigUtgift = erFremtidigUtgift,
-//                                offentligTransport = null,
-//                            )
-//                        }
-//                    }
-//                }
-//            }
-//
-//        kall.vedtak.apiRespons
-//            .lagreOpphør(
-//                stønadstype = Stønadstype.BOUTGIFTER,
-//                behandlingId = behandlingId,
-//                opphørDto =
-//                    opphørDto(
-//                        opphørsdato = 1 mars 2025,
-//                    ),
-//            ).expectProblemDetail(
-//                forventetStatus = HttpStatus.BAD_REQUEST,
-//                forventetDetail =
-//                    "Opphør er et ugyldig vedtaksresultat fordi " +
-//                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
-//            )
-//    }
+    @Test
+    fun `skal ikke kunne lagre opphør ved endringer i vedtak før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.BOUTGIFTER,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakBoutgifter(fom, tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        løpendeutgifterEnBolig(fom.plusMonths(1).tilFørsteDagIMåneden(), tom)
+                    }
+                }
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                vilkår {
+                    oppdater { vilkårsvurdering ->
+                        with(vilkårsvurdering.vilkårsett.single()) {
+                            SvarPåVilkårDto(
+                                id = id,
+                                behandlingId = behandlingId,
+                                delvilkårsett = delvilkårsett,
+                                fom = fom.plusMonths(1).tilFørsteDagIMåneden(),
+                                tom = 28 februar 2025,
+                                utgift = utgift,
+                                erFremtidigUtgift = erFremtidigUtgift,
+                                offentligTransport = null,
+                            )
+                        }
+                    }
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.BOUTGIFTER,
+                behandlingId = behandlingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 1 mars 2025,
+                    ),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
+            )
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseOpphørIntegrationTest.kt
@@ -1,19 +1,25 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.juni
 import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.util.lagreDagligReiseDto
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.dto.FaktaDagligReiseOffentligTransportDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 
 class DagligReiseOpphørIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
@@ -58,71 +64,71 @@ class DagligReiseOpphørIntegrationTest(
         assertThat(andelerOpphør.maxByOrNull { it.tom }!!.tom).isBeforeOrEqualTo(14 mars 2025)
     }
 
-//    @Test
-//    fun `skal ikke kunne opphøre dersom pris er endret før opphørsdato`() {
-//        val fom = 1 januar 2025
-//        val tom = 31 mars 2025
-//
-//        val førstegangsbehandlingContext =
-//            opprettBehandlingOgGjennomførBehandlingsløp(
-//                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
-//            ) {
-//                aktivitet {
-//                    opprett {
-//                        aktivitetTiltakTso(fom, tom)
-//                    }
-//                }
-//                målgruppe {
-//                    opprett {
-//                        målgruppeAAP(fom, tom)
-//                    }
-//                }
-//                vilkår {
-//                    opprett {
-//                        offentligTransport(
-//                            fom = fom.plusMonths(1),
-//                            tom = tom,
-//                        )
-//                    }
-//                }
-//            }
-//
-//        val revurderingId =
-//            opprettRevurderingOgGjennomførBehandlingsløp(
-//                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-//                tilSteg = StegType.BEREGNE_YTELSE,
-//            ) {
-//                vilkår {
-//                    oppdaterDagligReise { vilkårDagligReise, _ ->
-//                        vilkårDagligReise.single().id to
-//                            lagreDagligReiseDto(
-//                                fom = fom.plusMonths(1),
-//                                tom = 28 februar 2025,
-//                                fakta =
-//                                    FaktaDagligReiseOffentligTransportDto(
-//                                        reisedagerPerUke = 3,
-//                                        prisEnkelbillett = 40,
-//                                        prisSyvdagersbillett = null,
-//                                        prisTrettidagersbillett = 1200,
-//                                    ),
-//                            )
-//                    }
-//                }
-//            }
-//
-//        kall.vedtak.apiRespons
-//            .lagreOpphør(
-//                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
-//                behandlingId = revurderingId,
-//                opphørDto =
-//                    opphørDto(
-//                        opphørsdato = 1 mars 2025,
-//                    ),
-//            ).expectProblemDetail(
-//                forventetStatus = HttpStatus.BAD_REQUEST,
-//                forventetDetail =
-//                    "Opphør er et ugyldig vedtaksresultat fordi " +
-//                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
-//            )
-//    }
+    @Test
+    fun `skal ikke kunne opphøre dersom pris er endret før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTso(fom, tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+                vilkår {
+                    opprett {
+                        offentligTransport(
+                            fom = fom.plusMonths(1),
+                            tom = tom,
+                        )
+                    }
+                }
+            }
+
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                vilkår {
+                    oppdaterDagligReise { vilkårDagligReise, _ ->
+                        vilkårDagligReise.single().id to
+                            lagreDagligReiseDto(
+                                fom = fom.plusMonths(1),
+                                tom = 28 februar 2025,
+                                fakta =
+                                    FaktaDagligReiseOffentligTransportDto(
+                                        reisedagerPerUke = 3,
+                                        prisEnkelbillett = 40,
+                                        prisSyvdagersbillett = null,
+                                        prisTrettidagersbillett = 1200,
+                                    ),
+                            )
+                    }
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.DAGLIG_REISE_TSO,
+                behandlingId = revurderingId,
+                opphørDto =
+                    opphørDto(
+                        opphørsdato = 1 mars 2025,
+                    ),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
+            )
+    }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseOpphørIntegrationTest.kt
@@ -128,7 +128,7 @@ class DagligReiseOpphørIntegrationTest(
                 forventetStatus = HttpStatus.BAD_REQUEST,
                 forventetDetail =
                     "Opphør er et ugyldig vedtaksresultat fordi " +
-                        "opphørsdato er etter eller lik tidligste endring (01.02.2025)",
+                        "opphørsdato (01.03.2025) er etter tidligste endring (01.02.2025)",
             )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerOpphørIntegrationTest.kt
@@ -96,12 +96,12 @@ class LæremidlerOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
             .lagreOpphør(
                 stønadstype = Stønadstype.LÆREMIDLER,
                 behandlingId = behandlingId,
-                opphørDto = opphørDto(opphørsdato = 1 mars 2025),
+                opphørDto = opphørDto(opphørsdato = 2 mars 2025),
             ).expectProblemDetail(
                 forventetStatus = HttpStatus.BAD_REQUEST,
                 forventetDetail =
                     "Opphør er et ugyldig vedtaksresultat fordi " +
-                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
+                        "opphørsdato (02.03.2025) er etter tidligste endring (01.03.2025)",
             )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerOpphørIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/læremidler/LæremidlerOpphørIntegrationTest.kt
@@ -4,15 +4,20 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.april
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectOkWithBody
+import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.kall.expectProblemDetail
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
+import no.nav.tilleggsstonader.sak.vedtak.barnetilsyn.TilsynBarnTestUtil.opphørDto
 import no.nav.tilleggsstonader.sak.vedtak.domain.ÅrsakOpphør
 import no.nav.tilleggsstonader.sak.vedtak.læremidler.dto.OpphørLæremidlerResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 
 class LæremidlerOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
     @Test
@@ -54,49 +59,49 @@ class LæremidlerOpphørIntegrationTest : CleanDatabaseIntegrationTest() {
         }
     }
 
-//    @Test
-//    fun `skal ikke kunne opphøre med endringer i vilkårperiode før opphørsdato`() {
-//        val fom = 1 januar 2025
-//        val tom = 31 mars 2025
-//
-//        val førstegangsbehandlingContext =
-//            opprettBehandlingOgGjennomførBehandlingsløp(
-//                stønadstype = Stønadstype.LÆREMIDLER,
-//            ) {
-//                aktivitet {
-//                    opprett {
-//                        aktivitetUtdanningLæremidler(fom, tom)
-//                    }
-//                }
-//                målgruppe {
-//                    opprett {
-//                        målgruppeAAP(fom, tom)
-//                    }
-//                }
-//            }
-//
-//        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
-//
-//        val behandlingId =
-//            opprettRevurderingOgGjennomførBehandlingsløp(
-//                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
-//                tilSteg = StegType.BEREGNE_YTELSE,
-//            ) {
-//                målgruppe {
-//                    oppdaterTomPåEnesteMålgruppe(28 februar 2025)
-//                }
-//            }
-//
-//        kall.vedtak.apiRespons
-//            .lagreOpphør(
-//                stønadstype = Stønadstype.LÆREMIDLER,
-//                behandlingId = behandlingId,
-//                opphørDto = opphørDto(opphørsdato = 1 mars 2025),
-//            ).expectProblemDetail(
-//                forventetStatus = HttpStatus.BAD_REQUEST,
-//                forventetDetail =
-//                    "Opphør er et ugyldig vedtaksresultat fordi " +
-//                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
-//            )
-//    }
+    @Test
+    fun `skal ikke kunne opphøre med endringer i vilkårperiode før opphørsdato`() {
+        val fom = 1 januar 2025
+        val tom = 31 mars 2025
+
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.LÆREMIDLER,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetUtdanningLæremidler(fom, tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom, tom)
+                    }
+                }
+            }
+
+        testoppsettService.settAndelerTilOkForBehandling(førstegangsbehandlingContext.behandlingId)
+
+        val behandlingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.BEREGNE_YTELSE,
+            ) {
+                målgruppe {
+                    oppdaterTomPåEnesteMålgruppe(28 februar 2025)
+                }
+            }
+
+        kall.vedtak.apiRespons
+            .lagreOpphør(
+                stønadstype = Stønadstype.LÆREMIDLER,
+                behandlingId = behandlingId,
+                opphørDto = opphørDto(opphørsdato = 1 mars 2025),
+            ).expectProblemDetail(
+                forventetStatus = HttpStatus.BAD_REQUEST,
+                forventetDetail =
+                    "Opphør er et ugyldig vedtaksresultat fordi " +
+                        "opphørsdato er etter eller lik tidligste endring (01.03.2025)",
+            )
+    }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legger tilbake tester som fantes før, og fikser en bug i mismatch mellom tidligste endring og opphør som ble meldt inn av Tone.