### PR TITLE
💬 Fjern tekst som ikke gjelder lengere fra kjørelistebrev

### DIFF
--- a/src/test/resources/privatBil/kjoreliste_behandling_brev.html
+++ b/src/test/resources/privatBil/kjoreliste_behandling_brev.html
@@ -156,8 +156,7 @@ th {
             </div>
         </div>
         <p>Antall dager viser hvor mange dager innenfor perioden hvor kjøring med bil dekkes. Parkeringskostnad,
-            fergekostnad og bompenger dekkes med en samlet sum per uke. Du kan ikke få pengestøtte for flere dager enn
-            det du er innvilget i vedtaket om pengestøtte til daglige reiser. Ved høye parkeringsutgifter må du sende
+            fergekostnad og bompenger dekkes med en samlet sum per uke. Ved høye parkeringsutgifter må du sende
             inn kvittering før beløpet blir utbetalt. Du får pengene inn på konto i løpet av 2-3 virkedager.</p>
         <p>Pengestøtten beregnes etter en fast sats per kilometer. Følgende satser gjelder:</p>
         <ul>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tidligere kun man kun få innvilget innenfor rammevedtaket. Nå har saksbehandler fått mulighet til å overstyre dette.