### PR TITLE
Flagg reiser i rammevedtak som er før tidligste endring

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/ReisevurderingPrivatBilMapper.kt
@@ -32,8 +32,8 @@ object ReisevurderingPrivatBilMapper {
             )
         return ReisevurderingPrivatBilDto(
             reiseId = reiseId,
-            rammevedtak = gjeldendeRammevedtakForReise?.tilDto(),
-            forrigeRammevedtak = forrigeRammevedtakForReise?.tilDto(),
+            rammevedtak = gjeldendeRammevedtakForReise?.tilDto(beregningsplan = null),
+            forrigeRammevedtak = forrigeRammevedtakForReise?.tilDto(beregningsplan = null),
             uker = ukeVurderingerDto,
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapper.kt
@@ -217,7 +217,7 @@ class VedtakDtoMapper(
                     gjelderFraOgMed = data.vedtaksperioder.avkortPerioderFør(tidligsteEndring).minOfOrNull { it.fom },
                     gjelderTilOgMed = data.vedtaksperioder.avkortPerioderFør(tidligsteEndring).maxOfOrNull { it.tom },
                     begrunnelse = data.begrunnelse,
-                    rammevedtakPrivatBil = data.rammevedtakPrivatBil?.tilDto(),
+                    rammevedtakPrivatBil = data.rammevedtakPrivatBil?.tilDto(data.beregningsplan),
                 )
             }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -149,27 +149,15 @@ class DagligReiseVedtakController(
                 ?.data
                 ?: return null
 
-        val data =
-            PrivatBilOppsummertBeregningDto(
-                reiser =
-                    vedtaksdata
-                        .hentRammevedtakMedBeregningsresultat()
-                        .map { (beregningsresultatForReise, rammevedtakForReise) ->
-                            beregningsresultatForReise.oppsummerReise(rammevedtakForReise)
-                        },
-            )
-
-        return data.filtrerBortPerioderFraTidligereVedtak()
-    }
-
-    // TODO Denne er i KjøreliseBehandling
-    private fun PrivatBilOppsummertBeregningDto.filtrerBortPerioderFraTidligereVedtak() =
-        copy(
+        return PrivatBilOppsummertBeregningDto(
             reiser =
-                reiser
-                    .map { reise -> reise.copy(perioder = reise.perioder.filter { !it.fraTidligereVedtak }) }
-                    .filter { it.perioder.isNotEmpty() },
+                vedtaksdata
+                    .hentRammevedtakMedBeregningsresultat()
+                    .map { (beregningsresultatForReise, rammevedtakForReise) ->
+                        beregningsresultatForReise.oppsummerReise(rammevedtakForReise)
+                    },
         )
+    }
 
     private fun beregnVedtak(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/DagligReiseVedtakController.kt
@@ -149,15 +149,27 @@ class DagligReiseVedtakController(
                 ?.data
                 ?: return null
 
-        return PrivatBilOppsummertBeregningDto(
-            reiser =
-                vedtaksdata
-                    .hentRammevedtakMedBeregningsresultat()
-                    .map { (beregningsresultatForReise, rammevedtakForReise) ->
-                        beregningsresultatForReise.oppsummerReise(rammevedtakForReise)
-                    },
-        )
+        val data =
+            PrivatBilOppsummertBeregningDto(
+                reiser =
+                    vedtaksdata
+                        .hentRammevedtakMedBeregningsresultat()
+                        .map { (beregningsresultatForReise, rammevedtakForReise) ->
+                            beregningsresultatForReise.oppsummerReise(rammevedtakForReise)
+                        },
+            )
+
+        return data.filtrerBortPerioderFraTidligereVedtak()
     }
+
+    // TODO Denne er i KjøreliseBehandling
+    private fun PrivatBilOppsummertBeregningDto.filtrerBortPerioderFraTidligereVedtak() =
+        copy(
+            reiser =
+                reiser
+                    .map { reise -> reise.copy(perioder = reise.perioder.filter { !it.fraTidligereVedtak }) }
+                    .filter { it.perioder.isNotEmpty() },
+        )
 
     private fun beregnVedtak(
         behandlingId: BehandlingId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/PrivatBilBeregningsresultatMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/PrivatBilBeregningsresultatMapper.kt
@@ -36,6 +36,7 @@ fun BeregningsresultatForReisePrivatBil.oppsummerReise(rammevedtakForReise: Ramm
         reiseavstandEnVei = rammevedtakForReise.grunnlag.reiseavstandEnVei,
         aktivitetsadresse = rammevedtakForReise.aktivitetsadresse,
         perioder = this.perioder.map { it.oppsummerPeriode(rammevedtakForReise) }.sortedBy { it.ukenummer },
+        fraTidligereVedtak = this.perioder.all { it.fraTidligereVedtak },
     )
 
 private fun BeregningsresultatForReisePrivatBilPeriode.oppsummerPeriode(
@@ -80,9 +81,11 @@ data class OppsummertBeregningForReiseDto(
     val reiseavstandEnVei: BigDecimal,
     val aktivitetsadresse: String?,
     val perioder: List<OppsummertBeregningForPeriodeDto>,
+    val fraTidligereVedtak: Boolean,
 ) {
     val totaltStønadsbeløpMedPerioderFraForrigeVedtak = perioder.sumOf { it.stønadsbeløp }
-    val totaltStønadsbeløpUtenPerioderFraForrigeVedtak = perioder.filter { !it.fraTidligereVedtak }.sumOf { it.stønadsbeløp }
+    val totaltStønadsbeløpUtenPerioderFraForrigeVedtak =
+        perioder.filter { !it.fraTidligereVedtak }.sumOf { it.stønadsbeløp }
 }
 
 data class OppsummertBeregningForPeriodeDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/detaljerteVedtaksperioder/DetaljertVedtaksperioderDagligReiseMapper.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.detaljerteVedtaksperioder
 
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForPeriode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReise
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakForReiseMedPrivatBil
@@ -56,6 +57,7 @@ object DetaljertVedtaksperioderDagligReiseMapper {
     private fun List<RammevedtakForReiseMedPrivatBil>?.tilDetaljerteVedtaksperioderPrivatBil(
         stønadstype: Stønadstype,
         adresser: Map<ReiseId, String>,
+        beregningsplan: Beregningsplan? = null,
     ): List<DetaljertVedtaksperiodeDagligReise> =
         this.orEmpty().map { reise ->
             DetaljertVedtaksperiodeDagligReise(
@@ -63,7 +65,7 @@ object DetaljertVedtaksperioderDagligReiseMapper {
                 typeDagligReise = TypeDagligReise.PRIVAT_BIL,
                 detaljertBeregningsperioder = null,
                 adresse = adresser[reise.reiseId] ?: reise.aktivitetsadresse,
-                rammevedtakPrivatBil = reise.tilDto(),
+                rammevedtakPrivatBil = reise.tilDto(beregningsplan),
             )
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/BeregningsresultatDagligReiseDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/BeregningsresultatDagligReiseDto.kt
@@ -89,7 +89,7 @@ fun BeregningDagligReise.tilDto(
 ): BeregningDagligReiseDto =
     BeregningDagligReiseDto(
         beregningsresultat = beregningsresultatDagligReise.tilDto(beregningsplan, vilkår),
-        rammevedtakPrivatBil = rammevedtakPrivatBil?.tilDto(),
+        rammevedtakPrivatBil = rammevedtakPrivatBil?.tilDto(beregningsplan),
     )
 
 fun BeregningsresultatDagligReise.tilDto(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDto.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto
 
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilSatsForDelperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
@@ -38,9 +39,13 @@ data class RammeForReiseMedPrivatBilDelperiodeSatserDto(
     val dagsatsUtenParkering: BigDecimal,
 ) : Periode<LocalDate>
 
-fun RammevedtakPrivatBil.tilDto() =
+fun RammevedtakPrivatBil.tilDto(beregningsplan: Beregningsplan): RammevedtakPrivatBilDto =
     RammevedtakPrivatBilDto(
-        reiser = reiser.map { it.tilDto() },
+        reiser =
+            reiser
+                .filter { reise ->
+                    beregningsplan.tidligsteEndring?.let { reise.grunnlag.fom >= it } ?: true
+                }.map { it.tilDto() },
     )
 
 fun RammevedtakForReiseMedPrivatBil.tilDto(): RammeForReiseMedPrivatBilDto =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDto.kt
@@ -20,6 +20,7 @@ data class RammeForReiseMedPrivatBilDto(
     val delperioder: List<DelperiodeDto>,
     val reiseavstandEnVei: BigDecimal,
     val aktivitetsadresse: String?,
+    val fraTidligereVedtak: Boolean,
 )
 
 data class DelperiodeDto(
@@ -39,16 +40,13 @@ data class RammeForReiseMedPrivatBilDelperiodeSatserDto(
     val dagsatsUtenParkering: BigDecimal,
 ) : Periode<LocalDate>
 
-fun RammevedtakPrivatBil.tilDto(beregningsplan: Beregningsplan): RammevedtakPrivatBilDto =
+fun RammevedtakPrivatBil.tilDto(beregningsplan: Beregningsplan?): RammevedtakPrivatBilDto =
     RammevedtakPrivatBilDto(
         reiser =
-            reiser
-                .filter { reise ->
-                    beregningsplan.tidligsteEndring?.let { reise.grunnlag.tom >= it } ?: true
-                }.map { it.tilDto() },
+            reiser.map { it.tilDto(beregningsplan) },
     )
 
-fun RammevedtakForReiseMedPrivatBil.tilDto(): RammeForReiseMedPrivatBilDto =
+fun RammevedtakForReiseMedPrivatBil.tilDto(beregningsplan: Beregningsplan?): RammeForReiseMedPrivatBilDto =
     RammeForReiseMedPrivatBilDto(
         reiseId = reiseId,
         fom = grunnlag.fom,
@@ -66,6 +64,7 @@ fun RammevedtakForReiseMedPrivatBil.tilDto(): RammeForReiseMedPrivatBilDto =
             },
         reiseavstandEnVei = grunnlag.reiseavstandEnVei,
         aktivitetsadresse = aktivitetsadresse,
+        fraTidligereVedtak = beregningsplan?.tidligsteEndring?.let { it >= grunnlag.tom } ?: false,
     )
 
 fun RammeForReiseMedPrivatBilSatsForDelperiode.tilDto() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDto.kt
@@ -44,7 +44,7 @@ fun RammevedtakPrivatBil.tilDto(beregningsplan: Beregningsplan): RammevedtakPriv
         reiser =
             reiser
                 .filter { reise ->
-                    beregningsplan.tidligsteEndring?.let { reise.grunnlag.fom >= it } ?: true
+                    beregningsplan.tidligsteEndring?.let { reise.grunnlag.tom >= it } ?: true
                 }.map { it.tilDto() },
     )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapperTest.kt
@@ -2,7 +2,9 @@ package no.nav.tilleggsstonader.sak.vedtak
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
@@ -147,25 +149,33 @@ class VedtakDtoMapperTest {
     @Nested
     inner class DagligReise {
         @Test
-        fun `skal kun inkludere rammevedtak-reiser fra og med tidligste endring`() {
-            val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 9 januar 2026, tom = 9 januar 2026)
+        fun `skal kun ekskludere rammevedtak-reiser som er avsluttet før tidligste endring`() {
+            val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 januar 2026, tom = 31 januar 2026)
+            val reiseSomDekkerTidligsteEndring =
+                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 20 januar 2026, tom = 8 februar 2026)
             val reiseLikTidligsteEndring =
-                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 10 januar 2026, tom = 10 januar 2026)
+                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 februar 2026, tom = 28 februar 2026)
             val reiseEtterEndring =
-                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 11 januar 2026, tom = 11 januar 2026)
+                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 mars 2026, tom = 31 mars 2026)
             val vedtak =
                 DagligReiseTestUtil.innvilgelse(
                     data =
                         DagligReiseTestUtil.defaultInnvilgelseDagligReise.copy(
                             rammevedtakPrivatBil =
                                 RammevedtakPrivatBil(
-                                    reiser = listOf(reiseFørEndring, reiseLikTidligsteEndring, reiseEtterEndring),
+                                    reiser =
+                                        listOf(
+                                            reiseFørEndring,
+                                            reiseSomDekkerTidligsteEndring,
+                                            reiseLikTidligsteEndring,
+                                            reiseEtterEndring,
+                                        ),
                                 ),
                             beregningsplan =
                                 Beregningsplan(
                                     omfang = Beregningsomfang.FRA_DATO,
-                                    fraDato = 10 januar 2026,
-                                    tidligsteEndring = 10 januar 2026,
+                                    fraDato = 1 februar 2026,
+                                    tidligsteEndring = 1 februar 2026,
                                 ),
                         ),
                 )
@@ -173,6 +183,7 @@ class VedtakDtoMapperTest {
             val dto = vedtakDtoMapper.toDto(vedtak, forrigeIverksatteBehandlingId = null) as InnvilgelseDagligReiseResponse
 
             assertThat(dto.rammevedtakPrivatBil!!.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+                reiseSomDekkerTidligsteEndring.reiseId,
                 reiseLikTidligsteEndring.reiseId,
                 reiseEtterEndring.reiseId,
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapperTest.kt
@@ -149,7 +149,7 @@ class VedtakDtoMapperTest {
     @Nested
     inner class DagligReise {
         @Test
-        fun `skal kun ekskludere rammevedtak-reiser som er avsluttet før tidligste endring`() {
+        fun `skal kun flagge rammevedtak-reiser som er avsluttet før tidligste endring`() {
             val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 januar 2026, tom = 31 januar 2026)
             val reiseSomDekkerTidligsteEndring =
                 rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 20 januar 2026, tom = 8 februar 2026)
@@ -182,11 +182,17 @@ class VedtakDtoMapperTest {
 
             val dto = vedtakDtoMapper.toDto(vedtak, forrigeIverksatteBehandlingId = null) as InnvilgelseDagligReiseResponse
 
-            assertThat(dto.rammevedtakPrivatBil!!.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+            val reiser = dto.rammevedtakPrivatBil!!.reiser
+            assertThat(reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+                reiseFørEndring.reiseId,
                 reiseSomDekkerTidligsteEndring.reiseId,
                 reiseLikTidligsteEndring.reiseId,
                 reiseEtterEndring.reiseId,
             )
+            assertThat(reiser.single { it.reiseId == reiseFørEndring.reiseId }.fraTidligereVedtak).isTrue()
+            assertThat(reiser.single { it.reiseId == reiseSomDekkerTidligsteEndring.reiseId }.fraTidligereVedtak).isFalse()
+            assertThat(reiser.single { it.reiseId == reiseLikTidligsteEndring.reiseId }.fraTidligereVedtak).isFalse()
+            assertThat(reiser.single { it.reiseId == reiseEtterEndring.reiseId }.fraTidligereVedtak).isFalse()
         }
 
         @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/VedtakDtoMapperTest.kt
@@ -2,10 +2,14 @@ package no.nav.tilleggsstonader.sak.vedtak
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.util.Applikasjonsversjon
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.util.vedtaksperiode
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.DagligReiseTestUtil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.InnvilgelseDagligReiseResponse
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto.OpphørDagligReiseResponse
 import no.nav.tilleggsstonader.sak.vedtak.domain.GeneriskVedtak
 import no.nav.tilleggsstonader.sak.vedtak.domain.OpphørDagligReise
@@ -21,6 +25,7 @@ import no.nav.tilleggsstonader.sak.vedtak.passAvBarn.dto.AvslagPassAvBarnDto
 import no.nav.tilleggsstonader.sak.vedtak.passAvBarn.dto.InnvilgelsePassAvBarnResponse
 import no.nav.tilleggsstonader.sak.vedtak.passAvBarn.dto.OpphørPassAvBarnResponse
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.dagligReise.DagligReiseVilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -141,6 +146,38 @@ class VedtakDtoMapperTest {
 
     @Nested
     inner class DagligReise {
+        @Test
+        fun `skal kun inkludere rammevedtak-reiser fra og med tidligste endring`() {
+            val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 9 januar 2026, tom = 9 januar 2026)
+            val reiseLikTidligsteEndring =
+                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 10 januar 2026, tom = 10 januar 2026)
+            val reiseEtterEndring =
+                rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 11 januar 2026, tom = 11 januar 2026)
+            val vedtak =
+                DagligReiseTestUtil.innvilgelse(
+                    data =
+                        DagligReiseTestUtil.defaultInnvilgelseDagligReise.copy(
+                            rammevedtakPrivatBil =
+                                RammevedtakPrivatBil(
+                                    reiser = listOf(reiseFørEndring, reiseLikTidligsteEndring, reiseEtterEndring),
+                                ),
+                            beregningsplan =
+                                Beregningsplan(
+                                    omfang = Beregningsomfang.FRA_DATO,
+                                    fraDato = 10 januar 2026,
+                                    tidligsteEndring = 10 januar 2026,
+                                ),
+                        ),
+                )
+
+            val dto = vedtakDtoMapper.toDto(vedtak, forrigeIverksatteBehandlingId = null) as InnvilgelseDagligReiseResponse
+
+            assertThat(dto.rammevedtakPrivatBil!!.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+                reiseLikTidligsteEndring.reiseId,
+                reiseEtterEndring.reiseId,
+            )
+        }
+
         @Test
         fun `skal mappe opphørt vedtak til dto`() {
             val opphørsdato = LocalDate.of(2024, 1, 15)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDtoTest.kt
@@ -1,0 +1,60 @@
+package no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto
+
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
+import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RammevedtakPrivatBilDtoTest {
+    @Test
+    fun `skal kun inkludere reiser fra og med tidligste endring`() {
+        val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 9 januar 2026, tom = 9 januar 2026)
+        val reiseLikTidligsteEndring =
+            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 10 januar 2026, tom = 10 januar 2026)
+        val reiseEtterEndring =
+            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 11 januar 2026, tom = 11 januar 2026)
+        val rammevedtak =
+            RammevedtakPrivatBil(
+                reiser = listOf(reiseFørEndring, reiseLikTidligsteEndring, reiseEtterEndring),
+            )
+
+        val dto =
+            rammevedtak.tilDto(
+                Beregningsplan(
+                    omfang = Beregningsomfang.FRA_DATO,
+                    fraDato = 10 januar 2026,
+                    tidligsteEndring = 10 januar 2026,
+                ),
+            )
+
+        assertThat(dto.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+            reiseLikTidligsteEndring.reiseId,
+            reiseEtterEndring.reiseId,
+        )
+    }
+
+    @Test
+    fun `skal inkludere alle reiser når tidligste endring er null`() {
+        val reise1 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 9 januar 2026, tom = 9 januar 2026)
+        val reise2 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 10 januar 2026, tom = 10 januar 2026)
+        val reise3 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 11 januar 2026, tom = 11 januar 2026)
+        val rammevedtak = RammevedtakPrivatBil(reiser = listOf(reise1, reise2, reise3))
+
+        val dto =
+            rammevedtak.tilDto(
+                Beregningsplan(
+                    omfang = Beregningsomfang.ALLE_PERIODER,
+                ),
+            )
+
+        assertThat(dto.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+            reise1.reiseId,
+            reise2.reiseId,
+            reise3.reiseId,
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDtoTest.kt
@@ -1,6 +1,8 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise.dto
 
+import no.nav.tilleggsstonader.libs.utils.dato.februar
 import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
@@ -11,27 +13,30 @@ import org.junit.jupiter.api.Test
 
 class RammevedtakPrivatBilDtoTest {
     @Test
-    fun `skal kun inkludere reiser fra og med tidligste endring`() {
-        val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 9 januar 2026, tom = 9 januar 2026)
+    fun `skal kun ekskludere reiser som er avsluttet før tidligste endring`() {
+        val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 januar 2026, tom = 31 januar 2026)
+        val reiseSomDekkerTidligsteEndring =
+            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 20 januar 2026, tom = 8 februar 2026)
         val reiseLikTidligsteEndring =
-            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 10 januar 2026, tom = 10 januar 2026)
+            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 februar 2026, tom = 28 februar 2026)
         val reiseEtterEndring =
-            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 11 januar 2026, tom = 11 januar 2026)
+            rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 mars 2026, tom = 31 mars 2026)
         val rammevedtak =
             RammevedtakPrivatBil(
-                reiser = listOf(reiseFørEndring, reiseLikTidligsteEndring, reiseEtterEndring),
+                reiser = listOf(reiseFørEndring, reiseSomDekkerTidligsteEndring, reiseLikTidligsteEndring, reiseEtterEndring),
             )
 
         val dto =
             rammevedtak.tilDto(
                 Beregningsplan(
                     omfang = Beregningsomfang.FRA_DATO,
-                    fraDato = 10 januar 2026,
-                    tidligsteEndring = 10 januar 2026,
+                    fraDato = 1 februar 2026,
+                    tidligsteEndring = 1 februar 2026,
                 ),
             )
 
         assertThat(dto.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+            reiseSomDekkerTidligsteEndring.reiseId,
             reiseLikTidligsteEndring.reiseId,
             reiseEtterEndring.reiseId,
         )
@@ -39,9 +44,9 @@ class RammevedtakPrivatBilDtoTest {
 
     @Test
     fun `skal inkludere alle reiser når tidligste endring er null`() {
-        val reise1 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 9 januar 2026, tom = 9 januar 2026)
-        val reise2 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 10 januar 2026, tom = 10 januar 2026)
-        val reise3 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 11 januar 2026, tom = 11 januar 2026)
+        val reise1 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 januar 2026, tom = 31 januar 2026)
+        val reise2 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 februar 2026, tom = 28 februar 2026)
+        val reise3 = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 mars 2026, tom = 31 mars 2026)
         val rammevedtak = RammevedtakPrivatBil(reiser = listOf(reise1, reise2, reise3))
 
         val dto =

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDtoTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/dto/RammevedtakPrivatBilDtoTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 
 class RammevedtakPrivatBilDtoTest {
     @Test
-    fun `skal kun ekskludere reiser som er avsluttet før tidligste endring`() {
+    fun `skal kun flagge reiser som er avsluttet før tidligste endring`() {
         val reiseFørEndring = rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 1 januar 2026, tom = 31 januar 2026)
         val reiseSomDekkerTidligsteEndring =
             rammeForReiseMedPrivatBil(reiseId = ReiseId.random(), fom = 20 januar 2026, tom = 8 februar 2026)
@@ -36,10 +36,15 @@ class RammevedtakPrivatBilDtoTest {
             )
 
         assertThat(dto.reiser.map { it.reiseId }).containsExactlyInAnyOrder(
+            reiseFørEndring.reiseId,
             reiseSomDekkerTidligsteEndring.reiseId,
             reiseLikTidligsteEndring.reiseId,
             reiseEtterEndring.reiseId,
         )
+        assertThat(dto.reiser.single { it.reiseId == reiseFørEndring.reiseId }.fraTidligereVedtak).isTrue()
+        assertThat(dto.reiser.single { it.reiseId == reiseSomDekkerTidligsteEndring.reiseId }.fraTidligereVedtak).isFalse()
+        assertThat(dto.reiser.single { it.reiseId == reiseLikTidligsteEndring.reiseId }.fraTidligereVedtak).isFalse()
+        assertThat(dto.reiser.single { it.reiseId == reiseEtterEndring.reiseId }.fraTidligereVedtak).isFalse()
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Alle reiser blir sendt med til beregningsplan og brev, som kan være forvirrende ettersom det ikke er gjort endringer for disse. Flagger de reisene som er før tidligste endring, slik at frontend kan filtrere ut disse ved behov