### PR TITLE
Registrer kjørte dager

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -40,7 +40,8 @@ class ReisevurderingController(
         val behandling = behandlingService.hentBehandling(behandlingId)
 
         val kjørelister = kjørelisteService.hentForFagsakId(behandling.fagsakId)
-        val reiserIGjeldendeRammevedtak = dagligReisePrivatBilService.hentRammevedtakForBehandlingId(behandlingId)?.reiser
+        val reiserIGjeldendeRammevedtak =
+            dagligReisePrivatBilService.hentRammevedtakForBehandlingId(behandlingId)?.reiser
         val reiserIForrigeRammevedtak =
             behandling.forrigeIverksatteBehandlingId
                 ?.let { dagligReisePrivatBilService.hentRammevedtakForBehandlingId(it)?.reiser }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingController.kt
@@ -8,6 +8,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.privatbil.ReisevurderingPrivatBilMapper.lagUkeVurderingDto
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.EndreAvklartDagRequest
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtDagService
 import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
 import no.nav.tilleggsstonader.sak.tilgang.TilgangService
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,6 +28,7 @@ class ReisevurderingController(
     private val kjørelisteService: KjørelisteService,
     private val dagligReisePrivatBilService: DagligReisePrivatBilService,
     private val avklartKjørelisteService: AvklartKjørelisteService,
+    private val registrertKjørtDagService: RegistrertKjørtDagService,
 ) {
     @GetMapping("{behandlingId}")
     fun hentReisevurderingForBehandling(
@@ -43,6 +45,7 @@ class ReisevurderingController(
             behandling.forrigeIverksatteBehandlingId
                 ?.let { dagligReisePrivatBilService.hentRammevedtakForBehandlingId(it)?.reiser }
         val avklarteUker = avklartKjørelisteService.hentAvklarteUkerForBehandling(behandlingId)
+        val registrerteUker = registrertKjørtDagService.hentForBehandling(behandlingId)
         val alleReiseIder =
             ((reiserIGjeldendeRammevedtak ?: emptyList()) + (reiserIForrigeRammevedtak ?: emptyList()))
                 .map { it.reiseId }
@@ -56,6 +59,7 @@ class ReisevurderingController(
                 forrigeRammevedtakForReise = forrigeReise,
                 avklarteUker = avklarteUker,
                 kjørelister = kjørelister,
+                registrerteUker = registrerteUker,
             )
         }
     }
@@ -72,7 +76,7 @@ class ReisevurderingController(
         behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
 
         val oppdatertAvklartUke = avklartKjørelisteService.oppdaterAvklartUke(behandlingId, ukeId, avklarteDager)
-        val kjøreliste = kjørelisteService.hentKjøreliste(oppdatertAvklartUke.kjørelisteId)
+        val kjøreliste = oppdatertAvklartUke.kjørelisteId?.let { kjørelisteService.hentKjøreliste(it) }
 
         return lagUkeVurderingDto(
             uke = oppdatertAvklartUke.uke,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -49,7 +49,7 @@ object ReisevurderingPrivatBilMapper {
         forrigeRammevedtakForReise: RammevedtakForReiseMedPrivatBil?,
     ): ReiseId =
         gjeldendeRammevedtakForReise?.reiseId ?: forrigeRammevedtakForReise?.reiseId
-        ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
+            ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
 
     private fun lagUkeVurderingerDto(
         gjeldendeRammevedtakForReise: RammevedtakForReiseMedPrivatBil?,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -73,7 +73,7 @@ object ReisevurderingPrivatBilMapper {
             val avklartUke = avklarteUker.singleOrNull { it.reiseId == reiseId && it.uke == uke }
             val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
             val registrertKjørtUke =
-                registrerteUker.singleOrNull { it.reiseId == reiseId && it.dager.any { dag -> dag.dato in datoerForUke } }
+                registrerteUker.firstOrNull { it.reiseId == reiseId && it.dager.any { dag -> dag.dato in datoerForUke } }
 
             lagUkeVurderingDto(
                 uke = uke,
@@ -101,9 +101,7 @@ object ReisevurderingPrivatBilMapper {
             fraDato = datoer.min(),
             tilDato = datoer.max(),
             erUkeSlettet = erUkeSlettet,
-            status =
-                avklartUke?.status
-                    ?: if (registrertKjørtUke != null) UkeStatus.MANUELT_REGISTRERT else UkeStatus.IKKE_MOTTATT_KJØRELISTE,
+            status = utledUkeStatus(avklartUke, registrertKjørtUke),
             avvik = avklartUke?.typeAvvik?.let { AvvikUke(typeAvvik = it) },
             behandletDato = avklartUke?.behandletDato,
             kjørelisteInnsendtDato = kjøreliste?.datoMottatt?.toLocalDate(),
@@ -167,6 +165,13 @@ object ReisevurderingPrivatBilMapper {
             parkeringsutgift = parkeringsutgift,
             avklartKjørtDagStatus = avklartKjørtDagStatus,
         )
+
+    private fun utledUkeStatus(
+        avklartUke: AvklartKjørtUke?,
+        registrertKjørtUke: RegistrertKjørtUke?,
+    ): UkeStatus =
+        avklartUke?.status
+            ?: if (registrertKjørtUke != null) UkeStatus.MANUELT_REGISTRERT else UkeStatus.IKKE_MOTTATT_KJØRELISTE
 
     private fun erUkeSlettet(
         uke: UkeIÅr,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -6,6 +6,7 @@ import no.nav.tilleggsstonader.sak.infrastruktur.exception.feil
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUke
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.tilDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
@@ -17,6 +18,7 @@ object ReisevurderingPrivatBilMapper {
         forrigeRammevedtakForReise: RammevedtakForReiseMedPrivatBil?,
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
+        registrerteUker: List<RegistrertKjørtUke> = emptyList(),
     ): ReisevurderingPrivatBilDto {
         val reiseId =
             finnReiseId(
@@ -29,6 +31,7 @@ object ReisevurderingPrivatBilMapper {
                 forrigeRammevedtakForReise = forrigeRammevedtakForReise,
                 avklarteUker = avklarteUker,
                 kjørelister = kjørelister,
+                registrerteUker = registrerteUker,
             )
         return ReisevurderingPrivatBilDto(
             reiseId = reiseId,
@@ -53,6 +56,7 @@ object ReisevurderingPrivatBilMapper {
         forrigeRammevedtakForReise: RammevedtakForReiseMedPrivatBil?,
         avklarteUker: List<AvklartKjørtUke>,
         kjørelister: List<Kjøreliste>,
+        registrerteUker: List<RegistrertKjørtUke>,
     ): List<UkeVurderingDto> {
         val reiseId =
             finnReiseId(
@@ -68,6 +72,8 @@ object ReisevurderingPrivatBilMapper {
             val datoerForUke = (gjeldendeDatoerForUke + forrigeUker[uke].orEmpty()).distinct().sorted()
             val avklartUke = avklarteUker.singleOrNull { it.reiseId == reiseId && it.uke == uke }
             val kjørelisteForUke = avklartUke?.let { kjørelister.firstOrNull { it.id == avklartUke.kjørelisteId } }
+            val registrertKjørtUke =
+                registrerteUker.singleOrNull { it.reiseId == reiseId && it.dager.any { dag -> dag.dato in datoerForUke } }
 
             lagUkeVurderingDto(
                 uke = uke,
@@ -76,6 +82,7 @@ object ReisevurderingPrivatBilMapper {
                 avklartUke = avklartUke,
                 kjøreliste = kjørelisteForUke,
                 erUkeSlettet = erUkeSlettet(uke, gjeldendeUker, forrigeUker),
+                registrertKjørtUke = registrertKjørtUke,
             )
         }
     }
@@ -87,6 +94,7 @@ object ReisevurderingPrivatBilMapper {
         avklartUke: AvklartKjørtUke?,
         kjøreliste: Kjøreliste?,
         erUkeSlettet: Boolean,
+        registrertKjørtUke: RegistrertKjørtUke? = null,
     ): UkeVurderingDto =
         UkeVurderingDto(
             ukenummer = uke.ukenummer,
@@ -107,6 +115,7 @@ object ReisevurderingPrivatBilMapper {
                         gjeldendeDatoerForUke = gjeldendeDatoerForUke,
                         kjørelisteForUke = kjøreliste,
                         avklartUke = avklartUke,
+                        registrertKjørtUke = registrertKjørtUke,
                     )
                 },
         )
@@ -116,6 +125,7 @@ object ReisevurderingPrivatBilMapper {
         gjeldendeDatoerForUke: List<LocalDate>,
         kjørelisteForUke: Kjøreliste?,
         avklartUke: AvklartKjørtUke?,
+        registrertKjørtUke: RegistrertKjørtUke? = null,
     ): DagDto =
         DagDto(
             dato = dato,
@@ -131,7 +141,16 @@ object ReisevurderingPrivatBilMapper {
                             harKjørt = reisedag.harKjørt,
                             parkeringsutgift = reisedag.parkeringsutgift,
                         )
-                    },
+                    }
+                    ?: registrertKjørtUke
+                        ?.dager
+                        ?.firstOrNull { it.dato == dato }
+                        ?.let { registrertDag ->
+                            KjørelisteDagDto(
+                                harKjørt = registrertDag.harKjørt,
+                                parkeringsutgift = registrertDag.parkeringsutgift,
+                            )
+                        },
             // TODO: Vurder å kaste feil dersom denne er null
             // Hvis den eksisterer for en uke så burde alle dager eksistere?
             avklartDag = avklartUke?.dager?.singleOrNull { it.dato == dato }?.tilAvklartDagDto(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -49,7 +49,7 @@ object ReisevurderingPrivatBilMapper {
         forrigeRammevedtakForReise: RammevedtakForReiseMedPrivatBil?,
     ): ReiseId =
         gjeldendeRammevedtakForReise?.reiseId ?: forrigeRammevedtakForReise?.reiseId
-            ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
+        ?: feil("Kan ikke lage reisevudering. Mangler rammevedtak for reise")
 
     private fun lagUkeVurderingerDto(
         gjeldendeRammevedtakForReise: RammevedtakForReiseMedPrivatBil?,
@@ -101,7 +101,9 @@ object ReisevurderingPrivatBilMapper {
             fraDato = datoer.min(),
             tilDato = datoer.max(),
             erUkeSlettet = erUkeSlettet,
-            status = avklartUke?.status ?: UkeStatus.IKKE_MOTTATT_KJØRELISTE,
+            status =
+                avklartUke?.status
+                    ?: if (registrertKjørtUke != null) UkeStatus.MANUELT_REGISTRERT else UkeStatus.IKKE_MOTTATT_KJØRELISTE,
             avvik = avklartUke?.typeAvvik?.let { AvvikUke(typeAvvik = it) },
             behandletDato = avklartUke?.behandletDato,
             kjørelisteInnsendtDato = kjøreliste?.datoMottatt?.toLocalDate(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteDag
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteId
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteService
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUkeRepository
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakForReiseMedPrivatBil
@@ -33,6 +34,7 @@ class AvklartKjørelisteService(
     private val kjørelisteService: KjørelisteService,
     private val behandlingService: BehandlingService,
     private val unleashService: UnleashService,
+    private val registrertKjørtUkeRepository: RegistrertKjørtUkeRepository,
 ) {
     fun hentAvklarteUkerForBehandling(behandlingId: BehandlingId): List<AvklartKjørtUke> =
         avklartKjørtUkeRepository.findByBehandlingId(behandlingId)
@@ -47,16 +49,59 @@ class AvklartKjørelisteService(
 
         validerAtAlleDagerIKjørelistaErInnenForRammevedtaket(rammeForReise, kjøreliste)
 
-        val kjørelisteGruppertPåUker = kjøreliste.data.reisedager.groupBy { it.dato.tilUkeIÅr() }
+        val manueltRegistrerteUker =
+            avklartKjørtUkeRepository
+                .findByBehandlingId(behandlingId)
+                .filter { it.status == UkeStatus.MANUELT_REGISTRERT && it.reiseId == kjøreliste.data.reiseId }
+                .map { it.uke }
+                .toSet()
 
         val avklarteUker =
-            kjørelisteGruppertPåUker.map { (ukeIÅr, reisedager) ->
-                utledAvklartUke(
+            kjøreliste.data.reisedager
+                .groupBy { it.dato.tilUkeIÅr() }
+                .filterNot { (ukeIÅr, _) -> ukeIÅr in manueltRegistrerteUker }
+                .map { (ukeIÅr, reisedager) ->
+                    utledAvklartUke(
+                        behandlingId = behandlingId,
+                        ukeIÅr = ukeIÅr,
+                        reisedager = reisedager,
+                        kjørelisteId = kjøreliste.id,
+                        rammevedtak = rammeForReise,
+                    )
+                }
+
+        avklartKjørtUkeRepository.insertAll(avklarteUker)
+    }
+
+    fun avklarUkerFraRegistrerteDager(behandlingId: BehandlingId) {
+        val registrerteUker = registrertKjørtUkeRepository.findByBehandlingId(behandlingId)
+
+        val avklarteUker =
+            registrerteUker.map { uke ->
+                val dager = uke.dager.toList()
+                val avklarteDager =
+                    dager.map { dag ->
+                        AvklartKjørtDag(
+                            dato = dag.dato,
+                            godkjentGjennomførtKjøring =
+                                if (dag.harKjørt) GodkjentGjennomførtKjøring.JA else GodkjentGjennomførtKjøring.NEI,
+                            automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                            avvik = emptyList(),
+                            parkeringsutgift = dag.parkeringsutgift,
+                            avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
+                        )
+                    }
+
+                AvklartKjørtUke(
                     behandlingId = behandlingId,
-                    ukeIÅr = ukeIÅr,
-                    reisedager = reisedager,
-                    kjørelisteId = kjøreliste.id,
-                    rammevedtak = rammeForReise,
+                    kjørelisteId = null,
+                    reiseId = uke.reiseId,
+                    fom = dager.minOf { it.dato },
+                    tom = dager.maxOf { it.dato },
+                    uke = dager.minOf { it.dato }.tilUkeIÅr(),
+                    status = UkeStatus.MANUELT_REGISTRERT,
+                    dager = avklarteDager.toSet(),
+                    avklartKjørtUkeStatus = AvklartKjørtUkeStatus.NY,
                 )
             }
 
@@ -72,7 +117,10 @@ class AvklartKjørelisteService(
         val oppdaterteDager = oppdaterAvklarteDager(eksisterendeUke.dager, request)
 
         val rammevedtak = henteReiseFraVedtak(behandlingId, eksisterendeUke.reiseId)
-        val innsendteKjørelisteDager = kjørelisteService.hentKjøreliste(eksisterendeUke.kjørelisteId).data.reisedager
+        val innsendteKjørelisteDager =
+            eksisterendeUke.kjørelisteId
+                ?.let { kjørelisteService.hentKjøreliste(it).data.reisedager }
+                ?: emptyList()
 
         validerOppdatertAvklartKjørtUke(
             oppdaterteDager = oppdaterteDager,
@@ -291,10 +339,10 @@ class AvklartKjørelisteService(
         val avklarteUkerForrigeBehandling = hentAvklarteUkerForBehandling(behandlingIdForGjenbruk)
         val avklarteUkerNyBehandling = hentAvklarteUkerForBehandling(behandlingId)
 
-        val kjørelisterSomFinneIForrigeBehandling = avklarteUkerForrigeBehandling.map { it.kjørelisteId }.toSet()
+        val kjørelisterSomFinneIForrigeBehandling = avklarteUkerForrigeBehandling.mapNotNull { it.kjørelisteId }.toSet()
         val kjørelisterSomFinneINyMenIkkeGammelBehandling =
             avklarteUkerNyBehandling
-                .map { it.kjørelisteId }
+                .mapNotNull { it.kjørelisteId }
                 .filterNot { kjørelisterSomFinneIForrigeBehandling.contains(it) }
                 .distinct() // En kjøreliste kan dekke flere uker
                 .map { kjørelisteService.hentKjøreliste(it) }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteService.kt
@@ -74,6 +74,12 @@ class AvklartKjørelisteService(
     }
 
     fun avklarUkerFraRegistrerteDager(behandlingId: BehandlingId) {
+        val eksisterendeManueltRegistrerteUker =
+            avklartKjørtUkeRepository
+                .findByBehandlingId(behandlingId)
+                .filter { it.status == UkeStatus.MANUELT_REGISTRERT }
+        avklartKjørtUkeRepository.deleteAll(eksisterendeManueltRegistrerteUker)
+
         val registrerteUker = registrertKjørtUkeRepository.findByBehandlingId(behandlingId)
 
         val avklarteUker =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValidering.kt
@@ -92,9 +92,8 @@ private fun AvklartKjørtDag.validerBegrunnelse(innsendtKjørelisteDag: Kjøreli
         "Må oppgi begrunnelse for parkeringsutgift over 100 for dag ${dato.norskFormat()}"
     }
 
-    brukerfeilHvis(innsendtKjørelisteDag == null) {
-        "Må oppgi begrunnelse for å endre dag ${dato.norskFormat()} når det ikke finnes en opprinnelig kjøreliste for dagen"
-    }
+    // Ingen videre validering mot kjøreliste dersom det ikke finnes en (manuell søknad)
+    if (innsendtKjørelisteDag == null) return
 
     brukerfeilHvis(godkjentGjennomførtKjøring == GodkjentGjennomførtKjøring.JA && !innsendtKjørelisteDag.harKjørt) {
         "Må oppgi begrunnelse for å godkjenne kjøring når bruker ikke har oppgitt å ha kjørt for dag ${dato.norskFormat()}"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteValidering.kt
@@ -92,8 +92,9 @@ private fun AvklartKjørtDag.validerBegrunnelse(innsendtKjørelisteDag: Kjøreli
         "Må oppgi begrunnelse for parkeringsutgift over 100 for dag ${dato.norskFormat()}"
     }
 
-    // Ingen videre validering mot kjøreliste dersom det ikke finnes en (manuell søknad)
-    if (innsendtKjørelisteDag == null) return
+    brukerfeilHvis(innsendtKjørelisteDag == null) {
+        "Må oppgi begrunnelse for å endre dag ${dato.norskFormat()} når det ikke finnes en opprinnelig kjøreliste for dagen"
+    }
 
     brukerfeilHvis(godkjentGjennomførtKjøring == GodkjentGjennomførtKjøring.JA && !innsendtKjørelisteDag.harKjørt) {
         "Må oppgi begrunnelse for å godkjenne kjøring når bruker ikke har oppgitt å ha kjørt for dag ${dato.norskFormat()}"

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørtUke.kt
@@ -22,7 +22,7 @@ data class AvklartKjørtUke(
     @Column("behandling_id")
     val behandlingId: BehandlingId,
     @Column("kjoreliste_id")
-    val kjørelisteId: KjørelisteId,
+    val kjørelisteId: KjørelisteId? = null,
     val reiseId: ReiseId,
     override val fom: LocalDate,
     override val tom: LocalDate,
@@ -59,6 +59,7 @@ data class AvklartKjørtUke(
 
 enum class UkeStatus {
     OK_AUTOMATISK, // brukes hvis automatisk godkjent
+    MANUELT_REGISTRERT, // brukes når uke er registrert av saksbehandler og krever manuell gjennomgang
     OK_MANUELT, // brukes hvis saksbehandler godtar avvik
     AVVIK, // parkeringsutgifter/for mange dager etc. saksbehandler må ta stilling til uka
     IKKE_MOTTATT_KJØRELISTE,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDag.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDag.kt
@@ -1,0 +1,15 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDate
+import java.util.UUID
+
+@Table("registrert_kjort_dag")
+data class RegistrertKjørtDag(
+    @Id val id: UUID = UUID.randomUUID(),
+    val dato: LocalDate,
+    @Column("har_kjort") val harKjørt: Boolean,
+    val parkeringsutgift: Int? = null,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagController.kt
@@ -25,21 +25,21 @@ class RegistrertKjørtDagController(
     @GetMapping("{behandlingId}")
     fun hentForBehandling(
         @PathVariable behandlingId: BehandlingId,
-    ): List<RegistrertKjørtUke> {
+    ): List<RegistrertKjørtUkeDto> {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerLesetilgangTilBehandling(behandlingId)
-        return registrertKjørtDagService.hentForBehandling(behandlingId)
+        return registrertKjørtDagService.hentForBehandling(behandlingId).map { it.tilDto() }
     }
 
     @PostMapping("{behandlingId}")
     fun lagreUke(
         @PathVariable behandlingId: BehandlingId,
         @RequestBody request: RegistrertKjørtUkePostRequest,
-    ): RegistrertKjørtUke {
+    ): RegistrertKjørtUkeDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
-        return registrertKjørtDagService.lagreUke(behandlingId, request)
+        return registrertKjørtDagService.lagreUke(behandlingId, request).tilDto()
     }
 
     @PutMapping("{behandlingId}/{ukeId}")
@@ -47,10 +47,10 @@ class RegistrertKjørtDagController(
         @PathVariable behandlingId: BehandlingId,
         @PathVariable ukeId: UUID,
         @RequestBody request: RegistrertKjørtUkePutRequest,
-    ): RegistrertKjørtUke {
+    ): RegistrertKjørtUkeDto {
         tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
         tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
-        return registrertKjørtDagService.oppdaterUke(behandlingId, ukeId, request)
+        return registrertKjørtDagService.oppdaterUke(behandlingId, ukeId, request).tilDto()
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagController.kt
@@ -1,0 +1,56 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.tilgang.AuditLoggerEvent
+import no.nav.tilleggsstonader.sak.tilgang.TilgangService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/registrert-kjort-dag")
+@ProtectedWithClaims(issuer = "azuread")
+class RegistrertKjørtDagController(
+    private val tilgangService: TilgangService,
+    private val behandlingService: BehandlingService,
+    private val registrertKjørtDagService: RegistrertKjørtDagService,
+) {
+    @GetMapping("{behandlingId}")
+    fun hentForBehandling(
+        @PathVariable behandlingId: BehandlingId,
+    ): List<RegistrertKjørtUke> {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
+        tilgangService.validerLesetilgangTilBehandling(behandlingId)
+        return registrertKjørtDagService.hentForBehandling(behandlingId)
+    }
+
+    @PostMapping("{behandlingId}")
+    fun lagreUke(
+        @PathVariable behandlingId: BehandlingId,
+        @RequestBody request: RegistrertKjørtUkePostRequest,
+    ): RegistrertKjørtUke {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
+        tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
+        return registrertKjørtDagService.lagreUke(behandlingId, request)
+    }
+
+    @PutMapping("{behandlingId}/{ukeId}")
+    fun oppdaterUke(
+        @PathVariable behandlingId: BehandlingId,
+        @PathVariable ukeId: UUID,
+        @RequestBody request: RegistrertKjørtUkePutRequest,
+    ): RegistrertKjørtUke {
+        tilgangService.settBehandlingsdetaljerForRequest(behandlingId)
+        tilgangService.validerSkrivetilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
+        return registrertKjørtDagService.oppdaterUke(behandlingId, ukeId, request)
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagRequest.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagRequest.kt
@@ -1,0 +1,21 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import java.time.LocalDate
+
+data class RegistrertKjørtDagRequest(
+    val dato: LocalDate,
+    val harKjørt: Boolean,
+    val parkeringsutgift: Int? = null,
+)
+
+data class RegistrertKjørtUkePostRequest(
+    val reiseId: ReiseId,
+    val begrunnelse: String?,
+    val dager: List<RegistrertKjørtDagRequest>,
+)
+
+data class RegistrertKjørtUkePutRequest(
+    val begrunnelse: String?,
+    val dager: List<RegistrertKjørtDagRequest>,
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagService.kt
@@ -11,7 +11,7 @@ class RegistrertKjørtDagService(
     private val registrertKjørtUkeRepository: RegistrertKjørtUkeRepository,
 ) {
     fun hentForBehandling(behandlingId: BehandlingId): List<RegistrertKjørtUke> =
-        registrertKjørtUkeRepository.findByBehandlingId(behandlingId)
+        registrertKjørtUkeRepository.findByBehandlingId(behandlingId).map { it }
 
     fun lagreUke(
         behandlingId: BehandlingId,
@@ -36,12 +36,13 @@ class RegistrertKjørtDagService(
         brukerfeilHvis(eksisterende.behandlingId != behandlingId) {
             "Uke $ukeId tilhører ikke behandling $behandlingId"
         }
-        return registrertKjørtUkeRepository.update(
-            eksisterende.copy(
-                begrunnelse = request.begrunnelse,
-                dager = request.dager.tilDomene(),
-            ),
-        )
+        return registrertKjørtUkeRepository
+            .update(
+                eksisterende.copy(
+                    begrunnelse = request.begrunnelse,
+                    dager = request.dager.tilDomene(),
+                ),
+            )
     }
 
     private fun List<RegistrertKjørtDagRequest>.tilDomene(): Set<RegistrertKjørtDag> =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtDagService.kt
@@ -1,0 +1,55 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.brukerfeilHvis
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class RegistrertKjørtDagService(
+    private val registrertKjørtUkeRepository: RegistrertKjørtUkeRepository,
+) {
+    fun hentForBehandling(behandlingId: BehandlingId): List<RegistrertKjørtUke> =
+        registrertKjørtUkeRepository.findByBehandlingId(behandlingId)
+
+    fun lagreUke(
+        behandlingId: BehandlingId,
+        request: RegistrertKjørtUkePostRequest,
+    ): RegistrertKjørtUke {
+        val uke =
+            RegistrertKjørtUke(
+                behandlingId = behandlingId,
+                reiseId = request.reiseId,
+                begrunnelse = request.begrunnelse,
+                dager = request.dager.tilDomene(),
+            )
+        return registrertKjørtUkeRepository.insert(uke)
+    }
+
+    fun oppdaterUke(
+        behandlingId: BehandlingId,
+        ukeId: UUID,
+        request: RegistrertKjørtUkePutRequest,
+    ): RegistrertKjørtUke {
+        val eksisterende = registrertKjørtUkeRepository.findByIdOrThrow(ukeId)
+        brukerfeilHvis(eksisterende.behandlingId != behandlingId) {
+            "Uke $ukeId tilhører ikke behandling $behandlingId"
+        }
+        return registrertKjørtUkeRepository.update(
+            eksisterende.copy(
+                begrunnelse = request.begrunnelse,
+                dager = request.dager.tilDomene(),
+            ),
+        )
+    }
+
+    private fun List<RegistrertKjørtDagRequest>.tilDomene(): Set<RegistrertKjørtDag> =
+        map { dag ->
+            RegistrertKjørtDag(
+                dato = dag.dato,
+                harKjørt = dag.harKjørt,
+                parkeringsutgift = dag.parkeringsutgift,
+            )
+        }.toSet()
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtUke.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtUke.kt
@@ -1,0 +1,19 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.MappedCollection
+import org.springframework.data.relational.core.mapping.Table
+import java.util.UUID
+
+@Table("registrert_kjort_uke")
+data class RegistrertKjørtUke(
+    @Id val id: UUID = UUID.randomUUID(),
+    @Column("behandling_id") val behandlingId: BehandlingId,
+    val reiseId: ReiseId,
+    val begrunnelse: String? = null,
+    @MappedCollection(idColumn = "registrert_kjort_uke_id")
+    val dager: Set<RegistrertKjørtDag> = emptySet(),
+)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtUkeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtUkeDto.kt
@@ -1,0 +1,35 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import java.time.LocalDate
+import java.util.UUID
+
+data class RegistrertKjørtUkeDto(
+    val id: UUID,
+    val reiseId: ReiseId,
+    val begrunnelse: String?,
+    val dager: List<RegistrertKjørtDagDto>,
+)
+
+data class RegistrertKjørtDagDto(
+    val id: UUID,
+    val dato: LocalDate,
+    val harKjørt: Boolean,
+    val parkeringsutgift: Int?,
+)
+
+fun RegistrertKjørtUke.tilDto(): RegistrertKjørtUkeDto =
+    RegistrertKjørtUkeDto(
+        id = id,
+        reiseId = reiseId,
+        begrunnelse = begrunnelse,
+        dager = dager.map { it.tilDto() },
+    )
+
+fun RegistrertKjørtDag.tilDto(): RegistrertKjørtDagDto =
+    RegistrertKjørtDagDto(
+        id = id,
+        dato = dato,
+        harKjørt = harKjørt,
+        parkeringsutgift = parkeringsutgift,
+    )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtUkeRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/registrertekjørtedager/RegistrertKjørtUkeRepository.kt
@@ -1,0 +1,14 @@
+package no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager
+
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.InsertUpdateRepository
+import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface RegistrertKjørtUkeRepository :
+    RepositoryInterface<RegistrertKjørtUke, UUID>,
+    InsertUpdateRepository<RegistrertKjørtUke> {
+    fun findByBehandlingId(behandlingId: BehandlingId): List<RegistrertKjørtUke>
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RegistrerKjørelisteSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RegistrerKjørelisteSteg.kt
@@ -3,15 +3,18 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
 import no.nav.tilleggsstonader.sak.behandlingsflyt.BehandlingSteg
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
 import org.springframework.stereotype.Service
 
 @Service
-class RegistrerKjørelisteSteg : BehandlingSteg<Void?> {
+class RegistrerKjørelisteSteg(
+    private val avklartKjørelisteService: AvklartKjørelisteService,
+) : BehandlingSteg<Void?> {
     override fun utførSteg(
         saksbehandling: Saksbehandling,
         data: Void?,
     ) {
-        // Ikke noe å gjøre da dette er det første steget i en manuell kjørelistebehandling
+        avklartKjørelisteService.avklarUkerFraRegistrerteDager(saksbehandling.id)
     }
 
     override fun stegType(): StegType = StegType.REGISTRER_KJØRELISTE

--- a/src/main/resources/db/migration/V142__registrert_kjort_dag.sql
+++ b/src/main/resources/db/migration/V142__registrert_kjort_dag.sql
@@ -1,0 +1,20 @@
+create table registrert_kjort_uke
+(
+    id            UUID                            NOT NULL PRIMARY KEY,
+    behandling_id UUID REFERENCES behandling (id) NOT NULL,
+    reise_id      UUID                            NOT NULL,
+    begrunnelse   VARCHAR                         NULL
+);
+
+create index idx_registrert_kjort_uke_behandling_id on registrert_kjort_uke (behandling_id);
+
+create table registrert_kjort_dag
+(
+    id                      UUID    NOT NULL PRIMARY KEY,
+    registrert_kjort_uke_id UUID    NOT NULL REFERENCES registrert_kjort_uke (id),
+    dato                    DATE    NOT NULL,
+    har_kjort               BOOLEAN NOT NULL,
+    parkeringsutgift        INT     NULL
+);
+
+create index idx_registrert_kjort_dag_uke_id on registrert_kjort_dag (registrert_kjort_uke_id);

--- a/src/main/resources/db/migration/V143__nullable_kjoreliste_id_avklart_kjort_uke.sql
+++ b/src/main/resources/db/migration/V143__nullable_kjoreliste_id_avklart_kjort_uke.sql
@@ -1,0 +1,2 @@
+ALTER TABLE avklart_kjort_uke
+    ALTER COLUMN kjoreliste_id DROP NOT NULL;

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.sak.privatbil
 
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
 import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtDag
 import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUke
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
@@ -227,14 +228,56 @@ class ReisevurderingPrivatBilMapperTest {
                 registrerteUker = listOf(registrertUke),
             )
 
-        // registrertKjørtUke sier harKjørt=false, men ingen kjøreliste finnes — vi forventer registrertUke
-        assertThat(
-            dto.uker
-                .single()
-                .dager
-                .single()
-                .kjørelisteDag
-                ?.harKjørt,
-        ).isFalse()
+        @Test
+        fun `uke med registrertKjørtUke men uten avklartUke får status MANUELT_REGISTRERT`() {
+            val reiseId = ReiseId.random()
+            val behandlingId = BehandlingId.random()
+            val gjeldendeReise =
+                rammeForReiseMedPrivatBil(
+                    reiseId = reiseId,
+                    fom = 6 januar 2025,
+                    tom = 6 januar 2025,
+                )
+            val registrertUke =
+                RegistrertKjørtUke(
+                    behandlingId = behandlingId,
+                    reiseId = reiseId,
+                    dager = setOf(RegistrertKjørtDag(dato = 6 januar 2025, harKjørt = true)),
+                )
+
+            val dto =
+                ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                    gjeldendeRammevedtakForReise = gjeldendeReise,
+                    forrigeRammevedtakForReise = null,
+                    avklarteUker = emptyList(),
+                    kjørelister = emptyList(),
+                    registrerteUker = listOf(registrertUke),
+                )
+
+            assertThat(dto.uker.single().status).isEqualTo(UkeStatus.MANUELT_REGISTRERT)
+        }
+
+        @Test
+        fun `uke uten avklartUke og uten registrertKjørtUke får status IKKE_MOTTATT_KJØRELISTE`() {
+            val reiseId = ReiseId.random()
+            val gjeldendeReise =
+                rammeForReiseMedPrivatBil(
+                    reiseId = reiseId,
+                    fom = 6 januar 2025,
+                    tom = 6 januar 2025,
+                )
+
+            val dto =
+                ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                    gjeldendeRammevedtakForReise = gjeldendeReise,
+                    forrigeRammevedtakForReise = null,
+                    avklarteUker = emptyList(),
+                    kjørelister = emptyList(),
+                )
+
+            assertThat(dto.uker.single().status).isEqualTo(UkeStatus.IKKE_MOTTATT_KJØRELISTE)
+        }
     }
 }
+
+

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -1,14 +1,25 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.tilUkeIÅr
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtDagStatus
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUke
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatus
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UtfyltDagAutomatiskVurdering
 import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtDag
 import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUke
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.UUID
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode as KontrakterDatoperiode
 
 class ReisevurderingPrivatBilMapperTest {
     @Test
@@ -206,6 +217,86 @@ class ReisevurderingPrivatBilMapperTest {
     fun `innsendt kjøreliste har prioritet over registrertKjørtUke`() {
         val reiseId = ReiseId.random()
         val behandlingId = BehandlingId.random()
+        val kjørelisteId = KjørelisteId.random()
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 6 januar 2025,
+            )
+
+        // Lag innsendt kjøreliste med harKjørt=true og parkeringsutgift=100
+        val kjøreliste =
+            KjørelisteUtil.kjøreliste(
+                id = kjørelisteId,
+                reiseId = reiseId,
+                periode = KontrakterDatoperiode(6 januar 2025, 6 januar 2025),
+                kjørteDager = listOf(KjørtDag(dato = 6 januar 2025, parkeringsutgift = 100)),
+            )
+
+        // Lag avklart uke som matcher kjørelisten
+        val avklartUke =
+            AvklartKjørtUke(
+                id = UUID.randomUUID(),
+                behandlingId = behandlingId,
+                kjørelisteId = kjørelisteId,
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 6 januar 2025,
+                uke = (6 januar 2025).tilUkeIÅr(),
+                status = UkeStatus.OK_AUTOMATISK,
+                avklartKjørtUkeStatus = AvklartKjørtUkeStatus.NY,
+                dager =
+                    setOf(
+                        AvklartKjørtDag(
+                            dato = 6 januar 2025,
+                            godkjentGjennomførtKjøring = GodkjentGjennomførtKjøring.JA,
+                            automatiskVurdering = UtfyltDagAutomatiskVurdering.OK,
+                            avvik = emptyList(),
+                            parkeringsutgift = 100,
+                            avklartKjørtDagStatus = AvklartKjørtDagStatus.NY,
+                        ),
+                    ),
+            )
+
+        // Lag registrert uke med andre verdier (harKjørt=false, parkeringsutgift=null)
+        val registrertUke =
+            RegistrertKjørtUke(
+                behandlingId = behandlingId,
+                reiseId = reiseId,
+                dager =
+                    setOf(
+                        RegistrertKjørtDag(
+                            dato = 6 januar 2025,
+                            harKjørt = false, // registrert sier false
+                            parkeringsutgift = null, // registrert sier null
+                        ),
+                    ),
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = null,
+                avklarteUker = listOf(avklartUke),
+                kjørelister = listOf(kjøreliste),
+                registrerteUker = listOf(registrertUke),
+            )
+
+        // Sjekk at innsendt kjøreliste har prioritet over registrert
+        val dag =
+            dto.uker
+                .single()
+                .dager
+                .single()
+        assertThat(dag.kjørelisteDag?.harKjørt).isTrue() // fra kjørelisten, ikke registrert (false)
+        assertThat(dag.kjørelisteDag?.parkeringsutgift).isEqualTo(100) // fra kjørelisten, ikke registrert (null)
+    }
+
+    @Test
+    fun `uke med registrertKjørtUke men uten avklartUke får status MANUELT_REGISTRERT`() {
+        val reiseId = ReiseId.random()
+        val behandlingId = BehandlingId.random()
         val gjeldendeReise =
             rammeForReiseMedPrivatBil(
                 reiseId = reiseId,
@@ -216,7 +307,7 @@ class ReisevurderingPrivatBilMapperTest {
             RegistrertKjørtUke(
                 behandlingId = behandlingId,
                 reiseId = reiseId,
-                dager = setOf(RegistrertKjørtDag(dato = 6 januar 2025, harKjørt = false, parkeringsutgift = null)),
+                dager = setOf(RegistrertKjørtDag(dato = 6 januar 2025, harKjørt = true)),
             )
 
         val dto =
@@ -228,56 +319,27 @@ class ReisevurderingPrivatBilMapperTest {
                 registrerteUker = listOf(registrertUke),
             )
 
-        @Test
-        fun `uke med registrertKjørtUke men uten avklartUke får status MANUELT_REGISTRERT`() {
-            val reiseId = ReiseId.random()
-            val behandlingId = BehandlingId.random()
-            val gjeldendeReise =
-                rammeForReiseMedPrivatBil(
-                    reiseId = reiseId,
-                    fom = 6 januar 2025,
-                    tom = 6 januar 2025,
-                )
-            val registrertUke =
-                RegistrertKjørtUke(
-                    behandlingId = behandlingId,
-                    reiseId = reiseId,
-                    dager = setOf(RegistrertKjørtDag(dato = 6 januar 2025, harKjørt = true)),
-                )
+        assertThat(dto.uker.single().status).isEqualTo(UkeStatus.MANUELT_REGISTRERT)
+    }
 
-            val dto =
-                ReisevurderingPrivatBilMapper.tilReisevurderingDto(
-                    gjeldendeRammevedtakForReise = gjeldendeReise,
-                    forrigeRammevedtakForReise = null,
-                    avklarteUker = emptyList(),
-                    kjørelister = emptyList(),
-                    registrerteUker = listOf(registrertUke),
-                )
+    @Test
+    fun `uke uten avklartUke og uten registrertKjørtUke får status IKKE_MOTTATT_KJØRELISTE`() {
+        val reiseId = ReiseId.random()
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 6 januar 2025,
+            )
 
-            assertThat(dto.uker.single().status).isEqualTo(UkeStatus.MANUELT_REGISTRERT)
-        }
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = null,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+            )
 
-        @Test
-        fun `uke uten avklartUke og uten registrertKjørtUke får status IKKE_MOTTATT_KJØRELISTE`() {
-            val reiseId = ReiseId.random()
-            val gjeldendeReise =
-                rammeForReiseMedPrivatBil(
-                    reiseId = reiseId,
-                    fom = 6 januar 2025,
-                    tom = 6 januar 2025,
-                )
-
-            val dto =
-                ReisevurderingPrivatBilMapper.tilReisevurderingDto(
-                    gjeldendeRammevedtakForReise = gjeldendeReise,
-                    forrigeRammevedtakForReise = null,
-                    avklarteUker = emptyList(),
-                    kjørelister = emptyList(),
-                )
-
-            assertThat(dto.uker.single().status).isEqualTo(UkeStatus.IKKE_MOTTATT_KJØRELISTE)
-        }
+        assertThat(dto.uker.single().status).isEqualTo(UkeStatus.IKKE_MOTTATT_KJØRELISTE)
     }
 }
-
-

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -1,6 +1,9 @@
 package no.nav.tilleggsstonader.sak.privatbil
 
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUke
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
@@ -150,5 +153,88 @@ class ReisevurderingPrivatBilMapperTest {
         assertThat(dagSlettetPerDato[8 januar 2025]).isFalse() // onsdag — i gjeldende
         assertThat(dagSlettetPerDato[9 januar 2025]).isFalse() // torsdag — i gjeldende
         assertThat(dagSlettetPerDato[10 januar 2025]).isFalse() // fredag — i gjeldende
+    }
+
+    @Test
+    fun `mapper uke med registrertKjørtUke til kjørelisteDag fra registrerte dager`() {
+        val reiseId = ReiseId.random()
+        val behandlingId = BehandlingId.random()
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 10 januar 2025,
+            )
+        val registrertUke =
+            RegistrertKjørtUke(
+                behandlingId = behandlingId,
+                reiseId = reiseId,
+                dager =
+                    setOf(
+                        RegistrertKjørtDag(dato = 6 januar 2025, harKjørt = true, parkeringsutgift = 80),
+                        RegistrertKjørtDag(dato = 7 januar 2025, harKjørt = false),
+                        RegistrertKjørtDag(dato = 8 januar 2025, harKjørt = true, parkeringsutgift = null),
+                        RegistrertKjørtDag(dato = 9 januar 2025, harKjørt = false),
+                        RegistrertKjørtDag(dato = 10 januar 2025, harKjørt = true, parkeringsutgift = 50),
+                    ),
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = null,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+                registrerteUker = listOf(registrertUke),
+            )
+
+        val dager = dto.uker.single().dager
+        val dagPerDato = dager.associateBy { it.dato }
+
+        assertThat(dagPerDato[6 januar 2025]?.kjørelisteDag?.harKjørt).isTrue()
+        assertThat(dagPerDato[6 januar 2025]?.kjørelisteDag?.parkeringsutgift).isEqualTo(80)
+        assertThat(dagPerDato[7 januar 2025]?.kjørelisteDag?.harKjørt).isFalse()
+        assertThat(dagPerDato[7 januar 2025]?.kjørelisteDag?.parkeringsutgift).isNull()
+        assertThat(dagPerDato[8 januar 2025]?.kjørelisteDag?.harKjørt).isTrue()
+        assertThat(dagPerDato[8 januar 2025]?.kjørelisteDag?.parkeringsutgift).isNull()
+        assertThat(dagPerDato[10 januar 2025]?.kjørelisteDag?.harKjørt).isTrue()
+        assertThat(dagPerDato[10 januar 2025]?.kjørelisteDag?.parkeringsutgift).isEqualTo(50)
+    }
+
+    @Test
+    fun `innsendt kjøreliste har prioritet over registrertKjørtUke`() {
+        val reiseId = ReiseId.random()
+        val behandlingId = BehandlingId.random()
+        val gjeldendeReise =
+            rammeForReiseMedPrivatBil(
+                reiseId = reiseId,
+                fom = 6 januar 2025,
+                tom = 6 januar 2025,
+            )
+        val registrertUke =
+            RegistrertKjørtUke(
+                behandlingId = behandlingId,
+                reiseId = reiseId,
+                dager = setOf(RegistrertKjørtDag(dato = 6 januar 2025, harKjørt = false, parkeringsutgift = null)),
+            )
+
+        val dto =
+            ReisevurderingPrivatBilMapper.tilReisevurderingDto(
+                gjeldendeRammevedtakForReise = gjeldendeReise,
+                forrigeRammevedtakForReise = null,
+                avklarteUker = emptyList(),
+                kjørelister = emptyList(),
+                registrerteUker = listOf(registrertUke),
+            )
+
+        // registrertKjørtUke sier harKjørt=false, men ingen kjøreliste finnes — vi forventer registrertUke
+        assertThat(
+            dto.uker
+                .single()
+                .dager
+                .single()
+                .kjørelisteDag
+                ?.harKjørt,
+        ).isFalse()
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapperTest.kt
@@ -214,7 +214,7 @@ class ReisevurderingPrivatBilMapperTest {
     }
 
     @Test
-    fun `innsendt kjøreliste har prioritet over registrertKjørtUke`() {
+    fun `bruker registrertKjørtUke når dersom de er sendt inn og kjøreliste mangler`() {
         val reiseId = ReiseId.random()
         val behandlingId = BehandlingId.random()
         val kjørelisteId = KjørelisteId.random()
@@ -225,7 +225,6 @@ class ReisevurderingPrivatBilMapperTest {
                 tom = 6 januar 2025,
             )
 
-        // Lag innsendt kjøreliste med harKjørt=true og parkeringsutgift=100
         val kjøreliste =
             KjørelisteUtil.kjøreliste(
                 id = kjørelisteId,
@@ -234,7 +233,6 @@ class ReisevurderingPrivatBilMapperTest {
                 kjørteDager = listOf(KjørtDag(dato = 6 januar 2025, parkeringsutgift = 100)),
             )
 
-        // Lag avklart uke som matcher kjørelisten
         val avklartUke =
             AvklartKjørtUke(
                 id = UUID.randomUUID(),
@@ -259,7 +257,6 @@ class ReisevurderingPrivatBilMapperTest {
                     ),
             )
 
-        // Lag registrert uke med andre verdier (harKjørt=false, parkeringsutgift=null)
         val registrertUke =
             RegistrertKjørtUke(
                 behandlingId = behandlingId,
@@ -268,8 +265,8 @@ class ReisevurderingPrivatBilMapperTest {
                     setOf(
                         RegistrertKjørtDag(
                             dato = 6 januar 2025,
-                            harKjørt = false, // registrert sier false
-                            parkeringsutgift = null, // registrert sier null
+                            harKjørt = false,
+                            parkeringsutgift = null,
                         ),
                     ),
             )
@@ -283,14 +280,13 @@ class ReisevurderingPrivatBilMapperTest {
                 registrerteUker = listOf(registrertUke),
             )
 
-        // Sjekk at innsendt kjøreliste har prioritet over registrert
         val dag =
             dto.uker
                 .single()
                 .dager
                 .single()
-        assertThat(dag.kjørelisteDag?.harKjørt).isTrue() // fra kjørelisten, ikke registrert (false)
-        assertThat(dag.kjørelisteDag?.parkeringsutgift).isEqualTo(100) // fra kjørelisten, ikke registrert (null)
+        assertThat(dag.kjørelisteDag?.harKjørt).isTrue()
+        assertThat(dag.kjørelisteDag?.parkeringsutgift).isEqualTo(100)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
@@ -39,7 +39,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AvklartKjørelisteServiceTest {
-    private val avklartKjørtUkeRepository = mockk<AvklartKjørtUkeRepository>()
+    private val avklartKjørtUkeRepository = mockk<AvklartKjørtUkeRepository>(relaxed = true)
     private val kjørelisteService = mockk<KjørelisteService>()
     private val vedtakService = mockk<VedtakService>()
     private val behandlingService = mockk<BehandlingService>()
@@ -443,8 +443,11 @@ class AvklartKjørelisteServiceTest {
 
             val oppdatertUke = updateSlot.captured.single()
             assertThat(oppdatertUke.avklartKjørtUkeStatus).isEqualTo(AvklartKjørtUkeStatus.ENDRET)
-            assertThat(oppdatertUke.dager.filter { it.avklartKjørtDagStatus == AvklartKjørtDagStatus.SLETTET }.map { it.dato })
-                .containsExactlyInAnyOrder(mandagUke, mandagUke.plusDays(4))
+            assertThat(
+                oppdatertUke.dager
+                    .filter { it.avklartKjørtDagStatus == AvklartKjørtDagStatus.SLETTET }
+                    .map { it.dato },
+            ).containsExactlyInAnyOrder(mandagUke, mandagUke.plusDays(4))
         }
 
         @Test
@@ -575,6 +578,7 @@ class AvklartKjørelisteServiceTest {
             val insertSlot = slot<List<AvklartKjørtUke>>()
 
             every { registrertKjørtUkeRepository.findByBehandlingId(behandlingId) } returns listOf(registrertUke)
+            every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns emptyList()
             every { avklartKjørtUkeRepository.insertAll(capture(insertSlot)) } returns emptyList()
 
             service.avklarUkerFraRegistrerteDager(behandlingId)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/avklartedager/AvklartKjørelisteServiceTest.kt
@@ -14,6 +14,10 @@ import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrT
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteId
 import no.nav.tilleggsstonader.sak.privatbil.KjørelisteService
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.UkeStatus.MANUELT_REGISTRERT
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtDag
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUke
+import no.nav.tilleggsstonader.sak.privatbil.registrertekjørtedager.RegistrertKjørtUkeRepository
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
@@ -40,6 +44,7 @@ class AvklartKjørelisteServiceTest {
     private val vedtakService = mockk<VedtakService>()
     private val behandlingService = mockk<BehandlingService>()
     private val unleashService = mockk<UnleashService>()
+    private val registrertKjørtUkeRepository = mockk<RegistrertKjørtUkeRepository>()
 
     private val service =
         AvklartKjørelisteService(
@@ -48,6 +53,7 @@ class AvklartKjørelisteServiceTest {
             kjørelisteService = kjørelisteService,
             behandlingService = behandlingService,
             unleashService = unleashService,
+            registrertKjørtUkeRepository = registrertKjørtUkeRepository,
         )
 
     private val reiseId = ReiseId.random()
@@ -241,7 +247,7 @@ class AvklartKjørelisteServiceTest {
                         KjørelisteUtil.KjørtDag(dato = mandag.plusDays(dagOffset.toLong()), parkeringsutgift = null)
                     },
             )
-        every { kjørelisteService.hentKjøreliste(eksisterendeUke.kjørelisteId) } returns innsendtKjøreliste
+        every { kjørelisteService.hentKjøreliste(eksisterendeUke.kjørelisteId!!) } returns innsendtKjøreliste
         every { behandlingService.hentBehandling(behandlingId) } returns behandling
         every { unleashService.isEnabled(Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK) } returns false
 
@@ -549,6 +555,103 @@ class AvklartKjørelisteServiceTest {
             service.sletteMarkerUkerOgDagerUtenforAvkortetRammevedtak(behandlingId, rammevedtak)
 
             verify(exactly = 0) { avklartKjørtUkeRepository.updateAll(any()) }
+        }
+    }
+
+    @Nested
+    inner class AvklarUkerFraRegistrerteDager {
+        @Test
+        fun `uke fra registrerte dager får status MANUELT_REGISTRERT og kjørelisteId er null`() {
+            val registrertUke =
+                RegistrertKjørtUke(
+                    behandlingId = behandlingId,
+                    reiseId = reiseId,
+                    dager =
+                        setOf(
+                            RegistrertKjørtDag(dato = mandag, harKjørt = true),
+                            RegistrertKjørtDag(dato = mandag.plusDays(1), harKjørt = false),
+                        ),
+                )
+            val insertSlot = slot<List<AvklartKjørtUke>>()
+
+            every { registrertKjørtUkeRepository.findByBehandlingId(behandlingId) } returns listOf(registrertUke)
+            every { avklartKjørtUkeRepository.insertAll(capture(insertSlot)) } returns emptyList()
+
+            service.avklarUkerFraRegistrerteDager(behandlingId)
+
+            val uke = insertSlot.captured.single()
+            assertThat(uke.status).isEqualTo(MANUELT_REGISTRERT)
+            assertThat(uke.kjørelisteId).isNull()
+            assertThat(uke.dager).hasSize(2)
+        }
+    }
+
+    @Nested
+    inner class AvklarUkerFraKjøreliste {
+        @Test
+        fun `kjøreliste for uke med MANUELT_REGISTRERT overstyrer ikke den manuelt registrerte uken`() {
+            val insertSlot = slot<List<AvklartKjørtUke>>()
+            val manueltRegistrertUke =
+                lagUke(fom = mandag, tom = fredag).copy(
+                    kjørelisteId = null,
+                    status = UkeStatus.MANUELT_REGISTRERT,
+                )
+            val kjøreliste =
+                KjørelisteUtil.kjøreliste(
+                    reiseId = reiseId,
+                    periode = Datoperiode(mandag, fredag),
+                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(dato = mandag)),
+                )
+
+            settOppVedtakMock()
+            every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns listOf(manueltRegistrertUke)
+            every { avklartKjørtUkeRepository.insertAll(capture(insertSlot)) } returns emptyList()
+
+            service.avklarUkerFraKjøreliste(behandlingId, kjøreliste)
+
+            assertThat(insertSlot.captured).isEmpty()
+        }
+
+        @Test
+        fun `kjøreliste for uke uten MANUELT_REGISTRERT behandles normalt`() {
+            val insertSlot = slot<List<AvklartKjørtUke>>()
+            val kjøreliste =
+                KjørelisteUtil.kjøreliste(
+                    reiseId = reiseId,
+                    periode = Datoperiode(mandag, fredag),
+                    kjørteDager = listOf(KjørelisteUtil.KjørtDag(dato = mandag)),
+                )
+
+            settOppVedtakMock()
+            every { avklartKjørtUkeRepository.findByBehandlingId(behandlingId) } returns emptyList()
+            every { avklartKjørtUkeRepository.insertAll(capture(insertSlot)) } returns emptyList()
+
+            service.avklarUkerFraKjøreliste(behandlingId, kjøreliste)
+
+            assertThat(insertSlot.captured).hasSize(1)
+            assertThat(insertSlot.captured.single().uke).isEqualTo(mandag.tilUkeIÅr())
+        }
+
+        private fun settOppVedtakMock() {
+            val vedtakData =
+                InnvilgelseDagligReise(
+                    rammevedtakPrivatBil =
+                        RammevedtakPrivatBil(
+                            reiser = listOf(rammeForReiseMedPrivatBil(reiseId = reiseId, fom = mandag, tom = fredag)),
+                        ),
+                    beregningsresultat = BeregningsresultatDagligReise(offentligTransport = null, privatBil = null),
+                    vedtaksperioder = emptyList(),
+                    beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
+                )
+            val generiskVedtak =
+                GeneriskVedtak(
+                    behandlingId = behandlingId,
+                    type = TypeVedtak.INNVILGELSE,
+                    data = vedtakData,
+                    gitVersjon = Applikasjonsversjon.versjon,
+                    tidligsteEndring = null,
+                )
+            every { vedtakService.hentVedtakEllerFeil(behandlingId) } returns generiskVedtak
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For at en SB skal ha mulighet til å registrere en kjøreliste manuelt på vegne av en bruker som har sendt inn kjørelisten på et annet format enn en digitalsøknad.

Denne PR-en har blant annet to store endringer:
- To nye tabell for registrerte uker og dager - har vi de feltene vi trenger?
- Gjør kjørelisteId nullable - fordi det ikke finnes noe kjørelisteId dersom det er opprettet en manuell kjøreliste

[Se front-end PR](https://github.com/navikt/tilleggsstonader-sak-frontend/pull/1227)
