### PR TITLE
Beregningsplan beregning privat bil revurdering

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningService.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.offentligTransp
 import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.feil.brukerfeilHvis
-import no.nav.tilleggsstonader.libs.feil.feil
 import no.nav.tilleggsstonader.libs.feil.feilHvis
 import no.nav.tilleggsstonader.libs.utils.norskFormat
 import no.nav.tilleggsstonader.sak.behandling.domain.Saksbehandling
@@ -38,7 +37,7 @@ class OffentligTransportBeregningService(
     ): BeregningsresultatOffentligTransport? {
         if (beregningsplan.omfang == Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT) {
             return forrigeBeregningsresultat
-                ?: feil("Kan ikke gjenbruke forrige beregningsresultat uten forrige iverksatt behandling")
+            // ?: feil("Kan ikke gjenbruke forrige beregningsresultat uten forrige iverksatt behandling")
         }
 
         if (behandling.stønadstype == Stønadstype.DAGLIG_REISE_TSR) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/offentligTransport/OffentligTransportBeregningService.kt
@@ -37,7 +37,6 @@ class OffentligTransportBeregningService(
     ): BeregningsresultatOffentligTransport? {
         if (beregningsplan.omfang == Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT) {
             return forrigeBeregningsresultat
-            // ?: feil("Kan ikke gjenbruke forrige beregningsresultat uten forrige iverksatt behandling")
         }
 
         if (behandling.stønadstype == Stønadstype.DAGLIG_REISE_TSR) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
@@ -95,9 +95,13 @@ class PrivatBilBeregningRevurderingService(
         vilkårStatus: VilkårStatus,
     ): RammevedtakForReiseMedPrivatBil? =
         when (beregningsplan.omfang) {
-            Beregningsomfang.ALLE_PERIODER -> nyRammeForReise
-            Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT -> forrigeRammeForReise
-            Beregningsomfang.KUN_NYE_KJORELISTE_UKER -> forrigeRammeForReise
+            Beregningsomfang.ALLE_PERIODER ->
+                nyRammeForReise
+                    ?: feil("Forventer at det finnes et nytt rammevedtak for reise i ny beregning når vilkår har status $vilkårStatus")
+            Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT ->
+                forrigeRammeForReise
+                    ?: feil("Forventer at det finnes et rammevedtak for reise i forrige beregning når vilkår har status $vilkårStatus")
+            Beregningsomfang.KUN_NYE_KJORELISTE_UKER -> error("Forventer ikke å komme hit ved beregningsomfang ${beregningsplan.omfang}")
             Beregningsomfang.FRA_DATO ->
                 velgRammeForReiseBasertPåBeregnFraDato(
                     beregnFra = beregningsplan.fraDato ?: feil("Forventer at fraDato finnes for beregningsplan med omfang FRA_DATO"),
@@ -117,11 +121,11 @@ class PrivatBilBeregningRevurderingService(
             "Forventer at det finnes et rammevedtak for reise både i eksisterende og ny beregning når vilkår har status $vilkårStatus"
         }
 
-        val reiseErFørberegnFra =
+        val reiseErFørBeregnFra =
             forrigeRammeForReise.grunnlag.tom < beregnFra &&
                 nyRammeForReise.grunnlag.tom < beregnFra
 
-        return if (reiseErFørberegnFra) {
+        return if (reiseErFørBeregnFra) {
             forrigeRammeForReise
         } else {
             validerReisedagerIkkeRedusert(forrigeRammeForReise, nyRammeForReise)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingService.kt
@@ -5,6 +5,8 @@ import no.nav.tilleggsstonader.libs.feil.feil
 import no.nav.tilleggsstonader.libs.feil.feilHvis
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
@@ -40,7 +42,7 @@ class PrivatBilBeregningRevurderingService(
         reiserMedBil: List<ReiseMedPrivatBil>,
         forrigeRammevedtak: RammevedtakPrivatBil,
         nyttRammevedtak: RammevedtakPrivatBil?,
-        tidligsteEndring: LocalDate?,
+        beregningsplan: Beregningsplan,
     ): RammevedtakPrivatBil? {
         brukerfeilHvis(!unleashService.isEnabled(Toggle.KAN_REVURDERE_PRIVAT_BIL)) {
             "Muligheten for å revurdere daglige reiser med privat bil er skrudd av."
@@ -55,7 +57,7 @@ class PrivatBilBeregningRevurderingService(
                     vilkårStatus = reise.status,
                     forrigeRammeForReise = forrigeRammerByReiseId[reise.reiseId],
                     nyRammeForReise = nyeRammerByReiseId?.get(reise.reiseId),
-                    tidligsteEndring = tidligsteEndring,
+                    beregningsplan = beregningsplan,
                 )
             }
 
@@ -70,41 +72,56 @@ class PrivatBilBeregningRevurderingService(
         vilkårStatus: VilkårStatus?,
         forrigeRammeForReise: RammevedtakForReiseMedPrivatBil?,
         nyRammeForReise: RammevedtakForReiseMedPrivatBil?,
-        tidligsteEndring: LocalDate?,
+        beregningsplan: Beregningsplan,
     ): RammevedtakForReiseMedPrivatBil? =
         when (vilkårStatus) {
             VilkårStatus.NY -> nyRammeForReise ?: feil("Forventer at det finnes et nytt rammevedtak for nye reiser")
             VilkårStatus.SLETTET -> null
             VilkårStatus.ENDRET, VilkårStatus.UENDRET ->
-                velgRammeForReiseBasertPåTidligsteEndring(
+                velgRammeForReiseBasertPåBeregningsplan(
                     forrigeRammeForReise,
                     nyRammeForReise,
-                    tidligsteEndring,
+                    beregningsplan,
                     vilkårStatus,
                 )
 
             null -> feil("Forventer at alle vilkår har en status.")
         }
 
-    private fun velgRammeForReiseBasertPåTidligsteEndring(
+    private fun velgRammeForReiseBasertPåBeregningsplan(
         forrigeRammeForReise: RammevedtakForReiseMedPrivatBil?,
         nyRammeForReise: RammevedtakForReiseMedPrivatBil?,
-        tidligsteEndring: LocalDate?,
+        beregningsplan: Beregningsplan,
         vilkårStatus: VilkårStatus,
-    ): RammevedtakForReiseMedPrivatBil? {
-        feilHvis(tidligsteEndring == null) {
-            "Forventer at tidligste endring finnes for en revurdering"
+    ): RammevedtakForReiseMedPrivatBil? =
+        when (beregningsplan.omfang) {
+            Beregningsomfang.ALLE_PERIODER -> nyRammeForReise
+            Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT -> forrigeRammeForReise
+            Beregningsomfang.KUN_NYE_KJORELISTE_UKER -> forrigeRammeForReise
+            Beregningsomfang.FRA_DATO ->
+                velgRammeForReiseBasertPåBeregnFraDato(
+                    beregnFra = beregningsplan.fraDato ?: feil("Forventer at fraDato finnes for beregningsplan med omfang FRA_DATO"),
+                    forrigeRammeForReise = forrigeRammeForReise,
+                    nyRammeForReise = nyRammeForReise,
+                    vilkårStatus = vilkårStatus,
+                )
         }
 
+    private fun velgRammeForReiseBasertPåBeregnFraDato(
+        beregnFra: LocalDate,
+        forrigeRammeForReise: RammevedtakForReiseMedPrivatBil?,
+        nyRammeForReise: RammevedtakForReiseMedPrivatBil?,
+        vilkårStatus: VilkårStatus,
+    ): RammevedtakForReiseMedPrivatBil {
         feilHvis(forrigeRammeForReise == null || nyRammeForReise == null) {
             "Forventer at det finnes et rammevedtak for reise både i eksisterende og ny beregning når vilkår har status $vilkårStatus"
         }
 
-        val reiseErFørTidligsteEndring =
-            forrigeRammeForReise.grunnlag.tom < tidligsteEndring &&
-                nyRammeForReise.grunnlag.tom < tidligsteEndring
+        val reiseErFørberegnFra =
+            forrigeRammeForReise.grunnlag.tom < beregnFra &&
+                nyRammeForReise.grunnlag.tom < beregnFra
 
-        return if (reiseErFørTidligsteEndring) {
+        return if (reiseErFørberegnFra) {
             forrigeRammeForReise
         } else {
             validerReisedagerIkkeRedusert(forrigeRammeForReise, nyRammeForReise)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilRammevedtakBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilRammevedtakBeregningService.kt
@@ -72,7 +72,7 @@ class PrivatBilRammevedtakBeregningService(
                 reiserMedBil = reiserMedBil,
                 forrigeRammevedtak = forrigeRammevedtakPrivatBil,
                 nyttRammevedtak = nyttRammevedtakPrivatBil,
-                tidligsteEndring = beregningsplan.tidligsteEndring,
+                beregningsplan = beregningsplan,
             )
         }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingServiceTest.kt
@@ -31,8 +31,8 @@ class PrivatBilBeregningRevurderingServiceTest {
     private fun reiseMedStatus(
         status: VilkårStatus,
         reiseId: ReiseId = this.reiseId,
-        fom: java.time.LocalDate = 1 januar 2025,
-        tom: java.time.LocalDate = 31 mars 2025,
+        fom: LocalDate = 1 januar 2025,
+        tom: LocalDate = 31 mars 2025,
     ) = ReiseMedPrivatBil(
         fom = fom,
         tom = tom,
@@ -145,6 +145,54 @@ class PrivatBilBeregningRevurderingServiceTest {
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
+        }
+
+        @Test
+        fun `reise med status UENDRET og beregningsomfang ALLE_PERIODER bruker nytt`() {
+            val forrigeRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 31 mars 2025)
+            val nyttRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 31 mars 2025)
+
+            val resultat =
+                service.beregnRammevedtakVedRevurdering(
+                    reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET)),
+                    forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
+                    nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
+                    beregningsplan = Beregningsplan(Beregningsomfang.ALLE_PERIODER),
+                )
+
+            assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
+        }
+
+        @Test
+        fun `reise med status UENDRET og beregningsomfang GJENBRUK_FORRIGE_RESULTAT bruker forrige`() {
+            val forrigeRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 31 mars 2025)
+            val nyttRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 februar 2025, tom = 30 april 2025)
+
+            val resultat =
+                service.beregnRammevedtakVedRevurdering(
+                    reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET)),
+                    forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
+                    nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
+                    beregningsplan = Beregningsplan(Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT),
+                )
+
+            assertThat(resultat!!.reiser).containsExactly(forrigeRammevedtakForReise)
+        }
+
+        @Test
+        fun `reise med status UENDRET og beregningsomfang KUN_NYE_KJORELISTE_UKER bruker forrige`() {
+            val forrigeRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 31 mars 2025)
+            val nyttRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 februar 2025, tom = 30 april 2025)
+
+            val resultat =
+                service.beregnRammevedtakVedRevurdering(
+                    reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET)),
+                    forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
+                    nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
+                    beregningsplan = Beregningsplan(Beregningsomfang.KUN_NYE_KJORELISTE_UKER),
+                )
+
+            assertThat(resultat!!.reiser).containsExactly(forrigeRammevedtakForReise)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingServiceTest.kt
@@ -10,6 +10,8 @@ import no.nav.tilleggsstonader.libs.utils.dato.mars
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammevedtakPrivatBil
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
@@ -18,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class PrivatBilBeregningRevurderingServiceTest {
     private val unleashService = mockk<UnleashService>()
@@ -60,7 +63,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.NY)),
                     forrigeRammevedtak = forrigeRammevedtakForReiseForReise,
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 januar 2025,
+                    beregningsplan = beregnFraDato(1 januar 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
@@ -73,7 +76,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.NY)),
                     forrigeRammevedtak = rammevedtakPrivatBil(reiseId = ReiseId.random()),
                     nyttRammevedtak = null,
-                    tidligsteEndring = 1 februar 2025,
+                    beregningsplan = beregnFraDato(1 februar 2025),
                 )
             }.hasMessageContaining("Forventer at det finnes et nytt rammevedtak for nye reiser")
         }
