### PR TITLE
🐛 Beregning daglige reiser privat bil skal gjenbruke forrige resultat dersom beregningsplanen har det som omfang

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteSteg.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/KjørelisteSteg.kt
@@ -57,7 +57,7 @@ class KjørelisteSteg(
             privatBilBeregningService.beregn(
                 behandling = saksbehandling,
                 rammevedtak = rammevedtakPrivatBil,
-                beregnFra = eksisterendeVedtak.beregningsplan.beregnFra(),
+                beregningsplan = eksisterendeVedtak.beregningsplan,
                 brukersNavKontor = brukersNavKontor,
                 forrigeBeregningsresultat = hentForrigePrivatBilBeregningsresultat(saksbehandling),
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningService.kt
@@ -13,6 +13,8 @@ import no.nav.tilleggsstonader.sak.privatbil.avklartedager.AvklartKjørtUkeStatu
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.GodkjentGjennomførtKjøring
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.alleErUendret
 import no.nav.tilleggsstonader.sak.privatbil.avklartedager.finnDagerInnenforPeriode
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatForReisePrivatBilDag
@@ -32,11 +34,15 @@ class PrivatBilBeregningService(
     fun beregn(
         behandling: Saksbehandling,
         rammevedtak: RammevedtakPrivatBil?,
-        beregnFra: LocalDate?,
+        beregningsplan: Beregningsplan,
         brukersNavKontor: String?,
         forrigeBeregningsresultat: BeregningsresultatPrivatBil?,
     ): BeregningsresultatPrivatBil? {
         if (rammevedtak == null) return null
+
+        if (beregningsplan.omfang == Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT) {
+            return forrigeBeregningsresultat
+        }
 
         val avklarteUkerForBehandling = avklartKjørelisteService.hentAvklarteUkerForBehandling(behandling.id)
 
@@ -46,7 +52,7 @@ class PrivatBilBeregningService(
             brukersNavKontor = brukersNavKontor,
             forrigeBeregningsresultat = forrigeBeregningsresultat,
             behandlingType = behandling.type,
-            beregnFra = beregnFra,
+            beregnFra = beregningsplan.beregnFra(),
         )
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest.kt
@@ -82,7 +82,7 @@ class RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest(
     }
 
     @Test
-    fun `revurdering privat bil med omfant GJENBRUK_FORRIGE skal gjenbruke forrige resultat`() {
+    fun `revurdering privat bil med omfang GJENBRUK_FORRIGE_RESULTAT skal gjenbruke forrige resultat`() {
         val førstegangsbehandlingContext =
             opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
                 defaultDagligReisePrivatBilTsoTestdata(fom, tom)

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest.kt
@@ -1,14 +1,18 @@
 package no.nav.tilleggsstonader.sak.vedtak.dagligReise
 
 import io.mockk.every
+import no.nav.tilleggsstonader.kontrakter.felles.Datoperiode
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.utils.dato.januar
 import no.nav.tilleggsstonader.sak.IntegrationTest
+import no.nav.tilleggsstonader.sak.behandling.domain.BehandlingType
 import no.nav.tilleggsstonader.sak.behandlingsflyt.StegType
 import no.nav.tilleggsstonader.sak.felles.domain.FaktiskMålgruppe
 import no.nav.tilleggsstonader.sak.infrastruktur.unleash.Toggle
+import no.nav.tilleggsstonader.sak.integrasjonstest.gjennomførKjørelisteBehandling
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
+import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
@@ -24,7 +28,7 @@ import java.time.LocalDate
 class RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest(
     @Autowired private val vedtakService: VedtakService,
 ) : IntegrationTest() {
-    val fom: LocalDate = 1 januar 2026
+    val fom: LocalDate = 2 januar 2026
     val tom: LocalDate = 31 januar 2026
 
     /**
@@ -75,6 +79,45 @@ class RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest(
         assertThat(vedtakRevurdering.beregningsplan.omfang).isEqualTo(Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT)
         assertThat(vedtakRevurdering.beregningsresultat.offentligTransport)
             .isEqualTo(vedtakFørstegangsbehandling.beregningsresultat.offentligTransport)
+    }
+
+    @Test
+    fun `revurdering privat bil med omfant GJENBRUK_FORRIGE skal gjenbruke forrige resultat`() {
+        val førstegangsbehandlingContext =
+            opprettBehandlingOgGjennomførBehandlingsløp(Stønadstype.DAGLIG_REISE_TSO) {
+                defaultDagligReisePrivatBilTsoTestdata(fom, tom)
+                sendInnKjøreliste {
+                    periode = Datoperiode(fom, tom)
+                    kjørteDager = listOf(KjørtDag(dato = fom, parkeringsutgift = 50))
+                }
+            }
+
+        val kjørelistebehandling =
+            testoppsettService
+                .hentBehandlinger(førstegangsbehandlingContext.fagsakId)
+                .single { it.type == BehandlingType.KJØRELISTE }
+
+        gjennomførKjørelisteBehandling(kjørelistebehandling)
+
+        val vedtakKjørelistebehandling =
+            vedtakService.hentVedtak<InnvilgelseDagligReise>(kjørelistebehandling.id).data
+
+        // Kun begrunnelse endres, så tidligsteEndring skal forbli null → GJENBRUK_FORRIGE_RESULTAT.
+        val revurderingId =
+            opprettRevurderingOgGjennomførBehandlingsløp(
+                fraBehandlingId = førstegangsbehandlingContext.behandlingId,
+                tilSteg = StegType.SIMULERING,
+            ) {
+                aktivitet {
+                    oppdaterEnesteAktivitet { this.copy(begrunnelse = "oppdatert begrunnelse") }
+                }
+            }
+
+        val vedtakRevurdering = vedtakService.hentVedtak<InnvilgelseDagligReise>(revurderingId).data
+
+        assertThat(vedtakRevurdering.beregningsplan.omfang).isEqualTo(Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT)
+        assertThat(vedtakRevurdering.beregningsresultat.privatBil)
+            .isEqualTo(vedtakKjørelistebehandling.beregningsresultat.privatBil)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.sak.integrasjonstest.opprettBehandlingOgGjennomf�
 import no.nav.tilleggsstonader.sak.integrasjonstest.opprettRevurderingOgGjennomførBehandlingsløp
 import no.nav.tilleggsstonader.sak.util.KjørelisteUtil.KjørtDag
 import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.VedtakService
 import no.nav.tilleggsstonader.sak.vedtak.domain.InnvilgelseDagligReise
 import no.nav.tilleggsstonader.sak.vedtak.domain.TypeDagligReise
@@ -115,9 +116,10 @@ class RevurderingDagligReiseGjenbrukForrigeBeregningsresultatIntegrationTest(
 
         val vedtakRevurdering = vedtakService.hentVedtak<InnvilgelseDagligReise>(revurderingId).data
 
+        val dummyBeregningsplan = Beregningsplan(omfang = Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT)
         assertThat(vedtakRevurdering.beregningsplan.omfang).isEqualTo(Beregningsomfang.GJENBRUK_FORRIGE_RESULTAT)
-        assertThat(vedtakRevurdering.beregningsresultat.privatBil)
-            .isEqualTo(vedtakKjørelistebehandling.beregningsresultat.privatBil)
+        assertThat(vedtakRevurdering.copy(beregningsplan = dummyBeregningsplan))
+            .isEqualTo(vedtakKjørelistebehandling.copy(beregningsplan = dummyBeregningsplan))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/sak/vedtak/dagligReise/beregning/privatBil/PrivatBilBeregningsresultatServiceTest.kt
@@ -22,6 +22,8 @@ import no.nav.tilleggsstonader.sak.util.KjørelisteUtil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammeForReiseMedPrivatBil
 import no.nav.tilleggsstonader.sak.util.RammevedtakPrivatBilUtil.rammevedtakPrivatBil
 import no.nav.tilleggsstonader.sak.util.saksbehandling
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsomfang
+import no.nav.tilleggsstonader.sak.vedtak.Beregningsplan
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.beregning.avrundetStønadsbeløp
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.BeregningsresultatPrivatBil
 import no.nav.tilleggsstonader.sak.vedtak.dagligReise.domain.RammeForReiseMedPrivatBilDelperiode
@@ -64,7 +66,7 @@ class PrivatBilBeregningsresultatServiceTest {
                 rammevedtak = rammevedtak,
                 brukersNavKontor = brukersNavKontor,
                 forrigeBeregningsresultat = forrigeBeregningsresultat,
-                beregnFra = null,
+                beregningsplan = Beregningsplan(omfang = Beregningsomfang.ALLE_PERIODER),
             ),
         )
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi hadde noen problemer med simulering i prod fordi beregningen prøvde å hente ut beregnFraDato som ikke eksisterer dersom omfanget er satt til GJENBRUK_FORRIGE_RESULTAT