### PR TITLE
Henter ut bruker sitt nav-kontor/oppfølgingskontor i personopplysning-endepunktet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Component
 class ArbeidsfordelingService(
     @Qualifier("shortCache")
     private val cacheManager: CacheManager,
+    @Qualifier("longCache")
+    private val longCacheManager: CacheManager,
     private val arbeidsfordelingClient: ArbeidsfordelingClient,
     private val oppfolgingsenhetClient: OppfolgingsenhetClient,
     private val personService: PersonService,
@@ -81,9 +83,11 @@ class ArbeidsfordelingService(
         stønadstype: Stønadstype,
     ): String = hentNavEnhet(personIdent, stønadstype)?.enhetNr ?: MASKINELL_JOURNALFOERENDE_ENHET
 
-    fun hentBrukersNavKontor(personIdent: String): String =
-        oppfolgingsenhetClient.hentOppfølgingsenhet(personIdent)
-            ?: error("Finner ikke oppfølgingsenhet for person")
+    fun hentBrukersNavKontor(personIdent: String): Oppfolgingsenhet =
+        longCacheManager.getValue("brukers-nav-kontor", personIdent) {
+            oppfolgingsenhetClient.hentOppfølgingsenhet(personIdent)
+                ?: error("Finner ikke oppfølgingsenhet for person")
+        }
 
     private fun lagArbeidsfordelingKritierieForPerson(
         personIdent: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClient.kt
@@ -27,7 +27,7 @@ class OppfolgingsenhetClient(
      *
      * Bruker oppfølgingsenhet til å knytte utbetalinger til et NAV-kontor for tiltaksenheten.
      */
-    fun hentOppfølgingsenhet(fnr: String): String? {
+    fun hentOppfølgingsenhet(fnr: String): Oppfolgingsenhet? {
         val request =
             OppfolgingsenhetRequest(
                 variables = OppfolgingsenhetRequestVariables(fnr = fnr),
@@ -53,7 +53,7 @@ class OppfolgingsenhetClient(
         }
 
         val data = response.data ?: error("Data er null fra oppfolgingsenhet")
-        return data.oppfolgingsEnhet?.enhet?.id
+        return data.oppfolgingsEnhet?.enhet
     }
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
@@ -1,11 +1,13 @@
 package no.nav.tilleggsstonader.sak.opplysninger
 
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningType
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
 import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
 import no.nav.tilleggsstonader.sak.opplysninger.dto.Adressebeskyttelse
+import no.nav.tilleggsstonader.sak.opplysninger.dto.NavKontorDto
 import no.nav.tilleggsstonader.sak.opplysninger.dto.NavnDto
 import no.nav.tilleggsstonader.sak.opplysninger.dto.PersonopplysningerDto
 import no.nav.tilleggsstonader.sak.opplysninger.egenansatt.EgenAnsattService
@@ -14,6 +16,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.PersonService
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gjeldende
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.gradering
 import no.nav.tilleggsstonader.sak.util.antallÅrSiden
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -23,7 +26,10 @@ class PersonopplysningerService(
     private val personService: PersonService,
     private val fullmaktService: FullmaktService,
     private val egenAnsattService: EgenAnsattService,
+    private val arbeidsfordelingService: ArbeidsfordelingService,
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     // TODO denne burde hente fra grunnlag?
     fun hentPersonopplysninger(behandlingId: BehandlingId): PersonopplysningerDto =
         hentPersonopplysninger(behandlingService.hentAktivIdent(behandlingId))
@@ -49,8 +55,19 @@ class PersonopplysningerService(
             erSkjermet = egenAnsattService.erEgenAnsatt(ident),
             dødsdato = pdlSøker.dødsfall.gjeldende()?.dødsdato,
             harGeografiskTilknytningUtland = harGeografiskTilknytningUtland(ident),
+            navKontor = hentNavKontor(ident),
         )
     }
+
+    private fun hentNavKontor(ident: String): NavKontorDto? =
+        try {
+            arbeidsfordelingService
+                .hentBrukersNavKontor(ident)
+                .let { enhet -> enhet.id?.let { id -> NavKontorDto(enhetId = id, navn = enhet.navn) } }
+        } catch (e: Exception) {
+            logger.warn("Fant ikke nav-kontor for person: ${e.message}")
+            null
+        }
 
     private fun harGeografiskTilknytningUtland(ident: String): Boolean {
         val geografiskTilknytning = personService.hentGeografiskTilknytning(ident)

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerService.kt
@@ -1,6 +1,7 @@
 package no.nav.tilleggsstonader.sak.opplysninger
 
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningType
+import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
@@ -65,7 +66,8 @@ class PersonopplysningerService(
                 .hentBrukersNavKontor(ident)
                 .let { enhet -> enhet.id?.let { id -> NavKontorDto(enhetId = id, navn = enhet.navn) } }
         } catch (e: Exception) {
-            logger.warn("Fant ikke nav-kontor for person: ${e.message}")
+            logger.warn("Fant ikke nav-kontor, returnerer null. Se secure-logs for feilmelding")
+            secureLogger.warn("Fant ikke navkontor for person $ident", e)
             null
         }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/dto/PersonopplysningerDto.kt
@@ -15,6 +15,7 @@ data class PersonopplysningerDto(
     val dødsdato: LocalDate?,
     val alder: Int,
     val harGeografiskTilknytningUtland: Boolean,
+    val navKontor: NavKontorDto?,
 )
 
 data class StatsborgerskapDto(
@@ -123,6 +124,11 @@ enum class Folkeregisterpersonstatus(
             map.getOrDefault(status.status, UKJENT)
     }
 }
+
+data class NavKontorDto(
+    val enhetId: String,
+    val navn: String,
+)
 
 data class NavnDto(
     val fornavn: String,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteSteg.kt
@@ -37,7 +37,7 @@ class KjørelisteSteg(
     ) {
         val brukersNavKontor =
             if (saksbehandling.stønadstype == Stønadstype.DAGLIG_REISE_TSR) {
-                arbeidsfordelingService.hentBrukersNavKontor(saksbehandling.ident)
+                arbeidsfordelingService.hentBrukersNavKontor(saksbehandling.ident).id
             } else {
                 null
             }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/DagligReiseBeregningService.kt
@@ -46,7 +46,7 @@ class DagligReiseBeregningService(
 
         val brukersNavKontor =
             if (behandling.stønadstype == Stønadstype.DAGLIG_REISE_TSR) {
-                arbeidsfordelingService.hentBrukersNavKontor(behandling.ident)
+                arbeidsfordelingService.hentBrukersNavKontor(behandling.ident).id
             } else {
                 null
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/ArbeidsfordelingServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.tilleggsstonader.sak.opplysninger.pdl.domain.AdressebeskyttelseFor
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.domain.PersonMedAdresseBeskyttelse
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.sak.opplysninger.pdl.dto.tilDiskresjonskode
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -25,6 +26,7 @@ import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 
 class ArbeidsfordelingServiceTest {
     val cacheManager = ConcurrentMapCacheManager()
+    val longCacheManager = ConcurrentMapCacheManager()
     val personService = mockk<PersonService>()
     val egenAnsattService = mockk<EgenAnsattService>()
     val arbeidsfordelingClient = mockk<ArbeidsfordelingClient>()
@@ -33,6 +35,7 @@ class ArbeidsfordelingServiceTest {
     val service =
         ArbeidsfordelingService(
             cacheManager = cacheManager,
+            longCacheManager = longCacheManager,
             arbeidsfordelingClient = arbeidsfordelingClient,
             oppfolgingsenhetClient = oppfolgingsenhetClient,
             personService = personService,
@@ -171,14 +174,26 @@ class ArbeidsfordelingServiceTest {
 
     @Nested
     inner class HentBrukersNavKontor {
+        private val enhet = Oppfolgingsenhet(id = "9999", navn = "NAV Testkontor", kilde = "NORG")
+
         @Test
-        fun `skal bruke oppfolgingsenhet`() {
-            every { oppfolgingsenhetClient.hentOppfølgingsenhet(søkerIdent) } returns "9999"
+        fun `returnerer oppfølgingsenhet med id og navn`() {
+            every { oppfolgingsenhetClient.hentOppfølgingsenhet(søkerIdent) } returns enhet
 
             val navKontor = service.hentBrukersNavKontor(søkerIdent)
 
-            assertThat(navKontor).isEqualTo("9999")
+            assertThat(navKontor.id).isEqualTo("9999")
+            assertThat(navKontor.navn).isEqualTo("NAV Testkontor")
             verify(exactly = 0) { arbeidsfordelingClient.finnNavKontorForGeografiskOmråde(any(), any(), any()) }
+        }
+
+        @Test
+        fun `kaster feil når oppfølgingsenhet ikke finnes`() {
+            every { oppfolgingsenhetClient.hentOppfølgingsenhet(søkerIdent) } returns null
+
+            assertThat(Assertions.catchThrowable { service.hentBrukersNavKontor(søkerIdent) })
+                .hasMessageContaining("Finner ikke oppfølgingsenhet for person")
+                .isInstanceOf(IllegalStateException::class.java)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClientTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/arbeidsfordeling/OppfolgingsenhetClientTest.kt
@@ -55,7 +55,8 @@ class OppfolgingsenhetClientTest {
 
         val navKontor = client.hentOppfølgingsenhet("12345678901")
 
-        assertThat(navKontor).isEqualTo("1234")
+        assertThat(navKontor?.id).isEqualTo("1234")
+        assertThat(navKontor?.navn).isEqualTo("NAV Test")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/ArbeidsfordelingClientMockConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/ArbeidsfordelingClientMockConfig.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingClient
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.NavKontor
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.Oppfolgingsenhet
 import no.nav.tilleggsstonader.sak.arbeidsfordeling.OppfolgingsenhetClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -32,7 +33,7 @@ class ArbeidsfordelingClientMockConfig {
 
         fun resetTilDefault(client: OppfolgingsenhetClient) {
             clearMocks(client)
-            every { client.hentOppfølgingsenhet(any()) } returns "1014"
+            every { client.hentOppfølgingsenhet(any()) } returns Oppfolgingsenhet(id = "1014", navn = "Nav Midt-Agder", kilde = "NORG")
         }
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/opplysninger/PersonopplysningerServiceTest.kt
@@ -4,6 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningDto
 import no.nav.tilleggsstonader.kontrakter.pdl.GeografiskTilknytningType
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.tilleggsstonader.sak.arbeidsfordeling.Oppfolgingsenhet
 import no.nav.tilleggsstonader.sak.behandling.BehandlingService
 import no.nav.tilleggsstonader.sak.fagsak.domain.FagsakPersonService
 import no.nav.tilleggsstonader.sak.felles.domain.FagsakPersonId
@@ -28,6 +30,7 @@ class PersonopplysningerServiceTest {
     private val personService = mockk<PersonService>()
     private val fullmaktService = mockk<FullmaktService>()
     private val egenAnsattService = mockk<EgenAnsattService>()
+    private val arbeidsfordelingService = mockk<ArbeidsfordelingService>()
 
     private val service =
         PersonopplysningerService(
@@ -36,6 +39,7 @@ class PersonopplysningerServiceTest {
             personService = personService,
             fullmaktService = fullmaktService,
             egenAnsattService = egenAnsattService,
+            arbeidsfordelingService = arbeidsfordelingService,
         )
 
     @BeforeEach
@@ -52,6 +56,8 @@ class PersonopplysningerServiceTest {
                 null,
                 null,
             )
+        every { arbeidsfordelingService.hentBrukersNavKontor(any()) } returns
+            Oppfolgingsenhet(id = "1014", navn = "Nav Midt-Agder", kilde = "NORG")
     }
 
     @Nested
@@ -102,6 +108,40 @@ class PersonopplysningerServiceTest {
 
             assertThat(service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random()).adressebeskyttelse)
                 .isEqualTo(Adressebeskyttelse.FORTROLIG)
+        }
+    }
+
+    @Nested
+    inner class NavKontorMapping {
+        @Test
+        fun `skal returnere nav-kontor med id og navn`() {
+            every { arbeidsfordelingService.hentBrukersNavKontor(any()) } returns
+                Oppfolgingsenhet(id = "1014", navn = "Nav Midt-Agder", kilde = "NORG")
+
+            val result = service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random())
+
+            assertThat(result.navKontor?.enhetId).isEqualTo("1014")
+            assertThat(result.navKontor?.navn).isEqualTo("Nav Midt-Agder")
+        }
+
+        @Test
+        fun `skal returnere null for nav-kontor når oppfølgingsenhet ikke finnes`() {
+            every { arbeidsfordelingService.hentBrukersNavKontor(any()) } throws
+                IllegalStateException("Finner ikke oppfølgingsenhet for person")
+
+            val result = service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random())
+
+            assertThat(result.navKontor).isNull()
+        }
+
+        @Test
+        fun `skal returnere null for nav-kontor når enhet-id er null`() {
+            every { arbeidsfordelingService.hentBrukersNavKontor(any()) } returns
+                Oppfolgingsenhet(id = null, navn = "Nav Ukjent", kilde = "NORG")
+
+            val result = service.hentPersonopplysningerForFagsakPerson(FagsakPersonId.random())
+
+            assertThat(result.navKontor).isNull()
         }
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Slik at frontend kan vise det i person-header: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/1265