### PR TITLE
sorter vedtaksperioder for daglig reise

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
@@ -33,6 +33,7 @@ object DetaljertVedtaksperioderDagligReiseMapper {
             reiserPrivatBilTso.tilDetaljerteVedtaksperioderPrivatBil(Stønadstype.DAGLIG_REISE_TSO, adresserTso),
             reiserPrivatBilTsr.tilDetaljerteVedtaksperioderPrivatBil(Stønadstype.DAGLIG_REISE_TSR, adresserTsr),
         ).flatten()
+            .sortedBy { it.detaljertBeregningsperioder?.firstOrNull()?.fom ?: it.rammevedtakPrivatBil?.fom }
     }
 
     private fun InnvilgelseEllerOpphørDagligReise.hentUtOffentligTransport(): List<BeregningsresultatForReise> =
@@ -72,8 +73,8 @@ object DetaljertVedtaksperioderDagligReiseMapper {
     ): DetaljertVedtaksperiodeDagligReise {
         val detaljertBeregningsperioder =
             perioder
-                .sortedByDescending { it.grunnlag.fom }
                 .map { it.tilDetaljertBeregningsperiode() }
+                .sortedByDescending { it.fom }
 
         return DetaljertVedtaksperiodeDagligReise(
             stønadstype = stønadstype,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapperTest.kt
@@ -217,7 +217,13 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
                                         ),
                                         BeregningsresultatForReise(
                                             reiseId = offentligTransportTidligReiseId,
-                                            perioder = listOf(beregningsresultatForPeriode(1 februar 2026, 28 februar 2026)),
+                                            perioder =
+                                                listOf(
+                                                    beregningsresultatForPeriode(
+                                                        1 februar 2026,
+                                                        28 februar 2026,
+                                                    ),
+                                                ),
                                         ),
                                     ),
                             ),
@@ -253,7 +259,12 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
                                     ),
                             ),
                     ),
-                rammevedtakPrivatBil = RammevedtakPrivatBilUtil.rammevedtakPrivatBil(reiseId = privatBilReiseId, fom = 1 mars 2026, tom = 31 mars 2026),
+                rammevedtakPrivatBil =
+                    RammevedtakPrivatBilUtil.rammevedtakPrivatBil(
+                        reiseId = privatBilReiseId,
+                        fom = 1 mars 2026,
+                        tom = 31 mars 2026,
+                    ),
                 beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
             )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapperTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise.detaljerteVedtaksperioder
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.felles.domain.VedtaksperiodeId
@@ -18,7 +19,12 @@ import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsgrunnlagO
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilDag
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilGrunnlag
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatOffentligTransport
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.VedtaksperiodeGrunnlag
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
@@ -29,6 +35,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.LocalDate
 
 class DetaljertVedtaksperioderDagligReiseMapperTest {
@@ -187,6 +194,92 @@ class DetaljertVedtaksperioderDagligReiseMapperTest {
         assertThat(privatBil.rammevedtakPrivatBil?.reiseId).isEqualTo(privatBilReiseId)
         assertThat(privatBil.adresse).isEqualTo("Testveien 2")
         assertThat(privatBil.detaljertBeregningsperioder).isNull()
+    }
+
+    @Test
+    fun `skal sortere detaljerte vedtaksperioder på fom for blandede typer`() {
+        val offentligTransportTidligReiseId = ReiseId.random()
+        val offentligTransportSenReiseId = ReiseId.random()
+        val privatBilReiseId = ReiseId.random()
+
+        val vedtak =
+            InnvilgelseDagligReise(
+                vedtaksperioder = defaultVedtaksperioder,
+                beregningsresultat =
+                    BeregningsresultatDagligReise(
+                        offentligTransport =
+                            BeregningsresultatOffentligTransport(
+                                reiser =
+                                    listOf(
+                                        BeregningsresultatForReise(
+                                            reiseId = offentligTransportSenReiseId,
+                                            perioder = listOf(beregningsresultatForPeriode(5 mars 2026, 31 mars 2026)),
+                                        ),
+                                        BeregningsresultatForReise(
+                                            reiseId = offentligTransportTidligReiseId,
+                                            perioder = listOf(beregningsresultatForPeriode(1 februar 2026, 28 februar 2026)),
+                                        ),
+                                    ),
+                            ),
+                        privatBil =
+                            BeregningsresultatPrivatBil(
+                                reiser =
+                                    listOf(
+                                        BeregningsresultatForReisePrivatBil(
+                                            reiseId = privatBilReiseId,
+                                            perioder =
+                                                listOf(
+                                                    BeregningsresultatForReisePrivatBilPeriode(
+                                                        fom = 1 mars 2026,
+                                                        tom = 31 mars 2026,
+                                                        grunnlag =
+                                                            BeregningsresultatForReisePrivatBilGrunnlag(
+                                                                dager =
+                                                                    listOf(
+                                                                        BeregningsresultatForReisePrivatBilDag(
+                                                                            dato = 1 mars 2026,
+                                                                            parkeringskostnad = 0,
+                                                                            dagsatsUtenParkering = BigDecimal("100.00"),
+                                                                            stønadsbeløpForDag = BigDecimal("100.00"),
+                                                                        ),
+                                                                    ),
+                                                            ),
+                                                        stønadsbeløp = BigDecimal("100.00"),
+                                                        brukersNavKontor = null,
+                                                        fraTidligereVedtak = false,
+                                                    ),
+                                                ),
+                                        ),
+                                    ),
+                            ),
+                    ),
+                rammevedtakPrivatBil = RammevedtakPrivatBilUtil.rammevedtakPrivatBil(reiseId = privatBilReiseId, fom = 1 mars 2026, tom = 31 mars 2026),
+                beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
+            )
+
+        val resultat =
+            finnDetaljerteVedtaksperioderDagligReise(
+                vedtaksdataTso = vedtak,
+                vedtaksdataTsr = null,
+                adresserTso =
+                    mapOf(
+                        offentligTransportTidligReiseId to "adresse 1",
+                        privatBilReiseId to "adresse 2",
+                        offentligTransportSenReiseId to "adresse 3",
+                    ),
+                adresserTsr = emptyMap(),
+            )
+
+        val fomDatoer =
+            resultat.map {
+                it.detaljertBeregningsperioder?.firstOrNull()?.fom ?: it.rammevedtakPrivatBil?.fom
+            }
+
+        assertThat(fomDatoer).containsExactly(
+            1 februar 2026,
+            1 mars 2026,
+            5 mars 2026,
+        )
     }
 
     private fun innvilgelse(data: InnvilgelseDagligReise = defaultInnvilgelseDagligReise) =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

vedtaksperioder er per nå ikke sortert, kun satt basert på hvilken rekkefølge man registrerte. nice å sortere disse