@@ -88,7 +91,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.SLETTET)),
                     forrigeRammevedtak = rammevedtakPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 28 februar 2025),
                     nyttRammevedtak = null,
-                    tidligsteEndring = 1 mars 2025,
+                    beregningsplan = beregnFraDato(1 mars 2025),
                 )
 
             assertThat(resultat).isNull()
@@ -101,7 +104,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.SLETTET, fom = 1 januar 2025, tom = 28 januar 2025)),
                     forrigeRammevedtak = rammevedtakPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 28 januar 2025),
                     nyttRammevedtak = null,
-                    tidligsteEndring = 1 mars 2025,
+                    beregningsplan = beregnFraDato(1 mars 2025),
                 )
 
             assertThat(resultat).isNull()
@@ -120,7 +123,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET, fom = 1 januar 2025, tom = 28 januar 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 mars 2025,
+                    beregningsplan = beregnFraDato(1 mars 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(forrigeRammevedtakForReise)
@@ -138,25 +141,10 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET, fom = 1 januar 2025, tom = 31 mars 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(reiserIForrigeRammevedtak)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 februar 2025,
+                    beregningsplan = beregnFraDato(1 februar 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
-        }
-
-        @Test
-        fun `reise med status UENDRET med tidligsteEndring null kaster feil`() {
-            val forrigeRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 28 januar 2025)
-            val nyttRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 28 januar 2025)
-
-            assertThatThrownBy {
-                service.beregnRammevedtakVedRevurdering(
-                    reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET, fom = 1 januar 2025, tom = 28 januar 2025)),
-                    forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
-                    nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = null,
-                )
-            }.hasMessageContaining("Forventer at tidligste endring finnes for en revurdering")
         }
     }
 
