### PR TITLE
Ikke tillat å endre typen på et daglig-reise vilkår hvis dette er kopiert med fra forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårService.kt
@@ -79,6 +79,7 @@ class DagligReiseVilkårService(
         validerDelperiodeFomOgTomMotNyttVilkår(nyttVilkår)
 
         val eksisterendeVilkår = vilkårRepository.findByIdOrThrow(vilkårId).mapTilVilkårDagligReise()
+        validerMotEksisterendeVilkår(nyttVilkår, eksisterendeVilkår)
 
         val vilkår = lagVilkårMedVurderingerOgResultat(behandlingId, nyttVilkår, eksisterendeVilkår)
         val lagretVilkår = vilkårRepository.update(vilkår.mapTilVilkår())
@@ -204,6 +205,18 @@ class DagligReiseVilkårService(
             brukerfeilHvisIkke(tom == delperiodeTom) {
                 "Delperioden sin tom ${delperiodeTom?.norskFormat()} er ikke den samme som reiseperioden sin tom ${tom.norskFormat()}"
             }
+        }
+    }
+
+    private fun validerMotEksisterendeVilkår(
+        nyttVilkår: LagreVilkårDagligReise,
+        eksisterendeVilkår: VilkårDagligReise,
+    ) {
+        brukerfeilHvis(
+            eksisterendeVilkår.status in setOf(VilkårStatus.UENDRET, VilkårStatus.ENDRET) &&
+                eksisterendeVilkår.fakta.type != nyttVilkår.fakta.type,
+        ) {
+            "Du kan ikke endre type på en eksisterende reise fra forrige behandling. For å endre type må du slette reisen og opprette en ny reise."
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårServiceTest.kt
@@ -13,22 +13,29 @@ import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
+import no.nav.tilleggsstonader.sak.infrastruktur.exception.ApiFeil
 import no.nav.tilleggsstonader.sak.infrastruktur.exception.Feil
 import no.nav.tilleggsstonader.sak.util.dummyReiseId
 import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.faktaPrivatBil
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.util.vilkårDagligReise
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.VilkårDagligReiseMapper.mapTilVilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.FaktaOffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.domain.LagreVilkårDagligReise
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaDelperiodePrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.SvarOgBegrunnelse
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
 
 class DagligReiseVilkårServiceTest {
     val vilkårRepository = mockk<VilkårRepository>()
@@ -156,6 +163,127 @@ class DagligReiseVilkårServiceTest {
                     vilkårId = VilkårId.random(),
                 )
             }.withMessage("Kan ikke oppdatere vilkår når behandling er på steg=INNGANGSVILKÅR.")
+    }
+
+    @Test
+    fun `skal ikke kunne endre type på uendret vilkår fra forrige behandling`() {
+        val behandling = saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.DAGLIG_REISE_TSO))
+        val vilkårId = VilkårId.random()
+        val eksisterendeVilkår =
+            vilkårDagligReise(
+                behandlingId = behandling.id,
+                status = VilkårStatus.UENDRET,
+                fom = 1 januar 2025,
+                tom = 31 januar 2025,
+                fakta =
+                    faktaPrivatBil(
+                        reiseperioder =
+                            listOf(
+                                FaktaDelperiodePrivatBil(
+                                    fom = 1 januar 2025,
+                                    tom = 31 januar 2025,
+                                    reisedagerPerUke = 5,
+                                    bompengerPerDag = null,
+                                    fergekostnadPerDag = null,
+                                ),
+                            ),
+                    ),
+            ).copy(id = vilkårId)
+
+        every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårRepository.findByIdOrNull(vilkårId) } returns eksisterendeVilkår.mapTilVilkår()
+
+        assertThatExceptionOfType(ApiFeil::class.java)
+            .isThrownBy {
+                dagligReiseVilkårService.oppdaterVilkår(
+                    nyttVilkår = nyttVilkår,
+                    behandlingId = behandling.id,
+                    vilkårId = vilkårId,
+                )
+            }.withMessage(
+                "Du kan ikke endre type på en eksisterende reise fra forrige behandling. For å endre type må du slette reisen og opprette en ny reise.",
+            )
+    }
+
+    @Test
+    fun `skal ikke kunne endre type på endret vilkår fra forrige behandling`() {
+        val behandling = saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.DAGLIG_REISE_TSO))
+        val vilkårId = VilkårId.random()
+        val eksisterendeVilkår =
+            vilkårDagligReise(
+                behandlingId = behandling.id,
+                status = VilkårStatus.ENDRET,
+                fom = 1 januar 2025,
+                tom = 31 januar 2025,
+                fakta =
+                    faktaPrivatBil(
+                        reiseperioder =
+                            listOf(
+                                FaktaDelperiodePrivatBil(
+                                    fom = 1 januar 2025,
+                                    tom = 31 januar 2025,
+                                    reisedagerPerUke = 5,
+                                    bompengerPerDag = null,
+                                    fergekostnadPerDag = null,
+                                ),
+                            ),
+                    ),
+            ).copy(id = vilkårId)
+
+        every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårRepository.findByIdOrNull(vilkårId) } returns eksisterendeVilkår.mapTilVilkår()
+
+        assertThatExceptionOfType(ApiFeil::class.java)
+            .isThrownBy {
+                dagligReiseVilkårService.oppdaterVilkår(
+                    nyttVilkår = nyttVilkår,
+                    behandlingId = behandling.id,
+                    vilkårId = vilkårId,
+                )
+            }.withMessage(
+                "Du kan ikke endre type på en eksisterende reise fra forrige behandling. For å endre type må du slette reisen og opprette en ny reise.",
+            )
+    }
+
+    @Test
+    fun `skal kunne endre type på nytt vilkår`() {
+        val behandling = saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.DAGLIG_REISE_TSO))
+        val vilkårId = VilkårId.random()
+        val eksisterendeVilkår =
+            vilkårDagligReise(
+                behandlingId = behandling.id,
+                status = VilkårStatus.NY,
+                fom = 1 januar 2025,
+                tom = 31 januar 2025,
+                fakta =
+                    faktaPrivatBil(
+                        reiseperioder =
+                            listOf(
+                                FaktaDelperiodePrivatBil(
+                                    fom = 1 januar 2025,
+                                    tom = 31 januar 2025,
+                                    reisedagerPerUke = 5,
+                                    bompengerPerDag = null,
+                                    fergekostnadPerDag = null,
+                                ),
+                            ),
+                    ),
+            ).copy(id = vilkårId)
+
+        every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårRepository.findByIdOrNull(vilkårId) } returns eksisterendeVilkår.mapTilVilkår()
+        every { vilkårRepository.update(any<Vilkår>()) } answers { firstArg() }
+
+        dagligReiseVilkårService.oppdaterVilkår(
+            nyttVilkår = nyttVilkår,
+            behandlingId = behandling.id,
+            vilkårId = vilkårId,
+        )
+
+        verify(exactly = 1) { vilkårRepository.update(any<Vilkår>()) }
     }
 
     fun faktaOffentligTransport(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/dagligReise/DagligReiseVilkårServiceTest.kt
@@ -36,6 +36,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import java.util.Optional
 
 class DagligReiseVilkårServiceTest {
     val vilkårRepository = mockk<VilkårRepository>()
@@ -192,7 +193,7 @@ class DagligReiseVilkårServiceTest {
 
         every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
         every { unleashService.isEnabled(any()) } returns true
-        every { vilkårRepository.findByIdOrNull(vilkårId) } returns eksisterendeVilkår.mapTilVilkår()
+        every { vilkårRepository.findById(vilkårId) } returns Optional.of(eksisterendeVilkår.mapTilVilkår())
 
         assertThatExceptionOfType(ApiFeil::class.java)
             .isThrownBy {
@@ -233,7 +234,7 @@ class DagligReiseVilkårServiceTest {
 
         every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
         every { unleashService.isEnabled(any()) } returns true
-        every { vilkårRepository.findByIdOrNull(vilkårId) } returns eksisterendeVilkår.mapTilVilkår()
+        every { vilkårRepository.findById(vilkårId) } returns Optional.of(eksisterendeVilkår.mapTilVilkår())
 
         assertThatExceptionOfType(ApiFeil::class.java)
             .isThrownBy {
@@ -274,7 +275,7 @@ class DagligReiseVilkårServiceTest {
 
         every { behandlingService.hentSaksbehandling(behandling.id) } returns behandling
         every { unleashService.isEnabled(any()) } returns true
-        every { vilkårRepository.findByIdOrNull(vilkårId) } returns eksisterendeVilkår.mapTilVilkår()
+        every { vilkårRepository.findById(vilkårId) } returns Optional.of(eksisterendeVilkår.mapTilVilkår())
         every { vilkårRepository.update(any<Vilkår>()) } answers { firstArg() }
 
         dagligReiseVilkårService.oppdaterVilkår(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Kan føre til litt problemer om reiseId plutselig peker på offentlig transport når den tidligere var en referanse til et rammevedtak. 

Løser(/unngår) også et problem hvor beregningsresultatet ikke blir nullstilt hvis man gjør dette.