### PR TITLE
Ved manuell registrering av en innsendt kjøreliste skal det valideres at journalpostid'en ligger på fagsaken

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValidering.kt
@@ -1,0 +1,44 @@
+package no.nav.tilleggsstonader.sak.privatbil.manuellRegistrering
+
+import no.nav.tilleggsstonader.libs.feil.brukerfeilHvis
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+interface KjørelisteJournalpostValidering {
+    fun validerJournalpost(
+        behandlingId: BehandlingId,
+        journalpostId: String,
+    )
+}
+
+@Service
+@Profile("!mock-journalpost")
+class KjørelisteJournalpostValideringService(
+    private val fagsakService: FagsakService,
+    private val journalpostService: JournalpostService,
+) : KjørelisteJournalpostValidering {
+    override fun validerJournalpost(
+        behandlingId: BehandlingId,
+        journalpostId: String,
+    ) {
+        val fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
+        val journalpost = journalpostService.hentJournalpost(journalpostId)
+        val journalpostFagsakId = journalpost.sak?.fagsakId
+
+        brukerfeilHvis(journalpostFagsakId != fagsak.eksternId.id.toString()) {
+            "Journalpost med id=$journalpostId finnes ikke på fagsak"
+        }
+    }
+}
+
+@Service
+@Profile("mock-journalpost")
+class KjørelisteJournalpostValideringNoop : KjørelisteJournalpostValidering {
+    override fun validerJournalpost(
+        behandlingId: BehandlingId,
+        journalpostId: String,
+    ) = Unit
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValidering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValidering.kt
@@ -29,7 +29,7 @@ class KjørelisteJournalpostValideringService(
         val journalpostFagsakId = journalpost.sak?.fagsakId
 
         brukerfeilHvis(journalpostFagsakId != fagsak.eksternId.id.toString()) {
-            "Journalpost med id=$journalpostId finnes ikke på fagsak"
+            "Journalpost med id=$journalpostId finnes ikke på saksnummer ${fagsak.eksternId.id}. Journalfør dokumentet på riktig saksnummer i gosys."
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteManuellRegistreringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteManuellRegistreringService.kt
@@ -23,6 +23,7 @@ class KjørelisteManuellRegistreringService(
     private val behandlingService: BehandlingService,
     private val dagligReisePrivatBilService: DagligReisePrivatBilService,
     private val avklartKjørelisteService: AvklartKjørelisteService,
+    private val kjørelisteJournalpostValidering: KjørelisteJournalpostValidering,
 ) {
     fun hentKjørelisteOversikt(behandlingId: BehandlingId): KjørelisteOversiktDto {
         val behandling = behandlingService.hentBehandling(behandlingId)
@@ -60,6 +61,7 @@ class KjørelisteManuellRegistreringService(
             )
 
         validerManuellKjøreliste(behandling = behandling, innsendtKjøreliste = innsendtKjøreliste)
+        kjørelisteJournalpostValidering.validerJournalpost(behandlingId, request.journalpostId)
 
         return kjørelisteService.lagre(
             innsendtKjøreliste = innsendtKjøreliste,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValideringTest.kt
@@ -1,0 +1,63 @@
+package no.nav.tilleggsstonader.sak.privatbil.manuellRegistrering
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.kontrakter.journalpost.Sak
+import no.nav.tilleggsstonader.sak.fagsak.FagsakService
+import no.nav.tilleggsstonader.sak.fagsak.domain.EksternFagsakId
+import no.nav.tilleggsstonader.sak.felles.domain.FagsakId
+import no.nav.tilleggsstonader.sak.journalføring.JournalpostService
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.journalpost
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class KjørelisteJournalpostValideringTest {
+    private val fagsakService = mockk<FagsakService>()
+    private val journalpostService = mockk<JournalpostService>()
+    private val validering = KjørelisteJournalpostValideringService(fagsakService, journalpostService)
+
+    @Test
+    fun `skal godta journalpost som finnes på fagsaken`() {
+        val behandlingId =
+            no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+                .random()
+        val fagsakId = FagsakId.random()
+        val fagsak = fagsak(id = fagsakId, eksternId = EksternFagsakId(id = 1, fagsakId = fagsakId))
+        val journalpostId = "123"
+
+        every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak
+        every { journalpostService.hentJournalpost(journalpostId) } returns
+            journalpost(
+                journalpostId = journalpostId,
+                sak = Sak(fagsakId = fagsak.eksternId.id.toString()),
+            )
+
+        validering.validerJournalpost(behandlingId, journalpostId)
+
+        verify(exactly = 1) { journalpostService.hentJournalpost(journalpostId) }
+    }
+
+    @Test
+    fun `skal feile når journalpost ligger på annen fagsak`() {
+        val behandlingId =
+            no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+                .random()
+        val fagsakId = FagsakId.random()
+        val fagsak = fagsak(id = fagsakId, eksternId = EksternFagsakId(id = 1, fagsakId = fagsakId))
+        val annenFagsakId = FagsakId.random()
+        val annenFagsak = fagsak(id = annenFagsakId, eksternId = EksternFagsakId(id = 2, fagsakId = annenFagsakId))
+
+        every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak
+        every { journalpostService.hentJournalpost("999") } returns
+            journalpost(
+                journalpostId = "999",
+                sak = Sak(fagsakId = annenFagsak.eksternId.id.toString()),
+            )
+
+        assertThatThrownBy {
+            validering.validerJournalpost(behandlingId, "999")
+        }.hasMessageContaining("Journalpost med id=999 finnes ikke på fagsak")
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValideringTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteJournalpostValideringTest.kt
@@ -58,6 +58,8 @@ class KjørelisteJournalpostValideringTest {
 
         assertThatThrownBy {
             validering.validerJournalpost(behandlingId, "999")
-        }.hasMessageContaining("Journalpost med id=999 finnes ikke på fagsak")
+        }.hasMessageContaining(
+            "Journalpost med id=999 finnes ikke på saksnummer ${fagsak.eksternId.id}. Journalfør dokumentet på riktig saksnummer i gosys.",
+        )
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteManuellRegistreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/privatbil/manuellRegistrering/KjørelisteManuellRegistreringServiceTest.kt
@@ -1,0 +1,102 @@
+package no.nav.tilleggsstonader.sak.privatbil.manuellRegistrering
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verifyOrder
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.ekstern.stønad.DagligReisePrivatBilService
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.privatbil.InnsendtKjøreliste
+import no.nav.tilleggsstonader.sak.privatbil.Kjøreliste
+import no.nav.tilleggsstonader.sak.privatbil.KjørelisteDag
+import no.nav.tilleggsstonader.sak.privatbil.KjørelisteId
+import no.nav.tilleggsstonader.sak.privatbil.KjørelisteService
+import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørelisteService
+import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil
+import no.nav.tilleggsstonader.sak.util.behandling
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class KjørelisteManuellRegistreringServiceTest {
+    private val kjørelisteService = mockk<KjørelisteService>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val dagligReisePrivatBilService = mockk<DagligReisePrivatBilService>()
+    private val avklartKjørelisteService = mockk<AvklartKjørelisteService>(relaxed = true)
+    private val kjørelisteJournalpostValidering = mockk<KjørelisteJournalpostValidering>()
+
+    private val service =
+        KjørelisteManuellRegistreringService(
+            kjørelisteService = kjørelisteService,
+            behandlingService = behandlingService,
+            dagligReisePrivatBilService = dagligReisePrivatBilService,
+            avklartKjørelisteService = avklartKjørelisteService,
+            kjørelisteJournalpostValidering = kjørelisteJournalpostValidering,
+        )
+
+    @Test
+    fun `skal validere journalpost før kjøreliste lagres`() {
+        val behandlingId = BehandlingId.random()
+        val fagsak = fagsak()
+        val behandling = behandling(fagsak = fagsak, id = behandlingId)
+        val reiseId = ReiseId.random()
+        val fom = 5 januar 2026
+        val tom = 11 januar 2026
+        val reisedager =
+            (0..6).map { offset ->
+                KjørelisteDag(
+                    dato = fom.plusDays(offset.toLong()),
+                    harKjørt = true,
+                    parkeringsutgift = 10,
+                )
+            }
+        val request =
+            LagreManuellKjørelisteRequest(
+                journalpostId = "journalpost-1",
+                reiseId = reiseId,
+                begrunnelse = "begrunnelse",
+                reisedager = reisedager,
+            )
+        val rammevedtak = RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil(reiseId = reiseId, fom = fom, tom = tom)
+        val forventetKjøreliste =
+            Kjøreliste(
+                id = KjørelisteId.random(),
+                journalpostId = request.journalpostId,
+                fagsakId = fagsak.id,
+                datoMottatt = LocalDateTime.now(),
+                begrunnelse = request.begrunnelse,
+                manueltLagretIBehandling = behandlingId,
+                data = InnsendtKjøreliste(reiseId = reiseId, reisedager = reisedager),
+            )
+
+        justRun { behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId) }
+        every { behandlingService.hentBehandling(behandlingId) } returns behandling
+        every { dagligReisePrivatBilService.hentRammevedtakForReiseIBehandling(behandlingId, reiseId) } returns rammevedtak
+        every { kjørelisteService.hentForFagsakId(fagsak.id) } returns emptyList()
+        justRun { kjørelisteJournalpostValidering.validerJournalpost(behandlingId, request.journalpostId) }
+        every {
+            kjørelisteService.lagre(
+                any(),
+                fagsak.id,
+                request.journalpostId,
+                request.begrunnelse,
+                true,
+                behandlingId,
+            )
+        } returns forventetKjøreliste
+
+        val result = service.lagreManuellKjøreliste(behandlingId, request)
+
+        assertThat(result).isEqualTo(forventetKjøreliste)
+        verifyOrder {
+            behandlingService.markerBehandlingSomPåbegyntHvisDenHarStatusOpprettet(behandlingId)
+            behandlingService.hentBehandling(behandlingId)
+            kjørelisteJournalpostValidering.validerJournalpost(behandlingId, request.journalpostId)
+            kjørelisteService.lagre(any(), fagsak.id, request.journalpostId, request.begrunnelse, true, behandlingId)
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -15,6 +15,7 @@ import no.nav.tilleggsstonader.kontrakter.journalpost.Dokumentvariantformat
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalposttype
 import no.nav.tilleggsstonader.kontrakter.journalpost.Journalstatus
+import no.nav.tilleggsstonader.kontrakter.journalpost.Sak
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
 import no.nav.tilleggsstonader.libs.utils.dato.januar
@@ -473,6 +474,7 @@ fun journalpost(
     journalposttype: Journalposttype = Journalposttype.I,
     journalstatus: Journalstatus = Journalstatus.MOTTATT,
     tema: String = Tema.TSO.toString(),
+    sak: Sak? = null,
     dokumenter: List<DokumentInfo>? = null,
     bruker: Bruker? = null,
     kanal: String? = "NAV_NO",
@@ -482,6 +484,7 @@ fun journalpost(
     journalposttype = journalposttype,
     journalstatus = journalstatus,
     tema = tema,
+    sak = sak,
     dokumenter = dokumenter,
     bruker = bruker,
     kanal = kanal,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når vi knytter en journalpost mot en manuelt registret kjøreliste er dette for å knytte opp bruker sin innsending med den strukturerte dataen.

Vi må ha en forventning om at kjørelisten er journalført på denne fagsaken, da saksbehandler i teorien kan ha journalført papir-kjørelisten på en annen fagsak på bruker. Om saksbehandler ikke har journalført journalposten på riktig sak må dette ryddes opp i Gosys.

Sørger for at valideringen kun gjøres ved kjøring i miljø. Dette for at vi skal kunne teste lokalt (og i integrasjonstester) uten å måtte mocke opp en journalpost i tillegg.