### PR TITLE
Ikke simuler hvis det ikke finnes andeler på behandling og ingen andeler som er sendt til økonomi i forrige iverksatte behandling

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringSteg.kt
@@ -42,7 +42,7 @@ class SimuleringSteg(
             saksbehandling.forrigeIverksatteBehandlingId
                 ?.let { tilkjentYtelseService.hentForBehandlingEllerNull(it) }
                 ?.andelerTilkjentYtelse
-                ?.isNotEmpty() ?: false
+                ?.any { it.erSendtTilUtbetaling() } ?: false
 
         return harAndelerPåBehandling || harAndelerPåForrigeIverksatteBehandling
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -170,6 +170,16 @@ data class AndelTilkjentYtelse(
     }
 
     fun erNullandel() = beløp == 0 && satstype == Satstype.UGYLDIG && type == TypeAndel.UGYLDIG
+
+    fun erSendtTilUtbetaling() =
+        statusIverksetting in
+            listOf(
+                StatusIverksetting.FEILET,
+                StatusIverksetting.HOS_OPPDRAG,
+                StatusIverksetting.MOTTATT,
+                StatusIverksetting.OK,
+                StatusIverksetting.SENDT,
+            )
 }
 
 data class Iverksetting(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -177,7 +177,8 @@ data class AndelTilkjentYtelse(
             StatusIverksetting.HOS_OPPDRAG,
             StatusIverksetting.MOTTATT,
             StatusIverksetting.OK,
-            StatusIverksetting.SENDT -> true
+            StatusIverksetting.SENDT,
+            -> true
             else -> false
         }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/utbetaling/tilkjentytelse/domain/AndelTilkjentYtelse.kt
@@ -172,14 +172,14 @@ data class AndelTilkjentYtelse(
     fun erNullandel() = beløp == 0 && satstype == Satstype.UGYLDIG && type == TypeAndel.UGYLDIG
 
     fun erSendtTilUtbetaling() =
-        statusIverksetting in
-            listOf(
-                StatusIverksetting.FEILET,
-                StatusIverksetting.HOS_OPPDRAG,
-                StatusIverksetting.MOTTATT,
-                StatusIverksetting.OK,
-                StatusIverksetting.SENDT,
-            )
+        when (statusIverksetting) {
+            StatusIverksetting.FEILET,
+            StatusIverksetting.HOS_OPPDRAG,
+            StatusIverksetting.MOTTATT,
+            StatusIverksetting.OK,
+            StatusIverksetting.SENDT -> true
+            else -> false
+        }
 }
 
 data class Iverksetting(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
@@ -105,10 +105,11 @@ class SimuleringStegTest {
 
         @Test
         fun `skal ikke utføre simulering ved innvilgelse når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
+fun `skal ikke utføre simulering for innvilget revurdering når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
             val forrigeIverksatteBehandlingId = BehandlingId.random()
             val saksbehandling =
                 saksbehandling(
-                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    type = BehandlingType.REVURDERING,
                     forrigeIverksatteBehandlingId = forrigeIverksatteBehandlingId,
                 )
             every { tilkjentYtelseSerivce.hentForBehandling(saksbehandling.id) } returns

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
@@ -104,8 +104,7 @@ class SimuleringStegTest {
         }
 
         @Test
-        fun `skal ikke utføre simulering ved innvilgelse når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
-fun `skal ikke utføre simulering for innvilget revurdering når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
+        fun `skal ikke utføre simulering for revurdering når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
             val forrigeIverksatteBehandlingId = BehandlingId.random()
             val saksbehandling =
                 saksbehandling(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/utbetaling/simulering/SimuleringStegTest.kt
@@ -6,7 +6,9 @@ import io.mockk.verify
 import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseService
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.andelTilkjentYtelse
 import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.TilkjentYtelseUtil.tilkjentYtelse
+import no.nav.tilleggsstonader.sak.utbetaling.tilkjentytelse.domain.StatusIverksetting
 import no.nav.tilleggsstonader.sak.util.saksbehandling
 import no.nav.tilleggsstonader.sak.vedtak.TypeVedtak
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
@@ -72,12 +74,54 @@ class SimuleringStegTest {
                     saksbehandling.id,
                 ).copy(andelerTilkjentYtelse = emptySet())
             every { tilkjentYtelseSerivce.hentForBehandlingEllerNull(forrigeIverksatteBehandlingId) } returns
-                tilkjentYtelse(forrigeIverksatteBehandlingId)
+                tilkjentYtelse(forrigeIverksatteBehandlingId, andelTilkjentYtelse(statusIverksetting = StatusIverksetting.OK))
             mockVedtakMedType(TypeVedtak.OPPHØR)
 
             simuleringSteg.utførSteg(saksbehandling, null)
 
             verify { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
+        }
+
+        @Test
+        fun `skal ikke utføre simulering for opphør når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
+            val forrigeIverksatteBehandlingId = BehandlingId.random()
+            val saksbehandling =
+                saksbehandling(
+                    type = BehandlingType.REVURDERING,
+                    forrigeIverksatteBehandlingId = forrigeIverksatteBehandlingId,
+                )
+            every { tilkjentYtelseSerivce.hentForBehandling(saksbehandling.id) } returns
+                tilkjentYtelse(
+                    saksbehandling.id,
+                ).copy(andelerTilkjentYtelse = emptySet())
+            every { tilkjentYtelseSerivce.hentForBehandlingEllerNull(forrigeIverksatteBehandlingId) } returns
+                tilkjentYtelse(forrigeIverksatteBehandlingId, andelTilkjentYtelse(statusIverksetting = StatusIverksetting.UBEHANDLET))
+            mockVedtakMedType(TypeVedtak.OPPHØR)
+
+            simuleringSteg.utførSteg(saksbehandling, null)
+
+            verify(exactly = 0) { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
+        }
+
+        @Test
+        fun `skal ikke utføre simulering ved innvilgelse når forrige iverksatte behandling har andeler som ikke er sendt til økonomi`() {
+            val forrigeIverksatteBehandlingId = BehandlingId.random()
+            val saksbehandling =
+                saksbehandling(
+                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                    forrigeIverksatteBehandlingId = forrigeIverksatteBehandlingId,
+                )
+            every { tilkjentYtelseSerivce.hentForBehandling(saksbehandling.id) } returns
+                tilkjentYtelse(
+                    saksbehandling.id,
+                ).copy(andelerTilkjentYtelse = emptySet())
+            every { tilkjentYtelseSerivce.hentForBehandlingEllerNull(forrigeIverksatteBehandlingId) } returns
+                tilkjentYtelse(forrigeIverksatteBehandlingId, andelTilkjentYtelse(statusIverksetting = StatusIverksetting.UBEHANDLET))
+            mockVedtakMedType(TypeVedtak.INNVILGELSE)
+
+            simuleringSteg.utførSteg(saksbehandling, null)
+
+            verify(exactly = 0) { simuleringService.hentOgLagreSimuleringsresultat(saksbehandling) }
         }
 
         @Test
@@ -164,7 +208,7 @@ class SimuleringStegTest {
                     saksbehandling.id,
                 ).copy(andelerTilkjentYtelse = emptySet())
             every { tilkjentYtelseSerivce.hentForBehandlingEllerNull(forrigeIverksatteBehandlingId) } returns
-                tilkjentYtelse(forrigeIverksatteBehandlingId)
+                tilkjentYtelse(forrigeIverksatteBehandlingId, andelTilkjentYtelse(statusIverksetting = StatusIverksetting.OK))
             mockVedtakMedType(TypeVedtak.INNVILGELSE)
 
             simuleringSteg.utførSteg(saksbehandling, null)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Hvis forsøker å simulere en behandling uten andeler feiler det hvis det ikke tidligere har vært utbetalinger i saken.

Konkret case:
- Bruker har søkt reise med bil
- **Førstegangbehandling, innvilger offentlig transport frem i tid**
- Bruker klager og får medhold
- **Revurdering, endrer fra offentlig transport til privat bil**
  - Andeler fra førstegangbehandling er ikke utbetalt enda
- **Feiler i dag i simulering-steg**