@@ -172,7 +160,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.ENDRET, fom = 1 januar 2025, tom = 28 februar 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 mars 2025,
+                    beregningsplan = beregnFraDato(1 mars 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
@@ -188,7 +176,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.ENDRET, fom = 1 januar 2025, tom = 30 april 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 februar 2025,
+                    beregningsplan = beregnFraDato(1 februar 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
@@ -204,7 +192,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.ENDRET, fom = 1 januar 2025, tom = 28 januar 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 mars 2025,
+                    beregningsplan = beregnFraDato(1 mars 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(forrigeRammevedtakForReise)
@@ -220,7 +208,7 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.ENDRET, fom = 1 februar 2025, tom = 31 mars 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 januar 2025,
+                    beregningsplan = beregnFraDato(1 januar 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
@@ -236,10 +224,12 @@ class PrivatBilBeregningRevurderingServiceTest {
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.ENDRET, fom = 1 februar 2025, tom = 31 mars 2025)),
                     forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
                     nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
-                    tidligsteEndring = 1 januar 2025,
+                    beregningsplan = beregnFraDato(1 januar 2025),
                 )
 
             assertThat(resultat!!.reiser).containsExactly(nyttRammevedtakForReise)
         }
     }
+
+    private fun beregnFraDato(fraDato: LocalDate) = Beregningsplan(omfang = Beregningsomfang.FRA_DATO, fraDato = fraDato)
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningRevurderingServiceTest.kt
@@ -180,19 +180,15 @@ class PrivatBilBeregningRevurderingServiceTest {
         }
 
         @Test
