### PR TITLE
Fjern resten av deprecated felter i oppgave

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/historikk/BehandlingshistorikkService.kt
@@ -95,7 +95,7 @@ class BehandlingshistorikkService(
                     when (this.steg) {
                         StegType.SEND_TIL_BESLUTTER -> metadataMap.remove("kommentarTilBeslutter")
                         StegType.BESLUTTE_VEDTAK -> metadataMap.remove("begrunnelse")
-                        else -> metadataMap
+                        else -> {}
                     }
 
                     JsonWrapper(jsonMapper.writeValueAsString(metadataMap))

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OpprettOppgave.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/opplysninger/oppgave/OpprettOppgave.kt
@@ -4,8 +4,6 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.tilBehandlingstema
 import no.nav.tilleggsstonader.kontrakter.felles.tilTema
 import no.nav.tilleggsstonader.kontrakter.oppgave.Behandlingstype
-import no.nav.tilleggsstonader.kontrakter.oppgave.IdentGruppe
-import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveIdentV2
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveMappe
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgavePrioritet
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
@@ -36,7 +34,6 @@ fun tilOpprettOppgaveRequest(
     behandlingstype: Behandlingstype? = null,
 ): OpprettOppgaveRequest =
     OpprettOppgaveRequest(
-        ident = OppgaveIdentV2(ident = personIdent, gruppe = IdentGruppe.FOLKEREGISTERIDENT),
         personident = PersonIdent(ident = personIdent),
         tema = stønadstype.tilTema(),
         journalpostId = oppgave.journalpostId,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientMockConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OppgaveClientMockConfig.kt
@@ -8,13 +8,11 @@ import no.nav.tilleggsstonader.kontrakter.felles.Tema
 import no.nav.tilleggsstonader.kontrakter.oppgave.FinnMappeResponseDto
 import no.nav.tilleggsstonader.kontrakter.oppgave.FinnOppgaveRequest
 import no.nav.tilleggsstonader.kontrakter.oppgave.FinnOppgaveResponseDto
-import no.nav.tilleggsstonader.kontrakter.oppgave.IdentGruppe
 import no.nav.tilleggsstonader.kontrakter.oppgave.MappeDto
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppdatertOppgaveResponse
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgave
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveBruker
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveBrukerType
-import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveIdentV2
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveMappe
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.oppgave.OpprettOppgaveRequest
@@ -241,7 +239,6 @@ class OppgaveClientMockConfig {
             behandlingstema = behandlingstema,
             enhetsnummer = tildeltEnhetsnummer,
             personident = PersonIdent(ident = "12345678910"),
-            ident = OppgaveIdentV2(ident = "12345678910", gruppe = IdentGruppe.FOLKEREGISTERIDENT),
             journalpostId = journalpostId,
             mappeId = MAPPE_ID_KLAR,
         )
@@ -256,7 +253,6 @@ class OppgaveClientMockConfig {
                 behandlingstype = "ae0058",
                 enhetsnummer = "",
                 personident = PersonIdent(ident = "12345678910"),
-                ident = OppgaveIdentV2(ident = "12345678910", gruppe = IdentGruppe.FOLKEREGISTERIDENT),
                 journalpostId = (++journalPostId).toString(),
                 mappeId = MAPPE_ID_KLAR,
             )

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OpprettOppgaveConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/infrastruktur/mocks/OpprettOppgaveConfig.kt
@@ -3,8 +3,6 @@ package no.nav.tilleggsstonader.sak.infrastruktur.mocks
 import no.nav.tilleggsstonader.kontrakter.felles.tilBehandlingstema
 import no.nav.tilleggsstonader.kontrakter.felles.tilTema
 import no.nav.tilleggsstonader.kontrakter.oppgave.Behandlingstype
-import no.nav.tilleggsstonader.kontrakter.oppgave.IdentGruppe
-import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveIdentV2
 import no.nav.tilleggsstonader.kontrakter.oppgave.OppgaveMappe
 import no.nav.tilleggsstonader.kontrakter.oppgave.Oppgavetype
 import no.nav.tilleggsstonader.kontrakter.oppgave.OpprettOppgaveRequest
@@ -70,7 +68,6 @@ class OpprettOppgaveConfig(
             .leggTilOppgaveFraRepository(
                 OpprettOppgaveRequest(
                     personident = PersonIdent(ident = behandling.ident),
-                    ident = OppgaveIdentV2(ident = behandling.ident, gruppe = IdentGruppe.FOLKEREGISTERIDENT),
                     tema = behandling.stønadstype.tilTema(),
                     tilordnetRessurs = oppgave.tilordnetSaksbehandler,
                     oppgavetype = oppgavetype,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Rydde opp gamle deprecations som lager støy (kan vente på kontrakter bump sånn at feil kræsjer, nå er det bare "implisitt" riktig)