### PR TITLE
Reise til samling TSR

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningService.kt
@@ -101,7 +101,7 @@ class ReiseTilSamlingBeregningService(
 
             BeregningsresultatOffentligTransport(
                 reiseId = fakta.reiseId,
-                tiltaksvariant = fakta.tiltaksvariant,
+                aktivitetId = fakta.aktivitetId,
                 grunnlag =
                     BeregningsgrunnlagOffentligTransportForSamling(
                         adresse = fakta.adresse,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningService.kt
@@ -101,6 +101,7 @@ class ReiseTilSamlingBeregningService(
 
             BeregningsresultatOffentligTransport(
                 reiseId = fakta.reiseId,
+                tiltaksvariant = fakta.tiltaksvariant,
                 grunnlag =
                     BeregningsgrunnlagOffentligTransportForSamling(
                         adresse = fakta.adresse,
@@ -145,6 +146,7 @@ class ReiseTilSamlingBeregningService(
 
             BeregningsresultatPrivatBil(
                 reiseId = fakta.reiseId,
+                aktivitetId = fakta.aktivitetId,
                 grunnlag = grunnlag,
                 beløp = beregnBelopForPrivatBil(grunnlag),
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
@@ -24,7 +24,7 @@ data class BeregningsresultatPrivatBil(
     val reiseId: ReiseId,
     val grunnlag: BeregningsgrunnlagPrivatBilForSamling,
     val beløp: BigDecimal,
-    val aktivitetId: VilkårperiodeGlobalId,
+    val aktivitetId: VilkårperiodeGlobalId?,
 )
 
 data class BeregningsgrunnlagPrivatBilForSamling(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
@@ -1,8 +1,10 @@
 package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain
 
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.felles.domain.VedtaksperiodeId
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -15,12 +17,13 @@ data class BeregningsresultatOffentligTransport(
     val reiseId: ReiseId,
     val grunnlag: BeregningsgrunnlagOffentligTransportForSamling,
     val beløp: BigDecimal,
-)
+    val tiltaksvariant: TypeAktivitet? = null)
 
 data class BeregningsresultatPrivatBil(
     val reiseId: ReiseId,
     val grunnlag: BeregningsgrunnlagPrivatBilForSamling,
     val beløp: BigDecimal,
+    val aktivitetId: VilkårperiodeGlobalId,
 )
 
 data class BeregningsgrunnlagPrivatBilForSamling(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain
 
-import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.felles.domain.VedtaksperiodeId
 import no.nav.tilleggsstonader.sak.vedtak.domain.Vedtaksperiode
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
@@ -17,7 +16,7 @@ data class BeregningsresultatOffentligTransport(
     val reiseId: ReiseId,
     val grunnlag: BeregningsgrunnlagOffentligTransportForSamling,
     val beløp: BigDecimal,
-    val tiltaksvariant: TypeAktivitet? = null,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 )
 
 data class BeregningsresultatPrivatBil(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/domain/BeregningsresultatOffentligTransport.kt
@@ -17,7 +17,8 @@ data class BeregningsresultatOffentligTransport(
     val reiseId: ReiseId,
     val grunnlag: BeregningsgrunnlagOffentligTransportForSamling,
     val beløp: BigDecimal,
-    val tiltaksvariant: TypeAktivitet? = null)
+    val tiltaksvariant: TypeAktivitet? = null,
+)
 
 data class BeregningsresultatPrivatBil(
     val reiseId: ReiseId,

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
@@ -33,7 +33,7 @@ data class BeregningsresultatPrivatBilDto(
     val sats: BigDecimal,
     val totaltReiseavstand: BigDecimal,
     val beløp: BigDecimal,
-    val aktivitetId: VilkårperiodeGlobalId,
+    val aktivitetId: VilkårperiodeGlobalId?,
 )
 
 fun BeregningReiseTilSamling.tilDto(beregningsplan: Beregningsplan) =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.dto
 
-import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningReiseTilSamling
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningsresultatOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningsresultatPrivatBil

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
@@ -1,10 +1,12 @@
 package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.dto
 
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningReiseTilSamling
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningsresultatOffentligTransport
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningsresultatPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -20,6 +22,7 @@ data class BeregningsresultatOffentligTransportDto(
     val fom: LocalDate,
     val tom: LocalDate,
     val beløp: BigDecimal,
+    val tiltaksvariant: TypeAktivitet? = null,
 )
 
 data class BeregningsresultatPrivatBilDto(
@@ -30,6 +33,7 @@ data class BeregningsresultatPrivatBilDto(
     val sats: BigDecimal,
     val totaltReiseavstand: BigDecimal,
     val beløp: BigDecimal,
+    val aktivitetId: VilkårperiodeGlobalId,
 )
 
 fun BeregningReiseTilSamling.tilDto(beregningsplan: Beregningsplan) =
@@ -52,6 +56,7 @@ fun BeregningsresultatOffentligTransport.tilDto() =
         fom = grunnlag.fom,
         tom = grunnlag.tom,
         beløp = beløp,
+        tiltaksvariant = tiltaksvariant,
     )
 
 fun BeregningsresultatPrivatBil.tilDto() =
@@ -63,4 +68,5 @@ fun BeregningsresultatPrivatBil.tilDto() =
         sats = grunnlag.sats,
         totaltReiseavstand = grunnlag.totaltReiseavstand,
         beløp = beløp,
+        aktivitetId = aktivitetId,
     )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/dto/BeregningsresultatReiseTilSamlingDto.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.dto
 
-import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningReiseTilSamling
 import no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.domain.BeregningsresultatOffentligTransport
@@ -22,7 +21,7 @@ data class BeregningsresultatOffentligTransportDto(
     val fom: LocalDate,
     val tom: LocalDate,
     val beløp: BigDecimal,
-    val tiltaksvariant: TypeAktivitet? = null,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 )
 
 data class BeregningsresultatPrivatBilDto(
@@ -56,7 +55,7 @@ fun BeregningsresultatOffentligTransport.tilDto() =
         fom = grunnlag.fom,
         tom = grunnlag.tom,
         beløp = beløp,
-        tiltaksvariant = tiltaksvariant,
+        aktivitetId = aktivitetId,
     )
 
 fun BeregningsresultatPrivatBil.tilDto() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
@@ -39,7 +39,7 @@ data class FaktaReiseTilSamlingPrivatBil(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val reiseavstand: BigDecimal,
-    val aktivitetId: VilkårperiodeGlobalId,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 ) : VilkårFakta
 
 data class FaktaReiseTilSamlingUbestemt(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
@@ -32,12 +32,14 @@ data class FaktaReiseTilSamlingOffentligTransport(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val utgifterOffentligTransport: BigDecimal,
+    val tiltaksvariant: TypeAktivitet? = null,
 ) : VilkårFakta
 
 data class FaktaReiseTilSamlingPrivatBil(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val reiseavstand: BigDecimal,
+    val aktivitetId: VilkårperiodeGlobalId,
 ) : VilkårFakta
 
 data class FaktaReiseTilSamlingUbestemt(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/domain/VilkårFakta.kt
@@ -32,7 +32,7 @@ data class FaktaReiseTilSamlingOffentligTransport(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val utgifterOffentligTransport: BigDecimal,
-    val tiltaksvariant: TypeAktivitet? = null,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 ) : VilkårFakta
 
 data class FaktaReiseTilSamlingPrivatBil(

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårService.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling
 
-import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.feil.brukerfeilHvis
 import no.nav.tilleggsstonader.libs.feil.brukerfeilHvisIkke
@@ -31,6 +30,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domai
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.VilkårReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -154,28 +154,27 @@ class ReiseTilSamlingVilkårService(
         nyttVilkår: LagreVilkårReiseTilSamling,
         behandling: Saksbehandling,
     ) {
-        val gjelderPrivatBil = nyttVilkår.fakta.type == TypeReiseTilSamling.PRIVAT_BIL
-        val gjelderOffentligTransport = nyttVilkår.fakta.type == TypeReiseTilSamling.OFFENTLIG_TRANSPORT
-        val gjelderTsr = behandling.stønadstype == Stønadstype.REISE_TIL_SAMLING_TSR
+        if (behandling.stønadstype != Stønadstype.REISE_TIL_SAMLING_TSR) return
 
-        if (gjelderPrivatBil && gjelderTsr) {
-            validerAktivitetForPrivatBil(nyttVilkår, behandling.id)
-        }
+        val aktivitetId =
+            when (nyttVilkår.fakta.type) {
+                TypeReiseTilSamling.PRIVAT_BIL -> (nyttVilkår.fakta as FaktaPrivatBil).aktivitetId
+                TypeReiseTilSamling.OFFENTLIG_TRANSPORT -> (nyttVilkår.fakta as FaktaOffentligTransport).aktivitetId
+                else -> return
+            }
 
-        if (gjelderOffentligTransport && gjelderTsr) {
-            validerAktivitetForOffentligTransport(nyttVilkår, behandling.id)
-        }
+        validerAktivitetId(aktivitetId, nyttVilkår, behandling.id)
     }
 
-    private fun validerAktivitetForPrivatBil(
+    private fun validerAktivitetId(
+        aktivitetId: VilkårperiodeGlobalId?,
         nyttVilkår: LagreVilkårReiseTilSamling,
         behandlingId: BehandlingId,
     ) {
-        val fakta = nyttVilkår.fakta as FaktaPrivatBil
-        brukerfeilHvis(fakta.aktivitetId == null) {
-            "Aktivitet må velges for privat bil"
+        brukerfeilHvis(aktivitetId == null) {
+            "Aktivitet må velges"
         }
-        val aktivitet = vilkårperiodeService.hentAktivitet(fakta.aktivitetId!!, behandlingId)
+        val aktivitet = vilkårperiodeService.hentAktivitet(aktivitetId, behandlingId)
         brukerfeilHvis(aktivitet == null) {
             "Aktiviteten finnes ikke"
         }
@@ -185,20 +184,5 @@ class ReiseTilSamlingVilkårService(
         brukerfeilHvisIkke(aktivitet.inneholder(nyttVilkår)) {
             "Aktiviteten er ikke oppfylt hele vilkårperioden"
         }
-    }
-
-    private fun validerAktivitetForOffentligTransport(
-        nyttVilkår: LagreVilkårReiseTilSamling,
-        behandlingId: BehandlingId,
-    ) {
-        val fakta = nyttVilkår.fakta as FaktaOffentligTransport
-        brukerfeilHvis(fakta.tiltaksvariant == null) {
-            "Aktivitet må velges for offentlig transport"
-        }
-        vilkårperiodeService.validerAktivitetMedTiltaksvariantInnenforPeriode(
-            tiltaksvariant = fakta.tiltaksvariant,
-            periode = Datoperiode(fom = nyttVilkår.fom, tom = nyttVilkår.tom),
-            behandlingId = behandlingId,
-        )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårService.kt
@@ -1,5 +1,9 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling
 
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.feil.brukerfeilHvis
+import no.nav.tilleggsstonader.libs.feil.brukerfeilHvisIkke
 import no.nav.tilleggsstonader.libs.feil.feilHvis
 import no.nav.tilleggsstonader.libs.feil.feilHvisIkke
 import no.nav.tilleggsstonader.libs.unleash.UnleashService
@@ -10,6 +14,7 @@ import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
 import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
 import no.nav.tilleggsstonader.sak.infrastruktur.database.repository.findByIdOrThrow
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.vedtak.domain.TypeReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.SlettetVilkårResultat
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
@@ -22,10 +27,10 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.Vilk�
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.VilkårReiseTilSamlingMapper.mapTilVilkårReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaOffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaPrivatBil
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaReiseTilSamling
-import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaUbestemtType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.LagreVilkårReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.VilkårReiseTilSamling
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -34,6 +39,7 @@ class ReiseTilSamlingVilkårService(
     private val vilkårRepository: VilkårRepository,
     private val behandlingService: BehandlingService,
     private val vilkårService: VilkårService,
+    private val vilkårperiodeService: VilkårperiodeService,
     private val unleashService: UnleashService,
 ) {
     fun hentVilkårForBehandling(behandlingId: BehandlingId): List<VilkårReiseTilSamling> =
@@ -49,7 +55,8 @@ class ReiseTilSamlingVilkårService(
     ): VilkårReiseTilSamling {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         validerBehandling(behandling)
-        validerKanBehandleVilkåret()
+        validerFeatureToggle()
+        validerAktivitet(nyttVilkår, behandling)
 
         val vilkår = lagVilkårMedVurderingerOgResultat(behandlingId, nyttVilkår)
         val lagretVilkår = vilkårRepository.insert(vilkår.mapTilVilkår())
@@ -65,7 +72,8 @@ class ReiseTilSamlingVilkårService(
     ): VilkårReiseTilSamling {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         validerBehandling(behandling)
-        validerKanBehandleVilkåret()
+        validerFeatureToggle()
+        validerAktivitet(nyttVilkår, behandling)
 
         val eksisterendeVilkår = vilkårRepository.findByIdOrThrow(vilkårId).mapTilVilkårReiseTilSamling()
 
@@ -108,28 +116,8 @@ class ReiseTilSamlingVilkårService(
             status = utledStatus(eksisterendeVilkår),
             delvilkårsett = delvilkårsett,
             resultat = RegelEvaluering.utledVilkårResultat(delvilkårsett),
-            fakta = nyttVilkår.fakta.fjern0Verdier(),
+            fakta = nyttVilkår.fakta,
         )
-    }
-
-    private fun FaktaReiseTilSamling.fjern0Verdier(): FaktaReiseTilSamling {
-        when (this) {
-            is FaktaOffentligTransport -> {
-                return FaktaOffentligTransport(
-                    reiseId = this.reiseId,
-                    adresse = this.adresse,
-                    utgifterOffentligTransport = utgifterOffentligTransport,
-                )
-            }
-
-            is FaktaPrivatBil -> {
-                return this
-            }
-
-            is FaktaUbestemtType -> {
-                return this
-            }
-        }
     }
 
     private fun utledStatus(eksisterendeVilkår: VilkårReiseTilSamling?): VilkårStatus? =
@@ -154,11 +142,59 @@ class ReiseTilSamlingVilkårService(
         behandling.status.validerKanBehandlingRedigeres()
     }
 
-    private fun validerKanBehandleVilkåret() {
+    private fun validerFeatureToggle() {
         val kanBehandleReiseTilSamling = unleashService.isEnabled(Toggle.KAN_BEHANDLE_REISE_TIL_SAMLING)
 
         feilHvis(!kanBehandleReiseTilSamling) {
             "TS-sak støtter foreløpig ikke behandling av saker som gjelder reise til samling"
         }
+    }
+
+    private fun validerAktivitet(
+        nyttVilkår: LagreVilkårReiseTilSamling,
+        behandling: Saksbehandling,
+    ) {
+        val gjelderPrivatBil = nyttVilkår.fakta.type == TypeReiseTilSamling.PRIVAT_BIL
+        val gjelderOffentligTransport = nyttVilkår.fakta.type == TypeReiseTilSamling.OFFENTLIG_TRANSPORT
+
+        if (gjelderPrivatBil) {
+            validerAktivitetForPrivatBil(nyttVilkår, behandling.id)
+        }
+
+        if (gjelderOffentligTransport && behandling.stønadstype == Stønadstype.REISE_TIL_SAMLING_TSR) {
+            validerAktivitetForOffentligTransport(nyttVilkår, behandling.id)
+        }
+    }
+
+    private fun validerAktivitetForPrivatBil(
+        nyttVilkår: LagreVilkårReiseTilSamling,
+        behandlingId: BehandlingId,
+    ) {
+        val fakta = nyttVilkår.fakta as FaktaPrivatBil
+        val aktivitet = vilkårperiodeService.hentAktivitet(fakta.aktivitetId, behandlingId)
+        brukerfeilHvis(aktivitet == null) {
+            "Aktiviteten finnes ikke"
+        }
+        brukerfeilHvis(aktivitet.resultat != ResultatVilkårperiode.OPPFYLT) {
+            "Aktiviteten er ikke oppfylt"
+        }
+        brukerfeilHvisIkke(aktivitet.inneholder(nyttVilkår)) {
+            "Aktiviteten er ikke oppfylt hele vilkårperioden"
+        }
+    }
+
+    private fun validerAktivitetForOffentligTransport(
+        nyttVilkår: LagreVilkårReiseTilSamling,
+        behandlingId: BehandlingId,
+    ) {
+        val fakta = nyttVilkår.fakta as FaktaOffentligTransport
+        brukerfeilHvis(fakta.tiltaksvariant == null) {
+            "Aktivitet må velges for offentlig transport"
+        }
+        vilkårperiodeService.validerAktivitetMedTiltaksvariantInnenforPeriode(
+            tiltaksvariant = fakta.tiltaksvariant,
+            periode = Datoperiode(fom = nyttVilkår.fom, tom = nyttVilkår.tom),
+            behandlingId = behandlingId,
+        )
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårService.kt
@@ -156,12 +156,13 @@ class ReiseTilSamlingVilkårService(
     ) {
         val gjelderPrivatBil = nyttVilkår.fakta.type == TypeReiseTilSamling.PRIVAT_BIL
         val gjelderOffentligTransport = nyttVilkår.fakta.type == TypeReiseTilSamling.OFFENTLIG_TRANSPORT
+        val gjelderTsr = behandling.stønadstype == Stønadstype.REISE_TIL_SAMLING_TSR
 
-        if (gjelderPrivatBil) {
+        if (gjelderPrivatBil && gjelderTsr) {
             validerAktivitetForPrivatBil(nyttVilkår, behandling.id)
         }
 
-        if (gjelderOffentligTransport && behandling.stønadstype == Stønadstype.REISE_TIL_SAMLING_TSR) {
+        if (gjelderOffentligTransport && gjelderTsr) {
             validerAktivitetForOffentligTransport(nyttVilkår, behandling.id)
         }
     }
@@ -171,7 +172,10 @@ class ReiseTilSamlingVilkårService(
         behandlingId: BehandlingId,
     ) {
         val fakta = nyttVilkår.fakta as FaktaPrivatBil
-        val aktivitet = vilkårperiodeService.hentAktivitet(fakta.aktivitetId, behandlingId)
+        brukerfeilHvis(fakta.aktivitetId == null) {
+            "Aktivitet må velges for privat bil"
+        }
+        val aktivitet = vilkårperiodeService.hentAktivitet(fakta.aktivitetId!!, behandlingId)
         brukerfeilHvis(aktivitet == null) {
             "Aktiviteten finnes ikke"
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingDtoMapper.kt
@@ -37,10 +37,12 @@ object VilkårReiseTilSamlingDtoMapper {
     private fun FaktaOffentligTransport.tilDto() =
         FaktaReiseTilSamlingOffentligTransportDto(
             utgifterOffentligTransport = this.utgifterOffentligTransport,
+            tiltaksvariant = this.tiltaksvariant,
         )
 
     private fun FaktaPrivatBil.tilDto() =
         FaktaReiseTilSamlingPrivatBilDto(
             reiseavstand = this.reiseavstand,
+            aktivitetId = this.aktivitetId,
         )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingDtoMapper.kt
@@ -37,7 +37,7 @@ object VilkårReiseTilSamlingDtoMapper {
     private fun FaktaOffentligTransport.tilDto() =
         FaktaReiseTilSamlingOffentligTransportDto(
             utgifterOffentligTransport = this.utgifterOffentligTransport,
-            tiltaksvariant = this.tiltaksvariant,
+            aktivitetId = this.aktivitetId,
         )
 
     private fun FaktaPrivatBil.tilDto() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingMapper.kt
@@ -58,6 +58,7 @@ object VilkårReiseTilSamlingMapper {
             reiseId = this.reiseId,
             adresse = this.adresse,
             utgifterOffentligTransport = this.utgifterOffentligTransport,
+            tiltaksvariant = this.tiltaksvariant,
         )
 
     private fun FaktaReiseTilSamlingPrivatBil.mapTilFakta() =
@@ -65,6 +66,7 @@ object VilkårReiseTilSamlingMapper {
             reiseId = this.reiseId,
             adresse = this.adresse,
             reiseavstand = this.reiseavstand,
+            aktivitetId = this.aktivitetId,
         )
 
     private fun FaktaReiseTilSamlingUbestemt.mapTilFakta() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/VilkårReiseTilSamlingMapper.kt
@@ -58,7 +58,7 @@ object VilkårReiseTilSamlingMapper {
             reiseId = this.reiseId,
             adresse = this.adresse,
             utgifterOffentligTransport = this.utgifterOffentligTransport,
-            tiltaksvariant = this.tiltaksvariant,
+            aktivitetId = this.aktivitetId,
         )
 
     private fun FaktaReiseTilSamlingPrivatBil.mapTilFakta() =

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/domain/FaktaReiseTilSamling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/domain/FaktaReiseTilSamling.kt
@@ -1,5 +1,6 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain
 
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.libs.feil.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaReiseTilSamlingOffentligTransport
@@ -7,6 +8,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaReiseTilS
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaReiseTilSamlingUbestemt
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårFakta
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import java.math.BigDecimal
 
 sealed interface FaktaReiseTilSamling {
@@ -34,6 +36,7 @@ data class FaktaOffentligTransport(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val utgifterOffentligTransport: BigDecimal,
+    val tiltaksvariant: TypeAktivitet? = null,
 ) : FaktaReiseTilSamling {
     override val type = TypeReiseTilSamling.OFFENTLIG_TRANSPORT
 
@@ -46,6 +49,7 @@ data class FaktaOffentligTransport(
             reiseId = reiseId,
             adresse = adresse,
             utgifterOffentligTransport = utgifterOffentligTransport,
+            tiltaksvariant = tiltaksvariant,
         )
 
     private fun validerIngenNegativeUtgifter() {
@@ -59,6 +63,7 @@ data class FaktaPrivatBil(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val reiseavstand: BigDecimal,
+    val aktivitetId: VilkårperiodeGlobalId,
 ) : FaktaReiseTilSamling {
     override val type = TypeReiseTilSamling.PRIVAT_BIL
 
@@ -71,6 +76,7 @@ data class FaktaPrivatBil(
             reiseId = reiseId,
             adresse = adresse,
             reiseavstand = reiseavstand,
+            aktivitetId = aktivitetId,
         )
 
     private fun validerIngenNegativReiseavstand() {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/domain/FaktaReiseTilSamling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/domain/FaktaReiseTilSamling.kt
@@ -63,7 +63,7 @@ data class FaktaPrivatBil(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val reiseavstand: BigDecimal,
-    val aktivitetId: VilkårperiodeGlobalId,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 ) : FaktaReiseTilSamling {
     override val type = TypeReiseTilSamling.PRIVAT_BIL
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/domain/FaktaReiseTilSamling.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/domain/FaktaReiseTilSamling.kt
@@ -1,6 +1,5 @@
 package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain
 
-import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.libs.feil.brukerfeilHvis
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaReiseTilSamlingOffentligTransport
@@ -36,7 +35,7 @@ data class FaktaOffentligTransport(
     override val reiseId: ReiseId,
     override val adresse: String?,
     val utgifterOffentligTransport: BigDecimal,
-    val tiltaksvariant: TypeAktivitet? = null,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 ) : FaktaReiseTilSamling {
     override val type = TypeReiseTilSamling.OFFENTLIG_TRANSPORT
 
@@ -49,7 +48,7 @@ data class FaktaOffentligTransport(
             reiseId = reiseId,
             adresse = adresse,
             utgifterOffentligTransport = utgifterOffentligTransport,
-            tiltaksvariant = tiltaksvariant,
+            aktivitetId = aktivitetId,
         )
 
     private fun validerIngenNegativeUtgifter() {

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/dto/FaktaReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/dto/FaktaReiseTilSamlingDto.kt
@@ -51,7 +51,7 @@ data class FaktaReiseTilSamlingOffentligTransportDto(
 
 data class FaktaReiseTilSamlingPrivatBilDto(
     val reiseavstand: BigDecimal,
-    val aktivitetId: VilkårperiodeGlobalId,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 ) : FaktaReiseTilSamlingDto {
     override val type = TypeReiseTilSamling.PRIVAT_BIL
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/dto/FaktaReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/dto/FaktaReiseTilSamlingDto.kt
@@ -2,12 +2,14 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.dto
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaOffentligTransport
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaPrivatBil
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaUbestemtType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import java.math.BigDecimal
 
 @JsonTypeInfo(
@@ -32,6 +34,7 @@ sealed interface FaktaReiseTilSamlingDto {
 
 data class FaktaReiseTilSamlingOffentligTransportDto(
     val utgifterOffentligTransport: BigDecimal,
+    val tiltaksvariant: TypeAktivitet? = null,
 ) : FaktaReiseTilSamlingDto {
     override val type = TypeReiseTilSamling.OFFENTLIG_TRANSPORT
 
@@ -42,11 +45,13 @@ data class FaktaReiseTilSamlingOffentligTransportDto(
         reiseId = reiseId,
         adresse = adresse,
         utgifterOffentligTransport = utgifterOffentligTransport,
+        tiltaksvariant = tiltaksvariant,
     )
 }
 
 data class FaktaReiseTilSamlingPrivatBilDto(
     val reiseavstand: BigDecimal,
+    val aktivitetId: VilkårperiodeGlobalId,
 ) : FaktaReiseTilSamlingDto {
     override val type = TypeReiseTilSamling.PRIVAT_BIL
 
@@ -57,6 +62,7 @@ data class FaktaReiseTilSamlingPrivatBilDto(
         reiseId = reiseId,
         adresse = adresse,
         reiseavstand = reiseavstand,
+        aktivitetId = aktivitetId,
     )
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/dto/FaktaReiseTilSamlingDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/dto/FaktaReiseTilSamlingDto.kt
@@ -2,7 +2,6 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.dto
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeReiseTilSamling
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.ReiseId
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaOffentligTransport
@@ -34,7 +33,7 @@ sealed interface FaktaReiseTilSamlingDto {
 
 data class FaktaReiseTilSamlingOffentligTransportDto(
     val utgifterOffentligTransport: BigDecimal,
-    val tiltaksvariant: TypeAktivitet? = null,
+    val aktivitetId: VilkårperiodeGlobalId? = null,
 ) : FaktaReiseTilSamlingDto {
     override val type = TypeReiseTilSamling.OFFENTLIG_TRANSPORT
 
@@ -45,7 +44,7 @@ data class FaktaReiseTilSamlingOffentligTransportDto(
         reiseId = reiseId,
         adresse = adresse,
         utgifterOffentligTransport = utgifterOffentligTransport,
-        tiltaksvariant = tiltaksvariant,
+        aktivitetId = aktivitetId,
     )
 }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/FaktaOgVurderingMapper.kt
@@ -18,11 +18,14 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.DagpengerDagligReiseTsr
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.DagpengerReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetDagligReiseTso
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetDagligReiseTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetPassAvBarn
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetDagligReiseTso
@@ -30,14 +33,18 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenAktivitetReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeDagligReiseTso
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeDagligReiseTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppePassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.IngenMålgruppeReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.InnsattIFengselDagligReiseTsr
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.InnsattIFengselReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.KvalifiseringsstønadDagligReiseTsr
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.KvalifiseringsstønadReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeDagligReiseTso
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeDagligReiseTsr
@@ -45,6 +52,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppePassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.MålgruppeReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.NedsattArbeidsevneBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.NedsattArbeidsevneDagligReiseTso
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.NedsattArbeidsevneLæremidler
@@ -69,7 +77,9 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakspengerDagligReiseTsr
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.TiltakspengerReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UføretrygdBoutgifter
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UføretrygdDagligReiseTso
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UføretrygdLæremidler
@@ -80,6 +90,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.UtdanningReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAAP
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAAPLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingAldersVilkår
@@ -99,9 +110,11 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingTiltakReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUføretrygd
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUføretrygdLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUtdanningReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingUtdanningReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.VurderingerUtdanningLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetBoutgifterDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetDagligReiseTsoDto
@@ -109,6 +122,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivit
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetLæremidlerDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetPassAvBarnDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetReiseTilSamlingTsoDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarAktivitetReiseTilSamlingTsrDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.FaktaOgSvarMålgruppeDto
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.LagreVilkårperiode
 
@@ -167,8 +181,8 @@ private fun mapAktiviteter(
         }
 
         Stønadstype.REISE_TIL_SAMLING_TSR -> {
-            // TODO: Implementer mapping av aktiviteter for REISE_TIL_SAMLING_TSR
-            error("Mapping av aktiviteter for $stønadstype er ikke implementert")
+            require(faktaOgSvar is FaktaOgSvarAktivitetReiseTilSamlingTsrDto)
+            return mapAktiviteterReiseTilSamlingTsr(type, faktaOgSvar)
         }
 
         Stønadstype.FLYTTING_TSO,
@@ -214,8 +228,7 @@ private fun mapMålgruppe(
         }
 
         Stønadstype.REISE_TIL_SAMLING_TSR -> {
-            // TODO: Implementer mapping av målgruppe for REISE_TIL_SAMLING_TSR
-            error("Mapping av målgruppe for $stønadstype er ikke implementert")
+            mapMålgruppeReiseTilSamlingTsr(type)
         }
 
         Stønadstype.FLYTTING_TSO,
@@ -737,4 +750,49 @@ private fun mapMålgruppeReiseTilSamlingTso(
         MålgruppeType.TILTAKSPENGER -> error("Håndterer ikke tiltakspenger for reise til samling tso")
         MålgruppeType.KVALIFISERINGSSTØNAD -> error("Håndterer ikke kvalifiseringsprogram for reise til samling tso")
         MålgruppeType.INNSATT_I_FENGSEL -> error("Håndterer ikke innsatt i fengsel for reise til samling tso")
+    }
+
+private fun mapAktiviteterReiseTilSamlingTsr(
+    aktivitetType: AktivitetType,
+    faktaOgSvar: FaktaOgSvarAktivitetReiseTilSamlingTsrDto,
+): AktivitetReiseTilSamlingTsr =
+    when (aktivitetType) {
+        AktivitetType.TILTAK ->
+            TiltakReiseTilSamlingTsr(
+                vurderinger =
+                    VurderingTiltakReiseTilSamlingTsr(
+                        lønnet = VurderingLønnet(faktaOgSvar.svarLønnet),
+                        harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter),
+                        erAktivitetenObligatorisk = VurderingErAktivitetenObligatorisk(faktaOgSvar.svarErAktivitetenObligatorisk),
+                    ),
+                fakta = FaktaAktivitetReiseTilSamlingTsr(faktaOgSvar.aktivitetsdager),
+            )
+
+        AktivitetType.UTDANNING ->
+            UtdanningReiseTilSamlingTsr(
+                vurderinger =
+                    VurderingUtdanningReiseTilSamlingTsr(
+                        harUtgifter = VurderingHarUtgifter(faktaOgSvar.svarHarUtgifter),
+                        erAktivitetenObligatorisk = VurderingErAktivitetenObligatorisk(faktaOgSvar.svarErAktivitetenObligatorisk),
+                    ),
+                fakta = FaktaAktivitetReiseTilSamlingTsr(faktaOgSvar.aktivitetsdager),
+            )
+
+        AktivitetType.INGEN_AKTIVITET -> IngenAktivitetReiseTilSamlingTsr
+        AktivitetType.REELL_ARBEIDSSØKER -> feil("Reell arbeidssøker er ikke en gyldig aktivitet for reise til samling TSR")
+    }
+
+private fun mapMålgruppeReiseTilSamlingTsr(type: MålgruppeType): MålgruppeReiseTilSamlingTsr =
+    when (type) {
+        MålgruppeType.INGEN_MÅLGRUPPE -> IngenMålgruppeReiseTilSamlingTsr
+        MålgruppeType.DAGPENGER -> DagpengerReiseTilSamlingTsr()
+        MålgruppeType.TILTAKSPENGER -> TiltakspengerReiseTilSamlingTsr()
+        MålgruppeType.KVALIFISERINGSSTØNAD -> KvalifiseringsstønadReiseTilSamlingTsr()
+        MålgruppeType.INNSATT_I_FENGSEL -> InnsattIFengselReiseTilSamlingTsr()
+        MålgruppeType.OMSTILLINGSSTØNAD -> error("Håndterer ikke omstillingsstønad for reise til samling TSR")
+        MålgruppeType.OVERGANGSSTØNAD -> error("Håndterer ikke overgangsstønad for reise til samling TSR")
+        MålgruppeType.AAP -> error("Håndterer ikke AAP for reise til samling TSR")
+        MålgruppeType.UFØRETRYGD -> error("Håndterer ikke uføretrygd for reise til samling TSR")
+        MålgruppeType.NEDSATT_ARBEIDSEVNE -> error("Håndterer ikke nedsatt arbeidsevne for reise til samling TSR")
+        MålgruppeType.SYKEPENGER_100_PROSENT -> error("Støtter ikke sykepenger for reise til samling TSR")
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingJson.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/FaktaOgVurderingJson.kt
@@ -70,6 +70,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
     JsonSubTypes.Type(NedsattArbeidsevneReiseTilSamlingTso::class, name = "NEDSATT_ARBEIDSEVNE_REISE_TIL_SAMLING_TSO"),
     JsonSubTypes.Type(UføretrygdReiseTilSamlingTso::class, name = "UFØRETRYGD_REISE_TIL_SAMLING_TSO"),
     JsonSubTypes.Type(IngenMålgruppeReiseTilSamlingTso::class, name = "INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSO"),
+    JsonSubTypes.Type(UtdanningReiseTilSamlingTsr::class, name = "UTDANNING_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(TiltakReiseTilSamlingTsr::class, name = "TILTAK_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(IngenAktivitetReiseTilSamlingTsr::class, name = "INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(DagpengerReiseTilSamlingTsr::class, name = "DAGPENGER_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(TiltakspengerReiseTilSamlingTsr::class, name = "TILTAKSPENGER_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(KvalifiseringsstønadReiseTilSamlingTsr::class, name = "KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(InnsattIFengselReiseTilSamlingTsr::class, name = "INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR"),
+    JsonSubTypes.Type(IngenMålgruppeReiseTilSamlingTsr::class, name = "INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR"),
     failOnRepeatedNames = true,
 )
 sealed interface FaktaOgVurderingJson

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadReiseTilSamlingTsrFaktaOgVurdering.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/StønadReiseTilSamlingTsrFaktaOgVurdering.kt
@@ -1,0 +1,123 @@
+package no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger
+
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.AktivitetType
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.MålgruppeType
+
+sealed interface FaktaOgVurderingReiseTilSamlingTsr : FaktaOgVurdering {
+    override val type: TypeFaktaOgVurderingReiseTilSamlingTsr
+}
+
+sealed interface MålgruppeReiseTilSamlingTsr :
+    MålgruppeFaktaOgVurdering,
+    FaktaOgVurderingReiseTilSamlingTsr {
+    override val type: MålgruppeReiseTilSamlingTsrType
+}
+
+sealed interface AktivitetReiseTilSamlingTsr :
+    AktivitetFaktaOgVurdering,
+    FaktaOgVurderingReiseTilSamlingTsr {
+    override val type: AktivitetReiseTilSamlingTsrType
+}
+
+data class TiltakReiseTilSamlingTsr(
+    override val vurderinger: VurderingTiltakReiseTilSamlingTsr,
+    override val fakta: FaktaAktivitetReiseTilSamlingTsr,
+) : AktivitetReiseTilSamlingTsr {
+    override val type: AktivitetReiseTilSamlingTsrType =
+        AktivitetReiseTilSamlingTsrType.TILTAK_REISE_TIL_SAMLING_TSR
+}
+
+data class UtdanningReiseTilSamlingTsr(
+    override val vurderinger: VurderingUtdanningReiseTilSamlingTsr,
+    override val fakta: FaktaAktivitetReiseTilSamlingTsr,
+) : AktivitetReiseTilSamlingTsr {
+    override val type: AktivitetReiseTilSamlingTsrType =
+        AktivitetReiseTilSamlingTsrType.UTDANNING_REISE_TIL_SAMLING_TSR
+}
+
+data object IngenAktivitetReiseTilSamlingTsr : AktivitetReiseTilSamlingTsr {
+    override val type: AktivitetReiseTilSamlingTsrType =
+        AktivitetReiseTilSamlingTsrType.INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR
+    override val fakta: IngenFakta = IngenFakta
+    override val vurderinger: Vurderinger = IngenVurderinger
+}
+
+data object IngenMålgruppeReiseTilSamlingTsr : MålgruppeReiseTilSamlingTsr {
+    override val type: MålgruppeReiseTilSamlingTsrType =
+        MålgruppeReiseTilSamlingTsrType.INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR
+    override val vurderinger: IngenVurderinger = IngenVurderinger
+    override val fakta: IngenFakta = IngenFakta
+}
+
+data class DagpengerReiseTilSamlingTsr(
+    override val vurderinger: IngenVurderinger = IngenVurderinger,
+) : MålgruppeReiseTilSamlingTsr {
+    override val type: MålgruppeReiseTilSamlingTsrType =
+        MålgruppeReiseTilSamlingTsrType.DAGPENGER_REISE_TIL_SAMLING_TSR
+    override val fakta: IngenFakta = IngenFakta
+}
+
+data class TiltakspengerReiseTilSamlingTsr(
+    override val vurderinger: IngenVurderinger = IngenVurderinger,
+) : MålgruppeReiseTilSamlingTsr {
+    override val type: MålgruppeReiseTilSamlingTsrType =
+        MålgruppeReiseTilSamlingTsrType.TILTAKSPENGER_REISE_TIL_SAMLING_TSR
+    override val fakta: IngenFakta = IngenFakta
+}
+
+data class KvalifiseringsstønadReiseTilSamlingTsr(
+    override val vurderinger: IngenVurderinger = IngenVurderinger,
+) : MålgruppeReiseTilSamlingTsr {
+    override val type: MålgruppeReiseTilSamlingTsrType =
+        MålgruppeReiseTilSamlingTsrType.KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR
+    override val fakta: IngenFakta = IngenFakta
+}
+
+data class InnsattIFengselReiseTilSamlingTsr(
+    override val vurderinger: IngenVurderinger = IngenVurderinger,
+) : MålgruppeReiseTilSamlingTsr {
+    override val type: MålgruppeReiseTilSamlingTsrType =
+        MålgruppeReiseTilSamlingTsrType.INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR
+    override val fakta: IngenFakta = IngenFakta
+}
+
+data class VurderingTiltakReiseTilSamlingTsr(
+    override val lønnet: VurderingLønnet,
+    override val harUtgifter: VurderingHarUtgifter,
+    override val erAktivitetenObligatorisk: VurderingErAktivitetenObligatorisk,
+) : HarUtgifterVurdering,
+    LønnetVurdering,
+    ErAktivitetenObligatoriskVurdering
+
+data class VurderingUtdanningReiseTilSamlingTsr(
+    override val harUtgifter: VurderingHarUtgifter,
+    override val erAktivitetenObligatorisk: VurderingErAktivitetenObligatorisk,
+) : HarUtgifterVurdering,
+    ErAktivitetenObligatoriskVurdering
+
+data class FaktaAktivitetReiseTilSamlingTsr(
+    override val aktivitetsdager: Int? = null,
+) : Fakta,
+    FaktaAktivitetsdagerNullable
+
+sealed interface TypeFaktaOgVurderingReiseTilSamlingTsr : TypeFaktaOgVurdering
+
+enum class AktivitetReiseTilSamlingTsrType(
+    override val vilkårperiodeType: AktivitetType,
+) : TypeAktivitetOgVurdering,
+    TypeFaktaOgVurderingReiseTilSamlingTsr {
+    UTDANNING_REISE_TIL_SAMLING_TSR(AktivitetType.UTDANNING),
+    TILTAK_REISE_TIL_SAMLING_TSR(AktivitetType.TILTAK),
+    INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR(AktivitetType.INGEN_AKTIVITET),
+}
+
+enum class MålgruppeReiseTilSamlingTsrType(
+    override val vilkårperiodeType: MålgruppeType,
+) : TypeMålgruppeOgVurdering,
+    TypeFaktaOgVurderingReiseTilSamlingTsr {
+    INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR(MålgruppeType.INGEN_MÅLGRUPPE),
+    DAGPENGER_REISE_TIL_SAMLING_TSR(MålgruppeType.DAGPENGER),
+    TILTAKSPENGER_REISE_TIL_SAMLING_TSR(MålgruppeType.TILTAKSPENGER),
+    KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR(MålgruppeType.KVALIFISERINGSSTØNAD),
+    INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR(MålgruppeType.INNSATT_I_FENGSEL),
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/LagreVilkårperiode.kt
@@ -12,6 +12,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.AktivitetReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.DekketAvAnnetRegelverkVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.ErAktivitetenObligatoriskVurdering
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaAktivitetsdager
@@ -50,6 +51,7 @@ data class LagreVilkårperiode(
     JsonSubTypes.Type(FaktaOgSvarAktivitetDagligReiseTsoDto::class, name = "AKTIVITET_DAGLIG_REISE_TSO"),
     JsonSubTypes.Type(FaktaOgSvarAktivitetDagligReiseTsrDto::class, name = "AKTIVITET_DAGLIG_REISE_TSR"),
     JsonSubTypes.Type(FaktaOgSvarAktivitetReiseTilSamlingTsoDto::class, name = "AKTIVITET_REISE_TIL_SAMLING_TSO"),
+    JsonSubTypes.Type(FaktaOgSvarAktivitetReiseTilSamlingTsrDto::class, name = "AKTIVITET_REISE_TIL_SAMLING_TSR"),
 )
 sealed class FaktaOgSvarDto
 
@@ -90,6 +92,13 @@ data class FaktaOgSvarAktivitetReiseTilSamlingTsoDto(
     val svarLønnet: SvarJaNei? = null,
     val svarHarUtgifter: SvarJaNei? = null,
     val svarErAktivitetenObligatorisk: SvarJaNei? = null,
+) : FaktaOgSvarDto()
+
+data class FaktaOgSvarAktivitetReiseTilSamlingTsrDto(
+    val svarLønnet: SvarJaNei? = null,
+    val svarHarUtgifter: SvarJaNei? = null,
+    val svarErAktivitetenObligatorisk: SvarJaNei? = null,
+    val aktivitetsdager: Int? = null,
 ) : FaktaOgSvarDto()
 
 fun FaktaOgVurdering.tilFaktaOgSvarDto(): FaktaOgSvarDto =
@@ -185,5 +194,25 @@ fun FaktaOgVurdering.tilFaktaOgSvarDto(): FaktaOgSvarDto =
                         .takeIfVurderinger<ErAktivitetenObligatoriskVurdering>()
                         ?.erAktivitetenObligatorisk
                         ?.svar,
+            )
+
+        is AktivitetReiseTilSamlingTsr ->
+            FaktaOgSvarAktivitetReiseTilSamlingTsrDto(
+                svarLønnet =
+                    this.vurderinger
+                        .takeIfVurderinger<LønnetVurdering>()
+                        ?.lønnet
+                        ?.svar,
+                svarHarUtgifter =
+                    this.vurderinger
+                        .takeIfVurderinger<HarUtgifterVurdering>()
+                        ?.harUtgifter
+                        ?.svar,
+                svarErAktivitetenObligatorisk =
+                    this.vurderinger
+                        .takeIfVurderinger<ErAktivitetenObligatoriskVurdering>()
+                        ?.erAktivitetenObligatorisk
+                        ?.svar,
+                aktivitetsdager = this.fakta.takeIfFakta<FaktaAktivitetsdagerNullable>()?.aktivitetsdager,
             )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/dto/VilkårperiodeDto.kt
@@ -26,6 +26,7 @@ import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinge
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingLæremidler
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingPassAvBarn
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingReiseTilSamlingTso
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingReiseTilSamlingTsr
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfFakta
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaOgVurderingUtil.takeIfVurderinger
 import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.faktavurderinger.FaktaProsent
@@ -106,6 +107,8 @@ fun Vurdering.tilDto() = VurderingDto(svar = svar, resultat = resultat)
     JsonSubTypes.Type(AktivitetBoutgifterFaktaOgVurderingerDto::class, name = "AKTIVITET_BOUTGIFTER"),
     JsonSubTypes.Type(AktivitetDagligReiseTsoFaktaOgVurderingerDto::class, name = "AKTIVITET_DAGLIG_REISE_TSO"),
     JsonSubTypes.Type(AktivitetDagligReiseTsrFaktaOgVurderingerDto::class, name = "AKTIVITET_DAGLIG_REISE_TSR"),
+    JsonSubTypes.Type(AktivitetReiseTilSamlingTsoFaktaOgVurderingerDto::class, name = "AKTIVITET_REISE_TIL_SAMLING_TSO"),
+    JsonSubTypes.Type(AktivitetReiseTilSamlingTsrFaktaOgVurderingerDto::class, name = "AKTIVITET_REISE_TIL_SAMLING_TSR"),
 )
 sealed class FaktaOgVurderingerDto
 
@@ -153,6 +156,13 @@ data class AktivitetReiseTilSamlingTsoFaktaOgVurderingerDto(
     val lønnet: VurderingDto? = null,
     val harUtgifter: VurderingDto? = null,
     val erAktivitetenObligatorisk: VurderingDto? = null,
+) : FaktaOgVurderingerDto()
+
+data class AktivitetReiseTilSamlingTsrFaktaOgVurderingerDto(
+    val lønnet: VurderingDto? = null,
+    val harUtgifter: VurderingDto? = null,
+    val erAktivitetenObligatorisk: VurderingDto? = null,
+    val aktivitetsdager: Int? = null,
 ) : FaktaOgVurderingerDto()
 
 fun FaktaOgVurdering.tilFaktaOgVurderingDto(): FaktaOgVurderingerDto =
@@ -239,6 +249,18 @@ fun FaktaOgVurdering.tilFaktaOgVurderingDto(): FaktaOgVurderingerDto =
                                 .takeIfVurderinger<ErAktivitetenObligatoriskVurdering>()
                                 ?.erAktivitetenObligatorisk
                                 ?.tilDto(),
+                    )
+
+                is FaktaOgVurderingReiseTilSamlingTsr ->
+                    AktivitetReiseTilSamlingTsrFaktaOgVurderingerDto(
+                        lønnet = vurderinger.takeIfVurderinger<LønnetVurdering>()?.lønnet?.tilDto(),
+                        harUtgifter = vurderinger.takeIfVurderinger<HarUtgifterVurdering>()?.harUtgifter?.tilDto(),
+                        erAktivitetenObligatorisk =
+                            vurderinger
+                                .takeIfVurderinger<ErAktivitetenObligatoriskVurdering>()
+                                ?.erAktivitetenObligatorisk
+                                ?.tilDto(),
+                        aktivitetsdager = fakta.takeIfFakta<FaktaAktivitetsdagerNullable>()?.aktivitetsdager,
                     )
             }
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -697,12 +697,12 @@ fun faktaOffentligTransportReiseTilSamling(
     reiseId: ReiseId = dummyReiseId,
     adresse: String = "Tiltaksveien 1",
     utgifterOffentligTransport: BigDecimal = 40.toBigDecimal(),
-    tiltaksvariant: TypeAktivitet? = null,
+    aktivitetId: VilkårperiodeGlobalId? = null,
 ) = FaktaOffentligTransportReiseTilSamling(
     reiseId = reiseId,
     adresse = adresse,
     utgifterOffentligTransport = utgifterOffentligTransport,
-    tiltaksvariant = tiltaksvariant,
+    aktivitetId = aktivitetId,
 )
 
 fun faktaPrivatBilReiseTilSamling(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -709,7 +709,7 @@ fun faktaPrivatBilReiseTilSamling(
     reiseId: ReiseId = dummyReiseId,
     adresse: String = "Tiltaksveien 1",
     reiseavstand: BigDecimal = 20.toBigDecimal(),
-    aktivitetId: VilkårperiodeGlobalId = VilkårperiodeGlobalId(UUID.randomUUID()),
+    aktivitetId: VilkårperiodeGlobalId = VilkårperiodeGlobalId.random(),
 ) = FaktaPrivatBilReiseTilSamling(
     reiseId = reiseId,
     adresse = adresse,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/util/DomainUtil.kt
@@ -106,6 +106,7 @@ import java.util.UUID
 import kotlin.collections.List
 import kotlin.random.Random
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaOffentligTransport as FaktaOffentligTransportReiseTilSamling
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaPrivatBil as FaktaPrivatBilReiseTilSamling
 
 fun oppgave(
     behandling: Behandling,
@@ -696,10 +697,24 @@ fun faktaOffentligTransportReiseTilSamling(
     reiseId: ReiseId = dummyReiseId,
     adresse: String = "Tiltaksveien 1",
     utgifterOffentligTransport: BigDecimal = 40.toBigDecimal(),
+    tiltaksvariant: TypeAktivitet? = null,
 ) = FaktaOffentligTransportReiseTilSamling(
     reiseId = reiseId,
     adresse = adresse,
     utgifterOffentligTransport = utgifterOffentligTransport,
+    tiltaksvariant = tiltaksvariant,
+)
+
+fun faktaPrivatBilReiseTilSamling(
+    reiseId: ReiseId = dummyReiseId,
+    adresse: String = "Tiltaksveien 1",
+    reiseavstand: BigDecimal = 20.toBigDecimal(),
+    aktivitetId: VilkårperiodeGlobalId = VilkårperiodeGlobalId(UUID.randomUUID()),
+) = FaktaPrivatBilReiseTilSamling(
+    reiseId = reiseId,
+    adresse = adresse,
+    reiseavstand = reiseavstand,
+    aktivitetId = aktivitetId,
 )
 
 fun lagreDagligReiseDto(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningsTest.kt
@@ -3,7 +3,6 @@ package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.beregning
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
-import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.libs.feil.ApiFeil
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.libs.utils.dato.februar
@@ -72,7 +71,7 @@ class ReiseTilSamlingBeregningsTest {
                             reiseId = dummyReiseId,
                             adresse = "Samlingsgata 1",
                             utgifterOffentligTransport = 500.toBigDecimal(),
-                            tiltaksvariant = TypeAktivitet.GRUPPEAMO,
+                            aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID()),
                         ),
                 ),
                 vilkår(
@@ -100,8 +99,8 @@ class ReiseTilSamlingBeregningsTest {
             )
         val offentligTransport = result.offentligTransport
         assertThat(offentligTransport).hasSize(2)
-        assertThat(offentligTransport[0].tiltaksvariant).isEqualTo(TypeAktivitet.GRUPPEAMO)
-        assertThat(offentligTransport[1].tiltaksvariant).isNull()
+        assertThat(offentligTransport[0].aktivitetId).isNotNull()
+        assertThat(offentligTransport[1].aktivitetId).isNull()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningsTest.kt
@@ -105,7 +105,7 @@ class ReiseTilSamlingBeregningsTest {
 
     @Test
     fun `beregner privat bil riktig for ett vilkår`() {
-        val aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID())
+        val aktivitetId = VilkårperiodeGlobalId.random()
         every { vilkårService.hentOppfylteReiseTilSamlingVilkår(behandling.id) } returns
             listOf(
                 vilkår(

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningsTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/reiseTilSamling/beregning/ReiseTilSamlingBeregningsTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.sak.vedtak.reiseTilSamling.beregning
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
 import no.nav.tilleggsstonader.libs.feil.ApiFeil
 import no.nav.tilleggsstonader.libs.test.assertions.catchThrowableOfType
 import no.nav.tilleggsstonader.libs.utils.dato.februar
@@ -23,9 +24,11 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.FaktaReiseTilS
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårStatus
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårType
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkårsresultat
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class ReiseTilSamlingBeregningsTest {
     private val vilkårService = mockk<VilkårService>()
@@ -69,6 +72,7 @@ class ReiseTilSamlingBeregningsTest {
                             reiseId = dummyReiseId,
                             adresse = "Samlingsgata 1",
                             utgifterOffentligTransport = 500.toBigDecimal(),
+                            tiltaksvariant = TypeAktivitet.GRUPPEAMO,
                         ),
                 ),
                 vilkår(
@@ -96,10 +100,13 @@ class ReiseTilSamlingBeregningsTest {
             )
         val offentligTransport = result.offentligTransport
         assertThat(offentligTransport).hasSize(2)
+        assertThat(offentligTransport[0].tiltaksvariant).isEqualTo(TypeAktivitet.GRUPPEAMO)
+        assertThat(offentligTransport[1].tiltaksvariant).isNull()
     }
 
     @Test
     fun `beregner privat bil riktig for ett vilkår`() {
+        val aktivitetId = VilkårperiodeGlobalId(UUID.randomUUID())
         every { vilkårService.hentOppfylteReiseTilSamlingVilkår(behandling.id) } returns
             listOf(
                 vilkår(
@@ -114,6 +121,7 @@ class ReiseTilSamlingBeregningsTest {
                             reiseId = dummyReiseId,
                             adresse = "Samlingsgata 1",
                             reiseavstand = 20.toBigDecimal(),
+                            aktivitetId = aktivitetId,
                         ),
                 ),
             )
@@ -130,6 +138,7 @@ class ReiseTilSamlingBeregningsTest {
         val privatBil = result.privatBil
         assertThat(privatBil).hasSize(1)
         assertThat(privatBil.first().beløp).isEqualTo(59.toBigDecimal())
+        assertThat(privatBil.first().aktivitetId).isEqualTo(aktivitetId)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårControllerTest.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.CleanDatabaseIntegrationTest
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.integrasjonstest.extensions.opprettOgTilordneOppgaveForBehandling
+import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.util.FileUtil
 import no.nav.tilleggsstonader.sak.util.behandling
 import no.nav.tilleggsstonader.sak.util.dummyReiseId
@@ -21,6 +22,7 @@ import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.dto.F
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.dto.LagreVilkårReiseTilSamlingDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.dto.SlettVilkårRequestDto
 import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.dto.VilkårReiseTilSamlingDto
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.dto.VilkårperiodeDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -98,17 +100,43 @@ class ReiseTilSamlingVilkårControllerTest : CleanDatabaseIntegrationTest() {
 
     @Test
     fun `skal kunne lagre, endre og slette vilkår for reise til samling - privat bil`() {
+        val fom = 1 januar 2025
+        val tom = 31 januar 2025
+
+        val behandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(
+                stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO,
+                tilSteg = StegType.VILKÅR,
+            ) {
+                aktivitet {
+                    opprett {
+                        aktivitetTiltakTsoReiseTilSamling(fom = fom, tom = tom)
+                    }
+                }
+                målgruppe {
+                    opprett {
+                        målgruppeAAP(fom = fom, tom = tom)
+                    }
+                }
+            }
+
+        val aktivitet =
+            kall.vilkårperiode
+                .hentForBehandling(behandlingContext.behandlingId)
+                .vilkårperioder.aktiviteter
+                .single()
+
         val nyttVilkår =
             LagreVilkårReiseTilSamlingDto(
-                fom = 1 januar 2025,
-                tom = 31 januar 2025,
+                fom = fom,
+                tom = tom,
                 adresse = "Samlingsveien 1",
                 reiseId = dummyReiseId,
                 svar = svarPrivatBil,
-                fakta = faktaPrivatBil(),
+                fakta = faktaPrivatBil(aktivitet = aktivitet),
             )
 
-        val resultat = kall.vilkårReiseTilSamling.opprettVilkår(behandling.id, nyttVilkår)
+        val resultat = kall.vilkårReiseTilSamling.opprettVilkår(behandlingContext.behandlingId, nyttVilkår)
 
         assertThat(resultat.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
         assertThat(resultat.status).isEqualTo(VilkårStatus.NY)
@@ -116,10 +144,11 @@ class ReiseTilSamlingVilkårControllerTest : CleanDatabaseIntegrationTest() {
 
         val oppdatertVilkår =
             nyttVilkår.copy(
-                fakta = faktaPrivatBil(reiseavstand = BigDecimal("50")),
+                fakta = faktaPrivatBil(reiseavstand = BigDecimal("50"), aktivitet = aktivitet),
             )
 
-        val resultatOppdatert = kall.vilkårReiseTilSamling.oppdaterVilkår(oppdatertVilkår, resultat.id, behandling.id)
+        val resultatOppdatert =
+            kall.vilkårReiseTilSamling.oppdaterVilkår(oppdatertVilkår, resultat.id, behandlingContext.behandlingId)
 
         assertThat(resultatOppdatert.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
         assertThat(resultatOppdatert.status).isEqualTo(VilkårStatus.NY)
@@ -127,7 +156,7 @@ class ReiseTilSamlingVilkårControllerTest : CleanDatabaseIntegrationTest() {
 
         val resultatSlettet =
             kall.vilkårReiseTilSamling.slettVilkår(
-                behandlingId = behandling.id,
+                behandlingId = behandlingContext.behandlingId,
                 vilkårId = resultatOppdatert.id,
                 dto = SlettVilkårRequestDto(),
             )
@@ -135,7 +164,7 @@ class ReiseTilSamlingVilkårControllerTest : CleanDatabaseIntegrationTest() {
         assertThat(resultatSlettet.slettetPermanent).isTrue
         assertThat(resultatSlettet.vilkår.slettetKommentar).isNull()
 
-        val hentedeVilkår = kall.vilkårReiseTilSamling.hentVilkår(behandling.id)
+        val hentedeVilkår = kall.vilkårReiseTilSamling.hentVilkår(behandlingContext.behandlingId)
         assertThat(hentedeVilkår).isEmpty()
     }
 
@@ -176,10 +205,13 @@ class ReiseTilSamlingVilkårControllerTest : CleanDatabaseIntegrationTest() {
             utgifterOffentligTransport = utgifterOffentligTransport,
         )
 
-    private fun faktaPrivatBil(reiseavstand: BigDecimal = BigDecimal("35")) =
-        FaktaReiseTilSamlingPrivatBilDto(
-            reiseavstand = reiseavstand,
-        )
+    private fun faktaPrivatBil(
+        reiseavstand: BigDecimal = BigDecimal("35"),
+        aktivitet: VilkårperiodeDto,
+    ) = FaktaReiseTilSamlingPrivatBilDto(
+        reiseavstand = reiseavstand,
+        aktivitetId = aktivitet.globalId,
+    )
 
     private fun assertLagretVilkår(
         lagreVilkårRequest: LagreVilkårReiseTilSamlingDto,

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårServiceTest.kt
@@ -3,8 +3,6 @@ package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
-import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.feil.ApiFeil
@@ -82,7 +80,7 @@ class ReiseTilSamlingVilkårServiceTest {
                         reiseId = it.reiseId,
                         adresse = it.adresse,
                         utgifterOffentligTransport = it.utgifterOffentligTransport,
-                        tiltaksvariant = it.tiltaksvariant,
+                        aktivitetId = it.aktivitetId,
                     )
                 },
         )
@@ -154,6 +152,12 @@ class ReiseTilSamlingVilkårServiceTest {
         every { unleashService.isEnabled(any()) } returns true
         every { vilkårRepository.insert(any<Vilkår>()) } answers { firstArg() }
 
+        val aktivitetId = VilkårperiodeGlobalId.random()
+        val aktivitet = mockk<VilkårperiodeAktivitet>(relaxed = true)
+        every { aktivitet.resultat } returns ResultatVilkårperiode.OPPFYLT
+        every { aktivitet.inneholder(any<Periode<LocalDate>>()) } returns true
+        every { vilkårperiodeService.hentAktivitet(aktivitetId, any()) } returns aktivitet
+
         val vilkår =
             nyttVilkår.copy(
                 fakta =
@@ -161,7 +165,7 @@ class ReiseTilSamlingVilkårServiceTest {
                         reiseId = dummyReiseId,
                         adresse = "Samlingsveien 1",
                         utgifterOffentligTransport = 500.toBigDecimal(),
-                        tiltaksvariant = TypeAktivitet.GRUPPEAMO,
+                        aktivitetId = aktivitetId,
                     ),
             )
 
@@ -170,17 +174,11 @@ class ReiseTilSamlingVilkårServiceTest {
             behandlingId = behandling.id,
         )
 
-        verify {
-            vilkårperiodeService.validerAktivitetMedTiltaksvariantInnenforPeriode(
-                tiltaksvariant = TypeAktivitet.GRUPPEAMO,
-                periode = Datoperiode(fom = 1 januar 2025, tom = 31 januar 2025),
-                behandlingId = behandling.id,
-            )
-        }
+        verify(exactly = 1) { vilkårRepository.insert(any<Vilkår>()) }
     }
 
     @Test
-    fun `skal feile når tiltaksvariant mangler for offentlig transport TSR`() {
+    fun `skal feile når aktivitetId mangler for offentlig transport TSR`() {
         val behandling =
             saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSR))
         every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
@@ -193,7 +191,7 @@ class ReiseTilSamlingVilkårServiceTest {
                         reiseId = dummyReiseId,
                         adresse = "Samlingsveien 1",
                         utgifterOffentligTransport = 500.toBigDecimal(),
-                        tiltaksvariant = null,
+                        aktivitetId = null,
                     ),
             )
 
@@ -203,11 +201,11 @@ class ReiseTilSamlingVilkårServiceTest {
                     nyttVilkår = vilkår,
                     behandlingId = behandling.id,
                 )
-            }.withMessage("Aktivitet må velges for offentlig transport")
+            }.withMessage("Aktivitet må velges")
     }
 
     @Test
-    fun `skal ikke kreve tiltaksvariant for offentlig transport TSO`() {
+    fun `skal ikke kreve aktivitetId for offentlig transport TSO`() {
         val behandling =
             saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
         every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
@@ -221,7 +219,7 @@ class ReiseTilSamlingVilkårServiceTest {
                         reiseId = dummyReiseId,
                         adresse = "Samlingsveien 1",
                         utgifterOffentligTransport = 500.toBigDecimal(),
-                        tiltaksvariant = null,
+                        aktivitetId = null,
                     ),
             )
 
@@ -231,7 +229,7 @@ class ReiseTilSamlingVilkårServiceTest {
         )
 
         verify(exactly = 0) {
-            vilkårperiodeService.validerAktivitetMedTiltaksvariantInnenforPeriode(any(), any(), any())
+            vilkårperiodeService.hentAktivitet(any(), any())
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårServiceTest.kt
@@ -1,0 +1,375 @@
+package no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
+import no.nav.tilleggsstonader.kontrakter.felles.Periode
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
+import no.nav.tilleggsstonader.libs.feil.ApiFeil
+import no.nav.tilleggsstonader.libs.feil.Feil
+import no.nav.tilleggsstonader.libs.unleash.UnleashService
+import no.nav.tilleggsstonader.libs.utils.dato.januar
+import no.nav.tilleggsstonader.sak.behandling.BehandlingService
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingStatus
+import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
+import no.nav.tilleggsstonader.sak.felles.domain.BehandlingId
+import no.nav.tilleggsstonader.sak.felles.domain.VilkårId
+import no.nav.tilleggsstonader.sak.util.dummyReiseId
+import no.nav.tilleggsstonader.sak.util.fagsak
+import no.nav.tilleggsstonader.sak.util.faktaOffentligTransportReiseTilSamling
+import no.nav.tilleggsstonader.sak.util.faktaPrivatBilReiseTilSamling
+import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.VilkårService
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.SvarOgBegrunnelse
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.Vilkår
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.domain.VilkårRepository
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.RegelId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.regler.SvarId
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaOffentligTransport
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.FaktaPrivatBil
+import no.nav.tilleggsstonader.sak.vilkår.stønadsvilkår.reiseTilSamling.domain.LagreVilkårReiseTilSamling
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.VilkårperiodeService
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.ResultatVilkårperiode
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeAktivitet
+import no.nav.tilleggsstonader.sak.vilkår.vilkårperiode.domain.VilkårperiodeGlobalId
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ReiseTilSamlingVilkårServiceTest {
+    val vilkårRepository = mockk<VilkårRepository>()
+    val vilkårService = mockk<VilkårService>()
+    val behandlingService = mockk<BehandlingService>()
+    val unleashService = mockk<UnleashService>()
+    val vilkårperiodeService = mockk<VilkårperiodeService>(relaxed = true)
+
+    val reiseTilSamlingVilkårService =
+        ReiseTilSamlingVilkårService(
+            vilkårRepository = vilkårRepository,
+            behandlingService = behandlingService,
+            vilkårService = vilkårService,
+            vilkårperiodeService = vilkårperiodeService,
+            unleashService = unleashService,
+        )
+
+    val svarOffentligTransport =
+        mapOf(
+            RegelId.AVSTAND_OVER_TRETTI_KM to SvarOgBegrunnelse(svar = SvarId.JA, begrunnelse = "begrunnelse"),
+            RegelId.DOKUMENTERTE_UTGIFTER to SvarOgBegrunnelse(svar = SvarId.JA, begrunnelse = "begrunnelse"),
+            RegelId.DEKKET_AV_ANNET_STIPEND to SvarOgBegrunnelse(svar = SvarId.NEI),
+            RegelId.KAN_REISE_MED_OFFENTLIG_TRANSPORT to SvarOgBegrunnelse(svar = SvarId.JA),
+        )
+
+    val svarPrivatBil =
+        mapOf(
+            RegelId.AVSTAND_OVER_TRETTI_KM to SvarOgBegrunnelse(svar = SvarId.JA, begrunnelse = "begrunnelse"),
+            RegelId.DOKUMENTERTE_UTGIFTER to SvarOgBegrunnelse(svar = SvarId.JA, begrunnelse = "begrunnelse"),
+            RegelId.DEKKET_AV_ANNET_STIPEND to SvarOgBegrunnelse(svar = SvarId.NEI),
+            RegelId.KAN_REISE_MED_OFFENTLIG_TRANSPORT to SvarOgBegrunnelse(svar = SvarId.NEI, begrunnelse = "begrunnelse"),
+            RegelId.KAN_REISE_MED_EGEN_BIL to SvarOgBegrunnelse(svar = SvarId.JA),
+        )
+
+    val nyttVilkår =
+        LagreVilkårReiseTilSamling(
+            fom = 1 januar 2025,
+            tom = 31 januar 2025,
+            svar = svarOffentligTransport,
+            fakta =
+                faktaOffentligTransportReiseTilSamling().let {
+                    FaktaOffentligTransport(
+                        reiseId = it.reiseId,
+                        adresse = it.adresse,
+                        utgifterOffentligTransport = it.utgifterOffentligTransport,
+                        tiltaksvariant = it.tiltaksvariant,
+                    )
+                },
+        )
+
+    @Test
+    fun `skal ikke kunne opprette vilkår når behandlingen er låst for redigering`() {
+        val behandling = saksbehandling(status = BehandlingStatus.FERDIGSTILT)
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+
+        assertThatExceptionOfType(Feil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = nyttVilkår,
+                    behandlingId = BehandlingId.random(),
+                )
+            }.withMessage("Kan ikke gjøre endringer på denne behandlingen fordi den er ferdigstilt.")
+    }
+
+    @Test
+    fun `skal ikke kunne endre vilkår når behandlingen er låst for redigering`() {
+        val behandling = saksbehandling(status = BehandlingStatus.FERDIGSTILT)
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+
+        assertThatExceptionOfType(Feil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.oppdaterVilkår(
+                    nyttVilkår = nyttVilkår,
+                    behandlingId = BehandlingId.random(),
+                    vilkårId = VilkårId.random(),
+                )
+            }.withMessage("Kan ikke gjøre endringer på denne behandlingen fordi den er ferdigstilt.")
+    }
+
+    @Test
+    fun `skal ikke kunne opprette vilkår når behandlingen ikke er i vilkårsteget`() {
+        val behandling = saksbehandling(steg = StegType.INNGANGSVILKÅR)
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+
+        assertThatExceptionOfType(Feil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = nyttVilkår,
+                    behandlingId = BehandlingId.random(),
+                )
+            }.withMessage("Kan ikke oppdatere vilkår når behandling er på steg=INNGANGSVILKÅR.")
+    }
+
+    @Test
+    fun `skal feile hvis feature toggle for reise til samling ikke er skrudd på`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns false
+
+        assertThatExceptionOfType(Feil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = nyttVilkår,
+                    behandlingId = behandling.id,
+                )
+            }.withMessage("TS-sak støtter foreløpig ikke behandling av saker som gjelder reise til samling")
+    }
+
+    @Test
+    fun `skal validere aktivitet for offentlig transport ved opprettelse for TSR`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSR))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårRepository.insert(any<Vilkår>()) } answers { firstArg() }
+
+        val vilkår =
+            nyttVilkår.copy(
+                fakta =
+                    FaktaOffentligTransport(
+                        reiseId = dummyReiseId,
+                        adresse = "Samlingsveien 1",
+                        utgifterOffentligTransport = 500.toBigDecimal(),
+                        tiltaksvariant = TypeAktivitet.GRUPPEAMO,
+                    ),
+            )
+
+        reiseTilSamlingVilkårService.opprettNyttVilkår(
+            nyttVilkår = vilkår,
+            behandlingId = behandling.id,
+        )
+
+        verify {
+            vilkårperiodeService.validerAktivitetMedTiltaksvariantInnenforPeriode(
+                tiltaksvariant = TypeAktivitet.GRUPPEAMO,
+                periode = Datoperiode(fom = 1 januar 2025, tom = 31 januar 2025),
+                behandlingId = behandling.id,
+            )
+        }
+    }
+
+    @Test
+    fun `skal feile når tiltaksvariant mangler for offentlig transport TSR`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSR))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+
+        val vilkår =
+            nyttVilkår.copy(
+                fakta =
+                    FaktaOffentligTransport(
+                        reiseId = dummyReiseId,
+                        adresse = "Samlingsveien 1",
+                        utgifterOffentligTransport = 500.toBigDecimal(),
+                        tiltaksvariant = null,
+                    ),
+            )
+
+        assertThatExceptionOfType(ApiFeil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = vilkår,
+                    behandlingId = behandling.id,
+                )
+            }.withMessage("Aktivitet må velges for offentlig transport")
+    }
+
+    @Test
+    fun `skal ikke kreve tiltaksvariant for offentlig transport TSO`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårRepository.insert(any<Vilkår>()) } answers { firstArg() }
+
+        val vilkår =
+            nyttVilkår.copy(
+                fakta =
+                    FaktaOffentligTransport(
+                        reiseId = dummyReiseId,
+                        adresse = "Samlingsveien 1",
+                        utgifterOffentligTransport = 500.toBigDecimal(),
+                        tiltaksvariant = null,
+                    ),
+            )
+
+        reiseTilSamlingVilkårService.opprettNyttVilkår(
+            nyttVilkår = vilkår,
+            behandlingId = behandling.id,
+        )
+
+        verify(exactly = 0) {
+            vilkårperiodeService.validerAktivitetMedTiltaksvariantInnenforPeriode(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `skal feile når aktivitet ikke finnes for privat bil`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårperiodeService.hentAktivitet(any(), any()) } returns null
+
+        val vilkår =
+            nyttVilkår.copy(
+                svar = svarPrivatBil,
+                fakta =
+                    faktaPrivatBilReiseTilSamling().let {
+                        FaktaPrivatBil(
+                            reiseId = it.reiseId,
+                            adresse = it.adresse,
+                            reiseavstand = it.reiseavstand,
+                            aktivitetId = it.aktivitetId,
+                        )
+                    },
+            )
+
+        assertThatExceptionOfType(ApiFeil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = vilkår,
+                    behandlingId = behandling.id,
+                )
+            }.withMessage("Aktiviteten finnes ikke")
+    }
+
+    @Test
+    fun `skal feile når aktivitet ikke er oppfylt for privat bil`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+
+        val aktivitet = mockk<VilkårperiodeAktivitet>(relaxed = true)
+        every { aktivitet.resultat } returns ResultatVilkårperiode.IKKE_OPPFYLT
+        every { vilkårperiodeService.hentAktivitet(any(), any()) } returns aktivitet
+
+        val vilkår =
+            nyttVilkår.copy(
+                svar = svarPrivatBil,
+                fakta =
+                    faktaPrivatBilReiseTilSamling().let {
+                        FaktaPrivatBil(
+                            reiseId = it.reiseId,
+                            adresse = it.adresse,
+                            reiseavstand = it.reiseavstand,
+                            aktivitetId = it.aktivitetId,
+                        )
+                    },
+            )
+
+        assertThatExceptionOfType(ApiFeil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = vilkår,
+                    behandlingId = behandling.id,
+                )
+            }.withMessage("Aktiviteten er ikke oppfylt")
+    }
+
+    @Test
+    fun `skal feile når aktivitet ikke dekker hele vilkårperioden for privat bil`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+
+        val aktivitet = mockk<VilkårperiodeAktivitet>(relaxed = true)
+        every { aktivitet.resultat } returns ResultatVilkårperiode.OPPFYLT
+        every { aktivitet.fom } returns (1 januar 2025)
+        every { aktivitet.tom } returns (15 januar 2025)
+        every { aktivitet.inneholder(any<Periode<LocalDate>>()) } returns false
+        every { vilkårperiodeService.hentAktivitet(any(), any()) } returns aktivitet
+
+        val vilkår =
+            nyttVilkår.copy(
+                svar = svarPrivatBil,
+                fakta =
+                    faktaPrivatBilReiseTilSamling().let {
+                        FaktaPrivatBil(
+                            reiseId = it.reiseId,
+                            adresse = it.adresse,
+                            reiseavstand = it.reiseavstand,
+                            aktivitetId = it.aktivitetId,
+                        )
+                    },
+            )
+
+        assertThatExceptionOfType(ApiFeil::class.java)
+            .isThrownBy {
+                reiseTilSamlingVilkårService.opprettNyttVilkår(
+                    nyttVilkår = vilkår,
+                    behandlingId = behandling.id,
+                )
+            }.withMessage("Aktiviteten er ikke oppfylt hele vilkårperioden")
+    }
+
+    @Test
+    fun `skal kunne opprette vilkår for privat bil når aktiviteten er oppfylt og dekker hele perioden`() {
+        val behandling =
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+        every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
+        every { unleashService.isEnabled(any()) } returns true
+        every { vilkårRepository.insert(any<Vilkår>()) } answers { firstArg() }
+
+        val aktivitetId = VilkårperiodeGlobalId.random()
+        val aktivitet = mockk<VilkårperiodeAktivitet>(relaxed = true)
+        every { aktivitet.resultat } returns ResultatVilkårperiode.OPPFYLT
+        every { aktivitet.fom } returns (1 januar 2025)
+        every { aktivitet.tom } returns (31 januar 2025)
+        every { aktivitet.inneholder(any<Periode<LocalDate>>()) } returns true
+        every { vilkårperiodeService.hentAktivitet(aktivitetId, any()) } returns aktivitet
+
+        val vilkår =
+            nyttVilkår.copy(
+                svar = svarPrivatBil,
+                fakta =
+                    FaktaPrivatBil(
+                        reiseId = dummyReiseId,
+                        adresse = "Samlingsveien 1",
+                        reiseavstand = 20.toBigDecimal(),
+                        aktivitetId = aktivitetId,
+                    ),
+            )
+
+        reiseTilSamlingVilkårService.opprettNyttVilkår(
+            nyttVilkår = vilkår,
+            behandlingId = behandling.id,
+        )
+
+        verify(exactly = 1) { vilkårRepository.insert(any<Vilkår>()) }
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/stønadsvilkår/reiseTilSamling/ReiseTilSamlingVilkårServiceTest.kt
@@ -238,7 +238,7 @@ class ReiseTilSamlingVilkårServiceTest {
     @Test
     fun `skal feile når aktivitet ikke finnes for privat bil`() {
         val behandling =
-            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSR))
         every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
         every { unleashService.isEnabled(any()) } returns true
         every { vilkårperiodeService.hentAktivitet(any(), any()) } returns null
@@ -269,7 +269,7 @@ class ReiseTilSamlingVilkårServiceTest {
     @Test
     fun `skal feile når aktivitet ikke er oppfylt for privat bil`() {
         val behandling =
-            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSR))
         every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
         every { unleashService.isEnabled(any()) } returns true
 
@@ -303,7 +303,7 @@ class ReiseTilSamlingVilkårServiceTest {
     @Test
     fun `skal feile når aktivitet ikke dekker hele vilkårperioden for privat bil`() {
         val behandling =
-            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSO))
+            saksbehandling(steg = StegType.VILKÅR, fagsak = fagsak(stønadstype = Stønadstype.REISE_TIL_SAMLING_TSR))
         every { behandlingService.hentSaksbehandling(any<BehandlingId>()) } returns behandling
         every { unleashService.isEnabled(any()) } returns true
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/TypeFaktaOgVurderingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/TypeFaktaOgVurderingTest.kt
@@ -40,6 +40,7 @@ class TypeFaktaOgVurderingTest {
                 is TypeFaktaOgVurderingDagligReiseTso -> type.assertHarRiktigNavn(stønadstype)
                 is TypeFaktaOgVurderingDagligReiseTsr -> type.assertHarRiktigNavn(stønadstype)
                 is TypeFaktaOgVurderingReiseTilSamlingTso -> type.assertHarRiktigNavn(stønadstype)
+                is TypeFaktaOgVurderingReiseTilSamlingTsr -> type.assertHarRiktigNavn(stønadstype)
             }
         }
     }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/TypeFaktaOgVurderingTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/TypeFaktaOgVurderingTest.kt
@@ -24,6 +24,8 @@ val alleEnumTyperFaktaOgVurdering: List<Pair<Stønadstype, TypeFaktaOgVurdering>
         Stønadstype.DAGLIG_REISE_TSR to MålgruppeDagligReiseTsrType.entries,
         Stønadstype.REISE_TIL_SAMLING_TSO to AktivitetReiseTilSamlingTsoType.entries,
         Stønadstype.REISE_TIL_SAMLING_TSO to MålgruppeReiseTilSamlingTsoType.entries,
+        Stønadstype.REISE_TIL_SAMLING_TSR to AktivitetReiseTilSamlingTsrType.entries,
+        Stønadstype.REISE_TIL_SAMLING_TSR to MålgruppeReiseTilSamlingTsrType.entries,
     ).flatMap { (stønadstype, enums) -> enums.map { stønadstype to it } }
 
 class TypeFaktaOgVurderingTest {

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
@@ -309,7 +309,8 @@ class VilkårperiodeRepositoryJsonTest : CleanDatabaseIntegrationTest() {
                 when (type) {
                     MålgruppeReiseTilSamlingTsrType.DAGPENGER_REISE_TIL_SAMLING_TSR -> DagpengerReiseTilSamlingTsr::class
                     MålgruppeReiseTilSamlingTsrType.TILTAKSPENGER_REISE_TIL_SAMLING_TSR -> TiltakspengerReiseTilSamlingTsr::class
-                    MålgruppeReiseTilSamlingTsrType.KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR -> KvalifiseringsstønadReiseTilSamlingTsr::class
+                    MålgruppeReiseTilSamlingTsrType.KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR ->
+                        KvalifiseringsstønadReiseTilSamlingTsr::class
                     MålgruppeReiseTilSamlingTsrType.INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR -> InnsattIFengselReiseTilSamlingTsr::class
                     MålgruppeReiseTilSamlingTsrType.INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR -> IngenMålgruppeReiseTilSamlingTsr::class
                 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vilkår/vilkårperiode/domain/faktavurderinger/VilkårperiodeRepositoryJsonTest.kt
@@ -159,6 +159,8 @@ class VilkårperiodeRepositoryJsonTest : CleanDatabaseIntegrationTest() {
             return forventetTypeDagligReiseTsr(type)
         } else if (type is TypeFaktaOgVurderingReiseTilSamlingTso) {
             return forventetTypeReiseTilSamlingTso(type)
+        } else if (type is TypeFaktaOgVurderingReiseTilSamlingTsr) {
+            return forventetTypeReiseTilSamlingTsr(type)
         }
 
         error("Ukjent type")
@@ -295,6 +297,29 @@ class VilkårperiodeRepositoryJsonTest : CleanDatabaseIntegrationTest() {
                     AktivitetReiseTilSamlingTsoType.TILTAK_REISE_TIL_SAMLING_TSO -> TiltakReiseTilSamlingTso::class
                     AktivitetReiseTilSamlingTsoType.UTDANNING_REISE_TIL_SAMLING_TSO -> UtdanningReiseTilSamlingTso::class
                     AktivitetReiseTilSamlingTsoType.INGEN_AKTIVITET_REISE_TIL_SAMLING_TSO -> IngenAktivitetReiseTilSamlingTso::class
+                }
+            }
+        }.java
+
+    private fun forventetTypeReiseTilSamlingTsr(
+        type: TypeFaktaOgVurderingReiseTilSamlingTsr,
+    ): Class<out FaktaOgVurderingReiseTilSamlingTsr> =
+        when (type) {
+            is MålgruppeReiseTilSamlingTsrType -> {
+                when (type) {
+                    MålgruppeReiseTilSamlingTsrType.DAGPENGER_REISE_TIL_SAMLING_TSR -> DagpengerReiseTilSamlingTsr::class
+                    MålgruppeReiseTilSamlingTsrType.TILTAKSPENGER_REISE_TIL_SAMLING_TSR -> TiltakspengerReiseTilSamlingTsr::class
+                    MålgruppeReiseTilSamlingTsrType.KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR -> KvalifiseringsstønadReiseTilSamlingTsr::class
+                    MålgruppeReiseTilSamlingTsrType.INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR -> InnsattIFengselReiseTilSamlingTsr::class
+                    MålgruppeReiseTilSamlingTsrType.INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR -> IngenMålgruppeReiseTilSamlingTsr::class
+                }
+            }
+
+            is AktivitetReiseTilSamlingTsrType -> {
+                when (type) {
+                    AktivitetReiseTilSamlingTsrType.TILTAK_REISE_TIL_SAMLING_TSR -> TiltakReiseTilSamlingTsr::class
+                    AktivitetReiseTilSamlingTsrType.UTDANNING_REISE_TIL_SAMLING_TSR -> UtdanningReiseTilSamlingTsr::class
+                    AktivitetReiseTilSamlingTsrType.INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR -> IngenAktivitetReiseTilSamlingTsr::class
                 }
             }
         }.java

--- a/src/test/resources/vedtak/REISE_TIL_SAMLING/INNVILGELSE_REISE_TIL_SAMLING.json
+++ b/src/test/resources/vedtak/REISE_TIL_SAMLING/INNVILGELSE_REISE_TIL_SAMLING.json
@@ -20,7 +20,7 @@
           ]
         },
         "beløp": 245365,
-        "tiltaksvariant": null
+        "aktivitetId": null
       }
     ],
     "privatBil": []

--- a/src/test/resources/vedtak/REISE_TIL_SAMLING/INNVILGELSE_REISE_TIL_SAMLING.json
+++ b/src/test/resources/vedtak/REISE_TIL_SAMLING/INNVILGELSE_REISE_TIL_SAMLING.json
@@ -19,7 +19,8 @@
             }
           ]
         },
-        "beløp": 245365
+        "beløp": 245365,
+        "tiltaksvariant": null
       }
     ],
     "privatBil": []

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/DAGPENGER_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/DAGPENGER_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,5 @@
+{
+  "type": "DAGPENGER_REISE_TIL_SAMLING_TSR",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,5 @@
+{
+  "type": "INGEN_AKTIVITET_REISE_TIL_SAMLING_TSR",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,5 @@
+{
+  "type": "INGEN_MÅLGRUPPE_REISE_TIL_SAMLING_TSR",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,5 @@
+{
+  "type": "INNSATT_I_FENGSEL_REISE_TIL_SAMLING_TSR",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,5 @@
+{
+  "type": "KVALIFISERINGSSTØNAD_REISE_TIL_SAMLING_TSR",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/TILTAKSPENGER_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/TILTAKSPENGER_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,5 @@
+{
+  "type": "TILTAKSPENGER_REISE_TIL_SAMLING_TSR",
+  "fakta": {},
+  "vurderinger": {}
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/TILTAK_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/TILTAK_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,20 @@
+{
+  "type": "TILTAK_REISE_TIL_SAMLING_TSR",
+  "fakta": {
+    "aktivitetsdager": 3
+  },
+  "vurderinger": {
+    "lønnet": {
+      "svar": "NEI",
+      "resultat": "OPPFYLT"
+    },
+    "harUtgifter": {
+      "svar": "JA",
+      "resultat": "OPPFYLT"
+    },
+    "erAktivitetenObligatorisk": {
+      "svar": "JA",
+      "resultat": "OPPFYLT"
+    }
+  }
+}

--- a/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/UTDANNING_REISE_TIL_SAMLING_TSR.json
+++ b/src/test/resources/vilkår/vilkårperiode/REISE_TIL_SAMLING_TSR/UTDANNING_REISE_TIL_SAMLING_TSR.json
@@ -1,0 +1,16 @@
+{
+  "type": "UTDANNING_REISE_TIL_SAMLING_TSR",
+  "fakta": {
+    "aktivitetsdager": 3
+  },
+  "vurderinger": {
+    "harUtgifter": {
+      "svar": "JA",
+      "resultat": "OPPFYLT"
+    },
+    "erAktivitetenObligatorisk": {
+      "svar": "JA",
+      "resultat": "OPPFYLT"
+    }
+  }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For at vi skal kunne betale ut rett andeler med rett konto for TSR trenger vi å vite hvilke tiltaksvariant reisen gjelder for. Denne PRen legger til rette for å legge inn hvilke aktivitet reisen (vilkåret) er knyttet til. Vi lager en 1-1 relasjon for reise - aktivitet.

(Sorry for stor PR)