-        fun `reise med status UENDRET og beregningsomfang KUN_NYE_KJORELISTE_UKER bruker forrige`() {
-            val forrigeRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 januar 2025, tom = 31 mars 2025)
-            val nyttRammevedtakForReise = rammeForReiseMedPrivatBil(reiseId = reiseId, fom = 1 februar 2025, tom = 30 april 2025)
-
-            val resultat =
+        fun `reise med status UENDRET og beregningsomfang KUN_NYE_KJORELISTE_UKER kaster feil`() {
+            assertThatThrownBy {
                 service.beregnRammevedtakVedRevurdering(
                     reiserMedBil = listOf(reiseMedStatus(VilkårStatus.UENDRET)),
-                    forrigeRammevedtak = RammevedtakPrivatBil(reiser = listOf(forrigeRammevedtakForReise)),
-                    nyttRammevedtak = RammevedtakPrivatBil(reiser = listOf(nyttRammevedtakForReise)),
+                    forrigeRammevedtak = rammevedtakPrivatBil(reiseId = reiseId),
+                    nyttRammevedtak = null,
                     beregningsplan = Beregningsplan(Beregningsomfang.KUN_NYE_KJORELISTE_UKER),
                 )
-
-            assertThat(resultat!!.reiser).containsExactly(forrigeRammevedtakForReise)
+            }.hasMessageContaining("Forventer ikke å komme hit ved beregningsomfang ${Beregningsomfang.KUN_NYE_KJORELISTE_UKER}")
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Om man i dag går gjennom en revurdering (privat bil) uten å gjøre endringer får man feilen `Kan ikke gjenbruke forrige beregningsresultat uten forrige iverksatt behandling` i beregn-ytelse steget. Dette er fordi tidligste-endring er null, og vi har en forventning om at denne alltid skal være satt i en revurdering for privat bil.

I et case hvor saksbehandler ønsker å endre avklarte dager kan det være aktuelt for saksbehandler å gjøre dette (kom nylig en feilmelding i prod på dette).

Endrer logikken ved revurdering-beregning av privat bil til å bruke `BeregningsPlan`-objektet. Jeg minnes om at et også var tanken, men revurdering-logikk ble påbegynt før beregningsplan-logikken var på plass 🤔