### PR TITLE
Tillater at man registrerer flere manuelle kjørelister med samme journalpostid

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterMottattKjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterMottattKjørelisteService.kt
@@ -38,6 +38,10 @@ class HåndterMottattKjørelisteService(
     private val taskService: TaskService,
 ) {
     fun behandleKjøreliste(journalpost: Journalpost) {
+        feilHvis(kjørelisteService.eksistererForJournalpostId(journalpost.journalpostId)) {
+            "Kjøreliste med journalpostId=${journalpost.journalpostId} er allerede mottatt"
+        }
+
         val kjørelisteSkjema =
             hentKjørelisteSkjemaFraJournalpost(journalpost)
         val reiseId = ReiseId(UUID.fromString(kjørelisteSkjema.reiseId))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/privatbil/KjørelisteService.kt
@@ -44,4 +44,6 @@ class KjørelisteService(
     fun hentForFagsakId(fagsakId: FagsakId): List<Kjøreliste> = repository.findByFagsakId(fagsakId)
 
     fun hentKjøreliste(kjørelisteId: KjørelisteId): Kjøreliste = repository.findByIdOrThrow(kjørelisteId)
+
+    fun eksistererForJournalpostId(journalpostId: String): Boolean = repository.findByJournalpostId(journalpostId) != null
 }

--- a/src/main/resources/db/migration/V148__kjoreliste_journalpost_id_ikke_unik.sql
+++ b/src/main/resources/db/migration/V148__kjoreliste_journalpost_id_ikke_unik.sql
@@ -1,2 +1,2 @@
 DROP INDEX kjoreliste_journalpost_id_idx;
-CREATE INDEX ON kjoreliste (journalpost_id);
+CREATE INDEX idx_kjoreliste_journalpost_id ON kjoreliste (journalpost_id);

--- a/src/main/resources/db/migration/V148__kjoreliste_journalpost_id_ikke_unik.sql
+++ b/src/main/resources/db/migration/V148__kjoreliste_journalpost_id_ikke_unik.sql
@@ -1,0 +1,2 @@
+DROP INDEX kjoreliste_journalpost_id_idx;
+CREATE INDEX ON kjoreliste (journalpost_id);

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterMottattKjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/ekstern/journalføring/HåndterMottattKjørelisteServiceTest.kt
@@ -1,0 +1,33 @@
+package no.nav.tilleggsstonader.sak.ekstern.journalføring
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.journalpost.Journalpost
+import no.nav.tilleggsstonader.sak.privatbil.KjørelisteService
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class HåndterMottattKjørelisteServiceTest {
+    private val kjørelisteService = mockk<KjørelisteService>()
+    private val service =
+        HåndterMottattKjørelisteService(
+            journalpostClient = mockk(),
+            dagligReisePrivatBilService = mockk(),
+            behandlingService = mockk(),
+            journalpostService = mockk(),
+            fagsakService = mockk(),
+            kjørelisteService = kjørelisteService,
+            taskService = mockk(),
+        )
+
+    @Test
+    fun `skal kaste feil om kjøreliste med samme journalpostId allerede eksisterer`() {
+        val journalpostId = "duplikat-jp-123"
+        val journalpost = mockk<Journalpost>()
+        every { journalpost.journalpostId } returns journalpostId
+        every { kjørelisteService.eksistererForJournalpostId(journalpostId) } returns true
+
+        assertThatThrownBy { service.behandleKjøreliste(journalpost) }
+            .hasMessage("Kjøreliste med journalpostId=${journalpost.journalpostId} er allerede mottatt")
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ved mottak av kjøreliste på papir kan det være at samme journalpost har flere dokumenter som peker på forskjellige reiser innenfor en sak. Må derfor være mulig å registrere samme journalpostid på flere kjøreliste.

For kjørelister innsendt digital legges det på en validering. Vi forventer fortsatt unikhet på journalpostid mellom digitale kjørelister.