### PR TITLE
Utvider tidligste endring sjekk på daglig-reise vilkår med å sjekke om reiseId er endret. Da anser man hele vilkåret som endret

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringService.kt
@@ -275,7 +275,8 @@ data class TidligsteEndringIBehandlingUtleder(
                 vilkårTidligereBehandling.fakta is FaktaDagligReiseOffentligTransport -> {
                 val faktaNå = vilkårNå.fakta
                 val faktaTidligere = vilkårTidligereBehandling.fakta
-                faktaNå.reisedagerPerUke != faktaTidligere.reisedagerPerUke ||
+                faktaNå.reiseId != faktaTidligere.reiseId ||
+                    faktaNå.reisedagerPerUke != faktaTidligere.reisedagerPerUke ||
                     faktaNå.prisEnkelbillett != faktaTidligere.prisEnkelbillett ||
                     faktaNå.prisSyvdagersbillett != faktaTidligere.prisSyvdagersbillett ||
                     faktaNå.prisTrettidagersbillett != faktaTidligere.prisTrettidagersbillett
@@ -289,7 +290,8 @@ data class TidligsteEndringIBehandlingUtleder(
                 val sammenligningsTom =
                     minOf(requireNotNull(vilkårNå.tom), requireNotNull(vilkårTidligereBehandling.tom))
 
-                faktaNå.reiseavstandEnVei != faktaTidligere.reiseavstandEnVei ||
+                faktaNå.reiseId != faktaTidligere.reiseId ||
+                    faktaNå.reiseavstandEnVei != faktaTidligere.reiseavstandEnVei ||
                     normaliserPrivatBilDelperioder(faktaNå, sammenligningsFom, sammenligningsTom) !=
                     normaliserPrivatBilDelperioder(faktaTidligere, sammenligningsFom, sammenligningsTom)
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
@@ -171,6 +171,44 @@ class UtledTidligsteEndringServiceTest {
     }
 
     @Test
+    fun `utled tidligste endring når reiseId for offentlig transport endres`() {
+        val gammeltVilkår =
+            vilkår(
+                behandlingId = sisteIverksatteBehandling.id,
+                type = VilkårType.DAGLIG_REISE,
+                fom = originalFom,
+                tom = originalTom,
+                fakta =
+                    FaktaDagligReiseOffentligTransport(
+                        reiseId = ReiseId.random(),
+                        adresse = "Tiltaksgata 1",
+                        reisedagerPerUke = 5,
+                        prisEnkelbillett = 80,
+                        prisSyvdagersbillett = 500,
+                        prisTrettidagersbillett = 1800,
+                    ),
+            )
+        val nyttVilkårMedNyReiseId =
+            gammeltVilkår.copy(
+                behandlingId = behandling.id,
+                fakta = (gammeltVilkår.fakta as FaktaDagligReiseOffentligTransport).copy(reiseId = ReiseId.random()),
+            )
+
+        vilkårSisteIverksatteBehandling = listOf(gammeltVilkår)
+        vilkår = listOf(nyttVilkårMedNyReiseId)
+        vilkårperioder = vilkårperioderSisteIverksattBehandling
+        vedtaksperioder = vedtaksperioderSisteIverksatteBehandling
+
+        val result =
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandling.id,
+                vedtaksperioder,
+            )
+
+        assertThat(result).isEqualTo(originalFom)
+    }
+
+    @Test
     fun `utled tidligste endring når daglig reise vilkår slettes og opprettes likt med ny reiseId`() {
         val gammeltVilkår =
             vilkår(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringServiceTest.kt
@@ -171,6 +171,48 @@ class UtledTidligsteEndringServiceTest {
     }
 
     @Test
+    fun `utled tidligste endring når daglig reise vilkår slettes og opprettes likt med ny reiseId`() {
+        val gammeltVilkår =
+            vilkår(
+                behandlingId = sisteIverksatteBehandling.id,
+                type = VilkårType.DAGLIG_REISE,
+                fom = originalFom,
+                tom = originalTom,
+                fakta =
+                    FaktaDagligReiseOffentligTransport(
+                        reiseId = ReiseId.random(),
+                        adresse = "Tiltaksgata 1",
+                        reisedagerPerUke = 5,
+                        prisEnkelbillett = 80,
+                        prisSyvdagersbillett = 500,
+                        prisTrettidagersbillett = 1800,
+                    ),
+            )
+        val nyttVilkårMedNyReiseId =
+            gammeltVilkår.copy(
+                behandlingId = behandling.id,
+                fakta = (gammeltVilkår.fakta as FaktaDagligReiseOffentligTransport).copy(reiseId = ReiseId.random()),
+            )
+        val slettetVilkårIRevurdering =
+            gammeltVilkår
+                .copy(behandlingId = behandling.id)
+                .markerSlettet(slettetKommentar = "Slettet")
+
+        vilkårSisteIverksatteBehandling = listOf(gammeltVilkår)
+        vilkår = listOf(nyttVilkårMedNyReiseId, slettetVilkårIRevurdering)
+        vilkårperioder = vilkårperioderSisteIverksattBehandling
+        vedtaksperioder = vedtaksperioderSisteIverksatteBehandling
+
+        val result =
+            utledTidligsteEndringService.utledTidligsteEndringForBeregning(
+                behandling.id,
+                vedtaksperioder,
+            )
+
+        assertThat(result).isEqualTo(originalFom)
+    }
+
+    @Test
     fun `utled tidligste endring ignorer vedtaksperiode, ingen endring utenom vedtaksperioder, forvent ingen endring`() {
         vilkår = vilkårSisteIverksatteBehandling
         vilkårperioder = vilkårperioderSisteIverksattBehandling

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/tidligsteendring/UtledTidligsteEndringStepDefinitions.kt
@@ -45,6 +45,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.Vilkårperioder
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetFaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeFaktaOgVurdering
 import org.assertj.core.api.Assertions.assertThat
+import java.util.UUID
 
 enum class TidligsteEndringFellesNøkler(
     override val nøkkel: String,
@@ -257,18 +258,23 @@ class UtledTidligsteEndringStepDefinitions {
                         resultat = parseEnum(TidligsteEndringFellesNøkler.RESULTAT, rad),
                         type = VilkårType.DAGLIG_REISE,
                         status = parseEnum(TidligsteEndringFellesNøkler.STATUS, rad),
-                        fakta = mapPrivatBilFakta(rad),
+                        fakta = mapPrivatBilFakta(rad, reisenr),
                     )
             }.toMap()
 
-    private fun mapPrivatBilFakta(rad: Map<String, String>) =
-        FaktaDagligReisePrivatBil(
-            reiseId = ReiseId.random(),
-            reiseavstandEnVei = parseBigDecimal(DomenenøkkelPrivatBil.REISEAVSTAND_EN_VEI, rad),
-            faktaDelperioder = emptyList(),
-            adresse = "Tiltaksveien 1",
-            aktivitetId = VilkårperiodeGlobalId.random(),
-        )
+    private fun mapPrivatBilFakta(
+        rad: Map<String, String>,
+        reisenr: Int,
+    ) = FaktaDagligReisePrivatBil(
+        reiseId = reiseIdFraReisenr(reisenr),
+        reiseavstandEnVei = parseBigDecimal(DomenenøkkelPrivatBil.REISEAVSTAND_EN_VEI, rad),
+        faktaDelperioder = emptyList(),
+        adresse = "Tiltaksveien 1",
+        aktivitetId = VilkårperiodeGlobalId.random(),
+    )
+
+    private fun reiseIdFraReisenr(reisenr: Int): ReiseId =
+        ReiseId(UUID.nameUUIDFromBytes("tidligste-endring-reisenr-$reisenr".toByteArray()))
 
     private fun mapPrivatBilDelperioder(dataTable: DataTable): Map<Int, List<FaktaDelperiodePrivatBil>> =
         dataTable


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vet ikke hvor realistisk tilfelle det er, men vilkåret får i så fall en ny reiseId, og skal da anses som et nytt vilkår - og tidligsteEndring blir da fom