### PR TITLE
👔 Start å telle 30-dagersperioder fra starten av den 30-dagersperioden tidligste endring treffer

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -69,8 +69,7 @@ class BoutgifterBeregningService(
             typeVedtak = typeVedtak,
         )
 
-        val vedtaksperioderBeregning =
-            vedtaksperioder.tilVedtaksperiodeBeregning().sorted().splitFra(plan.beregnFra())
+        val vedtaksperioderBeregning = vedtaksperioder.tilVedtaksperiodeBeregning().sorted()
 
         val utgifterPerVilkårtype =
             boutgifterUtgiftService
@@ -89,7 +88,12 @@ class BoutgifterBeregningService(
             vedtaksperioderBeregning,
         )
 
-        val beregningsresultat = beregnAktuellePerioder(vedtaksperioderBeregning, utgifterPerVilkårtype)
+        val beregningsresultat =
+            beregnAktuellePerioder(
+                vedtaksperioder = vedtaksperioderBeregning,
+                utgifter = utgifterPerVilkårtype,
+                beregnFra = plan.beregnFra(),
+            )
 
         return if (forrigeVedtak != null) {
             settSammenGamleOgNyePerioder(
@@ -105,14 +109,16 @@ class BoutgifterBeregningService(
     private fun beregnAktuellePerioder(
         vedtaksperioder: List<VedtaksperiodeBeregning>,
         utgifter: BoutgifterPerUtgiftstype,
+        beregnFra: LocalDate?,
     ): List<BeregningsresultatForLøpendeMåned> =
         vedtaksperioder
             .sorted()
+            .fitrerVekkPerioderFørBeregnFra(beregnFra)
             .splittVedGrensenTilFaktiskeUtgifter(utgifter)
             .flatMap { it.perioder.splittTilLøpendeMåneder() }
             .map { UtbetalingPeriode(it, skalAvkorteUtbetalingPeriode(utgifter)) }
             .validerIngenLøpendeOgMidlertidigUtgiftISammeUtbetalingsperiode(utgifter)
-            .validerIngenUtgifterTilOvernattingKrysserUtbetalingsperioder(utgifter)
+            .validerIngenUtgifterTilOvernattingKrysserUtbetalingsperioder(utgifter, beregnFra)
             .validerIngenUtbetalingsperioderOverlapperFlereLøpendeUtgifter(
                 utgifter = utgifter,
                 finnMakssats = satsBoutgifterService::finnMakssats,
@@ -207,10 +213,19 @@ private fun validerMidlertidigeUtgifterStrekkerSegUtenforVedtaksperiodene(
     }
 }
 
+private fun List<VedtaksperiodeBeregning>.fitrerVekkPerioderFørBeregnFra(beregnFra: LocalDate?): List<VedtaksperiodeBeregning> {
+    if (beregnFra == null) return this
+    return this
+        .splitFra(beregnFra)
+        .filter { it.tom >= beregnFra }
+}
+
 private fun List<UtbetalingPeriode>.validerIngenUtgifterTilOvernattingKrysserUtbetalingsperioder(
     utgifter: BoutgifterPerUtgiftstype,
+    beregnFra: LocalDate?,
 ): List<UtbetalingPeriode> {
-    val utgifterTilOvernatting = utgifter[TypeBoutgift.UTGIFTER_OVERNATTING] ?: emptyList()
+    val utgifterTilOvernatting =
+        utgifter[TypeBoutgift.UTGIFTER_OVERNATTING]?.filter { beregnFra == null || it.tom >= beregnFra } ?: emptyList()
     val utbetalingsperioder = this
 
     val detFinnesUtgiftSomKrysserUtbetalingsperioder =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -112,7 +112,6 @@ class BoutgifterBeregningService(
         beregnFra: LocalDate?,
     ): List<BeregningsresultatForLøpendeMåned> =
         vedtaksperioder
-            .sorted()
             .filtrerVekkPerioderFørBeregnFra(beregnFra)
             .splittVedGrensenTilFaktiskeUtgifter(utgifter)
             .flatMap { it.perioder.splittTilLøpendeMåneder() }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningService.kt
@@ -113,7 +113,7 @@ class BoutgifterBeregningService(
     ): List<BeregningsresultatForLøpendeMåned> =
         vedtaksperioder
             .sorted()
-            .fitrerVekkPerioderFørBeregnFra(beregnFra)
+            .filtrerVekkPerioderFørBeregnFra(beregnFra)
             .splittVedGrensenTilFaktiskeUtgifter(utgifter)
             .flatMap { it.perioder.splittTilLøpendeMåneder() }
             .map { UtbetalingPeriode(it, skalAvkorteUtbetalingPeriode(utgifter)) }
@@ -213,7 +213,7 @@ private fun validerMidlertidigeUtgifterStrekkerSegUtenforVedtaksperiodene(
     }
 }
 
-private fun List<VedtaksperiodeBeregning>.fitrerVekkPerioderFørBeregnFra(beregnFra: LocalDate?): List<VedtaksperiodeBeregning> {
+private fun List<VedtaksperiodeBeregning>.filtrerVekkPerioderFørBeregnFra(beregnFra: LocalDate?): List<VedtaksperiodeBeregning> {
     if (beregnFra == null) return this
     return this
         .splitFra(beregnFra)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/boutgifter/beregning/BoutgifterBeregningLøpendeUtgifterEnBoligTest.kt
@@ -2,11 +2,14 @@ package no.nav.tilleggsstonader.sak.vedtak.boutgifter.beregning
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.libs.utils.dato.april
+import no.nav.tilleggsstonader.libs.utils.dato.desember
 import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.libs.utils.dato.mai
 import no.nav.tilleggsstonader.libs.utils.dato.mars
+import no.nav.tilleggsstonader.libs.utils.dato.november
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
@@ -313,5 +316,70 @@ class BoutgifterBeregningLøpendeUtgifterEnBoligTest {
         assertThat(perioder[2].fom).isEqualTo(1 april 2026)
         assertThat(perioder[2].tom).isEqualTo(30 april 2026)
         assertThat(perioder[2].stønadsbeløp).isEqualTo(600)
+    }
+
+    @Test
+    fun `revurdering av gammel satsjustering skal ikke skape gap mellom gamle og nye perioder`() {
+        every { vilkårperiodeService.hentVilkårperioder(any()) } returns
+            Vilkårperioder(
+                målgrupper = listOf(målgruppe(fom = 11 november 2025, tom = 31 mars 2026)),
+                aktiviteter = listOf(aktivitet(fom = 11 november 2025, tom = 31 mars 2026)),
+            )
+
+        val utgifter: BoutgifterPerUtgiftstype =
+            mapOf(
+                TypeBoutgift.LØPENDE_UTGIFTER_EN_BOLIG to
+                    listOf(
+                        lagUtgiftBeregningBoutgifter(
+                            fom = 11 november 2025,
+                            tom = 31 mars 2026,
+                            utgift = 3000,
+                        ),
+                    ),
+            )
+
+        // Gamle, nyttårskuttede perioder fra forrige (buggy) vedtak
+        val gamlePerioder =
+            listOf(
+                lagBeregningsresultatMåned(fom = 11 november 2025, tom = 10 desember 2025, utgifter = utgifter),
+                lagBeregningsresultatMåned(fom = 11 desember 2025, tom = 31 desember 2025, utgifter = utgifter),
+                lagBeregningsresultatMåned(fom = 1 januar 2026, tom = 31 januar 2026, utgifter = utgifter),
+            )
+
+        val innvilgelseBoutgifter =
+            innvilgelseBoutgifter(
+                beregningsresultat = BeregningsresultatBoutgifter(gamlePerioder),
+                vedtaksperioder =
+                    listOf(vedtaksperiode(fom = 11 november 2025, tom = 31 januar 2026)),
+            )
+
+        every { boutgifterUtgiftService.hentUtgifterTilBeregning(any()) } returns utgifter
+        every { vedtakRepository.findByIdOrThrow(any()) } returns innvilgelseBoutgifter
+
+        val saksbehandling =
+            saksbehandling(
+                forrigeIverksatteBehandlingId = BehandlingId.random(),
+                type = BehandlingType.REVURDERING,
+            )
+
+        val res =
+            boutgifterBeregningService
+                .beregn(
+                    behandling = saksbehandling,
+                    vedtaksperioder = listOf(vedtaksperiode(fom = 11 november 2025, tom = 31 mars 2026)),
+                    plan = Beregningsplan(Beregningsomfang.FRA_DATO, 1 februar 2026),
+                    typeVedtak = TypeVedtak.INNVILGELSE,
+                ).perioder
+
+        val perioder = res.map { Datoperiode(it.fom, it.tom) }
+
+        assertThat(perioder)
+            .containsExactly(
+                Datoperiode(11 november 2025, 10 desember 2025),
+                Datoperiode(11 desember 2025, 31 desember 2025),
+                Datoperiode(1 januar 2026, 31 januar 2026),
+                Datoperiode(1 februar 2026, 28 februar 2026),
+                Datoperiode(1 mars 2026, 31 mars 2026),
+            )
     }
 }


### PR DESCRIPTION
Ved revurdering av behandlinger med gamle, nyttårskuttede perioder (fra før vi sluttet å kutte 30-dagersperioder ved årsskiftet) beholdes de gamle periodene før `beregnFra`, mens nye perioder ble telt løpende fra vedtaksperiodens opprinnelige start. Dette kunne gi et gap på noen dager mellom gammel og ny periode, siden 30-dagerstellingen ikke tok hensyn til at gamle perioder allerede var kuttet.

Løsningen er å telle nye 30-dagersperiode fra starten av den 30-dagersperioden tidligste endrng treffer i stedet for fra vedtaksperiodens opprinnelige fom, slik at nye perioder alltid henger sammen med de beholdte gamle periodene uten opphold.

<img width="1496" height="1143" alt="image" src="https://github.com/user-attachments/assets/69cc073d-5677-4187-b0d5-459135eb0fae" />


